### PR TITLE
MLSearch module open telemetry instrumentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,10 +40,6 @@
     "javascript",
     "typescript"
   ],
-  "eslint.packageManager": "npm",
-  "cSpell.enableFiletypes": [
-    "aspnetcorerazor"
-  ],
   "dotnet.unitTestDebuggingOptions": {
     "allowFastEvaluate": true,
     "enableStepFiltering": true,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -207,7 +207,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Resources.Host" Version="0.1.0-beta.2" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.3" />
     <!-- For the build project -->
     <PackageVersion Include="CliWrap" Version="3.6.6" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 name: actual-chat-infra
 include:
   - ./services/opensearch/docker-compose.yaml
+  - ./services/aspire/docker-compose.yaml
 services:
   redis:
     image: "redis:7.2.4-alpine3.19"

--- a/services/aspire/docker-compose.yaml
+++ b/services/aspire/docker-compose.yaml
@@ -1,0 +1,14 @@
+services:
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.0.0
+    container_name: aspire-dashboard
+    environment:
+      - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true
+    ports:
+      - "18888:18888"
+      - "4317:18889"
+    stdin_open: true
+    tty: true
+    profiles:
+    - aspire
+    restart: unless-stopped

--- a/src/dotnet/App.Server/AppHost.Build.cs
+++ b/src/dotnet/App.Server/AppHost.Build.cs
@@ -26,6 +26,7 @@ using ActualLab.Diagnostics;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.Logging.Console;
+using OpenTelemetry.Logs;
 using Serilog;
 using Serilog.Events;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -86,6 +87,7 @@ public partial class AppHost
                 return;
 
             logging.ConfigureServerFilters(env.EnvironmentName);
+            logging.AddOpenTelemetry(options => options.AddOtlpExporter());
             logging.AddConsole();
             logging.AddConsoleFormatter<GoogleCloudConsoleFormatter, JsonConsoleFormatterOptions>();
             if (!AppLogging.DevLog.IsEmpty && appKind.IsServer() && !isTested) {

--- a/src/dotnet/MLSearch.Service/Diagnostics/MLSearchInstruments.cs
+++ b/src/dotnet/MLSearch.Service/Diagnostics/MLSearchInstruments.cs
@@ -1,0 +1,10 @@
+
+using System.Diagnostics.Metrics;
+
+namespace ActualChat.MLSearch.Diagnostics;
+
+public static class MLSearchInstruments
+{
+    public static readonly ActivitySource ActivitySource = new(ThisAssembly.AssemblyName, ThisAssembly.AssemblyInformationalVersion);
+    public static readonly Meter Meter = new(ThisAssembly.AssemblyName, ThisAssembly.AssemblyInformationalVersion);
+}

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
@@ -1,10 +1,11 @@
 using ActualChat.Chat;
 using ActualChat.MLSearch.ApiAdapters.ShardWorker;
+using ActualChat.MLSearch.Diagnostics;
 using ActualChat.Queues;
 
 namespace ActualChat.MLSearch.Indexing.ChatContent;
 
-internal interface IChatContentIndexWorker: IWorker<MLSearch_TriggerChatIndexing>;
+internal interface IChatContentIndexWorker : IWorker<MLSearch_TriggerChatIndexing>;
 
 internal sealed class ChatContentIndexWorker(
     int flushInterval,
@@ -16,35 +17,61 @@ internal sealed class ChatContentIndexWorker(
     IQueues queues
 ) : IChatContentIndexWorker
 {
+    private const string IndexChatInfoActivityName = $"IndexChatInfo@{nameof(ChatContentIndexWorker)}";
+    private const string LoadCursorActivityName = $"LoadCursor@{nameof(ChatContentIndexWorker)}";
+    private const string InitIndexerActivityName = $"InitIndexer@{nameof(ChatContentIndexWorker)}";
+    private const string ApplyActivityName = $"Apply@{nameof(ChatContentIndexWorker)}";
+    private const string FlushActivityName = $"Flush@{nameof(ChatContentIndexWorker)}";
+    private const string NumOfAppliedEventsTag = "num_of_applied_events";
+    private static readonly ActivitySource ActivitySource = MLSearchInstruments.ActivitySource;
+
     public async Task ExecuteAsync(MLSearch_TriggerChatIndexing job, CancellationToken cancellationToken)
     {
         var eventCount = 0;
         var chatId = job.ChatId;
 
-        await chatInfoIndexer.IndexAsync(chatId, cancellationToken).ConfigureAwait(false);
+        using (ActivitySource.StartActivity(IndexChatInfoActivityName, ActivityKind.Internal)) {
+            await chatInfoIndexer.IndexAsync(chatId, cancellationToken).ConfigureAwait(false);
+        }
 
         if (job.IndexingKind == IndexingKind.ChatInfo) {
             return;
         }
 
-        var cursor = await cursorStates.LoadAsync(chatId, cancellationToken).ConfigureAwait(false) ?? new(0, 0);
+        var cursor = await LoadCursorAsync(chatId, cancellationToken).ConfigureAwait(false);
 
         var indexer = indexerFactory.Create(chatId);
-        await indexer.InitAsync(cursor, cancellationToken).ConfigureAwait(false);
 
-        await foreach (var entry in GetUpdatedEntriesAsync(chatId, cursor, cancellationToken).ConfigureAwait(false)) {
-            await indexer.ApplyAsync(entry, cancellationToken).ConfigureAwait(false);
-            if (++eventCount % flushInterval == 0) {
-                await FlushAsync().ConfigureAwait(false);
-            }
-            if (eventCount==maxEventCount) {
-                break;
-            }
+        using (ActivitySource.StartActivity(InitIndexerActivityName, ActivityKind.Internal)) {
+            await indexer.InitAsync(cursor, cancellationToken).ConfigureAwait(false);
         }
 
+        var applyActivity = ActivitySource.StartActivity(ApplyActivityName, ActivityKind.Internal);
+        try {
+            await foreach (var entry in GetUpdatedEntriesAsync(chatId, cursor, cancellationToken).ConfigureAwait(false)) {
+                await indexer.ApplyAsync(entry, cancellationToken).ConfigureAwait(false);
+                if (++eventCount % flushInterval == 0) {
+                    applyActivity?.SetTag(NumOfAppliedEventsTag, flushInterval);
+                    applyActivity?.Dispose();
+                    applyActivity = null;
+
+                    await FlushAsync().ConfigureAwait(false);
+
+                    applyActivity = ActivitySource.StartActivity(ApplyActivityName, ActivityKind.Internal);
+                }
+                if (eventCount == maxEventCount) {
+                    break;
+                }
+            }
+
+            applyActivity?.SetTag(NumOfAppliedEventsTag, eventCount % flushInterval);
+        }
+        finally {
+            applyActivity?.Dispose();
+        }
         await FlushAsync().ConfigureAwait(false);
 
-        if (eventCount==maxEventCount) {
+        if (eventCount == maxEventCount) {
             await queues.Enqueue(job, cancellationToken).ConfigureAwait(false);
         }
         else if (!cancellationToken.IsCancellationRequested) {
@@ -53,8 +80,16 @@ internal sealed class ChatContentIndexWorker(
         }
         return;
 
+        async Task<ChatContentCursor> LoadCursorAsync(ChatId chatId, CancellationToken cancellationToken)
+        {
+            using var _ = ActivitySource.StartActivity(LoadCursorActivityName, ActivityKind.Internal);
+            return await cursorStates.LoadAsync(chatId, cancellationToken).ConfigureAwait(false) ?? new(0, 0);
+        }
+
         async Task FlushAsync()
         {
+            using var _ = ActivitySource.StartActivity(FlushActivityName, ActivityKind.Internal);
+
             var newCursor = await indexer.FlushAsync(cancellationToken).ConfigureAwait(false);
             await cursorStates.SaveAsync(chatId, newCursor, cancellationToken).ConfigureAwait(false);
         }

--- a/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
@@ -1,5 +1,8 @@
+using ActualChat.MLSearch.Diagnostics;
 using ActualChat.Queues;
 using ActualLab.Resilience;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 
 namespace ActualChat.MLSearch.Indexing.Initializer;
 
@@ -18,6 +21,12 @@ internal sealed class ChatIndexInitializerShard(
 ) : IChatIndexInitializerShard
 {
     public const string CursorKey = $"{nameof(ChatIndexInitializer)}.{nameof(Cursor)}";
+    private const string ClassName = nameof(ChatIndexInitializerShard);
+    private const string PostActivityName = $"{nameof(PostAsync)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
+    private const string OnScheduleJobActivityName = $"{nameof(OnScheduleJob)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
+    private const string OnCompleteJobActivityName = $"{nameof(OnCompleteJob)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
+    private const string OnUpdateCursorActivityName = $"{nameof(OnUpdateCursor)}@{ClassName}";
+    private static readonly ActivitySource ActivitySource = MLSearchInstruments.ActivitySource;
 
     // # Helper types
     public record Cursor(long LastVersion);
@@ -63,15 +72,16 @@ internal sealed class ChatIndexInitializerShard(
 
     // # Fields
     private object _lock = new();
-    private Channel<MLSearch_TriggerChatIndexingCompletion>? _events;
-    private Channel<MLSearch_TriggerChatIndexingCompletion> Events => LazyInitializer.EnsureInitialized(
+    private Channel<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)>? _events;
+    private Channel<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)> Events => LazyInitializer.EnsureInitialized(
         ref _events,
         ref _lock,
-        () => Channel.CreateBounded<MLSearch_TriggerChatIndexingCompletion>(new BoundedChannelOptions(InputBufferCapacity) {
-            FullMode = BoundedChannelFullMode.Wait,
-            SingleReader = true,
-            SingleWriter = false,
-        }));
+        () => Channel.CreateBounded<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)>(
+            new BoundedChannelOptions(InputBufferCapacity) {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = false,
+            }));
 
     // # Configuration properties
     public int InputBufferCapacity { get; init; } = 50;
@@ -87,7 +97,14 @@ internal sealed class ChatIndexInitializerShard(
 
     // # Public API methods
     public async ValueTask PostAsync(MLSearch_TriggerChatIndexingCompletion evt, CancellationToken cancellationToken = default)
-        => await Events.Writer.WriteAsync(evt, cancellationToken).ConfigureAwait(false);
+    {
+        using var activity = ActivitySource.StartActivity(PostActivityName, ActivityKind.Consumer);
+        var propagationContext = activity == null
+            ? default(PropagationContext?)
+            : new PropagationContext(activity.Context, Baggage.Current);
+
+        await Events.Writer.WriteAsync((evt, propagationContext), cancellationToken).ConfigureAwait(false);
+    }
 
     public async Task UseAsync(CancellationToken cancellationToken = default)
     {
@@ -123,8 +140,12 @@ internal sealed class ChatIndexInitializerShard(
     }
 
     // ## Schedule jobs
-    private ValueTask ScheduleJobForChatAsync(ChatInfo chatInfo, SharedState state, CancellationToken cancellationToken)
-        => OnScheduleJob(chatInfo, state, ScheduleJobRetrySettings, queues, clock, log, cancellationToken);
+    private async ValueTask ScheduleJobForChatAsync(ChatInfo chatInfo, SharedState state, CancellationToken cancellationToken)
+    {
+        using var _ = ActivitySource.StartActivity(OnScheduleJobActivityName, ActivityKind.Internal);
+
+        await OnScheduleJob(chatInfo, state, ScheduleJobRetrySettings, queues, clock, log, cancellationToken).ConfigureAwait(false);
+    }
 
     public static async ValueTask ScheduleIndexingJobAsync(
         ChatInfo chatInfo,
@@ -158,7 +179,7 @@ internal sealed class ChatIndexInitializerShard(
     }
 
     // ## Handle job completion events
-    private async IAsyncEnumerable<MLSearch_TriggerChatIndexingCompletion> ReadCompletionEvents(
+    private async IAsyncEnumerable<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)> ReadCompletionEvents(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (true) {
@@ -169,7 +190,20 @@ internal sealed class ChatIndexInitializerShard(
         // ReSharper disable once IteratorNeverReturns
     }
 
-    private ValueTask HandleCompletionEventAsync(MLSearch_TriggerChatIndexingCompletion evt, SharedState state, CancellationToken _) {
+    private ValueTask HandleCompletionEventAsync(
+        (MLSearch_TriggerChatIndexingCompletion, PropagationContext?) data,
+        SharedState state,
+        CancellationToken _)
+    {
+        var (evt, otelContext) = data;
+        Activity? activity = null;
+        if (otelContext.HasValue) {
+            var context = otelContext.Value;
+            Baggage.Current = context.Baggage;
+            activity = ActivitySource.StartActivity(OnCompleteJobActivityName, ActivityKind.Consumer, context.ActivityContext);
+        }
+        using var __ = activity;
+
         OnCompleteJob(evt, state);
         return ValueTask.CompletedTask;
     }
@@ -198,8 +232,12 @@ internal sealed class ChatIndexInitializerShard(
         // ReSharper disable once IteratorNeverReturns
     }
 
-    private ValueTask UpdateCursorAsync(Moment updateMoment, SharedState state, CancellationToken cancellationToken)
-        => OnUpdateCursor(updateMoment, state, StallJobTimeout, cursorStates, log, cancellationToken: cancellationToken);
+    private async ValueTask UpdateCursorAsync(Moment updateMoment, SharedState state, CancellationToken cancellationToken)
+    {
+        using var _ = ActivitySource.StartActivity(OnUpdateCursorActivityName, ActivityKind.Internal);
+
+        await OnUpdateCursor(updateMoment, state, StallJobTimeout, cursorStates, log, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
 
     public static async ValueTask UpdateCursorAsync(
         Moment updateMoment,

--- a/src/dotnet/MLSearch.Service/MLSearch.Service.csproj
+++ b/src/dotnet/MLSearch.Service/MLSearch.Service.csproj
@@ -6,5 +6,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OpenSearch.Client" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request adds aspire dashboard as an observability tool.
By default, aspire dashboard does not start, but one can run it along the other services as following:
```
docker compose --profile aspire up -d
```
Correspondingly, run the command below to stop everything
```
docker compose --profile aspire down
```