### PR TITLE
feat: removed cdn/media from CoreSettings #101

### DIFF
--- a/src/dotnet/Core/Module/CoreSettings.cs
+++ b/src/dotnet/Core/Module/CoreSettings.cs
@@ -4,6 +4,4 @@ public sealed class CoreSettings
 {
     public string Instance { get; set; } = "dev";
     public string GoogleStorageBucket { get; set; } = "";
-    public bool UseMediaServer { get; set; }
-    public bool UseCdnServer { get; set; }
 }

--- a/src/dotnet/Host/appsettings.Development.json
+++ b/src/dotnet/Host/appsettings.Development.json
@@ -1,9 +1,7 @@
 {
   "CoreSettings": {
     "Instance": "dev",
-    "GoogleStorageBucket": "",
-    "UseMediaServer": false,
-    "UseCdnServer": false
+    "GoogleStorageBucket": ""
   },
   "HostSettings": {
     "WebRootPath": "",

--- a/src/dotnet/UI.Blazor/Services/ContentUrlMapper.cs
+++ b/src/dotnet/UI.Blazor/Services/ContentUrlMapper.cs
@@ -1,7 +1,3 @@
-using ActualChat.Hosting;
-using ActualChat.Module;
-using Microsoft.Extensions.Hosting;
-
 namespace ActualChat.UI.Blazor.Services;
 
 public class ContentUrlMapper
@@ -10,21 +6,18 @@ public class ContentUrlMapper
     private readonly string _contentBaseUri;
     private readonly string _mediaBaseUri;
 
-    public ContentUrlMapper(CoreSettings settings, HostInfo hostInfo, NavigationManager nav)
+    public ContentUrlMapper(NavigationManager nav)
     {
         var baseUri = new Uri(nav.BaseUri);
 
-        if (hostInfo.IsDevelopmentInstance) {
-            // TODO: refactor when new certificate with subdomain is available
-            _transformUri = StringComparer.OrdinalIgnoreCase.Equals(baseUri.Host, "local.actual.chat");
-            _contentBaseUri = _transformUri ? $"{baseUri.Scheme}://cdn.{baseUri.Host}/" : "";
-            _mediaBaseUri = _transformUri ? $"{baseUri.Scheme}://media.{baseUri.Host}/" : "";
-        }
-        else {
-            _transformUri = baseUri.Host.EndsWith("actual.chat", StringComparison.OrdinalIgnoreCase);
-            // TODO: change to subdomain when new certificate is available
-            _contentBaseUri = settings.UseCdnServer ? $"{baseUri.Scheme}://cdn-{baseUri.Host}/" : "";
-            _mediaBaseUri = settings.UseMediaServer ? $"{baseUri.Scheme}://media-{baseUri.Host}/" : "";
+        _transformUri = baseUri.Host.EndsWith("actual.chat", StringComparison.OrdinalIgnoreCase);
+        _contentBaseUri = _transformUri ? $"{baseUri.Scheme}://cdn.{baseUri.Host}/" : "";
+        _mediaBaseUri = _transformUri ? $"{baseUri.Scheme}://media.{baseUri.Host}/" : "";
+
+        // TODO: remove this workaround when new cert is available
+        if (baseUri.Host.Equals("dev.actual.chat", StringComparison.OrdinalIgnoreCase)) {
+            _contentBaseUri = $"{baseUri.Scheme}://cdn-{baseUri.Host}/";
+            _mediaBaseUri = $"{baseUri.Scheme}://media-{baseUri.Host}/";
         }
     }
 


### PR DESCRIPTION
CoreSettings are not supposed to contain cdn/media server related settings. As far as I understood CoreSettings are used by plugins system only.
Since chat app can work in WASM mode as well as in SSB mode we need to distinguish client and server related settings. ContentUrlMapper can be executed on client side in WASM mode, but client appsettings mechanism is not implemented yet I decided to omit usage of settings for url rules logic.