### PR TITLE
fix: Sometimes we can see that image attachment preview is distorted (height and width are mixed up)

### DIFF
--- a/.config/local.actual.chat/nginx/nginx.conf
+++ b/.config/local.actual.chat/nginx/nginx.conf
@@ -28,6 +28,7 @@ server {
     listen 443 ssl;
     server_name local.actual.chat;
     ssl_protocols       TLSv1.2 TLSv1.3;
+	client_max_body_size 64M;
 
     location /sw.js {
         proxy_pass http://local.actual.chat:7080/dist/sw.js;

--- a/src/dotnet/Chat.UI.Blazor/Components/ChatView/Items/Attachment/ImageAttachment.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/ChatView/Items/Attachment/ImageAttachment.razor
@@ -4,7 +4,7 @@
     var attachment = Attachment;
     var url = UrlMapper.ContentUrl(Attachment.ContentId);
     var previewUrl = UrlMapper.ImagePreviewUrl(url, MaxWidth * ActualResolutionMultiplier, MaxHeight * ActualResolutionMultiplier);
-    var imgStyle = "max-width: 800px; max-height: 600px";
+    var imgStyle = $"max-width: {MaxWidth}px; max-height: {MaxHeight}px";
     if (attachment.Height > 0 && attachment.Width > 0) {
         var (width, height) = (attachment.Width, attachment.Height)
             .ToVector2()


### PR DESCRIPTION
For now I decided to correct size that we store in metadata.
But I think it would be better to do rotation according to info stored in EXIF metadata and remove EXIF metadata from the image (look likes all messendgers does it for security purpose) before storing it to blob.
What do you think about?