### PR TITLE
feat: grant users with @actua.chat domain with admin rights #94

### DIFF
--- a/src/dotnet/Users.Service/Module/UsersServiceModule.cs
+++ b/src/dotnet/Users.Service/Module/UsersServiceModule.cs
@@ -4,7 +4,6 @@ using ActualChat.Redis.Module;
 using ActualChat.Users.Db;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
-using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Stl.Fusion.Authentication.Commands;
@@ -23,6 +22,8 @@ public class UsersServiceModule : HostModule<UsersSettings>
     public UsersServiceModule(IPluginInfoProvider.Query _) : base(_) { }
     [ServiceConstructor]
     public UsersServiceModule(IPluginHost plugins) : base(plugins) { }
+
+    public static HttpMessageHandler? GoogleBackchannelHttpHandler { get; set; }
 
     public override void InjectServices(IServiceCollection services)
     {
@@ -50,6 +51,7 @@ public class UsersServiceModule : HostModule<UsersSettings>
             options.ClientId = Settings.GoogleClientId;
             options.ClientSecret = Settings.GoogleClientSecret;
             options.CorrelationCookie.SameSite = SameSiteMode.Lax;
+            options.BackchannelHttpHandler = GoogleBackchannelHttpHandler;
         }).AddMicrosoftAccount(options => {
             options.ClientId = Settings.MicrosoftAccountClientId;
             options.ClientSecret = Settings.MicrosoftAccountClientSecret;

--- a/src/dotnet/Users.Service/Users.Service.csproj.DotSettings
+++ b/src/dotnet/Users.Service/Users.Service.csproj.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Daemon/ConfigureAwaitAnalysisMode/@EntryValue">Library</s:String>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=backends/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=controllers_005Cbackend/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/Testing.Host/BlazorTester.cs
+++ b/tests/Testing.Host/BlazorTester.cs
@@ -35,4 +35,10 @@ public class BlazorTester : TestContext, IWebTester
             return;
         _serviceScope.Dispose();
     }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose(true);
+        return ValueTask.CompletedTask;
+    }
 }

--- a/tests/Testing.Host/PlaywrightTester.cs
+++ b/tests/Testing.Host/PlaywrightTester.cs
@@ -12,10 +12,10 @@ public sealed class PlaywrightTester : WebClientTester
         : base(appHost, clientServices)
     { }
 
-    public override void Dispose()
+    public override async ValueTask DisposeAsync()
     {
         _playwright?.Dispose();
-        base.Dispose();
+        await base.DisposeAsync();
     }
 
     public async ValueTask<IPlaywright> GetPlaywright()

--- a/tests/Testing.Host/WebClientTester.cs
+++ b/tests/Testing.Host/WebClientTester.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace ActualChat.Testing.Host;
 
-public interface IWebTester : IDisposable
+public interface IWebTester : IDisposable, IAsyncDisposable
 {
     public AppHost AppHost { get; }
     public IServiceProvider AppServices { get; }
@@ -44,12 +44,15 @@ public class WebClientTester : IWebClientTester
     }
 
     public virtual void Dispose()
+        => DisposeAsync().AsTask().Wait();
+
+    public virtual async ValueTask DisposeAsync()
     {
         if (!_mustDisposeClientServices || !_clientServicesLazy.IsValueCreated)
             return;
 
         if (ClientServices is IAsyncDisposable ad)
-            ad.DisposeAsync().AsTask().Wait();
+            await ad.DisposeAsync();
         else if (ClientServices is IDisposable d)
             d.Dispose();
     }

--- a/tests/Users.IntegrationTests/AdminGrantTest.cs
+++ b/tests/Users.IntegrationTests/AdminGrantTest.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using ActualChat.Host;
+using ActualChat.Testing.Host;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+
+namespace ActualChat.Users.IntegrationTests;
+
+public class AdminGrantTest : AppHostTestBase
+{
+    private WebClientTester _tester = null!;
+
+    private IUserInfos _userInfos = null!;
+
+    private AppHost _appHost = null!;
+
+    public AdminGrantTest(ITestOutputHelper @out) : base(@out)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        _appHost = await TestHostFactory.NewAppHost();
+        _tester = _appHost.NewWebClientTester();
+        _userInfos = _appHost.Services.GetRequiredService<IUserInfos>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await _tester.DisposeAsync().AsTask();
+        _appHost.Dispose();
+    }
+
+    [Fact]
+    public async Task UserWithActualChatDomainAndGoogleIdentityShouldBeGrantedWithAdminRights()
+    {
+        // arrange
+        var user = new User("", "BobAdmin").WithIdentity(new UserIdentity(GoogleDefaults.AuthenticationScheme, "123"))
+            .WithClaim(ClaimTypes.Email, "bob@actual.chat");
+
+        // act
+        user = await _tester.SignIn(user);
+        var isAdmin = await _userInfos.IsAdmin(user.Id, CancellationToken.None);
+
+        // assert
+        user.IsAuthenticated.Should().BeTrue();
+        isAdmin.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UserWithoutGoogleIdentityShouldNotBeGrantedWithAdminRights()
+    {
+        // arrange
+        var user = new User("", "JackNotAdmin").WithIdentity(MicrosoftAccountDefaults.AuthenticationScheme)
+            .WithClaim(ClaimTypes.Email, "jack@actual.chat");
+
+        // act
+        user = await _tester.SignIn(user);
+        var isAdmin = await _userInfos.IsAdmin(user.Id, CancellationToken.None);
+
+        // assert
+        user.IsAuthenticated.Should().BeTrue();
+        isAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UserWithNotActualChatDomainShouldNotBeGrantedWithAdminRights()
+    {
+        // arrange
+        var user = new User("", "AnnNotAdmin").WithIdentity(GoogleDefaults.AuthenticationScheme);
+
+        // act
+        user = await _tester.SignIn(user);
+        var isAdmin = await _userInfos.IsAdmin(user.Id, CancellationToken.None);
+
+        // assert
+        user.IsAuthenticated.Should().BeTrue();
+        isAdmin.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Changed logic of admin rights granting. Instead of the hard-coded list we check if user belongs to @actual.chat domain. Also user must have google identity.