### PR TITLE
Feat/1185 join anonymously

### DIFF
--- a/src/dotnet/Chat.Service.Migration/Migrations/20230329053031_MigrateChatPicture.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20230329053031_MigrateChatPicture.cs
@@ -17,70 +17,71 @@ namespace ActualChat.Chat.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            UpAsync(migrationBuilder).Wait();
+            // NOTE(DF): Obsolete: applied to all of our DBs. Now it causes migration in tests to fail.
+            //UpAsync(migrationBuilder).Wait();
         }
 
-        private async Task UpAsync(MigrationBuilder migrationBuilder)
-        {
-            var dbInitializer = DbInitializer.Get<ChatDbInitializer>();
-            var mediaDbInitializer = await DbInitializer.Get<MediaDbInitializer>()
-                .CompleteEarlierMigrations(this)
-                .ConfigureAwait(false);
-            var log = dbInitializer.Services.LogFor(GetType());
-
-            var blobStorageProvider = dbInitializer.Services.GetRequiredService<IBlobStorageProvider>();
-            var blobStorage = blobStorageProvider.GetBlobStorage(BlobScope.ContentRecord);
-
-            using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
-            using var mediaDbContext = mediaDbInitializer.DbHub.CreateDbContext(true);
-            mediaDbContext.ChangeTracker.AutoDetectChangesEnabled = false;
-
-            var dbChats = await dbContext.Chats
-                .Where(x => x.Picture != null)
-                .Where(x => x.Picture != "")
-                .OrderBy(c => c.Id)
-                .ToListAsync()
-                .ConfigureAwait(false);
-
-            log.LogInformation("Upgrading {Count} chat pictures", dbChats.Count);
-
-            var blobs = new List<(string OldPath, string NewPath)>(dbChats.Count);
-
-            foreach (var dbChat in dbChats) {
-                var mediaId = new MediaId(dbChat.Id, Generate.Option);
-                var hashCode = mediaId.Id.ToString().GetSHA256HashCode();
-                var media = new Media.Media {
-                    Id = mediaId,
-                    ContentId = $"media/{hashCode}/{mediaId.LocalId}{Path.GetExtension(dbChat.Picture)}",
-                };
-
-                mediaDbContext.Media.Add(new DbMedia(media));
-                blobs.Add((dbChat.Picture, media.ContentId));
-                dbChat.MediaId = mediaId;
-                dbChat.Picture = "";
-            }
-
-            log.LogInformation("Saving Media DB changes");
-            await mediaDbContext.SaveChangesAsync().ConfigureAwait(false);
-
-            await Parallel.ForEachAsync(blobs,
-                new ParallelOptions() { MaxDegreeOfParallelism = 4 },
-                async (blob, ct) => {
-                    var isCopied = await blobStorage.CopyIfExists(blob.OldPath, blob.NewPath, ct).ConfigureAwait(false);
-                    if (!isCopied)
-                        log.LogWarning("Couldn't copy blob: {Blob}", blob.OldPath);
-                }).ConfigureAwait(false);
-
-            log.LogInformation("Saving Chats DB changes");
-            await dbContext.SaveChangesAsync().ConfigureAwait(false);
-
-            await Parallel.ForEachAsync(blobs,
-                new ParallelOptions() { MaxDegreeOfParallelism = 4 },
-                async (blob, ct) => await blobStorage.DeleteIfExists(blob.OldPath, ct).ConfigureAwait(false)
-            ).ConfigureAwait(false);
-
-            log.LogInformation("Upgrading chat pictures: done");
-        }
+        // private async Task UpAsync(MigrationBuilder migrationBuilder)
+        // {
+        //     var dbInitializer = DbInitializer.Get<ChatDbInitializer>();
+        //     var mediaDbInitializer = await DbInitializer.Get<MediaDbInitializer>()
+        //         .CompleteEarlierMigrations(this)
+        //         .ConfigureAwait(false);
+        //     var log = dbInitializer.Services.LogFor(GetType());
+        //
+        //     var blobStorageProvider = dbInitializer.Services.GetRequiredService<IBlobStorageProvider>();
+        //     var blobStorage = blobStorageProvider.GetBlobStorage(BlobScope.ContentRecord);
+        //
+        //     using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
+        //     using var mediaDbContext = mediaDbInitializer.DbHub.CreateDbContext(true);
+        //     mediaDbContext.ChangeTracker.AutoDetectChangesEnabled = false;
+        //
+        //     var dbChats = await dbContext.Chats
+        //         .Where(x => x.Picture != null)
+        //         .Where(x => x.Picture != "")
+        //         .OrderBy(c => c.Id)
+        //         .ToListAsync()
+        //         .ConfigureAwait(false);
+        //
+        //     log.LogInformation("Upgrading {Count} chat pictures", dbChats.Count);
+        //
+        //     var blobs = new List<(string OldPath, string NewPath)>(dbChats.Count);
+        //
+        //     foreach (var dbChat in dbChats) {
+        //         var mediaId = new MediaId(dbChat.Id, Generate.Option);
+        //         var hashCode = mediaId.Id.ToString().GetSHA256HashCode();
+        //         var media = new Media.Media {
+        //             Id = mediaId,
+        //             ContentId = $"media/{hashCode}/{mediaId.LocalId}{Path.GetExtension(dbChat.Picture)}",
+        //         };
+        //
+        //         mediaDbContext.Media.Add(new DbMedia(media));
+        //         blobs.Add((dbChat.Picture, media.ContentId));
+        //         dbChat.MediaId = mediaId;
+        //         dbChat.Picture = "";
+        //     }
+        //
+        //     log.LogInformation("Saving Media DB changes");
+        //     await mediaDbContext.SaveChangesAsync().ConfigureAwait(false);
+        //
+        //     await Parallel.ForEachAsync(blobs,
+        //         new ParallelOptions() { MaxDegreeOfParallelism = 4 },
+        //         async (blob, ct) => {
+        //             var isCopied = await blobStorage.CopyIfExists(blob.OldPath, blob.NewPath, ct).ConfigureAwait(false);
+        //             if (!isCopied)
+        //                 log.LogWarning("Couldn't copy blob: {Blob}", blob.OldPath);
+        //         }).ConfigureAwait(false);
+        //
+        //     log.LogInformation("Saving Chats DB changes");
+        //     await dbContext.SaveChangesAsync().ConfigureAwait(false);
+        //
+        //     await Parallel.ForEachAsync(blobs,
+        //         new ParallelOptions() { MaxDegreeOfParallelism = 4 },
+        //         async (blob, ct) => await blobStorage.DeleteIfExists(blob.OldPath, ct).ConfigureAwait(false)
+        //     ).ConfigureAwait(false);
+        //
+        //     log.LogInformation("Upgrading chat pictures: done");
+        // }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/dotnet/Chat.Service.Migration/Migrations/20230502135356_JoinAnonymously.Designer.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20230502135356_JoinAnonymously.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ActualChat.Chat.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ActualChat.Chat.Migrations
 {
     [DbContext(typeof(ChatDbContext))]
-    partial class ChatDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230502135356_JoinAnonymously")]
+    partial class JoinAnonymously
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/dotnet/Chat.Service.Migration/Migrations/20230502135356_JoinAnonymously.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20230502135356_JoinAnonymously.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActualChat.Chat.Migrations
+{
+    /// <inheritdoc />
+    public partial class JoinAnonymously : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "allowed_author_kind",
+                table: "chats",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "allowed_author_kind",
+                table: "chats");
+        }
+    }
+}

--- a/src/dotnet/Chat.Service/AuthorsBackend.cs
+++ b/src/dotnet/Chat.Service/AuthorsBackend.cs
@@ -211,7 +211,7 @@ public class AuthorsBackend : DbServiceBase<ChatDbContext>, IAuthorsBackend
             var id = new AuthorId(chatId, localId, AssumeValid.Option);
             var author = new AuthorFull(id, VersionGenerator.NextVersion()) {
                 UserId = userId,
-                IsAnonymous = account.IsGuestOrNone,
+                IsAnonymous = command.Diff.IsAnonymous ?? account.IsGuestOrNone
             };
             author = DiffEngine.Patch(author, diff);
 
@@ -226,6 +226,7 @@ public class AuthorsBackend : DbServiceBase<ChatDbContext>, IAuthorsBackend
                             UserId = userId,
                             Name = RandomNameGenerator.Default.Generate(),
                             Bio = "Someone anonymous",
+                            IsAnonymous = true
                         },
                     });
                     var avatar = await Commander.Call(changeCommand, true, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/Chat.Service/Db/DbChat.cs
+++ b/src/dotnet/Chat.Service/Db/DbChat.cs
@@ -23,6 +23,7 @@ public class DbChat : IHasId<string>, IHasVersion<long>, IRequirementTarget
 
     // Permissions & Rules
     public bool IsPublic { get; set; }
+    public ChatAuthorKind AllowedAuthorKind { get; set; }
 
     public DateTime CreatedAt {
         get => _createdAt.DefaultKind(DateTimeKind.Utc);
@@ -34,6 +35,7 @@ public class DbChat : IHasId<string>, IHasVersion<long>, IRequirementTarget
             Title = Title,
             CreatedAt = CreatedAt,
             IsPublic = IsPublic,
+            AllowedAuthorKind = AllowedAuthorKind,
             MediaId = new MediaId(MediaId),
         };
 
@@ -48,6 +50,7 @@ public class DbChat : IHasId<string>, IHasVersion<long>, IRequirementTarget
         Title = model.Title;
         CreatedAt = model.CreatedAt;
         IsPublic = model.IsPublic;
+        AllowedAuthorKind = model.AllowedAuthorKind;
         Kind = model.Kind;
         MediaId = model.MediaId;
     }

--- a/src/dotnet/Chat.UI.Blazor/Components/AuthorModal.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/AuthorModal.razor
@@ -13,7 +13,11 @@
     <Buttons>
         @if (m.IsOwn) {
             <Button Class="btn-modal" Click="OnSettingsClick">Edit profile</Button>
-            <Button Class="btn-modal" Click="OnAuthorClicked">Change avatar</Button>
+            if (!m.Author.IsAnonymous) {
+                <Button Class="btn-modal" Click="OnAuthorClicked">Change avatar</Button>
+            } else if (m.EnableIncompleteUI) {
+                <Button Class="btn-modal danger" Click="OnRevealClicked">Reveal</Button>
+            }
         } else if (m.Author.IsAnonymous) {
             <Button Class="btn-modal" Click="OnCancel">OK</Button>
         } else {
@@ -31,6 +35,8 @@
     [Inject] private IAccounts Accounts { get; init; } = null!;
     [Inject] private IAuthors Authors { get; init; } = null!;
     [Inject] private AuthorUI AuthorUI { get; init; } = null!;
+    [Inject] private FeedbackUI FeedbackUI { get; init; } = null!;
+    [Inject] private Features Features { get; init; } = null!;
     [Inject] private ModalUI ModalUI { get; init; } = null!;
     [Inject] private History History { get; init; } = null!;
     [Inject] private UICommander UICommander { get; init; } = null!;
@@ -60,11 +66,14 @@
         var ownAccount = await Accounts.GetOwn(Session, cancellationToken);
         var account = await Authors.GetAccount(Session, ChatId, AuthorId, cancellationToken);
         var canStartPeerChat = await AuthorUI.CanStartPeerChat(AuthorId, cancellationToken);
+        var enableIncompleteUI = await Features.Get<UIFeatures.EnableIncompleteUI, bool>(cancellationToken);
+
         return new ComputedModel() {
             Author = author,
             Account = account,
             OwnAccount = ownAccount,
             CanStartPeerChat = canStartPeerChat,
+            EnableIncompleteUI = enableIncompleteUI,
         };
     }
 
@@ -77,6 +86,7 @@
         public Account OwnAccount { get; init; } = null!;
         public bool IsOwn => Account?.Id == OwnAccount.Id;
         public bool CanStartPeerChat { get; init; }
+        public bool EnableIncompleteUI { get; init; }
     }
 
     public sealed record Model(AuthorId AuthorId);
@@ -84,10 +94,13 @@
     private void OnCancel()
         => Modal.Close();
 
+    private Task OnRevealClicked()
+        => FeedbackUI.AskFeatureRequestFeedback("reveal-author", "Reveal yourself");
+
     private async Task OnAuthorClicked() {
         Modal.Close();
         await History.WhenNavigationCompleted;
-        await ModalUI.Show(new AvatarSelectModal.Model(AuthorId.ChatId, OnAvatarSelected));
+        await ModalUI.Show(new AvatarSelectModal.Model(AuthorId.ChatId, false, OnAvatarSelected));
     }
 
     private async Task OnStartPeerChat()

--- a/src/dotnet/Chat.UI.Blazor/Components/AuthorModalContent.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/AuthorModalContent.razor
@@ -1,12 +1,18 @@
 @{
     string headerTitle;
     var nameTitle = "Name";
-    if (Author.IsAnonymous) {
+    if (IsOwn) {
+        if (Author.IsAnonymous) {
+            headerTitle = "Your profile (Anonymous)";
+            nameTitle = "";
+        } else {
+            headerTitle = "Your profile";
+        }
+    }
+    else if (Author.IsAnonymous) {
         headerTitle = "Anonymous author";
         nameTitle = "";
-    } else if (IsOwn)
-        headerTitle = "Your profile";
-    else
+    } else
         headerTitle = Author.Avatar.Name;
 }
 
@@ -58,7 +64,7 @@
         </TileItem>
     }
 
-    @if (Author.IsAnonymous) {
+    @if (!IsOwn && Author.IsAnonymous) {
         <TileItem Class="anonymous-bio">
             <Icon>
                 <i class="icon-alert-triangle text-xl"></i>
@@ -70,7 +76,9 @@
             <Caption>
             </Caption>
         </TileItem>
-    } else if (!Author.Avatar.Bio.IsNullOrEmpty()) {
+    }
+
+    @if (!Author.IsAnonymous && !Author.Avatar.Bio.IsNullOrEmpty()) {
         <TileItem>
             <Icon>
                 <i class="icon-person text-xl"></i>

--- a/src/dotnet/Chat.UI.Blazor/Components/AvatarSelect/AvatarSelectModal.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/AvatarSelect/AvatarSelectModal.razor
@@ -109,7 +109,7 @@
     private Avatar GenerateAnonymous() {
         var next = IdGenerator.Next();
         return new Avatar {
-            Name = RandomNameGenerator.Default.Generate(),// $"Anonymous ({next})",
+            Name = RandomNameGenerator.Default.Generate(),
             Bio = "Someone anonymous",
             Picture = DefaultUserPicture.GetBoringAvatar(next),
         };

--- a/src/dotnet/Chat.UI.Blazor/Components/AvatarSelect/AvatarSelectModal.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/AvatarSelect/AvatarSelectModal.razor
@@ -1,12 +1,15 @@
 @namespace ActualChat.Chat.UI.Blazor.Components
 @implements IModalView<AvatarSelectModal.Model>
+@using Stl.Generators
 @inherits ComputedStateComponent<AvatarSelectModal.ViewModel>
 @{
     var m = State.Value;
+    var mode = ModalModel.ChatId.IsNone ? Mode.Join : Mode.Change;
+    var title = mode == Mode.Join ? "Choose avatar" : "Change your avatar";
 }
 
 <DialogFrame
-    Title="Change your avatar"
+    Title="@title"
     Class="avatar-select-modal">
     <Body>
     @if (m == ViewModel.None) {
@@ -14,9 +17,11 @@
     }
 
     <div class="avatar-select">
-        <div class="flex-x gap-x-1 text-sm font-normal">
-            You can change your avatar in the current chat here.
-        </div>
+        @if (mode == Mode.Change) {
+            <div class="flex-x gap-x-1 text-sm font-normal">
+                You can change your avatar in the current chat here.
+            </div>
+        }
         @foreach (var avatar in m.Avatars) {
             <Tile Click="_ => OnAvatarSelected(avatar)" Class="avatar-select-item">
                 <TileItem>
@@ -34,6 +39,30 @@
                 </TileItem>
             </Tile>
         }
+        @if (m.Anonymous != null) {
+            var avatar = m.Anonymous;
+            <div class="flex-y">
+                <div class="flex-x text-sm font-normal border-t-2 py-1">
+                    You can use anonymous avatar:
+                </div>
+                <Tile Click="_ => OnAnonymousSelected(avatar)" Class="avatar-select-item">
+                    <TileItem>
+                        <Icon>
+                            <AvatarCard Avatar="@avatar"/>
+                        </Icon>
+                        <Content>
+                            @avatar.Name
+                        </Content>
+                        <Right>
+                            <AnonymousIcon Class="w-5 h-5"/>
+                        </Right>
+                    </TileItem>
+                </Tile>
+                <div class="flex-x text-sm font-normal">
+                    <button class="underline mt-2" @onclick="@RegenerateAnonymousAvatar">Regenerate anonymous avatar</button>
+                </div>
+            </div>
+        }
     </div>
     </Body>
     <Buttons>
@@ -42,10 +71,14 @@
 </DialogFrame>
 
 @code {
+    private static RandomStringGenerator IdGenerator { get; } = new(10, Alphabet.AlphaNumeric);
+    private Avatar? _anonymous;
+
     [Inject] private Session Session { get; init; } = null!;
     [Inject] private IAvatars Avatars { get; init; } = null!;
     [Inject] private IAccounts Accounts { get; init; } = null!;
     [Inject] private IAuthors Authors { get; init; } = null!;
+    [Inject] private UICommander UICommander { get; init; } = null!;
 
     [CascadingParameter] public Modal Modal { get; set; } = null!;
     [Parameter] public Model ModalModel { get; set; } = null!;
@@ -63,7 +96,28 @@
             .Select(x => Avatars.GetOwn(Session, x, cancellationToken))
             .Collect();
         var existingAvatars = avatars.SkipNullItems().ToImmutableArray();
-        return new ViewModel(existingAvatars, selectedAvatarId);
+        var anonymous = GetAnonymous();
+        return new ViewModel(existingAvatars, selectedAvatarId, anonymous);
+    }
+
+    private Avatar? GetAnonymous() {
+        if (!ModalModel.AllowAnonymous)
+            return null;
+        return _anonymous ??= GenerateAnonymous();
+    }
+
+    private Avatar GenerateAnonymous() {
+        var next = IdGenerator.Next();
+        return new Avatar {
+            Name = RandomNameGenerator.Default.Generate(),// $"Anonymous ({next})",
+            Bio = "Someone anonymous",
+            Picture = DefaultUserPicture.GetBoringAvatar(next),
+        };
+    }
+
+    private void RegenerateAnonymousAvatar() {
+        _anonymous = GenerateAnonymous();
+        State.Recompute();
     }
 
     private async Task<Symbol> GetSelectedAvatarId(CancellationToken cancellationToken)
@@ -78,6 +132,20 @@
         }
     }
 
+    private async Task OnAnonymousSelected(Avatar anonymous) {
+        var account = await Accounts.GetOwn(Session, default);
+        var command = new IAvatars.ChangeCommand(Session, Symbol.Empty, null, new Change<AvatarFull>() {
+            Create = new AvatarFull() {
+                UserId = account.Id,
+                IsAnonymous = true,
+            }.WithMissingPropertiesFrom(anonymous),
+        });
+        var (avatar, error) = await UICommander.Run(command);
+        if (error != null)
+            return;
+        await OnAvatarSelected(avatar);
+    }
+
     private async Task OnAvatarSelected(AvatarFull avatar) {
         await ModalModel.OnAvatarSelected(avatar);
         Modal.Close();
@@ -86,9 +154,11 @@
     private void OnCancel()
         => Modal.Close();
 
-    public record Model(ChatId ChatId, Func<AvatarFull, Task> OnAvatarSelected);
+    private enum Mode { Join, Change }
 
-    public record ViewModel(ImmutableArray<AvatarFull> Avatars, Symbol SelectedAvatarId) {
-        public static readonly ViewModel None = new(ImmutableArray<AvatarFull>.Empty, Symbol.Empty);
+    public record Model(ChatId ChatId, bool AllowAnonymous, Func<AvatarFull, Task> OnAvatarSelected);
+
+    public record ViewModel(ImmutableArray<AvatarFull> Avatars, Symbol SelectedAvatarId, Avatar? Anonymous) {
+        public static readonly ViewModel None = new(ImmutableArray<AvatarFull>.Empty, Symbol.Empty, null);
     }
 }

--- a/src/dotnet/Chat.UI.Blazor/Components/ChatFooter.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/ChatFooter.razor
@@ -26,9 +26,11 @@
                         @if (!m.OtherUserId.IsNone) {
                             <span class="inline-flex mx-2 mr-1 items-center">to chat with</span>
                             <AccountName UserSid="@m.OtherUserId.Id"/>
-                        } else {
+                        } else if (m.CanUseAnonymousAvatar) {
                             <span class="inline-flex mx-2 items-center">or</span>
                             <Button Click="@OnJoin" Class="inline-flex btn-outline">Join anonymously</Button>
+                        } else {
+                            <span class="inline-flex ml-2 items-center">to join this chat</span>
                         }
                     </div>
                 }
@@ -69,13 +71,24 @@
             : default;
         var canPost = Chat.Rules.CanWrite();
         var canJoin = !canPost && Chat.Rules.CanJoin();
-        var avatars = await Avatars.ListOwnAvatarIds(Session, cancellationToken);
+        var hasMultipleAvatars = false;
+        var canUseAnonymousAvatar = false;
+        if (canJoin) {
+            canUseAnonymousAvatar = Chat.CanUseAnonymousAuthor();
+            if (!account.IsGuestOrNone) {
+                var avatars = await Avatars.ListOwnAvatarIds(Session, cancellationToken);
+                hasMultipleAvatars = avatars.Length > 1 || canUseAnonymousAvatar;
+            }
+        }
+
+
         return new () {
             OtherUserId = otherUserId,
             IsGuest = account.IsGuestOrNone,
             CanPost = canPost,
             CanJoin = canJoin,
-            HasMultipleAvatars = avatars.Length > 1,
+            HasMultipleAvatars = hasMultipleAvatars,
+            CanUseAnonymousAvatar = canUseAnonymousAvatar,
         };
     }
 
@@ -87,10 +100,10 @@
             return;
         }
 
-        await ModalUI.Show(new AvatarSelectModal.Model(ChatId.None, JoinWithAvatar));
+        await ModalUI.Show(new AvatarSelectModal.Model(ChatId.None, m.CanUseAnonymousAvatar, JoinWithAvatar));
 
         async Task JoinWithAvatar(AvatarFull avatar) {
-            var command = new IAuthors.JoinCommand(Session, Chat.Id, avatar.Id);
+            var command = new IAuthors.JoinCommand(Session, Chat.Id, avatar.Id, JoinAnonymously: avatar.IsAnonymous);
             await UICommander.Run(command);
         }
     }
@@ -104,5 +117,6 @@
         public bool CanPost { get; init; }
         public bool CanJoin { get; init; }
         public bool HasMultipleAvatars { get; init; }
+        public bool CanUseAnonymousAvatar { get; init; }
     }
 }

--- a/src/dotnet/Chat.UI.Blazor/Components/ChatRightPanel/ChatSettingsModal.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/ChatRightPanel/ChatSettingsModal.razor
@@ -36,6 +36,10 @@
                     <FormSection For="() => _form.IsPublic" Class="flex h-12 md:h-8 justify-center">
                         <ToggleEdit Id="@_form.IsPublicFormId" Label="Public chat &ndash; anyone can join" @bind-Value="_form.IsPublic"/>
                     </FormSection>
+
+                    <FormSection For="() => _form.AllowsAnonymous" Class="flex h-12 md:h-8 justify-center">
+                        <ToggleEdit Id="@_form.AllowsAnonymousFormId" Label="Allows anonymous to join" @bind-Value="_form.AllowsAnonymous"/>
+                    </FormSection>
                 }
                 @if (_form.IsPublic) {
                     @if (m.Link is { } publicUrl) {
@@ -98,6 +102,7 @@
         _form.Title = chat.Title;
         _form.Picture = chat.Picture?.ContentId ?? "";
         _form.IsPublic = chat.IsPublic;
+        _form.AllowsAnonymous = chat.AllowedAuthorKind == ChatAuthorKind.Any;
         _form.ImageUploadUrl = $"/api/chats/{chat.Id}/upload-picture";
     }
 
@@ -125,6 +130,7 @@
         var newChat = chat with {
             Title = _form.Title,
             IsPublic = _form.IsPublic,
+            AllowedAuthorKind = _form.AllowsAnonymous ? ChatAuthorKind.Any : ChatAuthorKind.RegularOnly,
             MediaId = _form.PictureId,
         };
         var command = new IChats.ChangeCommand(Session, chat.Id, chat.Version, new() {
@@ -155,18 +161,21 @@
         public string Picture { get; set; } = "";
         public MediaId PictureId { get; set; } = MediaId.None;
         public bool IsPublic { get; set; }
+        public bool AllowsAnonymous { get; set; }
         public string ImageUploadUrl { get; set; } = "";
 
         public string FormId { get; }
         public string TitleId { get; }
         public string PictureFormId { get; }
         public string IsPublicFormId { get; }
+        public string AllowsAnonymousFormId { get; }
 
         public FormModel(ComponentIdGenerator componentIdGenerator) {
             FormId = componentIdGenerator.Next("new-chat-form");
             TitleId = $"{FormId}-title";
             PictureFormId = $"{FormId}-picture";
             IsPublicFormId = $"{FormId}-is-public";
+            AllowsAnonymousFormId = $"{FormId}-allows-anonymous";
         }
     }
 

--- a/src/dotnet/Chat/Chat.cs
+++ b/src/dotnet/Chat/Chat.cs
@@ -31,6 +31,7 @@ public sealed record Chat(
     [DataMember] public string Title { get; init; } = "";
     [DataMember] public Moment CreatedAt { get; init; }
     [DataMember] public bool IsPublic { get; init; }
+    [DataMember] public ChatAuthorKind AllowedAuthorKind { get; init; }
     [DataMember] public MediaId MediaId { get; init; }
 
     // Populated only on front-end
@@ -53,5 +54,6 @@ public sealed record ChatDiff : RecordDiff
     [DataMember] public string? Title { get; init; }
     [DataMember] public ChatKind? Kind { get; init; }
     [DataMember] public bool? IsPublic { get; init; }
+    [DataMember] public ChatAuthorKind? AllowedAuthorKind { get; init; }
     [DataMember] public MediaId? MediaId { get; init; }
 }

--- a/src/dotnet/Chat/ChatAuthorKind.cs
+++ b/src/dotnet/Chat/ChatAuthorKind.cs
@@ -1,0 +1,9 @@
+﻿namespace ActualChat.Chat;
+
+[DataContract]
+public enum ChatAuthorKind
+{
+    [EnumMember] Any, /* Regular and Anonymous */
+    [EnumMember] RegularOnly,
+    /* In future we can support chats that allows anonymous authors only */
+}

--- a/src/dotnet/Chat/ChatExt.cs
+++ b/src/dotnet/Chat/ChatExt.cs
@@ -1,0 +1,10 @@
+﻿namespace ActualChat.Chat;
+
+public static class ChatExt
+{
+    public static bool CanUseAnonymousAuthor(this Chat chat)
+        => chat.AllowedAuthorKind == ChatAuthorKind.Any;
+    public static bool CanUseRegularAuthor(this Chat chat) =>
+        chat.AllowedAuthorKind == ChatAuthorKind.Any ||
+        chat.AllowedAuthorKind == ChatAuthorKind.RegularOnly;
+}

--- a/src/dotnet/Chat/ChatPermissions.cs
+++ b/src/dotnet/Chat/ChatPermissions.cs
@@ -6,16 +6,16 @@
 [Flags]
 public enum ChatPermissions
 {
-    Read            = 0x1,
-    Write           = 0x2, // Implies Read
-    SeeMembers      = 0x4,
+    Read           = 0x1,
+    Write          = 0x2, // Implies Read
+    SeeMembers     = 0x4,
 
-    Join            = 0x80, // Implies Read
-    Invite          = 0x100, // Implies SeeMember, Join (-> Read)
-    Leave           = 0x200,
+    Join           = 0x80, // Implies Read
+    Invite         = 0x100, // Implies SeeMember, Join (-> Read)
+    Leave          = 0x200,
 
-    EditProperties  = 0x1000,
-    EditRoles       = 0x2000,
+    EditProperties = 0x1000,
+    EditRoles      = 0x2000,
 
-    Owner           = 0x10_000, // Implies EditProperties, EditRoles, Invite (-> Join, Read), Write (-> Read)
+    Owner          = 0x10_000, // Implies EditProperties, EditRoles, Invite (-> Join, Read), Write (-> Read)
 }

--- a/src/dotnet/Chat/ChatPermissions.cs
+++ b/src/dotnet/Chat/ChatPermissions.cs
@@ -6,16 +6,16 @@
 [Flags]
 public enum ChatPermissions
 {
-    Read           = 0x1,
-    Write          = 0x2, // Implies Read
-    SeeMembers     = 0x4,
+    Read            = 0x1,
+    Write           = 0x2, // Implies Read
+    SeeMembers      = 0x4,
 
-    Join           = 0x80, // Implies Read
-    Invite         = 0x100, // Implies SeeMember, Join (-> Read)
-    Leave          = 0x200,
+    Join            = 0x80, // Implies Read
+    Invite          = 0x100, // Implies SeeMember, Join (-> Read)
+    Leave           = 0x200,
 
-    EditProperties = 0x1000,
-    EditRoles      = 0x2000,
+    EditProperties  = 0x1000,
+    EditRoles       = 0x2000,
 
-    Owner          = 0x10_000, // Implies EditProperties, EditRoles, Invite (-> Join, Read), Write (-> Read)
+    Owner           = 0x10_000, // Implies EditProperties, EditRoles, Invite (-> Join, Read), Write (-> Read)
 }

--- a/src/dotnet/Contacts.Service.Migration/Migrations/20221208093136_MoveChats2.cs
+++ b/src/dotnet/Contacts.Service.Migration/Migrations/20221208093136_MoveChats2.cs
@@ -18,57 +18,58 @@ namespace ActualChat.Contacts.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            UpAsync(migrationBuilder).Wait();
+            // NOTE(DF): Obsolete: applied to all of our DBs. Now it causes migration in tests to fail.
+            //UpAsync(migrationBuilder).Wait();
         }
 
-        private async Task UpAsync(MigrationBuilder migrationBuilder)
-        {
-            var dbInitializer = DbInitializer.Get<ContactsDbInitializer>();
-            var chatDbInitializer = await DbInitializer.Get<ChatDbInitializer>().CompleteEarlierMigrations(this);
-            var usersDbInitializer = await DbInitializer.Get<UsersDbInitializer>().CompleteEarlierMigrations(this);
-
-            var log = dbInitializer.Services.LogFor(GetType());
-            var clocks = dbInitializer.Services.Clocks();
-            var versionGenerator = dbInitializer.DbHub.VersionGenerator;
-
-            using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
-            using var chatDbContext = chatDbInitializer.DbHub.CreateDbContext();
-            using var usersDbContext = usersDbInitializer.DbHub.CreateDbContext();
-
-            // Removing all existing chat DbContacts
-            var dbContacts = await dbContext.Contacts
-                .Where(c => c.ChatId != null && c.ChatId != "")
-                .ToListAsync();
-            dbContext.Contacts.RemoveRange(dbContacts);
-            await dbContext.SaveChangesAsync();
-
-            // And recreating them
-            var dbAccounts = await usersDbContext.Accounts.ToDictionaryAsync(c => (Symbol)c.Id);
-            var dbChats = await chatDbContext.Chats.ToDictionaryAsync(c => (Symbol)c.Id);
-            var dbAuthors = await chatDbContext.Authors.Where(a => !a.HasLeft).ToListAsync();
-            foreach (var dbAuthor in dbAuthors) {
-                var userId = new UserId(dbAuthor.UserId, AssumeValid.Option);
-                if (userId.IsNone) // Anonymous author, we do nothing in this case
-                    continue;
-
-                var chat = dbChats.GetValueOrDefault(dbAuthor.ChatId);
-                if (chat == null) // No chat
-                    continue;
-                if (chat.Kind != ChatKind.Group) // Not a group chat
-                    continue;
-
-                var c = new DbContact() {
-                    Id = new ContactId(userId, new ChatId(chat.Id), AssumeValid.Option),
-                    Version = versionGenerator.NextVersion(),
-                    OwnerId = userId,
-                    UserId = null,
-                    ChatId = chat.Id,
-                    TouchedAt = clocks.SystemClock.Now,
-                };
-                dbContext.Add(c);
-            }
-            await dbContext.SaveChangesAsync();
-        }
+        // private async Task UpAsync(MigrationBuilder migrationBuilder)
+        // {
+        //     var dbInitializer = DbInitializer.Get<ContactsDbInitializer>();
+        //     var chatDbInitializer = await DbInitializer.Get<ChatDbInitializer>().CompleteEarlierMigrations(this);
+        //     var usersDbInitializer = await DbInitializer.Get<UsersDbInitializer>().CompleteEarlierMigrations(this);
+        //
+        //     var log = dbInitializer.Services.LogFor(GetType());
+        //     var clocks = dbInitializer.Services.Clocks();
+        //     var versionGenerator = dbInitializer.DbHub.VersionGenerator;
+        //
+        //     using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
+        //     using var chatDbContext = chatDbInitializer.DbHub.CreateDbContext();
+        //     using var usersDbContext = usersDbInitializer.DbHub.CreateDbContext();
+        //
+        //     // Removing all existing chat DbContacts
+        //     var dbContacts = await dbContext.Contacts
+        //         .Where(c => c.ChatId != null && c.ChatId != "")
+        //         .ToListAsync();
+        //     dbContext.Contacts.RemoveRange(dbContacts);
+        //     await dbContext.SaveChangesAsync();
+        //
+        //     // And recreating them
+        //     var dbAccounts = await usersDbContext.Accounts.ToDictionaryAsync(c => (Symbol)c.Id);
+        //     var dbChats = await chatDbContext.Chats.ToDictionaryAsync(c => (Symbol)c.Id);
+        //     var dbAuthors = await chatDbContext.Authors.Where(a => !a.HasLeft).ToListAsync();
+        //     foreach (var dbAuthor in dbAuthors) {
+        //         var userId = new UserId(dbAuthor.UserId, AssumeValid.Option);
+        //         if (userId.IsNone) // Anonymous author, we do nothing in this case
+        //             continue;
+        //
+        //         var chat = dbChats.GetValueOrDefault(dbAuthor.ChatId);
+        //         if (chat == null) // No chat
+        //             continue;
+        //         if (chat.Kind != ChatKind.Group) // Not a group chat
+        //             continue;
+        //
+        //         var c = new DbContact() {
+        //             Id = new ContactId(userId, new ChatId(chat.Id), AssumeValid.Option),
+        //             Version = versionGenerator.NextVersion(),
+        //             OwnerId = userId,
+        //             UserId = null,
+        //             ChatId = chat.Id,
+        //             TouchedAt = clocks.SystemClock.Now,
+        //         };
+        //         dbContext.Add(c);
+        //     }
+        //     await dbContext.SaveChangesAsync();
+        // }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         { }

--- a/src/dotnet/Users.Service.Migration/Migrations/20230329114145_MigrateAvatars.cs
+++ b/src/dotnet/Users.Service.Migration/Migrations/20230329114145_MigrateAvatars.cs
@@ -17,73 +17,74 @@ namespace ActualChat.Users.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            UpAsync(migrationBuilder).Wait();
+            // NOTE(DF): Obsolete: applied to all of our DBs. Now it causes migration in tests to fail.
+            //UpAsync(migrationBuilder).Wait();
         }
 
-        private async Task UpAsync(MigrationBuilder migrationBuilder)
-        {
-            var dbInitializer = DbInitializer.Get<UsersDbInitializer>();
-            var mediaDbInitializer = await DbInitializer.Get<MediaDbInitializer>()
-                .CompleteEarlierMigrations(this)
-                .ConfigureAwait(false);
-            var log = dbInitializer.Services.LogFor(GetType());
-
-            var blobStorageProvider = dbInitializer.Services.GetRequiredService<IBlobStorageProvider>();
-            var blobStorage = blobStorageProvider.GetBlobStorage(BlobScope.ContentRecord);
-
-            using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
-            using var mediaDbContext = mediaDbInitializer.DbHub.CreateDbContext(true);
-            mediaDbContext.ChangeTracker.AutoDetectChangesEnabled = false;
-
-            var dbAvatars = await dbContext.Avatars
-                .Where(x => x.Picture != null)
-                .Where(x => x.Picture != "")
-                .OrderBy(c => c.Id)
-                .ToListAsync()
-                .ConfigureAwait(false);
-
-            log.LogInformation("Upgrading {Count} avatars...", dbAvatars.Count);
-
-            var blobs = new List<(string OldPath, string NewPath)>(dbAvatars.Count);
-
-            foreach (var dbAvatar in dbAvatars) {
-                if (dbAvatar.Picture.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
-                    continue;
-
-                var mediaId = new MediaId(dbAvatar.UserId ?? "avatar", Generate.Option);
-                var hashCode = mediaId.Id.ToString().GetSHA256HashCode();
-                var media = new Media.Media {
-                    Id = mediaId,
-                    ContentId = $"media/{hashCode}/{mediaId.LocalId}{Path.GetExtension(dbAvatar.Picture)}",
-                };
-
-                mediaDbContext.Media.Add(new DbMedia(media));
-                blobs.Add((dbAvatar.Picture, media.ContentId));
-                dbAvatar.MediaId = mediaId;
-                dbAvatar.Picture = "";
-            }
-
-            log.LogInformation("Saving Media DB changes");
-            await mediaDbContext.SaveChangesAsync().ConfigureAwait(false);
-
-            await Parallel.ForEachAsync(blobs,
-                new ParallelOptions() { MaxDegreeOfParallelism = 4 },
-                async (blob, ct) => {
-                    var isCopied = await blobStorage.CopyIfExists(blob.OldPath, blob.NewPath, ct).ConfigureAwait(false);
-                    if (!isCopied)
-                        log.LogWarning("Couldn't copy blob: {Blob}", blob.OldPath);
-                }).ConfigureAwait(false);
-
-            log.LogInformation("Saving Avatars DB changes");
-            await dbContext.SaveChangesAsync().ConfigureAwait(false);
-
-            await Parallel.ForEachAsync(blobs,
-                new ParallelOptions() { MaxDegreeOfParallelism = 4 },
-                async (blob, ct) => await blobStorage.DeleteIfExists(blob.OldPath, ct).ConfigureAwait(false)
-            ).ConfigureAwait(false);
-
-            log.LogInformation("Upgrading avatars: done");
-        }
+        // private async Task UpAsync(MigrationBuilder migrationBuilder)
+        // {
+        //     var dbInitializer = DbInitializer.Get<UsersDbInitializer>();
+        //     var mediaDbInitializer = await DbInitializer.Get<MediaDbInitializer>()
+        //         .CompleteEarlierMigrations(this)
+        //         .ConfigureAwait(false);
+        //     var log = dbInitializer.Services.LogFor(GetType());
+        //
+        //     var blobStorageProvider = dbInitializer.Services.GetRequiredService<IBlobStorageProvider>();
+        //     var blobStorage = blobStorageProvider.GetBlobStorage(BlobScope.ContentRecord);
+        //
+        //     using var dbContext = dbInitializer.DbHub.CreateDbContext(true);
+        //     using var mediaDbContext = mediaDbInitializer.DbHub.CreateDbContext(true);
+        //     mediaDbContext.ChangeTracker.AutoDetectChangesEnabled = false;
+        //
+        //     var dbAvatars = await dbContext.Avatars
+        //         .Where(x => x.Picture != null)
+        //         .Where(x => x.Picture != "")
+        //         .OrderBy(c => c.Id)
+        //         .ToListAsync()
+        //         .ConfigureAwait(false);
+        //
+        //     log.LogInformation("Upgrading {Count} avatars...", dbAvatars.Count);
+        //
+        //     var blobs = new List<(string OldPath, string NewPath)>(dbAvatars.Count);
+        //
+        //     foreach (var dbAvatar in dbAvatars) {
+        //         if (dbAvatar.Picture.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+        //             continue;
+        //
+        //         var mediaId = new MediaId(dbAvatar.UserId ?? "avatar", Generate.Option);
+        //         var hashCode = mediaId.Id.ToString().GetSHA256HashCode();
+        //         var media = new Media.Media {
+        //             Id = mediaId,
+        //             ContentId = $"media/{hashCode}/{mediaId.LocalId}{Path.GetExtension(dbAvatar.Picture)}",
+        //         };
+        //
+        //         mediaDbContext.Media.Add(new DbMedia(media));
+        //         blobs.Add((dbAvatar.Picture, media.ContentId));
+        //         dbAvatar.MediaId = mediaId;
+        //         dbAvatar.Picture = "";
+        //     }
+        //
+        //     log.LogInformation("Saving Media DB changes");
+        //     await mediaDbContext.SaveChangesAsync().ConfigureAwait(false);
+        //
+        //     await Parallel.ForEachAsync(blobs,
+        //         new ParallelOptions() { MaxDegreeOfParallelism = 4 },
+        //         async (blob, ct) => {
+        //             var isCopied = await blobStorage.CopyIfExists(blob.OldPath, blob.NewPath, ct).ConfigureAwait(false);
+        //             if (!isCopied)
+        //                 log.LogWarning("Couldn't copy blob: {Blob}", blob.OldPath);
+        //         }).ConfigureAwait(false);
+        //
+        //     log.LogInformation("Saving Avatars DB changes");
+        //     await dbContext.SaveChangesAsync().ConfigureAwait(false);
+        //
+        //     await Parallel.ForEachAsync(blobs,
+        //         new ParallelOptions() { MaxDegreeOfParallelism = 4 },
+        //         async (blob, ct) => await blobStorage.DeleteIfExists(blob.OldPath, ct).ConfigureAwait(false)
+        //     ).ConfigureAwait(false);
+        //
+        //     log.LogInformation("Upgrading avatars: done");
+        // }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/dotnet/Users.Service.Migration/Migrations/20230502135455_JoinAnonymously.Designer.cs
+++ b/src/dotnet/Users.Service.Migration/Migrations/20230502135455_JoinAnonymously.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ActualChat.Users.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ActualChat.Users.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230502135455_JoinAnonymously")]
+    partial class JoinAnonymously
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/dotnet/Users.Service.Migration/Migrations/20230502135455_JoinAnonymously.cs
+++ b/src/dotnet/Users.Service.Migration/Migrations/20230502135455_JoinAnonymously.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActualChat.Users.Migrations
+{
+    /// <inheritdoc />
+    public partial class JoinAnonymously : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_anonymous",
+                table: "avatars",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_anonymous",
+                table: "avatars");
+        }
+    }
+}

--- a/src/dotnet/Users.Service/Avatars.cs
+++ b/src/dotnet/Users.Service/Avatars.cs
@@ -20,12 +20,6 @@ public class Avatars : IAvatars
     // [ComputeMethod]
     public virtual async Task<AvatarFull?> GetOwn(Session session, Symbol avatarId, CancellationToken cancellationToken)
     {
-        // TODO(DF): We use list here to filter own avatars. Is it better than filtering by user id?
-        // Anything related to sharding?
-        // var avatarIds = await ListOwnAvatarIds(session, cancellationToken).ConfigureAwait(false);
-        // if (!avatarIds.Contains(avatarId))
-        //     return null;
-
         var avatar = await Backend.Get(avatarId, cancellationToken).ConfigureAwait(false);
         if (avatar == null)
             return null;
@@ -75,18 +69,19 @@ public class Avatars : IAvatars
         var changeCommand = new IAvatarsBackend.ChangeCommand(avatarId, expectedVersion, change);
         avatar = await Commander.Call(changeCommand, true, cancellationToken).ConfigureAwait(false);
 
-        if (!avatar.IsAnonymous) { // We don't account anonymous avatars in the list
-            cancellationToken = default; // We don't cancel anything from here
-            var kvas = ServerKvas.GetClient(session);
-            var oldSettings = await kvas.GetUserAvatarSettings(cancellationToken).ConfigureAwait(false);
-            var settings = oldSettings;
-            if (change.Create.HasValue)
-                settings = settings.WithAvatarId(avatar.Id);
-            else if (change.Remove)
-                settings = settings.WithoutAvatarId(avatarId);
-            if (!ReferenceEquals(settings, oldSettings))
-                await kvas.SetUserAvatarSettings(settings, cancellationToken).ConfigureAwait(false);
-        }
+        if (avatar.IsAnonymous)
+            return avatar; // We don't account anonymous avatars in the list
+
+        cancellationToken = default; // We don't cancel anything from here
+        var kvas = ServerKvas.GetClient(session);
+        var oldSettings = await kvas.GetUserAvatarSettings(cancellationToken).ConfigureAwait(false);
+        var settings = oldSettings;
+        if (change.Create.HasValue)
+            settings = settings.WithAvatarId(avatar.Id);
+        else if (change.Remove)
+            settings = settings.WithoutAvatarId(avatarId);
+        if (!ReferenceEquals(settings, oldSettings))
+            await kvas.SetUserAvatarSettings(settings, cancellationToken).ConfigureAwait(false);
 
         return avatar;
     }

--- a/src/dotnet/Users.Service/Db/DbAvatar.cs
+++ b/src/dotnet/Users.Service/Db/DbAvatar.cs
@@ -20,6 +20,7 @@ public class DbAvatar : IHasId<string>, IHasVersion<long>, IRequirementTarget
     public string Picture { get; set; } = "";
     public string MediaId { get; set; } = "";
     public string Bio { get; set; } = "";
+    public bool IsAnonymous { get; set; }
 
     public DbAvatar() { }
     public DbAvatar(AvatarFull model) => UpdateFrom(model);
@@ -31,6 +32,7 @@ public class DbAvatar : IHasId<string>, IHasVersion<long>, IRequirementTarget
             MediaId = new MediaId(MediaId),
             Bio = Bio,
             Picture = Picture,
+            IsAnonymous = IsAnonymous,
         };
 
     public void UpdateFrom(AvatarFull model)
@@ -38,6 +40,7 @@ public class DbAvatar : IHasId<string>, IHasVersion<long>, IRequirementTarget
         var id = model.Id;
         this.RequireSameOrEmptyId(id);
         model.RequireSomeVersion();
+        var isNew = Id.IsNullOrEmpty();
 
         if (UserId.IsNullOrEmpty())
             UserId = model.UserId.Value.NullIfEmpty();
@@ -50,6 +53,10 @@ public class DbAvatar : IHasId<string>, IHasVersion<long>, IRequirementTarget
         MediaId = model.MediaId;
         Bio = model.Bio;
         Picture = model.Picture;
+        if (isNew)
+            IsAnonymous = model.IsAnonymous;
+        else if (IsAnonymous != model.IsAnonymous)
+            throw StandardError.Constraint("Can't change Avatar.IsAnonymous.");
     }
 
     internal class EntityConfiguration : IEntityTypeConfiguration<DbAvatar>

--- a/src/dotnet/Users/AvatarFull.cs
+++ b/src/dotnet/Users/AvatarFull.cs
@@ -14,6 +14,7 @@ public sealed record AvatarFull(Symbol Id, long Version = 0) : Avatar(Id, Versio
     public static new AvatarFull Loading { get; } = new(Symbol.Empty, -1); // Should differ by ref. from None
 
     [DataMember] public UserId UserId { get; init; }
+    [DataMember] public bool IsAnonymous { get; init; }
 
     public AvatarFull() : this(Symbol.Empty) { }
 

--- a/tests/Chat.IntegrationTests/ChatJoinAnonymouslyTest.cs
+++ b/tests/Chat.IntegrationTests/ChatJoinAnonymouslyTest.cs
@@ -1,0 +1,84 @@
+using ActualChat.Testing.Host;
+using ActualChat.Users;
+using Stl.Fusion.Authentication.Commands;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+public class ChatJoinAnonymouslyTest : AppHostTestBase
+{
+    public ChatJoinAnonymouslyTest(ITestOutputHelper @out) : base(@out) { }
+
+    [Theory]
+    // [InlineData(false)] TODO(DF): Guest user can not join to a chat with invite code, should we change this?
+    [InlineData(true)]
+    public async Task JoinWithGuestUser(bool isPublicChat)
+    {
+        using var appHost = await NewAppHost();
+
+        var (chatId, inviteId) = await ChatOperations.CreateChat(appHost, isPublicChat);
+
+        await using var tester = appHost.NewBlazorTester();
+        var session = tester.Session;
+        await tester.Commander.Call(new SetupSessionCommand(session)).ConfigureAwait(false);
+        var accounts = tester.AppServices.GetRequiredService<IAccounts>();
+        var account = await accounts.GetOwn(session, default).ConfigureAwait(false);
+        account.IsGuest.Should().BeTrue();
+
+        var author = await ChatOperations.JoinChat(tester, chatId, inviteId);
+
+        await ChatOperations.AssertJoined(tester, chatId);
+        author.IsAnonymous.Should().BeTrue();
+
+        var avatars = tester.AppServices.GetRequiredService<IAvatars>();
+        var avatar = await avatars.GetOwn(session, author.AvatarId, default).ConfigureAwait(false);
+        avatar.Should().NotBeNull();
+        avatar!.IsAnonymous.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task JoinWithSignedInUser(bool isPublicChat)
+    {
+        using var appHost = await NewAppHost();
+
+        var (chatId, inviteId) = await ChatOperations.CreateChat(appHost, isPublicChat);
+
+        await using var tester = appHost.NewBlazorTester();
+        var session = tester.Session;
+        await tester.SignIn(new User("", "Alice"));
+
+        var accounts = tester.AppServices.GetRequiredService<IAccounts>();
+        var account = await accounts.GetOwn(session, default).ConfigureAwait(false);
+        account.IsGuest.Should().BeFalse();
+
+        var anonymous = await CreateAnonymousAvatar(tester).ConfigureAwait(false);
+
+        var author = await ChatOperations
+            .JoinChat(tester, chatId, inviteId, joinAnonymously: true, avatarId: anonymous.Id)
+            .ConfigureAwait(false);
+
+        await ChatOperations.AssertJoined(tester, chatId);
+        author.IsAnonymous.Should().BeTrue();
+
+        var avatars = tester.AppServices.GetRequiredService<IAvatars>();
+        var avatar = await avatars.GetOwn(session, author.AvatarId, default).ConfigureAwait(false);
+        avatar.Should().NotBeNull();
+        avatar!.IsAnonymous.Should().BeTrue();
+    }
+
+    private async Task<AvatarFull> CreateAnonymousAvatar(IWebTester tester)
+    {
+        var session = tester.Session;
+        var accounts = tester.AppServices.GetRequiredService<IAccounts>();
+        var account = await accounts.GetOwn(session, default);
+        var command = new IAvatars.ChangeCommand(session, Symbol.Empty, null, new Change<AvatarFull>() {
+            Create = new AvatarFull() {
+                UserId = account.Id,
+                IsAnonymous = true,
+                Name = RandomNameGenerator.Default.Generate(),
+            },
+        });
+        return await tester.Commander.Call(command).ConfigureAwait(false);
+    }
+}

--- a/tests/Chat.IntegrationTests/ChatOperations.cs
+++ b/tests/Chat.IntegrationTests/ChatOperations.cs
@@ -1,0 +1,103 @@
+﻿using ActualChat.App.Server;
+using ActualChat.Invite;
+using ActualChat.Testing.Host;
+using ActualChat.Users;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+public static class ChatOperations
+{
+    public static async Task<(ChatId, Symbol)> CreateChat(AppHost appHost, bool isPublicChat)
+    {
+        await using var tester = appHost.NewBlazorTester();
+        var session = tester.Session;
+        await tester.SignIn(new User("", "Alice"));
+
+        var commander = tester.Commander;
+        var chat = await commander.Call(new IChats.ChangeCommand(session,
+            default,
+            null,
+            new () {
+                Create = new ChatDiff() {
+                    Title = "test chat",
+                    Kind = ChatKind.Group,
+                    IsPublic = isPublicChat,
+                },
+            }));
+        chat.Require();
+        var chatId = chat.Id;
+
+        var inviteId = Symbol.Empty;
+        if (!isPublicChat) {
+            // to join private chat we need to generate invite code
+            var invite = new Invite.Invite {
+                Remaining = 10,
+                Details = new ChatInviteOption(chatId),
+            };
+            invite = await commander.Call(new IInvites.GenerateCommand(session, invite));
+            inviteId = invite.Id;
+        }
+
+        return (chatId, inviteId);
+    }
+
+    public static async Task<AuthorFull> JoinChat(IWebTester tester, ChatId chatId, Symbol inviteId,
+        bool? joinAnonymously = null, Symbol avatarId = default)
+    {
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+
+        var chat = await chats.Get(session, chatId, default).ConfigureAwait(false);
+        var chatRules = await chats.GetRules(session, chatId, default).ConfigureAwait(false);
+        var canJoin = chatRules.CanJoin();
+        var isPublicChat = chat != null && chat.IsPublic;
+
+        if (!isPublicChat) {
+            canJoin.Should().BeFalse();
+            // to join private chat we need to activate invite code first
+            await commander.Call(new IInvites.UseCommand(session, inviteId), true);
+
+            var c = await Computed.Capture(() => chats.GetRules(session, chatId, default));
+            c = await c.When(x => x.CanJoin()).WaitAsync(TimeSpan.FromSeconds(3));
+            canJoin = c.Value.CanJoin();
+        }
+
+        canJoin.Should().BeTrue();
+
+        var command = new IAuthors.JoinCommand(session, chatId, AvatarId: avatarId, JoinAnonymously: joinAnonymously);
+        var author = await commander.Call(command, true).ConfigureAwait(false);
+        return author;
+    }
+
+    public static async Task AssertJoined(IWebTester tester, ChatId chatId)
+    {
+        var services = tester.AppServices;
+        var session = tester.Session;
+        var account = await services.GetRequiredService<IAccounts>().GetOwn(session, default).ConfigureAwait(false);
+        var chats = services.GetRequiredService<IChats>();
+
+        var cRules = await Computed.Capture(() => chats.GetRules(session, chatId, default));
+        await cRules.When(r => r.CanWrite()).WaitAsync(TimeSpan.FromSeconds(3));
+        var rules = await cRules.Use();
+        rules.CanRead().Should().BeTrue();
+        rules.CanWrite().Should().BeTrue();
+
+        var chat = await chats.Get(session, chatId, default).ConfigureAwait(false);
+        chat.Should().NotBeNull();
+        var authors = services.GetRequiredService<IAuthors>();
+        var author = await authors.GetOwn(session, chatId, default).ConfigureAwait(false);
+        author.Should().NotBeNull();
+        author!.UserId.Should().Be(account.Id);
+        author.HasLeft.Should().BeFalse();
+
+        var authorsUpgradeBackend = services.GetRequiredService<IAuthorsUpgradeBackend>();
+        var ownChatIds = await authorsUpgradeBackend.ListOwnChatIds(session, default).ConfigureAwait(false);
+        ownChatIds.Should().Contain(chatId);
+
+        var userIds = await authors.ListUserIds(session, chatId, default).ConfigureAwait(false);
+        userIds.Should().Contain(account.Id);
+        var authorIds = await authors.ListAuthorIds(session, chatId, default).ConfigureAwait(false);
+        authorIds.Should().Contain(author.Id);
+    }
+}

--- a/tests/Chat.IntegrationTests/ChatOperationsTest.cs
+++ b/tests/Chat.IntegrationTests/ChatOperationsTest.cs
@@ -77,60 +77,13 @@ public class ChatOperationsTest : AppHostTestBase
     {
         using var appHost = await NewAppHost();
 
-        ChatId chatId;
-        var inviteId = Symbol.Empty;
-        {
-            await using var tester = appHost.NewBlazorTester();
-            var session = tester.Session;
-            await tester.SignIn(new User("", "Alice"));
+        var (chatId, inviteId) = await ChatOperations.CreateChat(appHost, isPublicChat);
 
-            var commander = tester.Commander;
-            var chat = await commander.Call(new IChats.ChangeCommand(session, default, null, new() {
-                Create = new ChatDiff() {
-                    Title = "test chat",
-                    Kind = ChatKind.Group,
-                    IsPublic = isPublicChat,
-                },
-            }));
-            chat.Require();
-            chatId = chat.Id;
+        await using var tester = appHost.NewBlazorTester();
+        await tester.SignIn(new User("", "Bob").WithIdentity("no-admin"));
 
-            if (!isPublicChat) {
-                // to join private chat we need to generate invite code
-                var invite = new Invite.Invite {
-                    Remaining = 10,
-                    Details = new ChatInviteOption(chatId),
-                };
-                invite = await commander.Call(new IInvites.GenerateCommand(session, invite));
-                inviteId = invite.Id;
-            }
-        }
-
-        {
-            await using var tester = appHost.NewBlazorTester();
-            var session = tester.Session;
-            var account = await tester.SignIn(new User("", "Bob").WithIdentity("no-admin"));
-            var commander = tester.Commander;
-            var chats = tester.AppServices.GetRequiredService<IChats>();
-            var authors = tester.AppServices.GetRequiredService<IAuthors>();
-
-            var chatRules = await chats.GetRules(session, chatId, default);
-            var canJoin = chatRules.CanJoin();
-
-            if (!isPublicChat) {
-                canJoin.Should().BeFalse();
-                // to join private chat we need to activate invite code first
-                await commander.Call(new IInvites.UseCommand(session, inviteId));
-
-                var c = await Computed.Capture(() => chats.GetRules(session, chatId, default));
-                c = await c.When(x => x.CanJoin()).WaitAsync(TimeSpan.FromSeconds(3));
-                canJoin = c.Value.CanJoin();
-            }
-            canJoin.Should().BeTrue();
-
-            await authors.EnsureJoined(session, chatId, default);
-            await AssertJoined(tester.AppServices, session, chatId, account);
-        }
+        await ChatOperations.JoinChat(tester, chatId, inviteId);
+        await ChatOperations.AssertJoined(tester, chatId);
     }
 
     [Theory]
@@ -140,74 +93,45 @@ public class ChatOperationsTest : AppHostTestBase
     {
         using var appHost = await NewAppHost();
 
-        ChatId chatId;
-        Symbol inviteId = Symbol.Empty;
-        {
-            await using var tester = appHost.NewBlazorTester();
-            var session = tester.Session;
-            await tester.SignIn(new User("", "Alice"));
+        var (chatId, inviteId) = await ChatOperations.CreateChat(appHost, isPublicChat);
 
-            var commander = tester.Commander;
-            var chat = await commander.Call(new IChats.ChangeCommand(session, default, null, new() {
-                Create = new ChatDiff() {
-                    Title = "test chat",
-                    Kind = ChatKind.Group,
-                    IsPublic = isPublicChat,
-                },
-            }));
-            chat.Require();
-            chatId = chat.Id;
+        await using var tester = appHost.NewBlazorTester();
+        var session = tester.Session;
+        var account = await tester.SignIn(new User("", "Bob").WithIdentity("no-admin"));
+        var commander = tester.Commander;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var authors = tester.AppServices.GetRequiredService<IAuthors>();
 
-            if (!isPublicChat) {
-                // to join private chat we need to generate invite code
-                var invite = new Invite.Invite {
-                    Remaining = 10,
-                    Details = new ChatInviteOption(chatId),
-                };
-                invite = await commander.Call(new IInvites.GenerateCommand(session, invite));
-                inviteId = invite.Id;
-            }
+        if (!isPublicChat) {
+            await commander.Call(new IInvites.UseCommand(session, inviteId));
+            await Task.Delay(1000); // Let the command complete
         }
 
-        {
-            await using var tester = appHost.NewBlazorTester();
-            var session = tester.Session;
-            var account = await tester.SignIn(new User("", "Bob").WithIdentity("no-admin"));
-            var commander = tester.Commander;
-            var chats = tester.AppServices.GetRequiredService<IChats>();
-            var authors = tester.AppServices.GetRequiredService<IAuthors>();
+        await authors.EnsureJoined(session, chatId, default);
+        await ChatOperations.AssertJoined(tester, chatId);
 
-            if (!isPublicChat) {
-                await commander.Call(new IInvites.UseCommand(session, inviteId));
-                await Task.Delay(1000); // Let the command complete
-            }
+        var leaveCommand = new IAuthors.LeaveCommand(session, chatId);
+        await commander.Call(leaveCommand);
 
-            await authors.EnsureJoined(session, chatId, default);
-            await AssertJoined(tester.AppServices, session, chatId, account);
+        var permissions = await chats.GetRules(session, chatId, default);
+        permissions.CanRead().Should().Be(isPublicChat);
+        permissions.CanWrite().Should().BeFalse();
 
-            var leaveCommand = new IAuthors.LeaveCommand(session, chatId);
-            await commander.Call(leaveCommand);
+        var chat = await chats.Get(session, chatId, default);
+        if (isPublicChat)
+            chat.Should().NotBeNull();
+        else
+            chat.Should().BeNull();
 
-            var permissions = await chats.GetRules(session, chatId, default);
-            permissions.CanRead().Should().Be(isPublicChat);
-            permissions.CanWrite().Should().BeFalse();
+        await AssertNotJoined(tester.AppServices, session, chatId, account);
 
-            var chat = await chats.Get(session, chatId, default);
-            if (isPublicChat)
-                chat.Should().NotBeNull();
-            else
-                chat.Should().BeNull();
-
-            await AssertNotJoined(tester.AppServices, session, chatId, account);
-
-            // re-join again
-            if (!isPublicChat) {
-                await commander.Call(new IInvites.UseCommand(session, inviteId));
-                await Task.Delay(1000); // Let the command complete
-            }
-            await authors.EnsureJoined(session, chatId, default);
-            await AssertJoined(tester.AppServices, session, chatId, account);
+        // re-join again
+        if (!isPublicChat) {
+            await commander.Call(new IInvites.UseCommand(session, inviteId));
+            await Task.Delay(1000); // Let the command complete
         }
+        await authors.EnsureJoined(session, chatId, default);
+        await ChatOperations.AssertJoined(tester, chatId);
     }
 
     [Theory]
@@ -231,34 +155,6 @@ public class ChatOperationsTest : AppHostTestBase
         //assert
         rules.CanJoin().Should().BeFalse();
         rules.CanLeave().Should().BeFalse();
-    }
-
-    private static async Task AssertJoined(IServiceProvider services, Session session, ChatId chatId, Account account)
-    {
-        var chats = services.GetRequiredService<IChats>();
-
-        var cRules = await Computed.Capture(() => chats.GetRules(session, chatId, default));
-        await cRules.When(r => r.CanWrite()).WaitAsync(TimeSpan.FromSeconds(3));
-        var rules = await cRules.Use();
-        rules.CanRead().Should().BeTrue();
-        rules.CanWrite().Should().BeTrue();
-
-        var chat = await chats.Get(session, chatId, default);
-        chat.Should().NotBeNull();
-        var authors = services.GetRequiredService<IAuthors>();
-        var authorsUpgradeBackend = services.GetRequiredService<IAuthorsUpgradeBackend>();
-        var author = await authors.GetOwn(session, chatId, default);
-        author.Should().NotBeNull();
-        author!.UserId.Should().Be(account.Id);
-        author.HasLeft.Should().BeFalse();
-
-        var ownChatIds = await authorsUpgradeBackend.ListOwnChatIds(session, default);
-        ownChatIds.Should().Contain(chatId);
-
-        var userIds = await authors.ListUserIds(session, chatId, default);
-        userIds.Should().Contain(account.Id);
-        var authorIds = await authors.ListAuthorIds(session, chatId, default);
-        authorIds.Should().Contain(author.Id);
     }
 
     private static async Task AssertNotJoined(IServiceProvider services, Session session, ChatId chatId, Account account)


### PR DESCRIPTION
Adds possibility to join to a chat anonymously by selecting anonymous avatar (auto-generated).
![image](https://user-images.githubusercontent.com/20703715/235880997-146ea935-2d15-4316-a367-5f187566f69f.png)

Clicking on your own author bange will show that it's yours and anonymous.
![image](https://user-images.githubusercontent.com/20703715/235881569-43aeee4c-f30d-466e-bf34-2360851f4675.png)
From the card you can go to a profile as for non-anonymous avatar.
There also added a reveal button on the card. But this function is not implemented yet and shown only in development environment.

Other members can see only anonynous avatar name on the author card.
![image](https://user-images.githubusercontent.com/20703715/235882429-f78f290b-fe7b-4015-b8ce-3b1353ebf755.png)

Chat properties form is extended with a toggle that allows to forbid anonymous joins to the chat for guests and regular users as well.
![image](https://user-images.githubusercontent.com/20703715/235882934-bdd5d9cb-5089-4fc9-bb5d-0e878eb8ccf8.png)

