### PR TITLE
fix: link preview image looks blurry

### DIFF
--- a/src/dotnet/Chat.UI.Blazor/Components/ChatView/Items/LinkPreview/LinkPreviewView.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/ChatView/Items/LinkPreview/LinkPreviewView.razor
@@ -56,14 +56,15 @@
     }
 
     private (int? Width, int Height) GetImageMaxSize() {
+        const int sizeMultiplier = 2; // reduced images look blurry
         switch (Mode) {
             case LinkPreviewMode.Compact:
                 var maxHeight = ScreenSize.IsNarrow() ? 80 : 120;
-                return (maxHeight, maxHeight);
+                return (maxHeight * sizeMultiplier, maxHeight * sizeMultiplier);
             case LinkPreviewMode.Default:
             case LinkPreviewMode.Full:
                 maxHeight = ScreenSize.IsNarrow() ? 160  : 136;
-                return (null, maxHeight);
+                return (null, maxHeight * sizeMultiplier);
             default:
                 return (0, 0);
         }


### PR DESCRIPTION
#1659 

<img width="264" alt="image" src="https://github.com/Actual-Chat/actual-chat/assets/104059367/1c9be0d3-3ee6-4465-8013-109e37f2275f">
