### PR TITLE
chore: removed concurrency to fix test reports location

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,7 @@
 name: Integration tests
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 on:
   push:
     branches: ["master", "release/v*"]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 name: Unit tests
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 on:
   push:
     branches: ["**"]


### PR DESCRIPTION
Temporarily disabled concurrency to fix such inconvenient behavior - test reports are attached to Deploy workflow instead Unit Tests and Integration Tests workflow

<img width="1207" alt="Screenshot 2022-04-27 at 13 21 07" src="https://user-images.githubusercontent.com/4425748/165497690-995aaf18-e9a9-484a-94ea-20f6858ae1a8.png">
