### PR TITLE
fix: audio/transcript streams expiration #86

### DIFF
--- a/src/dotnet/Audio/AudioSettings.cs
+++ b/src/dotnet/Audio/AudioSettings.cs
@@ -4,4 +4,5 @@ public class AudioSettings
 {
     public string Redis { get; set; } = "";
     public TimeSpan IdleRecordingTimeout { get; set; } = TimeSpan.FromMinutes(2);
+    public TimeSpan EndedStreamTtl { get; set; } = TimeSpan.FromMinutes(1);
 }

--- a/src/dotnet/Host/appsettings.Development.json
+++ b/src/dotnet/Host/appsettings.Development.json
@@ -23,7 +23,8 @@
     "OverrideRedis": ""
   },
   "AudioSettings": {
-    "Redis": ""
+    "Redis": "",
+    "EndedStreamTtl": "00:01:00"
   },
   "ChatSettings": {
     "Db": "",

--- a/src/dotnet/Redis/RedisStreamerExt.cs
+++ b/src/dotnet/Redis/RedisStreamerExt.cs
@@ -1,0 +1,34 @@
+using Stl.Redis;
+
+namespace ActualChat.Redis;
+
+public static class RedisStreamerExt
+{
+    // TODO: Remove when Stl.Redis provides proper expiration handling
+    public static async Task Write<T>(
+        this RedisStreamer<T> streamer,
+        IAsyncEnumerable<T> stream,
+        TimeSpan endedStreamTtl,
+        ILogger log,
+        CancellationToken cancellationToken)
+    {
+        try {
+            await streamer.Write(stream, cancellationToken).ConfigureAwait(false);
+        }
+        finally {
+            await KeyExpireSilently(streamer, endedStreamTtl, log).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task KeyExpireSilently<T>(RedisStreamer<T> streamer, TimeSpan endedStreamTtl, ILogger log)
+    {
+        try
+        {
+            await streamer.RedisDb.Database.KeyExpireAsync(streamer.Key, endedStreamTtl).ConfigureAwait(false);
+        }
+        catch (Exception exc)
+        {
+            log.LogError(exc, "Could not set expiration for redis key='{RedisKey}'", streamer.Key);
+        }
+    }
+}


### PR DESCRIPTION
setting automatic removal of audio/transcription streams after some timeout (i.e. 1 min) after this stream is marked as completed