### PR TITLE
chore: run integration tests on PR event

### DIFF
--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -33,8 +33,8 @@ jobs:
     if: |
       github.ref == 'refs/heads/master' ||
       github.ref == 'refs/heads/dev' ||
-      startsWith(github.ref, 'refs/remotes/pull/') ||
-      startsWith(github.ref, 'refs/heads/release/')
+      startsWith(github.ref, 'refs/heads/release/') ||
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       semver2: ${{ steps.nbgv.outputs.SemVer2 }}


### PR DESCRIPTION
Seems like integration tests don't run for pull request event. Trying to fix it with this PR

On this screenshot you can see that integration tests were skipped for pull_request
![image](https://user-images.githubusercontent.com/4425748/171236658-6cdd22d0-707c-4623-8849-9f4890d282a7.png)