### PR TITLE
chore: get rid of class name typo.

### DIFF
--- a/src/dotnet/App.Server/AppHostLifecycleMonitor.cs
+++ b/src/dotnet/App.Server/AppHostLifecycleMonitor.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ActualChat.App.Server;
 
-internal class AppHostLificycleMonitor : IHostedLifecycleService
+internal class AppHostLifecycleMonitor : IHostedLifecycleService
 {
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     public Task StartingAsync(CancellationToken cancellationToken)

--- a/src/dotnet/App.Server/Startup.cs
+++ b/src/dotnet/App.Server/Startup.cs
@@ -88,7 +88,7 @@ public class Startup(IConfiguration cfg, IWebHostEnvironment environment)
         });
 
         // Configure lifecycle monitor
-        services.AddHostedService<AppHostLificycleMonitor>();
+        services.AddHostedService<AppHostLifecycleMonitor>();
 
         var moduleServices = new DefaultServiceProviderFactory().CreateServiceProvider(services);
         ModuleHost = new ModuleHostBuilder()


### PR DESCRIPTION
This PR renames AppHostLificycleMonitor to AppHostLifecycleMonitor.