### PR TITLE
fix: Attachment medias are missing for copied Design chat #2025

### DIFF
--- a/src/dotnet/Media.Service/MediaBackend.cs
+++ b/src/dotnet/Media.Service/MediaBackend.cs
@@ -84,7 +84,6 @@ public class MediaBackend(IServiceProvider services) : DbServiceBase<MediaDbCont
         if (mediaIds.Length == 0)
             return;
 
-        var oldChatSid = mediaIds[0].Scope;
         if (Computed.IsInvalidating())
             return;
 
@@ -96,7 +95,6 @@ public class MediaBackend(IServiceProvider services) : DbServiceBase<MediaDbCont
 
         var sids = mediaIds.Select(c => c.Value).ToList();
         var medias = await dbContext.Media
-            .Where(c => c.Id.StartsWith(oldChatSid))
  #pragma warning disable CA1310
             .Where(c => sids.Any(x => c.Id == x))
  #pragma warning restore CA1310


### PR DESCRIPTION
We should copy only medias created in scope of the source chat.
There can be media created in scope of other chats (e.g. attachements for forwarded messages). We do not copy such medias.