### PR TITLE
Notify first-time chat indexer about individual chat indexing continuation

### DIFF
--- a/src/dotnet/MLSearch.Contracts/IChatIndexInitializerTrigger.cs
+++ b/src/dotnet/MLSearch.Contracts/IChatIndexInitializerTrigger.cs
@@ -11,7 +11,10 @@ public static class ChatIndexInitializerShardKey
 public interface IChatIndexInitializerTrigger: IComputeService, IBackendService
 {
     [CommandHandler]
-    Task OnCommand(MLSearch_TriggerChatIndexingCompletion e, CancellationToken cancellationToken);
+    Task OnContinuation(MLSearch_SignalChatIndexingContinuation e, CancellationToken cancellationToken);
+
+    [CommandHandler]
+    Task OnCompletion(MLSearch_SignalChatIndexingCompletion e, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -21,7 +24,17 @@ public interface IChatIndexInitializerTrigger: IComputeService, IBackendService
 /// <param name="Id">Identifier of a chat where initialization is completed.</param>
 [DataContract, MemoryPackable(GenerateType.VersionTolerant)]
 // ReSharper disable once InconsistentNaming
-public sealed partial record MLSearch_TriggerChatIndexingCompletion(
+public sealed partial record MLSearch_SignalChatIndexingCompletion(
+    [property: DataMember, MemoryPackOrder(0)] ChatId Id
+) : IBackendCommand, IHasId<ChatId>, IHasShardKey<string>, ICommand<Unit>
+{
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackIgnore]
+    public string ShardKey => ChatIndexInitializerShardKey.Value;
+}
+
+[DataContract, MemoryPackable(GenerateType.VersionTolerant)]
+// ReSharper disable once InconsistentNaming
+public sealed partial record MLSearch_SignalChatIndexingContinuation(
     [property: DataMember, MemoryPackOrder(0)] ChatId Id
 ) : IBackendCommand, IHasId<ChatId>, IHasShardKey<string>, ICommand<Unit>
 {

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
@@ -66,12 +66,9 @@ internal sealed class ChatContentIndexWorker(
             await foreach (var entry in GetUpdatedEntriesAsync(chatId, cursor, cancellationToken).ConfigureAwait(false)) {
                 await indexer.ApplyAsync(entry, cancellationToken).ConfigureAwait(false);
                 if (++eventCount % FlushInterval == 0) {
-                    applyActivity?.SetTag(NumOfAppliedEventsTag, FlushInterval);
-                    applyActivity?.Dispose();
-                    applyActivity = null;
-
                     await FlushAsync().ConfigureAwait(false);
 
+                    applyActivity?.SetTag(NumOfAppliedEventsTag, FlushInterval).Dispose();
                     applyActivity = ActivitySource.StartActivity(ApplyActivityName, ActivityKind.Internal);
                 }
                 if (eventCount == MaxEventCount) {
@@ -79,12 +76,16 @@ internal sealed class ChatContentIndexWorker(
                 }
             }
 
-            applyActivity?.SetTag(NumOfAppliedEventsTag, eventCount % FlushInterval);
+            await FlushAsync().ConfigureAwait(false);
+            _ = applyActivity?.SetTag(NumOfAppliedEventsTag, eventCount % FlushInterval);
+        }
+        catch (Exception ex) {
+            _ = applyActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
         }
         finally {
             applyActivity?.Dispose();
         }
-        await FlushAsync().ConfigureAwait(false);
 
         if (eventCount == MaxEventCount) {
             await queues.Enqueue(job, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
@@ -12,7 +12,8 @@ internal sealed class ChatContentIndexWorker(
     ICursorStates<ChatContentCursor> cursorStates,
     IChatInfoIndexer chatInfoIndexer,
     IChatContentIndexerFactory indexerFactory,
-    IQueues queues
+    IQueues queues,
+    ILogger<ChatContentIndexWorker> log
 ) : IChatContentIndexWorker
 {
     private const string IndexChatInfoActivityName = $"IndexChatInfo@{nameof(ChatContentIndexWorker)}";
@@ -34,8 +35,9 @@ internal sealed class ChatContentIndexWorker(
         ICursorStates<ChatContentCursor> cursorStates,
         IChatInfoIndexer chatInfoIndexer,
         IChatContentIndexerFactory indexerFactory,
-        IQueues queues
-    ) : this(chatUpdateLoader, cursorStates, chatInfoIndexer, indexerFactory, queues)
+        IQueues queues,
+        ILogger<ChatContentIndexWorker> log
+    ) : this(chatUpdateLoader, cursorStates, chatInfoIndexer, indexerFactory, queues, log)
     {
         FlushInterval = flushInterval;
         MaxEventCount = maxEventCount;
@@ -45,6 +47,8 @@ internal sealed class ChatContentIndexWorker(
     {
         var eventCount = 0;
         var chatId = job.ChatId;
+
+        log.LogInformation("SMIDX: Begin semantic indexing of chat {}.", chatId);
 
         using (ActivitySource.StartActivity(IndexChatInfoActivityName, ActivityKind.Internal)) {
             await chatInfoIndexer.IndexAsync(chatId, cancellationToken).ConfigureAwait(false);
@@ -68,7 +72,10 @@ internal sealed class ChatContentIndexWorker(
                 if (++eventCount % FlushInterval == 0) {
                     await FlushAsync().ConfigureAwait(false);
 
-                    applyActivity?.SetTag(NumOfAppliedEventsTag, FlushInterval).Dispose();
+                    applyActivity?
+                        .SetTag(NumOfAppliedEventsTag, FlushInterval)
+                        .SetStatus(ActivityStatusCode.Ok)
+                        .Dispose();
                     applyActivity = ActivitySource.StartActivity(ApplyActivityName, ActivityKind.Internal);
                 }
                 if (eventCount == MaxEventCount) {
@@ -76,8 +83,16 @@ internal sealed class ChatContentIndexWorker(
                 }
             }
 
-            await FlushAsync().ConfigureAwait(false);
-            _ = applyActivity?.SetTag(NumOfAppliedEventsTag, eventCount % FlushInterval);
+            var remainingEventCount = eventCount % FlushInterval;
+            if (remainingEventCount > 0) {
+                await FlushAsync().ConfigureAwait(false);
+                _ = applyActivity?
+                    .SetTag(NumOfAppliedEventsTag, remainingEventCount)
+                    .SetStatus(ActivityStatusCode.Ok);
+            }
+        }
+        catch (OperationCanceledException) {
+            throw;
         }
         catch (Exception ex) {
             _ = applyActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
@@ -88,9 +103,11 @@ internal sealed class ChatContentIndexWorker(
         }
 
         if (eventCount == MaxEventCount) {
+            log.LogInformation("SMIDX: Rescheduling of semantic indexing of chat {}.", chatId);
             await queues.Enqueue(job, cancellationToken).ConfigureAwait(false);
         }
         else if (!cancellationToken.IsCancellationRequested) {
+            log.LogInformation("SMIDX: Semantic indexing of chat {} is completed.", chatId);
             var completionNotification = new MLSearch_TriggerChatIndexingCompletion(chatId);
             await queues.Enqueue(completionNotification, cancellationToken).ConfigureAwait(false);
         }

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexWorker.cs
@@ -105,10 +105,12 @@ internal sealed class ChatContentIndexWorker(
         if (eventCount == MaxEventCount) {
             log.LogInformation("SMIDX: Rescheduling of semantic indexing of chat {}.", chatId);
             await queues.Enqueue(job, cancellationToken).ConfigureAwait(false);
+            var continuationNotification = new MLSearch_SignalChatIndexingContinuation(chatId);
+            await queues.Enqueue(continuationNotification, cancellationToken).ConfigureAwait(false);
         }
         else if (!cancellationToken.IsCancellationRequested) {
             log.LogInformation("SMIDX: Semantic indexing of chat {} is completed.", chatId);
-            var completionNotification = new MLSearch_TriggerChatIndexingCompletion(chatId);
+            var completionNotification = new MLSearch_SignalChatIndexingCompletion(chatId);
             await queues.Enqueue(completionNotification, cancellationToken).ConfigureAwait(false);
         }
         return;

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexer.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexer.cs
@@ -190,7 +190,7 @@ internal sealed class ChatContentIndexer(
         // Update cursor value
         _cursor = _nextCursor = _buffer.Select(e => new ChatContentCursor(e)).Append(_nextCursor).Max()!;
 
-        log.LogInformation("Indexing of chat {}: {} docs updated, {} docs removed.", chatId, _outUpdates.Count, _outRemoves.Count);
+        log.LogInformation("SMIDX: Indexing of chat {} - {} docs updated, {} docs removed.", chatId, _outUpdates.Count, _outRemoves.Count);
 
         // Clear output buffers
         _outUpdates.Clear();

--- a/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexer.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatContent/ChatContentIndexer.cs
@@ -17,7 +17,8 @@ internal sealed class ChatContentIndexer(
     IChatContentDocumentLoader documentLoader,
     IChatContentMapper documentMapper,
     IChatContentArranger contentArranger,
-    ISink<ChatSlice, string> sink
+    ISink<ChatSlice, string> sink,
+    ILogger<ChatContentIndexer> log
 ) : IChatContentIndexer
 {
     private enum ChatEventType
@@ -142,9 +143,9 @@ internal sealed class ChatContentIndexer(
             foreach (var docId in existingDocuments.Select(doc => doc.Id)) {
                 var isDeleted = isEmptyContent || newDoc?.Id.Equals(docId, StringComparison.Ordinal) != true;
                 if (isDeleted) {
-                    _tailDocs.Remove(docId);
-                    _outUpdates.Remove(docId);
-                    _outRemoves.Add(docId);
+                    _ = _tailDocs.Remove(docId);
+                    _ = _outUpdates.Remove(docId);
+                    _ = _outRemoves.Add(docId);
                 }
             }
             // Add new document to output buffer and update caches
@@ -188,6 +189,8 @@ internal sealed class ChatContentIndexer(
 
         // Update cursor value
         _cursor = _nextCursor = _buffer.Select(e => new ChatContentCursor(e)).Append(_nextCursor).Max()!;
+
+        log.LogInformation("Indexing of chat {}: {} docs updated, {} docs removed.", chatId, _outUpdates.Count, _outRemoves.Count);
 
         // Clear output buffers
         _outUpdates.Clear();

--- a/src/dotnet/MLSearch.Service/Indexing/ChatIndexInitializerTrigger.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/ChatIndexInitializerTrigger.cs
@@ -6,6 +6,9 @@ namespace ActualChat.MLSearch.Indexing;
 internal class ChatIndexInitializerTrigger(IChatIndexInitializer indexInitializer)
     : IChatIndexInitializerTrigger
 {
-    public virtual async Task OnCommand(MLSearch_TriggerChatIndexingCompletion e, CancellationToken cancellationToken)
+    public virtual async Task OnContinuation(MLSearch_SignalChatIndexingContinuation e, CancellationToken cancellationToken)
+        => await indexInitializer.PostAsync(e, cancellationToken).ConfigureAwait(false);
+
+    public virtual async Task OnCompletion(MLSearch_SignalChatIndexingCompletion e, CancellationToken cancellationToken)
         => await indexInitializer.PostAsync(e, cancellationToken).ConfigureAwait(false);
 }

--- a/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializer.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializer.cs
@@ -5,7 +5,8 @@ namespace ActualChat.MLSearch.Indexing.Initializer;
 
 internal interface IChatIndexInitializer
 {
-    ValueTask PostAsync(MLSearch_TriggerChatIndexingCompletion job, CancellationToken cancellationToken);
+    ValueTask PostAsync(MLSearch_SignalChatIndexingContinuation evt, CancellationToken cancellationToken);
+    ValueTask PostAsync(MLSearch_SignalChatIndexingCompletion evt, CancellationToken cancellationToken);
 }
 
 internal sealed class ChatIndexInitializer(
@@ -26,13 +27,24 @@ internal sealed class ChatIndexInitializer(
     private int? _activeShardIndex;
     private int ActiveShardIndex => _activeShardIndex ??= shardIndexResolver.Resolve(new DummyEvent(), ShardScheme);
 
-    public async ValueTask PostAsync(MLSearch_TriggerChatIndexingCompletion evt, CancellationToken cancellationToken)
+    public async ValueTask PostAsync(MLSearch_SignalChatIndexingContinuation evt, CancellationToken cancellationToken)
+    {
+        CheckForActiveShard();
+        await chatIndexInitializerShard.PostAsync(evt, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask PostAsync(MLSearch_SignalChatIndexingCompletion evt, CancellationToken cancellationToken)
+    {
+        CheckForActiveShard();
+        await chatIndexInitializerShard.PostAsync(evt, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void CheckForActiveShard()
     {
         if (!_isHostingActiveShard) {
             throw StandardError.NotFound<ChatIndexInitializerShard>(
                 $"There is no active {nameof(ChatIndexInitializerShard)} at this node.");
         }
-        await chatIndexInitializerShard.PostAsync(evt, cancellationToken).ConfigureAwait(false);
     }
 
     protected override async Task OnRun(int shardIndex, CancellationToken cancellationToken)

--- a/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
@@ -211,12 +211,12 @@ internal sealed class ChatIndexInitializerShard(
     public static void HandleCompletionEvent(
         MLSearch_TriggerChatIndexingCompletion evt, SharedState state)
     {
-        Interlocked.Increment(ref state.EventCount);
+        _ = Interlocked.Increment(ref state.EventCount);
         if (state.ScheduledJobs.TryRemove(evt.Id, out var info) && info is var (version, _)) {
             if (Volatile.Read(ref state.MaxVersion) < version) {
                 Volatile.Write(ref state.MaxVersion, version);
             }
-            state.Semaphore.Release();
+            _ = state.Semaphore.Release();
         }
     }
 
@@ -282,7 +282,7 @@ internal sealed class ChatIndexInitializerShard(
                 if (state.ScheduledJobs.TryRemove(jobId, out var info) && info is var (_, timestamp)) {
                     log.LogWarning("Evicting indexing job for chat #{JobId} which is stall for {Interval}.",
                         jobId, updateMoment - timestamp);
-                    state.Semaphore.Release();
+                    _ = state.Semaphore.Release();
                 }
             }
             await cursorStates.SaveAsync(CursorKey, new Cursor(nextVersion), cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
+++ b/src/dotnet/MLSearch.Service/Indexing/Initializer/ChatIndexInitializerShard.cs
@@ -8,7 +8,8 @@ namespace ActualChat.MLSearch.Indexing.Initializer;
 
 internal interface IChatIndexInitializerShard
 {
-    ValueTask PostAsync(MLSearch_TriggerChatIndexingCompletion job, CancellationToken cancellationToken = default);
+    ValueTask PostAsync(MLSearch_SignalChatIndexingContinuation job, CancellationToken cancellationToken = default);
+    ValueTask PostAsync(MLSearch_SignalChatIndexingCompletion job, CancellationToken cancellationToken = default);
     Task UseAsync(CancellationToken cancellationToken = default);
 }
 
@@ -22,10 +23,11 @@ internal sealed class ChatIndexInitializerShard(
 {
     public const string CursorKey = $"{nameof(ChatIndexInitializer)}.{nameof(Cursor)}";
     private const string ClassName = nameof(ChatIndexInitializerShard);
-    private const string PostActivityName = $"{nameof(PostAsync)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
-    private const string OnScheduleJobActivityName = $"{nameof(OnScheduleJob)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
-    private const string OnCompleteJobActivityName = $"{nameof(OnCompleteJob)}({nameof(MLSearch_TriggerChatIndexingCompletion)})@{ClassName}";
-    private const string OnUpdateCursorActivityName = $"{nameof(OnUpdateCursor)}@{ClassName}";
+    private const string PostChatIndexingContinuationActivityName = $"{nameof(PostAsync)}({nameof(MLSearch_SignalChatIndexingContinuation)})@{ClassName}";
+    private const string PostChatIndexingCompletionActivityName = $"{nameof(PostAsync)}({nameof(MLSearch_SignalChatIndexingCompletion)})@{ClassName}";
+    private const string OnScheduleJobActivityName = $"{nameof(ScheduleIndexingJobAsync)}@{ClassName}";
+    private const string OnHandleJobEventActivityName = $"{nameof(HandleJobEventAsync)}@{ClassName}";
+    private const string OnUpdateCursorActivityName = $"{nameof(UpdateCursorAsync)}@{ClassName}";
     private static readonly ActivitySource ActivitySource = MLSearchInstruments.ActivitySource;
 
     // # Helper types
@@ -54,6 +56,15 @@ internal sealed class ChatIndexInitializerShard(
         public const string EvictStallJobs = "EvictStallJobs";
     }
 
+    private record JobEvent
+    {
+        public PropagationContext? PropagationContext { get; private set; }
+        private JobEvent(PropagationContext? propagationContext) => PropagationContext = propagationContext;
+
+        public record SignalContinuation(MLSearch_SignalChatIndexingContinuation Event, PropagationContext? PropagationContext) : JobEvent(PropagationContext);
+        public record SignalCompletion(MLSearch_SignalChatIndexingCompletion Event, PropagationContext? PropagationContext) : JobEvent(PropagationContext);
+    }
+
     // # Delegates
     public delegate ValueTask ScheduleJobHandler(
         ChatInfo chatInfo, SharedState state, RetrySettings retrySettings,
@@ -61,8 +72,10 @@ internal sealed class ChatIndexInitializerShard(
         MomentClock clock,
         ILogger log,
         CancellationToken cancellationToken);
+    public delegate void ContinueJobHandler(
+        MLSearch_SignalChatIndexingContinuation evt, Moment moment, SharedState state);
     public delegate void CompleteJobHandler(
-        MLSearch_TriggerChatIndexingCompletion evt, SharedState state);
+        MLSearch_SignalChatIndexingCompletion evt, SharedState state);
     public delegate ValueTask UpdateCursorHandler(
         Moment moment, SharedState state, TimeSpan stallJobTimeout,
         ICursorStates<Cursor> cursorStates,
@@ -72,11 +85,11 @@ internal sealed class ChatIndexInitializerShard(
 
     // # Fields
     private object _lock = new();
-    private Channel<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)>? _events;
-    private Channel<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)> Events => LazyInitializer.EnsureInitialized(
+    private Channel<JobEvent>? _events;
+    private Channel<JobEvent> Events => LazyInitializer.EnsureInitialized(
         ref _events,
         ref _lock,
-        () => Channel.CreateBounded<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)>(
+        () => Channel.CreateBounded<JobEvent>(
             new BoundedChannelOptions(InputBufferCapacity) {
                 FullMode = BoundedChannelFullMode.Wait,
                 SingleReader = true,
@@ -92,18 +105,29 @@ internal sealed class ChatIndexInitializerShard(
 
     public TimeSpan StallJobTimeout { get; init; } = TimeSpan.FromMinutes(3);
     public ScheduleJobHandler OnScheduleJob { get; init; } = ScheduleIndexingJobAsync;
+    public ContinueJobHandler OnContinueJob { get; init; } = HandleContinuationEvent;
     public CompleteJobHandler OnCompleteJob { get; init; } = HandleCompletionEvent;
     public UpdateCursorHandler OnUpdateCursor { get; init; } = UpdateCursorAsync;
 
     // # Public API methods
-    public async ValueTask PostAsync(MLSearch_TriggerChatIndexingCompletion evt, CancellationToken cancellationToken = default)
+    public async ValueTask PostAsync(MLSearch_SignalChatIndexingContinuation evt, CancellationToken cancellationToken = default)
     {
-        using var activity = ActivitySource.StartActivity(PostActivityName, ActivityKind.Consumer);
+        using var activity = ActivitySource.StartActivity(PostChatIndexingContinuationActivityName, ActivityKind.Consumer);
         var propagationContext = activity == null
             ? default(PropagationContext?)
             : new PropagationContext(activity.Context, Baggage.Current);
 
-        await Events.Writer.WriteAsync((evt, propagationContext), cancellationToken).ConfigureAwait(false);
+        await Events.Writer.WriteAsync(new JobEvent.SignalContinuation(evt, propagationContext), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask PostAsync(MLSearch_SignalChatIndexingCompletion evt, CancellationToken cancellationToken = default)
+    {
+        using var activity = ActivitySource.StartActivity(PostChatIndexingCompletionActivityName, ActivityKind.Consumer);
+        var propagationContext = activity == null
+            ? default(PropagationContext?)
+            : new PropagationContext(activity.Context, Baggage.Current);
+
+        await Events.Writer.WriteAsync(new JobEvent.SignalCompletion(evt, propagationContext), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UseAsync(CancellationToken cancellationToken = default)
@@ -114,12 +138,12 @@ internal sealed class ChatIndexInitializerShard(
         var chats = chatSequence
             .LoadAsync(cursor.LastVersion, cancellationToken)
             .Select(info => new ChatInfo(info));
-        var completionEvents = ReadCompletionEvents(cancellationToken);
+        var jobEvents = ReadJobEvents(cancellationToken);
         var updateCursorMoments = ReadUpdateCursorMoments(cancellationToken);
 
         await Task.WhenAll([
             RunAsync(chats, ScheduleJobForChatAsync, state, cancellationToken),
-            RunAsync(completionEvents, HandleCompletionEventAsync, state, cancellationToken),
+            RunAsync(jobEvents, HandleJobEventAsync, state, cancellationToken),
             RunAsync(updateCursorMoments, UpdateCursorAsync, state, cancellationToken),
         ]).ConfigureAwait(false);
     }
@@ -179,37 +203,56 @@ internal sealed class ChatIndexInitializerShard(
     }
 
     // ## Handle job completion events
-    private async IAsyncEnumerable<(MLSearch_TriggerChatIndexingCompletion, PropagationContext?)> ReadCompletionEvents(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<JobEvent> ReadJobEvents([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (true) {
             cancellationToken.ThrowIfCancellationRequested();
-            var completionEvent = await Events.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-            yield return completionEvent;
+            var jobEvent = await Events.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            yield return jobEvent;
         }
         // ReSharper disable once IteratorNeverReturns
     }
 
-    private ValueTask HandleCompletionEventAsync(
-        (MLSearch_TriggerChatIndexingCompletion, PropagationContext?) data,
+    private ValueTask HandleJobEventAsync(
+        JobEvent data,
         SharedState state,
-        CancellationToken _)
+        CancellationToken _ct)
     {
-        var (evt, otelContext) = data;
+        var otelContext = data.PropagationContext;
         Activity? activity = null;
         if (otelContext.HasValue) {
             var context = otelContext.Value;
             Baggage.Current = context.Baggage;
-            activity = ActivitySource.StartActivity(OnCompleteJobActivityName, ActivityKind.Consumer, context.ActivityContext);
+            activity = ActivitySource.StartActivity(OnHandleJobEventActivityName, ActivityKind.Consumer, context.ActivityContext);
         }
         using var __ = activity;
 
-        OnCompleteJob(evt, state);
+        switch (data) {
+            case JobEvent.SignalContinuation { Event: var evt }:
+                _ = activity?.SetTag("EventType", nameof(MLSearch_SignalChatIndexingContinuation));
+                OnContinueJob(evt, clock.Now, state);
+                break;
+            case JobEvent.SignalCompletion { Event: var evt }:
+                _ = activity?.SetTag("EventType", nameof(MLSearch_SignalChatIndexingCompletion));
+                OnCompleteJob(evt, state);
+                break;
+            default:
+                break;
+        }
         return ValueTask.CompletedTask;
     }
 
+    public static void HandleContinuationEvent(
+        MLSearch_SignalChatIndexingContinuation evt, Moment moment, SharedState state)
+    {
+        _ = Interlocked.Increment(ref state.EventCount);
+        if (state.ScheduledJobs.TryGetValue(evt.Id, out var info) && info is var (version, _)) {
+            _ = state.ScheduledJobs.TryUpdate(evt.Id, (version, moment), info);
+        }
+    }
+
     public static void HandleCompletionEvent(
-        MLSearch_TriggerChatIndexingCompletion evt, SharedState state)
+        MLSearch_SignalChatIndexingCompletion evt, SharedState state)
     {
         _ = Interlocked.Increment(ref state.EventCount);
         if (state.ScheduledJobs.TryRemove(evt.Id, out var info) && info is var (version, _)) {

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexWorkerTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexWorkerTests.cs
@@ -301,9 +301,9 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(contentIndexer.Object));
 
-        QueuedCommand? command = null;
+        var commands = new List<QueuedCommand>();
         var queues = QueuesMock.Create((cmd, _) => {
-            command = cmd;
+            commands.Add(cmd);
             return Task.CompletedTask;
         });
 
@@ -330,13 +330,15 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             It.Is<CancellationToken>(ct => ct == cancellationSource.Token)
         ), Times.Exactly(Math.Min(updateCount, maxUpdateCount)));
 
-        Assert.NotNull(command);
+        Assert.NotEmpty(commands);
         if (updateCount < maxUpdateCount) {
-            var completionEvent = Assert.IsType<MLSearch_TriggerChatIndexingCompletion>(command.UntypedCommand);
+            var completionEvent = Assert.IsType<MLSearch_SignalChatIndexingCompletion>(commands[0].UntypedCommand);
             Assert.Equal(chatId, completionEvent.Id);
         }
         else {
-            Assert.Equal(job, command.UntypedCommand);
+            Assert.Equal(2, commands.Count);
+            Assert.Contains(commands, cmd => cmd.UntypedCommand is MLSearch_TriggerChatIndexing evt && evt.Id == (chatId, IndexingKind.ChatContent));
+            Assert.Contains(commands, cmd => cmd.UntypedCommand is MLSearch_SignalChatIndexingContinuation evt && evt.Id == chatId);
         }
     }
 

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexWorkerTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexWorkerTests.cs
@@ -21,7 +21,8 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             Mock.Of<ICursorStates<ChatContentCursor>>(MockBehavior.Loose),
             Mock.Of<IChatInfoIndexer>(MockBehavior.Loose),
             Mock.Of<IChatContentIndexerFactory>(MockBehavior.Loose),
-            Mock.Of<IQueues>(MockBehavior.Loose)
+            Mock.Of<IQueues>(MockBehavior.Loose),
+            LogMock.Create<ChatContentIndexWorker>().Object
         );
 
         Assert.Equal(flushInterval, contentIndexWorker.FlushInterval);
@@ -34,34 +35,37 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
     public async Task ExecuteAsyncAlwaysCallsChatInfoIndexer(IndexingKind indexingKind)
     {
         var updateLoader = new Mock<IChatContentUpdateLoader>(MockBehavior.Loose);
-        updateLoader
+        _ = updateLoader
             .Setup(x => x.LoadChatUpdatesAsync(It.IsAny<ChatId>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<ChatEntry>());
 
         var cursor = new ChatContentCursor(77, 88);
         var cursorStates = new Mock<ICursorStates<ChatContentCursor>>(MockBehavior.Loose);
-        cursorStates
+        _ = cursorStates
             .Setup(x => x.LoadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(cursor);
 
         var chatInfoIndexer = new Mock<IChatInfoIndexer>(MockBehavior.Loose);
-        chatInfoIndexer
+        _ = chatInfoIndexer
             .Setup(i => i.IndexAsync(It.IsAny<ChatId>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var contentIndexerFactory = new Mock<IChatContentIndexerFactory>(MockBehavior.Loose);
-        contentIndexerFactory
+        _ = contentIndexerFactory
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(Mock.Of<IChatContentIndexer>(MockBehavior.Loose)));
 
         var queues = QueuesMock.Create();
+
+        var log = LogMock.Create<ChatContentIndexWorker>();
 
         var contentIndexWorker = new ChatContentIndexWorker(
             updateLoader.Object,
             cursorStates.Object,
             chatInfoIndexer.Object,
             contentIndexerFactory.Object,
-            queues.Object
+            queues.Object,
+            log.Object
         );
 
         var chatId = new ChatId(Generate.Option);
@@ -97,36 +101,39 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
     public async Task ExecuteAsyncCreatesAndInitializesChatContentIndexer()
     {
         var updateLoader = new Mock<IChatContentUpdateLoader>(MockBehavior.Loose);
-        updateLoader
+        _ = updateLoader
             .Setup(x => x.LoadChatUpdatesAsync(It.IsAny<ChatId>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<ChatEntry>());
 
         var cursor = new ChatContentCursor(77, 88);
         var cursorStates = new Mock<ICursorStates<ChatContentCursor>>(MockBehavior.Loose);
-        cursorStates
+        _ = cursorStates
             .Setup(x => x.LoadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(cursor);
 
         var chatInfoIndexer = new Mock<IChatInfoIndexer>(MockBehavior.Loose);
 
         var contentIndexer = new Mock<IChatContentIndexer>(MockBehavior.Loose);
-        contentIndexer
+        _ = contentIndexer
             .Setup(x => x.InitAsync(It.IsAny<ChatContentCursor>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var contentIndexerFactory = new Mock<IChatContentIndexerFactory>(MockBehavior.Loose);
-        contentIndexerFactory
+        _ = contentIndexerFactory
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(contentIndexer.Object));
 
         var queues = QueuesMock.Create();
+
+        var log = LogMock.Create<ChatContentIndexWorker>();
 
         var contentIndexWorker = new ChatContentIndexWorker(
             updateLoader.Object,
             cursorStates.Object,
             chatInfoIndexer.Object,
             contentIndexerFactory.Object,
-            queues.Object
+            queues.Object,
+            log.Object
         );
 
         var chatId = new ChatId(Generate.Option);
@@ -151,7 +158,7 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
         var chatId = new ChatId(Generate.Option);
         var updates = GenerateUpdates(chatId, updateCount);
         var updateLoader = new Mock<IChatContentUpdateLoader>(MockBehavior.Loose);
-        updateLoader
+        _ = updateLoader
             .Setup(x => x.LoadChatUpdatesAsync(It.IsAny<ChatId>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Returns(updates.ToAsyncEnumerable());
 
@@ -160,7 +167,7 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
 
         var appliedEntries = new List<ChatEntry>();
         var contentIndexer = new Mock<IChatContentIndexer>(MockBehavior.Loose);
-        contentIndexer
+        _ = contentIndexer
             .Setup(x => x.ApplyAsync(It.IsAny<ChatEntry>(), It.IsAny<CancellationToken>()))
             .Returns<ChatEntry, CancellationToken>((entry, _) => {
                 appliedEntries.Add(entry);
@@ -168,18 +175,21 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             });
 
         var contentIndexerFactory = new Mock<IChatContentIndexerFactory>(MockBehavior.Loose);
-        contentIndexerFactory
+        _ = contentIndexerFactory
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(contentIndexer.Object));
 
         var queues = QueuesMock.Create();
+
+        var log = LogMock.Create<ChatContentIndexWorker>();
 
         var contentIndexWorker = new ChatContentIndexWorker(
             updateLoader.Object,
             cursorStates.Object,
             chatInfoIndexer.Object,
             contentIndexerFactory.Object,
-            queues.Object
+            queues.Object,
+            log.Object
         ) {
             MaxEventCount = updateCount + 1,
             FlushInterval = updateCount + 1
@@ -207,12 +217,12 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
         var chatId = new ChatId(Generate.Option);
         var updates = GenerateUpdates(chatId, updateCount);
         var updateLoader = new Mock<IChatContentUpdateLoader>(MockBehavior.Loose);
-        updateLoader
+        _ = updateLoader
             .Setup(x => x.LoadChatUpdatesAsync(It.IsAny<ChatId>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Returns(updates.ToAsyncEnumerable());
 
         var cursorStates = new Mock<ICursorStates<ChatContentCursor>>(MockBehavior.Loose);
-        cursorStates
+        _ = cursorStates
             .Setup(x => x.SaveAsync(It.IsAny<string>(), It.IsAny<ChatContentCursor>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -220,16 +230,18 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
 
         var cursor = new ChatContentCursor(839470, 98237);
         var contentIndexer = new Mock<IChatContentIndexer>(MockBehavior.Loose);
-        contentIndexer
+        _ = contentIndexer
             .Setup(x => x.FlushAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(cursor));
 
         var contentIndexerFactory = new Mock<IChatContentIndexerFactory>(MockBehavior.Loose);
-        contentIndexerFactory
+        _ = contentIndexerFactory
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(contentIndexer.Object));
 
         var queues = QueuesMock.Create();
+
+        var log = LogMock.Create<ChatContentIndexWorker>();
 
         const int flushInterval = 33;
         var contentIndexWorker = new ChatContentIndexWorker(
@@ -237,7 +249,8 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             cursorStates.Object,
             chatInfoIndexer.Object,
             contentIndexerFactory.Object,
-            queues.Object
+            queues.Object,
+            log.Object
         ) {
             MaxEventCount = int.MaxValue,
             FlushInterval = flushInterval
@@ -248,7 +261,7 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
         var job = new MLSearch_TriggerChatIndexing(chatId, IndexingKind.ChatContent);
         await contentIndexWorker.ExecuteAsync(job, cancellationSource.Token);
 
-        var flushCount = (updateCount / flushInterval) + 1;
+        var flushCount = (updateCount + flushInterval - 1) / flushInterval;
 
         contentIndexer.Verify(x => x.FlushAsync(
             It.Is<CancellationToken>(ct => ct == cancellationSource.Token)
@@ -271,7 +284,7 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
         var chatId = new ChatId(Generate.Option);
         var updates = GenerateUpdates(chatId, updateCount);
         var updateLoader = new Mock<IChatContentUpdateLoader>(MockBehavior.Loose);
-        updateLoader
+        _ = updateLoader
             .Setup(x => x.LoadChatUpdatesAsync(It.IsAny<ChatId>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Returns(updates.ToAsyncEnumerable());
 
@@ -279,12 +292,12 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
         var chatInfoIndexer = new Mock<IChatInfoIndexer>(MockBehavior.Loose);
 
         var contentIndexer = new Mock<IChatContentIndexer>(MockBehavior.Loose);
-        contentIndexer
+        _ = contentIndexer
             .Setup(x => x.ApplyAsync(It.IsAny<ChatEntry>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.CompletedTask);
 
         var contentIndexerFactory = new Mock<IChatContentIndexerFactory>(MockBehavior.Loose);
-        contentIndexerFactory
+        _ = contentIndexerFactory
             .Setup(f => f.Create(It.IsAny<ChatId>()))
             .Returns(Task.FromResult(contentIndexer.Object));
 
@@ -294,12 +307,15 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
             return Task.CompletedTask;
         });
 
+        var log = LogMock.Create<ChatContentIndexWorker>();
+
         var contentIndexWorker = new ChatContentIndexWorker(
             updateLoader.Object,
             cursorStates.Object,
             chatInfoIndexer.Object,
             contentIndexerFactory.Object,
-            queues.Object
+            queues.Object,
+            log.Object
         ) {
             MaxEventCount = maxUpdateCount,
         };
@@ -316,8 +332,8 @@ public class ChatContentIndexWorkerTests(ITestOutputHelper @out) : TestBase(@out
 
         Assert.NotNull(command);
         if (updateCount < maxUpdateCount) {
-            Assert.IsType<MLSearch_TriggerChatIndexingCompletion>(command.UntypedCommand);
-            Assert.Equal(chatId, ((MLSearch_TriggerChatIndexingCompletion)command.UntypedCommand).Id);
+            var completionEvent = Assert.IsType<MLSearch_TriggerChatIndexingCompletion>(command.UntypedCommand);
+            Assert.Equal(chatId, completionEvent.Id);
         }
         else {
             Assert.Equal(job, command.UntypedCommand);

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerApplyTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerApplyTests.cs
@@ -16,14 +16,15 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
 
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var otherChatEntryId = new ChatEntryId(otherChatId, ChatEntryKind.Text, 2, AssumeValid.Option);
         var otherChatEntry = new ChatEntry(otherChatEntryId) {
@@ -40,15 +41,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         // Doc loader returns empty list, so event considered as new chat entry
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var chatId = new ChatId(Generate.Option);
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var chatEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 2, AssumeValid.Option);
         var chatEntry = new ChatEntry(chatEntryId) {
@@ -66,15 +68,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         // Doc loader returns empty list, so event considered as new chat entry
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var chatId = new ChatId(Generate.Option);
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var chatEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 2, AssumeValid.Option);
         var chatEntry = new ChatEntry(chatEntryId) {
@@ -97,15 +100,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         // Doc loader returns empty list, so event considered as new chat entry
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var chatId = new ChatId(Generate.Option);
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var chatEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 2, AssumeValid.Option);
         var chatEntry = new ChatEntry(chatEntryId) {
@@ -126,15 +130,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         // Doc loader returns empty list, so event doesn't have index footprint yet
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var chatId = new ChatId(Generate.Option);
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var chatEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 2, AssumeValid.Option);
         var removedEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 202, AssumeValid.Option);
@@ -162,16 +167,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = new Mock<IChatsBackend>(MockBehavior.Loose);
         // There must be no calls to GetTile, as updatedDoc contains single entry,
         // so there is no need of loading anything
-        chats.Setup(x => x.GetTile(
+        _ = chats.Setup(x => x.GetTile(
             It.IsAny<ChatId>(),
             It.IsAny<ChatEntryKind>(),
             It.IsAny<ActualLab.Mathematics.Range<long>>(),
-            It.Is<bool>(include => include == true),
+            It.Is<bool>(include => include),
             It.IsAny<CancellationToken>()));
 
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
         // Emulate loading tail documents
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadTailAsync(
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatContentCursor>(),
@@ -179,7 +184,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(tailDocuments);
         // On update, we get the document from index by entry id
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .Returns<IEnumerable<ChatEntryId>, CancellationToken>(
                 (entryIds, _) => {
@@ -191,8 +196,9 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
 
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
-        var contentIndexer = new ChatContentIndexer(updatedEntryId.ChatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(updatedEntryId.ChatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink, log.Object);
 
         var cursor = new ChatContentCursor(0, 0);
         await contentIndexer.InitAsync(cursor, CancellationToken.None);
@@ -240,7 +246,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
             It.IsAny<ChatId>(),
             It.IsAny<ChatEntryKind>(),
             It.IsAny<ActualLab.Mathematics.Range<long>>(),
-            It.Is<bool>(include => include == true),
+            It.Is<bool>(include => include),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -253,16 +259,16 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         var chats = new Mock<IChatsBackend>(MockBehavior.Loose);
         // There must be no calls to GetTile, as updatedDoc contains single entry,
         // so there is no need of loading anything
-        chats.Setup(x => x.GetTile(
+        _ = chats.Setup(x => x.GetTile(
             It.IsAny<ChatId>(),
             It.IsAny<ChatEntryKind>(),
             It.IsAny<ActualLab.Mathematics.Range<long>>(),
-            It.Is<bool>(include => include == true),
+            It.Is<bool>(include => include),
             It.IsAny<CancellationToken>()));
 
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
         // Emulate loading tail documents
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadTailAsync(
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatContentCursor>(),
@@ -270,7 +276,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(tailDocuments);
         // On update, we get the document from index by entry id
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([updatedDoc]);
 
@@ -278,8 +284,9 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
 
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
-        var contentIndexer = new ChatContentIndexer(updatedEntryId.ChatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(updatedEntryId.ChatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink, log.Object);
 
         var cursor = new ChatContentCursor(0, 0);
         await contentIndexer.InitAsync(cursor, CancellationToken.None);
@@ -294,7 +301,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         };
         await contentIndexer.ApplyAsync(updatedEntry, CancellationToken.None);
 
-        updatedDocIds.Add(updatedDoc.Id);
+        _ = updatedDocIds.Add(updatedDoc.Id);
 
         Assert.Same(updatedDoc, contentIndexer.TailDocs[updatedDoc.Id]);
         Assert.Same(updatedDoc, contentIndexer.OutUpdates[updatedDoc.Id]);
@@ -318,7 +325,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
             It.IsAny<ChatId>(),
             It.IsAny<ChatEntryKind>(),
             It.IsAny<ActualLab.Mathematics.Range<long>>(),
-            It.Is<bool>(include => include == true),
+            It.Is<bool>(include => include),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -388,9 +395,9 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
         }
 
         // Behavior must not depend on document order
-        existingDocs.Shuffle();
+        existingDocs = existingDocs.Shuffle().ToArray();
         // Behavior must not depend on entries order
-        allEntries.Shuffle();
+        allEntries = allEntries.Shuffle().ToList();
 
         var chats = new Mock<IChatsBackend>(MockBehavior.Loose);
         _ = chats
@@ -398,7 +405,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatEntryKind>(),
                 It.IsAny<ActualLab.Mathematics.Range<long>>(),
-                It.Is<bool>(include => include == true),
+                It.Is<bool>(include => include),
                 It.IsAny<CancellationToken>()))
             .Returns<ChatId, ChatEntryKind, ActualLab.Mathematics.Range<long>, bool, CancellationToken>(
                 (_, _, range, includeRemoved, _) => {
@@ -406,7 +413,7 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
                     return Task.FromResult(tile);
                 });
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(
                 It.IsAny<IEnumerable<ChatEntryId>>(),
                 It.IsAny<CancellationToken>()))
@@ -422,8 +429,9 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
 
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
-        var contentIndexer = new ChatContentIndexer(chatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(chatId, chats.Object, docLoader.Object, docMapper.Object, contentArranger, sink, log.Object);
         await contentIndexer.ApplyAsync(chatEntry, CancellationToken.None);
 
         var docsToRemove = existingDocs
@@ -498,15 +506,15 @@ public class ChatContentIndexerApplyTests(ITestOutputHelper @out) : TestBase(@ou
             if (isFirstDoc && !entryToDocMap.IsFirst) {
                 var firstEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 1, AssumeValid.Option);
                 entries.Add(new ChatSliceEntry(firstEntryId, 1, 1));
-                sbContent.AppendLine(FirstEntryContent);
+                _ = sbContent.AppendLine(FirstEntryContent);
             }
             entries.Add(new ChatSliceEntry(chatEntryId, 1, 1));
-            sbContent.Append(contentSlices[doc]);
+            _ = sbContent.Append(contentSlices[doc]);
             var sliceEnd = sliceStart + contentSlices[doc].Length;
             if (isLastDoc && !entryToDocMap.IsLast) {
                 var lastEntryId = new ChatEntryId(chatId, ChatEntryKind.Text, 3, AssumeValid.Option);
                 entries.Add(new ChatSliceEntry(lastEntryId, 1, 1));
-                sbContent.AppendLine(LastEntryContent);
+                _ = sbContent.AppendLine(LastEntryContent);
             }
 
             var startOffset = sliceStart > 0

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerFactoryTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerFactoryTests.cs
@@ -11,22 +11,25 @@ public class ChatContentIndexerFactoryTests(ITestOutputHelper @out) : TestBase(@
     public async Task CreateMethodReturnsIndexerInstance()
     {
         var serviceProvider = new Mock<IServiceProvider>(MockBehavior.Loose);
-        serviceProvider
+        _ = serviceProvider
             .Setup(x => x.GetService(typeof(IChatContentArrangerSelector)))
             .Returns(Mock.Of<IChatContentArrangerSelector>(MockBehavior.Loose));
         var chatsBackend = Mock.Of<IChatsBackend>(MockBehavior.Loose);
-        serviceProvider
+        _ = serviceProvider
             .Setup(x => x.GetService(typeof(IChatsBackend)))
             .Returns(chatsBackend);
-        serviceProvider
+        _ = serviceProvider
             .Setup(x => x.GetService(typeof(IChatContentDocumentLoader)))
             .Returns(Mock.Of<IChatContentDocumentLoader>(MockBehavior.Loose));
-        serviceProvider
+        _ = serviceProvider
             .Setup(x => x.GetService(typeof(IChatContentMapper)))
             .Returns(Mock.Of<IChatContentMapper>(MockBehavior.Loose));
-        serviceProvider
+        _ = serviceProvider
             .Setup(x => x.GetService(typeof(ISink<ChatSlice, string>)))
             .Returns(Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose));
+        _ = serviceProvider
+            .Setup(x => x.GetService(typeof(ILogger<ChatContentIndexer>)))
+            .Returns(LogMock.Create<ChatContentIndexer>().Object);
 
         var factory = new ChatContentIndexerFactory(serviceProvider.Object);
 

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerFlushTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerFlushTests.cs
@@ -38,7 +38,7 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
 
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
         // Emulate loading tail documents
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadTailAsync(
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatContentCursor>(),
@@ -46,7 +46,7 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(tailDocuments);
         // On update, we get the document from index by entry id
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadByEntryIdsAsync(It.IsAny<IEnumerable<ChatEntryId>>(), It.IsAny<CancellationToken>()))
             .Returns<IEnumerable<ChatEntryId>, CancellationToken>(
                 (ids, _) => {
@@ -67,7 +67,7 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
         });
 
         var contentArranger = new Mock<IChatContentArranger>(MockBehavior.Loose);
-        contentArranger
+        _ = contentArranger
             .Setup(x => x.Arrange(
                 It.IsAny<IReadOnlyCollection<ChatEntry>>(),
                 It.IsAny<IReadOnlyCollection<ChatSlice>>(),
@@ -83,7 +83,7 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
         IReadOnlyCollection<ChatSlice>? actualUpdates = null;
         IReadOnlyCollection<string>? actualRemoves = null;
         var sink = new Mock<ISink<ChatSlice, string>>(MockBehavior.Loose);
-        sink.Setup(x => x.ExecuteAsync(
+        _ = sink.Setup(x => x.ExecuteAsync(
                 It.IsAny<IReadOnlyCollection<ChatSlice>>(),
                 It.IsAny<IReadOnlyCollection<string>>(),
                 It.IsAny<CancellationToken>()))
@@ -94,9 +94,10 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
                     return Task.CompletedTask;
                 }
             );
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var maxTailSetSize = NewContent.Length / 2;
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper.Object, contentArranger.Object, sink.Object) {
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper.Object, contentArranger.Object, sink.Object, log.Object) {
             MaxTailSetSize = maxTailSetSize,
         };
 
@@ -143,9 +144,9 @@ public class ChatContentIndexerFlushTests(ITestOutputHelper @out) : TestBase(@ou
 
         // Check our buffers are in expected state
         Assert.Equal(NewContent.Length, contentIndexer.Buffer.Count);
-        Assert.Single(contentIndexer.OutUpdates);
+        _ = Assert.Single(contentIndexer.OutUpdates);
         Assert.True(contentIndexer.OutUpdates.ContainsKey(updatedDoc.Id));
-        Assert.Single(contentIndexer.OutRemoves);
+        _ = Assert.Single(contentIndexer.OutRemoves);
         Assert.Contains(removedDoc.Id, contentIndexer.OutRemoves);
 
         var contentCursor = await contentIndexer.FlushAsync(CancellationToken.None);

--- a/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerInitTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/ChatContent/ChatContentIndexerInitTests.cs
@@ -14,7 +14,7 @@ public class ChatContentIndexerInitTests(ITestOutputHelper @out) : TestBase(@out
         var tailDocuments = ChatContentTestHelpers.CreateDocuments();
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadTailAsync(
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatContentCursor>(),
@@ -24,9 +24,10 @@ public class ChatContentIndexerInitTests(ITestOutputHelper @out) : TestBase(@out
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
         var chatId = new ChatId(Generate.Option);
-        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink) {
+        var contentIndexer = new ChatContentIndexer(chatId, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object) {
             MaxTailSetSize = maxTailSetSize,
         };
 
@@ -53,7 +54,7 @@ public class ChatContentIndexerInitTests(ITestOutputHelper @out) : TestBase(@out
     {
         var chats = Mock.Of<IChatsBackend>(MockBehavior.Loose);
         var docLoader = new Mock<IChatContentDocumentLoader>(MockBehavior.Loose);
-        docLoader
+        _ = docLoader
             .Setup(x => x.LoadTailAsync(
                 It.IsAny<ChatId>(),
                 It.IsAny<ChatContentCursor>(),
@@ -63,10 +64,11 @@ public class ChatContentIndexerInitTests(ITestOutputHelper @out) : TestBase(@out
         var docMapper = Mock.Of<IChatContentMapper>(MockBehavior.Loose);
         var sink = Mock.Of<ISink<ChatSlice, string>>(MockBehavior.Loose);
         var contentArranger = Mock.Of<IChatContentArranger>(MockBehavior.Loose);
+        var log = LogMock.Create<ChatContentIndexer>();
 
-        var contentIndexer = new ChatContentIndexer(ChatId.None, chats, docLoader.Object, docMapper, contentArranger, sink);
+        var contentIndexer = new ChatContentIndexer(ChatId.None, chats, docLoader.Object, docMapper, contentArranger, sink, log.Object);
 
         var cursor = new ChatContentCursor(0, 0);
-        await Assert.ThrowsAsync<UniqueException>(() => contentIndexer.InitAsync(cursor, CancellationToken.None));
+        _ = await Assert.ThrowsAsync<UniqueException>(() => contentIndexer.InitAsync(cursor, CancellationToken.None));
     }
 }

--- a/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerShardTests.HandleCompletion.cs
+++ b/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerShardTests.HandleCompletion.cs
@@ -9,7 +9,7 @@ public partial class ChatIndexInitializerShardTests
     [Fact]
     public void HandleCompletionEventMethodIncrementsEventCounter()
     {
-        var evt = new MLSearch_TriggerChatIndexingCompletion(ChatId.None);
+        var evt = new MLSearch_SignalChatIndexingCompletion(ChatId.None);
         var state = new ChatIndexInitializerShard.SharedState(_fakeCursor, 1);
 
         var expected = state.EventCount + 1;
@@ -30,7 +30,7 @@ public partial class ChatIndexInitializerShardTests
         state.Semaphore.Wait();
         state.Semaphore.Wait();
 
-        var evt = new MLSearch_TriggerChatIndexingCompletion(chatId1);
+        var evt = new MLSearch_SignalChatIndexingCompletion(chatId1);
         ChatIndexInitializerShard.HandleCompletionEvent(evt, state);
 
         Assert.False(state.ScheduledJobs.ContainsKey(chatId1));
@@ -54,7 +54,7 @@ public partial class ChatIndexInitializerShardTests
 
         foreach (var _ in Enumerable.Range(0, 2)) {
             // Handle completion event for the same chat twice
-            var evt = new MLSearch_TriggerChatIndexingCompletion(chatId1);
+            var evt = new MLSearch_SignalChatIndexingCompletion(chatId1);
             ChatIndexInitializerShard.HandleCompletionEvent(evt, state);
         }
         // Verify only one semaphore slot is released
@@ -74,7 +74,7 @@ public partial class ChatIndexInitializerShardTests
         state.MaxVersion = 0;
         while (!state.ScheduledJobs.IsEmpty) {
             var chatId = state.ScheduledJobs.Keys.First();
-            var evt = new MLSearch_TriggerChatIndexingCompletion(chatId);
+            var evt = new MLSearch_SignalChatIndexingCompletion(chatId);
             ChatIndexInitializerShard.HandleCompletionEvent(evt, state);
         }
         Assert.Equal(versions.Max(), state.MaxVersion);

--- a/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerShardTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerShardTests.cs
@@ -83,7 +83,7 @@ public partial class ChatIndexInitializerShardTests(ITestOutputHelper @out) : Te
         var useTask = initializerShard.UseAsync(cancellationSource.Token);
 
         // Trigger job completion event
-        var completionEvt = new MLSearch_TriggerChatIndexingCompletion(new ChatId(Generate.Option));
+        var completionEvt = new MLSearch_SignalChatIndexingCompletion(new ChatId(Generate.Option));
         await initializerShard.PostAsync(completionEvt);
 
         // Wait for all flows to start
@@ -110,7 +110,7 @@ public partial class ChatIndexInitializerShardTests(ITestOutputHelper @out) : Te
                 It.Is<CancellationToken>(x => x == cancellationSource.Token)));
         mockCompleteJob
             .Verify(handler => handler(
-                It.Is<MLSearch_TriggerChatIndexingCompletion>(x => x == completionEvt),
+                It.Is<MLSearch_SignalChatIndexingCompletion>(x => x == completionEvt),
                 It.Is<ChatIndexInitializerShard.SharedState>(x => states.Add(x) || true)));
         mockUpdateCursor
             .Verify(handler => handler(
@@ -151,13 +151,13 @@ public partial class ChatIndexInitializerShardTests(ITestOutputHelper @out) : Te
         };
 
         var postTasks = Enumerable.Range(0, maxBufferCapacity)
-            .Select(_ => initializerShard.PostAsync(new MLSearch_TriggerChatIndexingCompletion(new ChatId(Generate.Option))).AsTask())
+            .Select(_ => initializerShard.PostAsync(new MLSearch_SignalChatIndexingCompletion(new ChatId(Generate.Option))).AsTask())
             .ToArray();
         // Ensure all posts up to buffer capacity are completed
         await Task.WhenAll(postTasks).WaitAsync(TimeSpan.FromSeconds(1));
 
         // Initiate over capacity Post call
-        var overCapacityPostTask = initializerShard.PostAsync(new MLSearch_TriggerChatIndexingCompletion(new ChatId(Generate.Option)));
+        var overCapacityPostTask = initializerShard.PostAsync(new MLSearch_SignalChatIndexingCompletion(new ChatId(Generate.Option)));
         Assert.False(overCapacityPostTask.IsCompleted);
 
         // Prepare using of shard
@@ -204,12 +204,12 @@ public partial class ChatIndexInitializerShardTests(ITestOutputHelper @out) : Te
     }
 
     private static Mock<ChatIndexInitializerShard.CompleteJobHandler> MockCompleteJobHandler(
-        Action<MLSearch_TriggerChatIndexingCompletion, ChatIndexInitializerShard.SharedState>? onCall = null
+        Action<MLSearch_SignalChatIndexingCompletion, ChatIndexInitializerShard.SharedState>? onCall = null
     )
     {
         var mock = new Mock<ChatIndexInitializerShard.CompleteJobHandler>(MockBehavior.Loose);
         mock.Setup(handler => handler(
-                It.IsAny<MLSearch_TriggerChatIndexingCompletion>(),
+                It.IsAny<MLSearch_SignalChatIndexingCompletion>(),
                 It.IsAny<ChatIndexInitializerShard.SharedState>()))
             .Callback(onCall ?? ((_, _) => {}));
         return mock;

--- a/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerTests.cs
+++ b/tests/MLSearch.UnitTests/Indexing/Initializer/ChatIndexInitializerTests.cs
@@ -67,7 +67,7 @@ public class ChatIndexInitializerTests(ITestOutputHelper @out) : TestBase(@out)
         await using var initializer = new ChatIndexInitializer(services, scheme, shardIndexResolver, shard, coordinator, logger);
         await Assert.ThrowsAsync<NotFoundException<ChatIndexInitializerShard>>(
             async () => await initializer.PostAsync(
-                new MLSearch_TriggerChatIndexingCompletion(ChatId.None), CancellationToken.None));
+                new MLSearch_SignalChatIndexingCompletion(ChatId.None), CancellationToken.None));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class ChatIndexInitializerTests(ITestOutputHelper @out) : TestBase(@out)
         _ = initializer.OnRun(InactiveShardIndex2, CancellationToken.None);
         await Assert.ThrowsAsync<NotFoundException<ChatIndexInitializerShard>>(
             async () => await initializer.PostAsync(
-                new MLSearch_TriggerChatIndexingCompletion(ChatId.None), CancellationToken.None));
+                new MLSearch_SignalChatIndexingCompletion(ChatId.None), CancellationToken.None));
     }
 
     [Theory]
@@ -106,7 +106,7 @@ public class ChatIndexInitializerTests(ITestOutputHelper @out) : TestBase(@out)
         var shard = new Mock<IChatIndexInitializerShard>(MockBehavior.Loose);
         shard
             .Setup(x => x.PostAsync(
-                It.IsAny<MLSearch_TriggerChatIndexingCompletion>(),
+                It.IsAny<MLSearch_SignalChatIndexingCompletion>(),
                 It.IsAny<CancellationToken>()))
             .Returns(ValueTask.CompletedTask)
             .Verifiable();
@@ -118,13 +118,13 @@ public class ChatIndexInitializerTests(ITestOutputHelper @out) : TestBase(@out)
             _ = initializer.OnRun(shardId, CancellationToken.None);
         }
 
-        var completionEvt = new MLSearch_TriggerChatIndexingCompletion(new ChatId(Generate.Option));
+        var completionEvt = new MLSearch_SignalChatIndexingCompletion(new ChatId(Generate.Option));
         var cancellationToken = new CancellationTokenSource().Token;
 
         await initializer.PostAsync(completionEvt, cancellationToken);
 
         shard.Verify(ms => ms.PostAsync(
-            It.Is<MLSearch_TriggerChatIndexingCompletion>(evt => evt==completionEvt),
+            It.Is<MLSearch_SignalChatIndexingCompletion>(evt => evt==completionEvt),
             It.Is<CancellationToken>(token => token==cancellationToken)
         ), Times.Once());
     }

--- a/tests/MLSearch.UnitTests/LogMock.cs
+++ b/tests/MLSearch.UnitTests/LogMock.cs
@@ -4,7 +4,8 @@ namespace ActualChat.MLSearch.UnitTests;
 
 public static class LogMock
 {
-    public static Mock<ILogger<T>> Create<T>() {
+    public static Mock<ILogger<T>> Create<T>()
+    {
         var logger = new Mock<ILogger<T>>(MockBehavior.Loose);
         logger
             .Setup(GetLogMethodExpression<T>())
@@ -12,21 +13,17 @@ public static class LogMock
         return logger;
     }
 
+    private static readonly Expression<Func<LogLevel, bool>> anyLogLevel = level => true;
+
     public static Expression<Action<ILogger<T>>> GetLogMethodExpression<T>(LogLevel? level = default)
     {
-        if (level.HasValue) {
-            return (ILogger<T> x) => x.Log(
-                It.Is<LogLevel>(lvl => lvl==level),
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>());
-        }
+        var logLevelCheck = level is null ? anyLogLevel : lvl => lvl == level;
         return (ILogger<T> x) => x.Log(
-            It.IsAny<LogLevel>(),
+            It.Is(logLevelCheck),
             It.IsAny<EventId>(),
             It.IsAny<It.IsAnyType>(),
             It.IsAny<Exception?>(),
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>());
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+        );
     }
 }


### PR DESCRIPTION
Indexing a single chat can take a considerable amount of time, as the process might be divided into several consecutive batches. In this PR, we inform first-time indexer upon the completion of each batch to prevent the job from timing out. Without this notification, the first-time indexers might schedule additional jobs, causing the number of active indexing jobs to exceed the specified upper limit.