### PR TITLE
Feat/2168 onboarding

### DIFF
--- a/src/dotnet/Chat.UI.Blazor/Components/Settings/AppSettings.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/Settings/AppSettings.razor
@@ -37,6 +37,16 @@
     <Title>Restart walk-through</Title>
 </Button>
 
+@if (m.IsAdmin) {
+    <TileTopic Topic="Onboarding"/>
+    <Button
+        Class="add-avatar-btn"
+        Click="@(OnRestartOnboarding)">
+        <Icon><i class="icon-refresh text-xl"></i></Icon>
+        <Title>Restart onboarding</Title>
+    </Button>
+}
+
 
 @code {
     private INativeAppSettings? NativeAppSettings { get; set; }
@@ -44,6 +54,7 @@
     [Inject] private ChatUIHub Hub { get; init; } = null!;
     [Inject] private AccountSettings AccountSettings { get; init; } = null!;
     [Inject] private IAnalyticsUI AnalyticsUI { get; init; } = null!;
+    [Inject] private OnboardingUI OnboardingUI { get; init; } = null!;
     private HostInfo HostInfo => Hub.HostInfo();
     private BubbleUI BubbleUI => Hub.BubbleUI;
     private ToastUI ToastUI => Hub.ToastUI;
@@ -59,12 +70,18 @@
 
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
         var settings = await AccountSettings.GetUserAppSettings(cancellationToken).ConfigureAwait(false);
-        return new (settings.IsAnalyticsEnabled ?? false);
+        var account = Hub.AccountUI.OwnAccount.Value;
+        return new (settings.IsAnalyticsEnabled ?? false, account.IsAdmin);
     }
 
     private async Task OnRestartWalkThrough() {
         await BubbleUI.ResetSettings().ConfigureAwait(true);
         ToastUI.Show("Walk-through tips are back!", "icon-checkmark-circle", ToastDismissDelay.Short);
+    }
+
+    private async Task OnRestartOnboarding() {
+        await OnboardingUI.ResetSettings().ConfigureAwait(true);
+        ToastUI.Show("Onboarding steps are back!", "icon-checkmark-circle", ToastDismissDelay.Short);
     }
 
     private async Task OnAnalyticsEnabledClick() {
@@ -77,7 +94,7 @@
 
     // Nested types
 
-    public record Model(bool IsAnalyticsEnabled) {
-        public static readonly Model None = new(false);
+    public record Model(bool IsAnalyticsEnabled, bool IsAdmin) {
+        public static readonly Model None = new(false, false);
     }
 }

--- a/src/dotnet/Chat.UI.Blazor/Components/Settings/AppSettings.razor
+++ b/src/dotnet/Chat.UI.Blazor/Components/Settings/AppSettings.razor
@@ -79,8 +79,8 @@
         ToastUI.Show("Walk-through tips are back!", "icon-checkmark-circle", ToastDismissDelay.Short);
     }
 
-    private async Task OnRestartOnboarding() {
-        await OnboardingUI.ResetSettings().ConfigureAwait(true);
+    private void OnRestartOnboarding() {
+        OnboardingUI.ResetSettings();
         ToastUI.Show("Onboarding steps are back!", "icon-checkmark-circle", ToastDismissDelay.Short);
     }
 

--- a/src/dotnet/Chat.UI.Blazor/Services/OnboardingUI/OnboardingUI.cs
+++ b/src/dotnet/Chat.UI.Blazor/Services/OnboardingUI/OnboardingUI.cs
@@ -108,4 +108,11 @@ public class OnboardingUI : ScopedServiceBase<ChatUIHub>, IOnboardingUI
         }
         return _localSettings.Value.HasUncompletedSteps;
     }
+
+    public Task ResetSettings()
+    {
+        _userSettings.Value = new UserOnboardingSettings();
+        _localSettings.Value = new LocalOnboardingSettings();
+        return Task.CompletedTask;
+    }
 }

--- a/src/dotnet/Chat.UI.Blazor/Services/OnboardingUI/OnboardingUI.cs
+++ b/src/dotnet/Chat.UI.Blazor/Services/OnboardingUI/OnboardingUI.cs
@@ -109,10 +109,9 @@ public class OnboardingUI : ScopedServiceBase<ChatUIHub>, IOnboardingUI
         return _localSettings.Value.HasUncompletedSteps;
     }
 
-    public Task ResetSettings()
+    public void ResetSettings()
     {
         _userSettings.Value = new UserOnboardingSettings();
         _localSettings.Value = new LocalOnboardingSettings();
-        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Relates to #2168 
Allow admins to reset obboardning steps status and start onboarding process from scratch.
![image](https://github.com/Actual-Chat/actual-chat/assets/20703715/fd0c057e-63d2-40ae-a084-7fe500dfd934)
