### PR TITLE
feat: improve security for place chats

### DIFF
--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -8,6 +8,8 @@ namespace ActualChat.Chat;
 
 public class Chats(IServiceProvider services) : IChats
 {
+    private IPlaces? _places;
+
     private IAccounts Accounts { get; } = services.GetRequiredService<IAccounts>();
     private IAuthors Authors { get; } = services.GetRequiredService<IAuthors>();
     private IAuthorsBackend AuthorsBackend { get; } = services.GetRequiredService<IAuthorsBackend>();
@@ -18,6 +20,8 @@ public class Chats(IServiceProvider services) : IChats
     private IChatsBackend Backend { get; } = services.GetRequiredService<IChatsBackend>();
     private IRolesBackend RolesBackend { get; } = services.GetRequiredService<IRolesBackend>();
     private ICommander Commander { get; } = services.Commander();
+
+    private IPlaces Places => _places ??= services.GetRequiredService<IPlaces>(); // Lazy resolving to prevent cyclic dependency
 
     // [ComputeMethod]
     public virtual async Task<Chat?> Get(Session session, ChatId chatId, CancellationToken cancellationToken)
@@ -181,18 +185,40 @@ public class Chats(IServiceProvider services) : IChats
             changeCommand = changeCommand with {
                 OwnerId = account.Id,
             };
+            var chatDiff = changeCommand.Change.Create.Value;
+            var placeId = chatDiff.PlaceId ?? PlaceId.None;
+            await ValidatePlaceChatChangeConstraints(placeId, chatDiff).ConfigureAwait(false);
         }
         else {
             var requiredPermissions = change.Remove
                 ? ChatPermissions.Owner
                 : ChatPermissions.EditProperties;
             chat.Require().Rules.Permissions.Require(requiredPermissions);
+            if (change.IsUpdate(out var chatDiff))
+                await ValidatePlaceChatChangeConstraints(chat.Id.PlaceId, chatDiff).ConfigureAwait(false);
         }
 
         chat = await Commander.Call(changeCommand, true, cancellationToken).ConfigureAwait(false);
         if (change.Create.HasValue)
             await Authors.EnsureJoined(session, chat.Id, cancellationToken).ConfigureAwait(false);
         return chat;
+
+        async Task ValidatePlaceChatChangeConstraints(PlaceId placeId, ChatDiff chatDiff)
+        {
+            if (placeId.IsNone)
+                return;
+
+            var place = await Places.Get(session, placeId, cancellationToken).ConfigureAwait(false);
+            if (place == null)
+                throw StandardError.Constraint("Requested place is unavailable.");
+
+            var placeMember = place.Rules.Author;
+            if (placeMember == null)
+                throw StandardError.Constraint("Only place members can add chats.");
+            var isOwner = place.Rules.IsOwner();
+            if (!isOwner && chatDiff.IsPublic == true)
+                throw StandardError.NotEnoughPermissions("Make chat public");
+        }
     }
 
     public virtual async Task<ChatEntry> OnUpsertTextEntry(Chats_UpsertTextEntry command, CancellationToken cancellationToken)

--- a/src/dotnet/Chat.Service/Places.cs
+++ b/src/dotnet/Chat.Service/Places.cs
@@ -4,11 +4,14 @@ namespace ActualChat.Chat;
 
 public class Places(IServiceProvider services) : IPlaces
 {
-    private IChats Chats { get; } = services.GetRequiredService<IChats>();
+    private IChats? _chats;
+
     private IAuthors Authors { get; } = services.GetRequiredService<IAuthors>();
     private IRoles Roles { get; } = services.GetRequiredService<IRoles>();
     private IContacts Contacts { get; } = services.GetRequiredService<IContacts>();
     private ICommander Commander { get; } = services.Commander();
+
+    private IChats Chats => _chats ??= services.GetRequiredService<IChats>(); // Lazy resolving to prevent cyclic dependency
 
     public virtual async Task<Place?> Get(Session session, PlaceId placeId, CancellationToken cancellationToken)
     {

--- a/src/dotnet/Chat.UI.Blazor/Components/ChatSettings/ChatSettingsStartModalPage.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/ChatSettings/ChatSettingsStartModalPage.razor
@@ -17,7 +17,8 @@
         return;
 
     Context.ModalDataBag.Set(nameof(ComputedModel.MembersCount), m.MembersCount);
-    var isPlaceChat = m.Chat.Id.IsPlaceChat;
+    var isPlaceChat = !_placeId.IsNone;
+    var canChangeChatType = _placeId.IsNone || _place != null && _place.Rules.CanApplyPublicChatType();
 }
 
 <Form Class="h-full" @ref="@_formRef" Model="@_form">
@@ -49,7 +50,7 @@
         <InputRadioGroup Name="chat_type" DisplayName="Chat type" @bind-Value="_form.IsPublic">
             <TileItem>
                 <Icon>
-                    <FormRadio id="@_form.IsPublicTrueFormId" Value="@true" />
+                    <FormRadio id="@_form.IsPublicTrueFormId" IsDisabled="@(!canChangeChatType)" Value="@true" />
                 </Icon>
                 <Content>
                     <Label InputId="@_form.IsPublicTrueFormId" Text="Public chat"></Label>
@@ -60,7 +61,7 @@
             </TileItem>
             <TileItem>
                 <Icon>
-                    <FormRadio id="@_form.IsPublicFalseFormId" Value="@false"/>
+                    <FormRadio id="@_form.IsPublicFalseFormId" IsDisabled="@(!canChangeChatType)" Value="@false"/>
                 </Icon>
                 <Content>
                     <Label InputId="@_form.IsPublicFalseFormId" Text="Private chat"></Label>
@@ -212,6 +213,8 @@
     private AvatarKind _avatarKind;
     private string? _avatarKey;
     private bool _isAdmin;
+    private PlaceId _placeId;
+    private Place? _place;
 
     [Inject] private ChatUIHub Hub { get; init; } = null!;
     [Inject] private ComponentIdGenerator ComponentIdGenerator { get; init; } = null!;
@@ -255,6 +258,12 @@
             AllowAnonymousAuthors = chat.AllowAnonymousAuthors,
             ImageUploadUrl = $"/api/chat-media/{chat.Id}/upload",
         };
+        _placeId = chat.Id.PlaceChatId.PlaceId;
+        if (!_placeId.IsNone) {
+            _place = await Hub.Places.Get(Hub.Session(), _placeId, default).Require().ConfigureAwait(false);
+            if (!_place.Rules.CanApplyPublicChatType())
+                _form.IsPublic = false;
+        }
         Context.PageDataBag.Set(formBagKey, _form);
     }
 

--- a/src/dotnet/Chat.UI.Blazor/Components/NewChat/NewChatModalProps.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/NewChat/NewChatModalProps.razor
@@ -1,6 +1,9 @@
 ﻿@using System.ComponentModel.DataAnnotations
 @inherits FusionComponentBase
 @namespace ActualChat.Chat.UI.Blazor.Components
+@{
+    var canChangeChatType = _placeId.IsNone || _place != null && _place.Rules.CanApplyPublicChatType();
+}
 
 <Form @ref="_formRef" Model="@_form" Id="@_form.FormId">
     <FormBlock>
@@ -33,7 +36,7 @@
         <InputRadioGroup Name="chat_type" DisplayName="Chat type" @bind-Value="_form.IsPublic">
             <TileItem>
                 <Icon>
-                    <FormRadio Id="@_form.IsPublicTrueFormId" Value="@true"/>
+                    <FormRadio Id="@_form.IsPublicTrueFormId" IsDisabled="@(!canChangeChatType)" Value="@true"/>
                 </Icon>
                 <Content>
                     <Label InputId="@_form.IsPublicTrueFormId" Text="Public chat"></Label>
@@ -44,7 +47,7 @@
             </TileItem>
             <TileItem>
                 <Icon>
-                    <FormRadio Id="@_form.IsPublicFalseFormId" Value="@false"/>
+                    <FormRadio Id="@_form.IsPublicFalseFormId" IsDisabled="@(!canChangeChatType)" Value="@false"/>
                 </Icon>
                 <Content>
                     <Label InputId="@_form.IsPublicFalseFormId" Text="Private chat"></Label>
@@ -116,6 +119,7 @@
     private FormModel _form = null!;
     private bool _isAdmin;
     private PlaceId _placeId;
+    private Place? _place;
 
     [Inject] private ChatUIHub Hub { get; init; } = null!;
     [Inject] private ComponentIdGenerator ComponentIdGenerator { get; init; } = null!;
@@ -130,6 +134,14 @@
         _form = new(ComponentIdGenerator);
         _isAdmin = Hub.AccountUI.OwnAccount.Value.IsAdmin;
         _placeId = PlaceId.Parse(PlaceSid);
+    }
+
+    protected override async Task OnInitializedAsync() {
+        if (!_placeId.IsNone) {
+            _place = await Hub.Places.Get(Hub.Session(), _placeId, default).Require().ConfigureAwait(false);
+            if (!_place.Rules.CanApplyPublicChatType())
+                _form.IsPublic = false;
+        }
     }
 
     private void OnImagePicked(MediaContent mediaContent) {

--- a/src/dotnet/Chat/ChatPermissionsExt.cs
+++ b/src/dotnet/Chat/ChatPermissionsExt.cs
@@ -35,7 +35,5 @@ public static class ChatPermissionsExt
     }
 
     public static Exception NotEnoughPermissions(ChatPermissions? required = null)
-        => required.HasValue
-            ? StandardError.NotEnoughPermissions(required.Value.ToString())
-            : StandardError.NotEnoughPermissions();
+        => StandardError.NotEnoughPermissions(required?.ToString());
 }

--- a/src/dotnet/Chat/ChatPermissionsExt.cs
+++ b/src/dotnet/Chat/ChatPermissionsExt.cs
@@ -35,10 +35,7 @@ public static class ChatPermissionsExt
     }
 
     public static Exception NotEnoughPermissions(ChatPermissions? required = null)
-    {
-        var message = "You can't perform this action: not enough permissions.";
-        return required.HasValue
-            ? new SecurityException($"{message} Requested permission: {required.Value}.")
-            : new SecurityException(message);
-    }
+        => required.HasValue
+            ? StandardError.NotEnoughPermissions(required.Value.ToString())
+            : StandardError.NotEnoughPermissions();
 }

--- a/src/dotnet/Chat/PlacePermissionsExt.cs
+++ b/src/dotnet/Chat/PlacePermissionsExt.cs
@@ -14,7 +14,5 @@ public static class PlacePermissionsExt
     }
 
     public static Exception NotEnoughPermissions(PlacePermissions? required = null)
-        => required.HasValue
-            ? StandardError.NotEnoughPermissions(required.Value.ToString())
-            : StandardError.NotEnoughPermissions();
+        => StandardError.NotEnoughPermissions(required?.ToString());
 }

--- a/src/dotnet/Chat/PlacePermissionsExt.cs
+++ b/src/dotnet/Chat/PlacePermissionsExt.cs
@@ -14,10 +14,7 @@ public static class PlacePermissionsExt
     }
 
     public static Exception NotEnoughPermissions(PlacePermissions? required = null)
-    {
-        var message = "You can't perform this action: not enough permissions.";
-        return required.HasValue
-            ? new SecurityException($"{message} Requested permission: {required.Value}.")
-            : new SecurityException(message);
-    }
+        => required.HasValue
+            ? StandardError.NotEnoughPermissions(required.Value.ToString())
+            : StandardError.NotEnoughPermissions();
 }

--- a/src/dotnet/Chat/PlaceRules.cs
+++ b/src/dotnet/Chat/PlaceRules.cs
@@ -23,6 +23,7 @@ public sealed partial record PlaceRules(
     public bool CanEditRoles() => Permissions.Has(PlacePermissions.EditRoles);
     public bool CanEditMembers() => Permissions.Has(PlacePermissions.EditMembers);
     public bool IsOwner() => Permissions.Has(PlacePermissions.Owner);
+    public bool CanApplyPublicChatType() => IsOwner();
 
     public bool Has(PlacePermissions required)
         => Permissions.Has(required);

--- a/src/dotnet/Core/Errors/StandardError.cs
+++ b/src/dotnet/Core/Errors/StandardError.cs
@@ -61,11 +61,10 @@ public static partial class StandardError
     public static Exception Security(string message)
         => new SecurityException(message);
 
-    public static Exception NotEnoughPermissions()
-        => Security("You can't perform this action: not enough permissions.");
-
-    public static Exception NotEnoughPermissions(string requestedPermission)
-        => Security($"You can't perform this action: not enough permissions. Requested permission: {requestedPermission}");
+    public static Exception NotEnoughPermissions(string? requiredPermission = null)
+        => requiredPermission.IsNullOrEmpty()
+            ? Security("You can't perform this action: not enough permissions.")
+            : Security($"You can't perform this action: not enough permissions. Requested permission: {requiredPermission}");
 
     public static Exception Configuration(string message)
         => new InternalError($"Configuration: {message}");

--- a/src/dotnet/Core/Errors/StandardError.cs
+++ b/src/dotnet/Core/Errors/StandardError.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Security;
 using ActualLab.Internal;
 
 namespace ActualChat;
@@ -56,6 +57,15 @@ public static partial class StandardError
 
     public static Exception Unauthorized(string message)
         => new UnauthorizedAccessException(message);
+
+    public static Exception Security(string message)
+        => new SecurityException(message);
+
+    public static Exception NotEnoughPermissions()
+        => Security("You can't perform this action: not enough permissions.");
+
+    public static Exception NotEnoughPermissions(string requestedPermission)
+        => Security($"You can't perform this action: not enough permissions. Requested permission: {requestedPermission}");
 
     public static Exception Configuration(string message)
         => new InternalError($"Configuration: {message}");


### PR DESCRIPTION
- adds checks that user have permissions to create a chat to specified place;
- adds checks that place member which is not owner should be able to create only private chats in a place;
- in ui chat type changing from private to public is blocked on 'New chat' modal for users who are not place owners;

![image](https://github.com/Actual-Chat/actual-chat/assets/20703715/e95d5d87-c8d4-45eb-83ef-c7a2f3517208)
