### PR TITLE
fix: default chat for admins restored #117

### DIFF
--- a/src/dotnet/Host/appsettings.Development.json
+++ b/src/dotnet/Host/appsettings.Development.json
@@ -14,7 +14,7 @@
     // "DefaultDb": "memory:ac_{instance_}{context}",
     "OverrideDb": "",
     // "OverrideDb": "memory:ac_{instance_}{context}",
-    // "ShouldRecreateDb": true,
+    "ShouldRecreateDb": true,
     "ShouldVerifyDb": false
   },
   "RedisSettings": {


### PR DESCRIPTION
Fixes #117 
ShouldRecreateDb was commented (I guess accidentally @alexis-kochetov). That led to ChatDbInitializer skipping, so the default chat was not created on local dev env and that led to redirect to `unavailable`