### PR TITLE
agent: Opus 4.5: add base classes for indexing and periodic task flows

### DIFF
--- a/src/dotnet/Core.Server/Flows/IndexingBatch.cs
+++ b/src/dotnet/Core.Server/Flows/IndexingBatch.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace ActualChat.Flows;
+
+/// <summary>
+/// Result of processing a batch in an indexing flow.
+/// </summary>
+/// <typeparam name="TCursor">Type of the cursor tracking indexing progress.</typeparam>
+/// <param name="IsEmpty">True if no items were found in this batch.</param>
+/// <param name="IsTailReached">True if we've caught up with the data source (no more immediate work).</param>
+/// <param name="NextCursor">Updated cursor position after processing this batch.</param>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct IndexingBatch<TCursor>(
+    bool IsEmpty,
+    bool IsTailReached,
+    TCursor? NextCursor);

--- a/src/dotnet/Core.Server/Flows/NewBatchIndexingFlow.cs
+++ b/src/dotnet/Core.Server/Flows/NewBatchIndexingFlow.cs
@@ -1,0 +1,71 @@
+using ActualLab.Versioning;
+using MemoryPack;
+
+namespace ActualChat.Flows;
+
+/// <summary>
+/// Convenience base class for batched entity indexing flows.
+/// Subclasses implement <see cref="GetBatch"/> and <see cref="ProcessBatch"/> to define the indexing logic.
+/// Handles cursor management automatically using (Id, Version) pairs.
+/// </summary>
+/// <typeparam name="TItem">Entity type that has Id and Version.</typeparam>
+/// <typeparam name="TId">Id type (must be a StringIdentifier).</typeparam>
+public abstract class NewBatchIndexingFlow<TItem, TId> : NewIndexingFlow<IndexingFlowCursor<TId>>
+    where TItem : class, IHasId<TId>, IHasVersion<long>
+    where TId : StringIdentifier
+{
+    // ═══════════════════════════════════════════════════════════════════
+    // Configuration
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>Number of items per batch. GetBatch should return at most this many items.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual int BatchSize { get; } = 100;
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Abstract Methods - Subclasses Must Implement
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Fetch next batch of items starting from cursor.
+    /// Should return items with (Id &gt; cursor.LastUpdatedId) OR (Version &gt; cursor.LastUpdatedVersion).
+    /// Items should be ordered by (Version, Id) to ensure consistent pagination.
+    /// </summary>
+    /// <param name="cursor">Current cursor position (null = start from beginning).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of items to process (empty if nothing to index).</returns>
+    protected abstract Task<IReadOnlyList<TItem>> GetBatch(
+        IndexingFlowCursor<TId>? cursor,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Process a batch of items (save to search index, transform, etc).
+    /// </summary>
+    /// <param name="batch">Items to process.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    protected abstract Task ProcessBatch(
+        IReadOnlyList<TItem> batch,
+        CancellationToken cancellationToken);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Core Implementation
+    // ═══════════════════════════════════════════════════════════════════
+
+    protected sealed override async Task<IndexingBatch<IndexingFlowCursor<TId>>> ProcessNextBatch(
+        IndexingFlowCursor<TId>? cursor,
+        CancellationToken cancellationToken)
+    {
+        var items = await GetBatch(cursor, cancellationToken).ConfigureAwait(false);
+
+        if (items.Count == 0)
+            return new(IsEmpty: true, IsTailReached: true, NextCursor: cursor);
+
+        await ProcessBatch(items, cancellationToken).ConfigureAwait(false);
+
+        var last = items[^1];
+        var nextCursor = new IndexingFlowCursor<TId>(last.Id, last.Version);
+        var isTailReached = items.Count < BatchSize;
+
+        return new(IsEmpty: false, IsTailReached: isTailReached, NextCursor: nextCursor);
+    }
+}

--- a/src/dotnet/Core.Server/Flows/NewIndexingFlow.cs
+++ b/src/dotnet/Core.Server/Flows/NewIndexingFlow.cs
@@ -1,0 +1,148 @@
+using ActualChat.Flows.Infrastructure;
+using MemoryPack;
+
+namespace ActualChat.Flows;
+
+/// <summary>
+/// Base class for cursor-based indexing flows.
+/// Subclasses implement <see cref="ProcessNextBatch"/> to define the indexing logic.
+/// The flow handles scheduling, reindexing detection, and resume timing automatically.
+/// </summary>
+/// <typeparam name="TCursor">Type of the cursor tracking indexing progress.</typeparam>
+public abstract class NewIndexingFlow<TCursor> : Flow<Unit>
+{
+    // ═══════════════════════════════════════════════════════════════════
+    // Persisted State
+    // ═══════════════════════════════════════════════════════════════════
+
+    [DataMember(Order = 100), MemoryPackOrder(100)]
+    public TCursor? Cursor { get; protected set; }
+
+    [DataMember(Order = 101), MemoryPackOrder(101)]
+    public Moment LastRunAt { get; protected set; }
+
+    [DataMember(Order = 102), MemoryPackOrder(102)]
+    public int FlowSetVersion { get; protected set; }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Configuration (override in subclasses)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Current flow set version. Bump this to force reindexing.
+    /// When FlowSetVersion &lt; CurrentFlowSetVersion, the cursor is reset.
+    /// </summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected abstract int CurrentFlowSetVersion { get; }
+
+    /// <summary>Maximum batches to process per Resume() call before committing.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual int MaxBatchesPerResume { get; } = 10;
+
+    /// <summary>How often to check for new items when tail is reached and items were processed.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual TimeSpan RecheckInterval { get; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Watchdog timer interval when tail is reached and nothing was processed.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual TimeSpan WatchdogInterval { get; } = TimeSpan.FromHours(24);
+
+    /// <summary>Timer quantization for resume scheduling.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual TimeSpan TimerDelayQuanta { get; } = TimeSpan.FromSeconds(1);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Abstract Methods - Subclasses Must Implement
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Process the next batch starting from current cursor position.
+    /// Returns information about what was processed and where to continue.
+    /// </summary>
+    /// <param name="cursor">Current cursor position (null = start from beginning).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="IndexingBatch{TCursor}"/> indicating:
+    /// - IsEmpty: whether any items were found
+    /// - IsTailReached: whether we've caught up with the data source
+    /// - NextCursor: updated cursor position
+    /// </returns>
+    protected abstract Task<IndexingBatch<TCursor>> ProcessNextBatch(
+        TCursor? cursor,
+        CancellationToken cancellationToken);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Optional Hooks
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Called before first indexing run (on start or after reset/reindex).
+    /// Return false to suspend the flow (awaits external resume).
+    /// </summary>
+    protected virtual Task<bool> OnBeforeIndex(CancellationToken cancellationToken)
+        => Task.FromResult(true);
+
+    /// <summary>
+    /// Called when tail is reached. Can perform cleanup, request index refreshes, etc.
+    /// </summary>
+    protected virtual Task OnTailReached(bool hasProcessedAny, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Decides whether to use RecheckInterval (true) or WatchdogInterval (false) after tail is reached.
+    /// Default: recheck if we processed anything, watchdog if idle.
+    /// </summary>
+    protected virtual bool ShouldRecheck(bool hasProcessedAny)
+        => hasProcessedAny;
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Core Resume Logic
+    // ═══════════════════════════════════════════════════════════════════
+
+    protected sealed override async ValueTask Resume(CancellationToken cancellationToken)
+    {
+        Runtime.DefaultResumeDelayQuanta = TimerDelayQuanta;
+        var needsReindex = FlowSetVersion < CurrentFlowSetVersion;
+
+        // Handle initialization or reindex
+        if (needsReindex) {
+            Cursor = default;
+            FlowSetVersion = CurrentFlowSetVersion;
+            Console.Log($"Reset cursor for reindex (v{FlowSetVersion})");
+            if (!await OnBeforeIndex(cancellationToken).ConfigureAwait(false)) {
+                Console.Log("Suspended by OnBeforeIndex");
+                return; // No resume scheduled - awaits external trigger
+            }
+        }
+
+        LastRunAt = Runtime.Now;
+
+        // Process batches until quota exhausted or tail reached
+        var batchCount = 0;
+        var hasProcessedAny = false;
+        IndexingBatch<TCursor> batch;
+
+        do {
+            batch = await ProcessNextBatch(Cursor, cancellationToken).ConfigureAwait(false);
+            if (!batch.IsEmpty) {
+                hasProcessedAny = true;
+                Cursor = batch.NextCursor;
+            }
+            batchCount++;
+        } while (!batch.IsEmpty && !batch.IsTailReached && batchCount < MaxBatchesPerResume);
+
+        Console.Log($"Processed {batchCount} batches, hasProcessedAny={hasProcessedAny}, tailReached={batch.IsTailReached}");
+
+        // Schedule next resume
+        if (!batch.IsTailReached) {
+            Runtime.ScheduleResume(); // More work immediately
+            return;
+        }
+
+        await OnTailReached(hasProcessedAny, cancellationToken).ConfigureAwait(false);
+
+        var delay = ShouldRecheck(hasProcessedAny) ? RecheckInterval : WatchdogInterval;
+        Runtime.ScheduleResumeIn(delay);
+        Console.Log($"Tail reached, will resume in {delay.ToShortString()}");
+    }
+}

--- a/src/dotnet/Core.Server/Flows/NewPeriodicFlow.cs
+++ b/src/dotnet/Core.Server/Flows/NewPeriodicFlow.cs
@@ -1,0 +1,90 @@
+using ActualChat.Flows.Infrastructure;
+using MemoryPack;
+
+namespace ActualChat.Flows;
+
+/// <summary>
+/// Base class for flows that execute a task periodically.
+/// Subclasses implement <see cref="Run"/> and <see cref="ComputeNextRunAt"/> to define the behavior.
+/// </summary>
+public abstract class NewPeriodicFlow : Flow<Unit>
+{
+    // ═══════════════════════════════════════════════════════════════════
+    // Persisted State
+    // ═══════════════════════════════════════════════════════════════════
+
+    [DataMember(Order = 100), MemoryPackOrder(100)]
+    public Moment LastRunAt { get; protected set; }
+
+    [DataMember(Order = 101), MemoryPackOrder(101)]
+    public Moment? NextRunAt { get; protected set; }
+
+    [DataMember(Order = 102), MemoryPackOrder(102)]
+    public int RunCount { get; protected set; }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Configuration (override in subclasses)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>Maximum delay between runs (caps the result of <see cref="ComputeNextRunAt"/>).</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual TimeSpan MaxDelay { get; } = TimeSpan.FromDays(7);
+
+    /// <summary>Timer quantization for resume scheduling.</summary>
+    [IgnoreDataMember, MemoryPackIgnore]
+    protected virtual TimeSpan TimerDelayQuanta { get; } = TimeSpan.FromSeconds(1);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Abstract Methods - Subclasses Must Implement
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>Execute the periodic task.</summary>
+    protected abstract Task Run(CancellationToken cancellationToken);
+
+    /// <summary>Compute when to run next. The result is clamped to [now, now + MaxDelay].</summary>
+    protected abstract Moment ComputeNextRunAt(Moment now);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Optional Hooks
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Called before each run. Return null to proceed, or a reason string to end the flow.
+    /// </summary>
+    protected virtual Task<string?> OnBeforeRun(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Core Resume Logic
+    // ═══════════════════════════════════════════════════════════════════
+
+    protected sealed override async ValueTask Resume(CancellationToken cancellationToken)
+    {
+        Runtime.DefaultResumeDelayQuanta = TimerDelayQuanta;
+        var now = Runtime.Now;
+
+        // Check if we should end
+        var endReason = await OnBeforeRun(cancellationToken).ConfigureAwait(false);
+        if (endReason is not null) {
+            Console.Log($"Ending: {endReason}");
+            SetResult(default);
+            return;
+        }
+
+        // Check if it's time to run
+        if (NextRunAt is null || now >= NextRunAt) {
+            await Run(cancellationToken).ConfigureAwait(false);
+            LastRunAt = now;
+            RunCount++;
+            Console.Log($"Run #{RunCount} completed");
+            NextRunAt = null; // Will be recomputed below
+        }
+
+        // Schedule next run
+        var nextRunAt = ComputeNextRunAt(now);
+        nextRunAt = now + (nextRunAt - now).Clamp(TimeSpan.Zero, MaxDelay);
+        NextRunAt = nextRunAt;
+        Runtime.ScheduleResumeAt(nextRunAt);
+        Console.Log($"Next run at {nextRunAt}");
+    }
+}


### PR DESCRIPTION
We are going to re-implement PeriodicFlow, BatchedIndexingFlowBase and IndexingFlowBase on top of new "flows". There are a few goals:
1. We need to reimplement them Flow<TResult> descendants, combinding both indexing flows into a single type (there is no non-batched indexing). Flow<TResult> is the new base type for "new" flows, see FlowBackend.Start and OnEvent to learn how it works. You can assume it all works on a single machine, even though the service is actually distributed (sharded).
2. We'll keep only the essential logic there, i.e. get rid of any not-so-useful extras.

The key differnce between the new and legacy flows (LegacyFlowBase descenants) is that there is just one event it "reacts" to: FlowResume. New flows are pretty much like tasks on .NET, but persistent ones. Something is supposed to resume them once they have to make further progress, and the assumption is that they are resumed only via this event. See TimerFlow to see how it works, and compare it to LegacyTimerFlow. See tests on all these flows as well.

You don't have to worry about the compatibility with the old flows in terms of data retention. We'll simply restart the whole flow system / recreate every flow.

Ok, now, let's start from this:
1. Learn everything you need to start the task
2. Describe the fields and methods of new types you are plannign to create. Feel free to use NewXxx naming.
3. Once we agree on design, I'll ask you to implement all of that.

...

1. "New" prefix is fine
2. No, they shouldn't - we assume they could be resumed eventually (e.g. once a new item is added).
3. No need to reimplement master flow for indexing flows for now
4. No need to implement the retry policy for now.

...

You know, let's adjust this on new indexing flow:
- It's fully up to you to decide on the design, but assume every entity has Id (no constraints) and Version (long, timestamp-like), and besides that, we may want to index pages of entities rather than entities (think page is a range of Ids).
- You can also add any helper types, such as IndexingPager, etc. - it's all up to you.