### PR TITLE
fix: navigate to end does not work in some chats (e.g. when chat has few messages)

### DIFF
--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.razor.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.razor.cs
@@ -119,7 +119,7 @@ public sealed partial class VirtualList<TItem> : ComputedStateComponent<UIHub, V
 
     protected override bool ShouldRender()
     {
-        var shouldRender = !Data.IsSimilarTo(LastData) // Data changed
+        var shouldRender = !ReferenceEquals(Data, LastData) // Data changed
             || RenderIndex == 0 // OR very first sync render without data loaded
             || (LastReportedItemVisibility.VisibleKeys.Count == 0 && !Data.HasAllItems);
         if (JSRef != null! && !shouldRender)


### PR DESCRIPTION
- VirtualListData.IsSimilarTo should be used on the VirtualList client level