### PR TITLE
chore: fix watch mode - duplicate env vars #249

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -108,10 +108,12 @@ internal static class Program
                     RedirectStandardError = true,
                     CreateNoWindow = true,
                     WorkingDirectory = Path.GetFullPath(Path.Combine("src", "dotnet", "Host")),
+                    EnvironmentVariables = {
+                        ["ASPNETCORE_ENVIRONMENT"] = "Development",
+                        ["EnableAnalyzer"] = "false",
+                        ["EnableNETAnalyzers"] = "false"
+                    }
                 };
-                psiDotnet.EnvironmentVariables.Add("ASPNETCORE_ENVIRONMENT", "Development");
-                psiDotnet.EnvironmentVariables.Add("EnableAnalyzer", "false");
-                psiDotnet.EnvironmentVariables.Add("EnableNETAnalyzers", "false");
                 dotnetProcess.StartInfo = psiDotnet;
                 dotnetProcess.OutputDataReceived += (object sender, DataReceivedEventArgs e) => {
                     if (e?.Data == null)
@@ -137,8 +139,10 @@ internal static class Program
                     RedirectStandardError = true,
                     CreateNoWindow = true,
                     WorkingDirectory = Path.GetFullPath(Path.Combine("src", "nodejs")),
+                    EnvironmentVariables = {
+                        ["CI"] = "true"
+                    }
                 };
-                psiNpm.EnvironmentVariables.Add("CI", "true");
                 npmProcess.StartInfo = psiNpm;
                 npmProcess.OutputDataReceived += (object sender, DataReceivedEventArgs e) => {
                     if (e?.Data == null)


### PR DESCRIPTION
When variable is already present our build fails with  error "Value does not fall within the expected range" which is not obvious and very frustrating