### PR TITLE
Fixed stale uploads cleaning and other minor stuff

### DIFF
--- a/src/dotnet/Media.Service/MediaProgressBackend.cs
+++ b/src/dotnet/Media.Service/MediaProgressBackend.cs
@@ -34,6 +34,7 @@ public class MediaProgressBackend(IServiceProvider services) : DbServiceBase<Med
 
         MediaProgress? progress;
         if (change.IsCreate(out var createProgress)) {
+            await dbContext.MediaProgresses.Lock(mediaId.Value, cancellationToken).ConfigureAwait(false);
             progress = createProgress with {
                 Version = VersionGenerator.NextVersion()
             };
@@ -41,6 +42,7 @@ public class MediaProgressBackend(IServiceProvider services) : DbServiceBase<Med
             dbContext.MediaProgresses.Add(dbMediaProgress);
         }
         else if (change.IsUpdate(out var updateProgress)) {
+            await dbContext.MediaProgresses.Lock(mediaId.Value, cancellationToken).ConfigureAwait(false);
             var dbMediaProgress = await dbContext.MediaProgresses
                 .Get(mediaId.Value, cancellationToken)
                 .ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentCleanup.cs
+++ b/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentCleanup.cs
@@ -30,4 +30,8 @@ public static class AttachmentCleanupFactory
                 uploadSessions.ReleaseReference(uploadSessionId);
                 return Task.CompletedTask;
             });
+
+    public static AttachmentCleanup ForStaleUploadSession(UploadSessions uploadSessions, string uploadSessionId)
+        => new (AttachmentCleanupKind.UploadSession,
+            () => uploadSessions.DeleteStaleSession(uploadSessionId));
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileAttachment.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileAttachment.razor
@@ -6,16 +6,12 @@
     MediaMimeTypes.TryGetExtension(Attachment.Media.ContentType, out var extension);
     var fileExtension = extension != null ? extension.Replace(".", "") : "";
     var fileCls = FileTypeHelper.FileColors.GetValueOrDefault(fileExtension, "file-default");
-    var iconOnlyCls = IconOnly ? "icon-only" : "";
-    var tooltipTitle = IconOnly ? GetTooltipTitle() : "";
 }
 
-<a class="file-attachment unfocusable @iconOnlyCls"
+<a class="file-attachment unfocusable"
    href="@url"
    target="_blank"
-   role="button"
-   data-tooltip="@tooltipTitle"
-   data-tooltip-position="@FloatingPosition.Top.ToPositionString()">
+   role="button">
     <div class="c-file-icon @fileCls">
         @if (fileCls == FileTypeHelper.FileClasses[FileType.Multimedia]) {
             <i class="icon-play-fill text-2xl"></i>
@@ -23,21 +19,19 @@
             <i class="icon-file text-xl"></i>
         }
     </div>
-    @if (!IconOnly) {
-        <div class="c-file-info">
-            <FileAttachmentTitle Title="@Attachment.Media.FileName"/>
-            <div class="c-bottom">
-                <div class="c-size">
-                    <span>@FileSizeFormatter.Format(fileSize)</span>
-                </div>
-                @if (_isLoaded) {
-                    <a class="c-open" href="@url" role="button">
-                        <span>Open in Folder</span>
-                    </a>
-                }
+    <div class="c-file-info">
+        <FileAttachmentTitle Title="@Attachment.Media.FileName"/>
+        <div class="c-bottom">
+            <div class="c-size">
+                <span>@FileSizeFormatter.Format(fileSize)</span>
             </div>
+            @if (_isLoaded) {
+                <a class="c-open" href="@url" role="button">
+                    <span>Open in Folder</span>
+                </a>
+            }
         </div>
-    }
+    </div>
 </a>
 
 @code {
@@ -49,10 +43,4 @@
 
     [Parameter, EditorRequired]
     public TextEntryAttachment Attachment { get; set; } = null!;
-    [Parameter] public bool IconOnly { get; set; }
-
-    private string GetTooltipTitle() {
-        var name = Attachment.Media.FileName;
-        return name.Length <= 24 ? name : $"{name[..10]}...{name[^10..]}";
-    }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileUploadAttachment.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileUploadAttachment.razor
@@ -13,8 +13,6 @@
     MediaMimeTypes.TryGetExtension(attachment.FileType, out var extension);
     var fileExtension = extension != null ? extension.Replace(".", "") : "";
     var fileCls = FileTypeHelper.FileColors.GetValueOrDefault(fileExtension, "file-default");
-    var iconOnlyCls = IconOnly ? "icon-only" : "";
-    var tooltipTitle = IconOnly ? GetTooltipTitle() : "";
     if (progress.IsFailed) {
         progressValue = Math.Max(progressValue, 30);
         uploadProgressClass += " attachment-upload-failed";
@@ -25,9 +23,7 @@
     var isUploading = progress.IsInProgress;
 }
 
-<div class="file-attachment upload-file unfocusable @iconOnlyCls"
-   data-tooltip="@tooltipTitle"
-   data-tooltip-position="@FloatingPosition.Top.ToPositionString()">
+<div class="file-attachment upload-file unfocusable">
     <div class="c-file-icon @fileCls">
         @if (previewState is PreviewAccessState.PendingGetAccessRequest) {
             <i class="icon-file-blocked text-2xl text-02"></i>
@@ -48,20 +44,18 @@
             }
         }
     </div>
-    @if (!IconOnly) {
-        <div class="c-file-info">
-            <FileAttachmentTitle Title="@attachment.FileName"/>
-            <div class="c-bottom">
-                <div class="c-size">
-                    <span>@FileSizeFormatter.Format(Attachment.Length)</span>
-                </div>
-                <div class="@uploadProgressClass"
-                     style="@uploadStyle"
-                     title="@stageDetails">
-                </div>
+    <div class="c-file-info">
+        <FileAttachmentTitle Title="@attachment.FileName"/>
+        <div class="c-bottom">
+            <div class="c-size">
+                <span>@FileSizeFormatter.Format(Attachment.Length)</span>
+            </div>
+            <div class="@uploadProgressClass"
+                 style="@uploadStyle"
+                 title="@stageDetails">
             </div>
         </div>
-    }
+    </div>
     @if (!progress.IsReady) {
         @if (progress.IsFailed && !state.NoAccess && RestartClick.HasDelegate) {
             <span class="reload-icon-wrapper">
@@ -75,12 +69,3 @@
         <i class="icon-trash03 text-2xl font-thin"></i>
     </ButtonRound>
 </div>
-
-@code {
-    [Parameter] public bool IconOnly { get; set; }
-
-    private string GetTooltipTitle() {
-        var name = Attachment.FileName;
-        return name.Length <= 24 ? name : $"{name[..10]}...{name[^10..]}";
-    }
-}

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
@@ -217,6 +217,7 @@ public sealed class BlazorUIAppModule(IServiceProvider moduleServices)
         fusion.AddService<ChatSendingMessagesTriggers>(ServiceLifetime.Scoped);
         services.AddScoped(c => new SendingMessages(c.AppUIHub()));
         services.AddScoped<VideoTranscoder>();
+        services.AddScoped<IUploadSessionRepo>(c => new UploadSessionRepo(c));
         services.AddScoped<UploadSessions>(c => new UploadSessions(c.AppUIHub()));
         services.AddScoped(c => new AttachmentsController(c.AppUIHub()));
         fusion.AddService<AttachmentsState>(ServiceLifetime.Scoped);

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionRepo.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionRepo.cs
@@ -4,7 +4,16 @@ using ActualChat.UI.Blazor.Services;
 
 namespace ActualChat.UI.Blazor.App.Services;
 
-public class UploadSessionRepo
+public interface IUploadSessionRepo
+{
+    Task Save(UploadSessionSnapshot session, bool flush = true);
+    Task<UploadSessionSnapshot?> Get(string sessionId);
+    Task<IEnumerable<KeyValuePair<string, UploadSessionSnapshot>>> GetAll();
+    Task Delete(string sessionId);
+    Task Flush();
+}
+
+public class UploadSessionRepo : IUploadSessionRepo
 {
     private readonly UploadSessionRepositoryInternal _internal;
 

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.Cleanup.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.Cleanup.cs
@@ -23,7 +23,7 @@ partial class UploadSessions
                     continue;
                 }
 
-                if (!CheckIfTouched(uploadSession.SessionId))
+                if (!CheckIfActive(uploadSession.SessionId))
                     staleItems.Add(item);
             }
 
@@ -40,7 +40,7 @@ partial class UploadSessions
             Log.LogDebug("About to delete {Count} stale upload sessions", staleItems.Count);
             foreach (var item in staleItems) {
                 try {
-                    var cleanup = AttachmentCleanupFactory.ForUploadSession(this, item.Key);
+                    var cleanup = AttachmentCleanupFactory.ForStaleUploadSession(this, item.Key);
                     await cleanup.Cleanup().ConfigureAwait(false);
                 }
                 catch (Exception ex) {

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
@@ -106,7 +106,11 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
 
         var fileProvider = snapshot.FileProvider;
         fileProvider.Initialize(Hub.Services);
-        await DeleteSessionResources(sessionId, fileProvider, snapshot.UploadId).ConfigureAwait(false);
+        await DeleteSessionResources(
+            sessionId,
+            fileProvider,
+            snapshot.TranscodedFilePath,
+            snapshot.UploadId).ConfigureAwait(false);
         Log.LogDebug("Deleted stale session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
     }
 
@@ -125,17 +129,12 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         var sessionId = session.SessionId;
         _sessions.TryRemove(sessionId, out _);
         var fileProvider = session.FileProvider;
-        await DeleteSessionResources(sessionId, fileProvider, session.UploadId).ConfigureAwait(false);
-        DeleteFile(session.TranscodedFilePath);
+        await DeleteSessionResources(
+            sessionId,
+            fileProvider,
+            session.TranscodedFilePath,
+            session.UploadId).ConfigureAwait(false);
         Log.LogDebug("Deleted session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
-    }
-
-    private static void DeleteFile(FilePath? filePath)
-    {
-        if (filePath?.IsEmpty != false || !File.Exists(filePath))
-            return;
-
-        File.Delete(filePath);
     }
 
     private Func<UploadSessionSnapshot, CancellationToken, Task> CreateStorage()
@@ -178,13 +177,22 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
     private bool CheckIfActive(string sessionId)
         => _sessions.TryGetValue(sessionId, out var sessionRef) && sessionRef.ReferenceCount > 0;
 
-    private async Task DeleteSessionResources(string sessionId, IFileProvider fileProvider, UploadId? uploadId)
+    private async Task DeleteSessionResources(string sessionId, IFileProvider fileProvider, string? transcodedFilePath, UploadId? uploadId)
     {
         if (uploadId is not null)
             await _uploadOperations.RemoveUpload(uploadId, CancellationToken.None).ConfigureAwait(false);
         await fileProvider.ClearForRemoving().ConfigureAwait(false);
+        DeleteFile(transcodedFilePath);
         await _repo.Delete(sessionId).ConfigureAwait(false);
         UploadSessionsState.Remove(sessionId);
+    }
+
+    private static void DeleteFile(FilePath? filePath)
+    {
+        if (filePath?.IsEmpty != false || !File.Exists(filePath))
+            return;
+
+        File.Delete(filePath);
     }
 
     // Nested types

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
@@ -5,7 +5,7 @@ namespace ActualChat.UI.Blazor.App.Services;
 public partial class UploadSessions : UIServiceBase<AppUIHub>
 {
     private readonly Task _cleanupTask;
-    private readonly UploadSessionRepo _repo;
+    private readonly IUploadSessionRepo _repo;
     private readonly UploadOperations _uploadOperations;
     private readonly ConcurrentDictionary<string, SessionRef> _sessions = new (StringComparer.Ordinal);
     private readonly Func<UploadSessionSnapshot, CancellationToken, Task> _storage;
@@ -14,7 +14,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
 
     public UploadSessions(AppUIHub hub) :base(hub)
     {
-        _repo = new UploadSessionRepo(hub.Services);
+        _repo = hub.Services.GetRequiredService<IUploadSessionRepo>();
         _uploadOperations = new UploadOperations(hub);
         _cleanupTask = BackgroundTask.Run(Cleanup);
         _storage = CreateStorage();
@@ -75,7 +75,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         Interlocked.Increment(ref sessionRef.ReferenceCount);
     }
 
-    public void ReleaseReference(string sessionId)
+    public void ReleaseReference(string sessionId, bool cancel = true)
     {
         if (!_sessions.TryGetValue(sessionId, out var sessionRef))
             throw new InvalidOperationException($"Session {sessionId} not found");
@@ -84,8 +84,35 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         if (newCount != 0)
             return;
 
-        var session = sessionRef.Session;
-        Log.LogDebug("Releasing reference for session '{SessionId}' ('{FileName}')", sessionId, session.FileProvider.Metadata.FileName);
+        if (!cancel)
+            return;
+
+        ReleaseSessionInternal(sessionRef.Session);
+    }
+
+    public async Task DeleteStaleSession(string sessionId)
+    {
+        if (_sessions.TryGetValue(sessionId, out var sessionRef) && sessionRef.ReferenceCount > 0)
+            throw StandardError.Constraint($"Session {sessionId} is active");
+
+        if (sessionRef is not null) {
+            ReleaseSessionInternal(sessionRef.Session);
+            return;
+        }
+
+        var snapshot = await _repo.Get(sessionId).ConfigureAwait(false);
+        if (snapshot is null)
+            return;
+
+        var fileProvider = snapshot.FileProvider;
+        fileProvider.Initialize(Hub.Services);
+        await DeleteSessionResources(sessionId, fileProvider, snapshot.UploadId).ConfigureAwait(false);
+        Log.LogDebug("Deleted stale session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
+    }
+
+    private void ReleaseSessionInternal(UploadSession session)
+    {
+        Log.LogDebug("Releasing reference for session '{SessionId}' ('{FileName}')", session.SessionId, session.FileProvider.Metadata.FileName);
         var completed = session.Cancel();
         _ = BackgroundTask.Run( async () => {
             await completed.WaitAsync(TimeSpan.FromSeconds(30)).SilentAwait(false);
@@ -96,14 +123,11 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
     private async Task DeleteSessionInternal(UploadSession session)
     {
         var sessionId = session.SessionId;
-        if (session.UploadId is {} uploadId)
-            await _uploadOperations.RemoveUpload(uploadId, CancellationToken.None).ConfigureAwait(false);
-        await session.FileProvider.ClearForRemoving().ConfigureAwait(false);
-        await _repo.Delete(sessionId).ConfigureAwait(false);
         _sessions.TryRemove(sessionId, out _);
-        UploadSessionsState.Remove(sessionId);
+        var fileProvider = session.FileProvider;
+        await DeleteSessionResources(sessionId, fileProvider, session.UploadId).ConfigureAwait(false);
         DeleteFile(session.TranscodedFilePath);
-        Log.LogDebug("Deleted session '{SessionId}' ('{FileName}')", sessionId, session.FileProvider.Metadata.FileName);
+        Log.LogDebug("Deleted session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
     }
 
     private static void DeleteFile(FilePath? filePath)
@@ -151,8 +175,17 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
     private void SetProgress(string sessionId, UploadSessionProgress progress)
         => UploadSessionsState.SetProgress(sessionId, progress);
 
-    private bool CheckIfTouched(string sessionId)
-        => _sessions.ContainsKey(sessionId);
+    private bool CheckIfActive(string sessionId)
+        => _sessions.TryGetValue(sessionId, out var sessionRef) && sessionRef.ReferenceCount > 0;
+
+    private async Task DeleteSessionResources(string sessionId, IFileProvider fileProvider, UploadId? uploadId)
+    {
+        if (uploadId is not null)
+            await _uploadOperations.RemoveUpload(uploadId, CancellationToken.None).ConfigureAwait(false);
+        await fileProvider.ClearForRemoving().ConfigureAwait(false);
+        await _repo.Delete(sessionId).ConfigureAwait(false);
+        UploadSessionsState.Remove(sessionId);
+    }
 
     // Nested types
     private class SessionRef(UploadSession session)

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.StartStoredRequests.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.StartStoredRequests.cs
@@ -23,10 +23,8 @@ partial class SendingMessages
             catch (Exception e) {
                 Log.LogError(e, "Failed to recreate stored post request");
                 // Failed to restart send message request.
-                // So forget about this request and cleanup attachment resources.
+                // So forget about this request.
                 await DiscardStoredPostRequest(entry.Uuid, cancellationToken).ConfigureAwait(false);
-                var uploadSessionIds = entry.AttachFileRequests.Select(x => x.UploadSessionId).ToArray();
-                await CleanupUploadSessions(entry.Uuid, uploadSessionIds).ConfigureAwait(false);
                 continue;
             }
             var resultSource = TaskCompletionSourceExt.New<ChatEntry?>();
@@ -49,20 +47,6 @@ partial class SendingMessages
         }
         catch (Exception e) {
             Log.LogError(e, "Failed to remove stored post request '{Id}'", postRequestUuid);
-        }
-    }
-
-    private async Task CleanupUploadSessions(string postRequestUuid, string[] uploadSessionIds)
-    {
-        foreach (var uploadSessionId in uploadSessionIds) {
-            try {
-                var cleanup = AttachmentCleanupFactory.ForUploadSession(UploadSessions, uploadSessionId);
-                await cleanup.Cleanup().ConfigureAwait(false);
-            }
-            catch (Exception e) {
-                Log.LogError(e, "Failed to cleanup upload session '{UploadSessionId}' for post request '{Id}'",
-                    uploadSessionId, postRequestUuid);
-            }
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
@@ -152,18 +152,11 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
         for (var i = 0; i < attachEntries.Length; i++) {
             var attachEntry = attachEntries[i];
             var sourceAttachment = sourceAttachments?[i];
-            var previewUrl = "";
-            Task<string> getPreviewUrl = Task.FromResult("");
-            AttachmentId? sourceAttachmentId = null;
-            if (sourceAttachment is SourceAttachment s) {
-                sourceAttachmentId = s.Id;
-                previewUrl = s.PreviewUrl;
-                getPreviewUrl = Task.FromResult(previewUrl);
-            }
+            AttachmentId? sourceAttachmentId = sourceAttachment?.Id;
+            var previewUrl = sourceAttachment is SourceAttachment s ? s.PreviewUrl : "";
             var uploadSessionId = attachEntry.UploadSessionId;
-            // TODO: to think what to do with this. For now UploadApp is responsible for resuming stored sessions.
-            var attachmentIsOk = false;
             Task<bool>? whenFilePermissionGranted = null;
+            Task<AttachmentPreview>? attachmentPreviewTask = null;
             try {
                 var session = await UploadSessions.TryGetSession(uploadSessionId).ConfigureAwait(false);
                 if (session is not null) {
@@ -180,30 +173,30 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
                             if (MediaTypeExt.IsVisualMedia(contentType))
                                 previewUrl = UrlMapper.ContentUrl(session.MediaRef.BlobId);
                         }
-                        if (!previewUrl.IsNullOrEmpty())
-                            getPreviewUrl = Task.FromResult(previewUrl);
-                        attachmentIsOk = true;
+                        attachmentPreviewTask = Task.FromResult(AttachmentPreview.Preview(previewUrl));
                     }
                     else {
                         var fileProvider = session.FileProvider;
                         var canAccess = await fileProvider.CheckAccess().ConfigureAwait(false);
                         if (canAccess) {
                             var whenUserConsentGrantedTask = fileProvider.WhenUserConsentGranted();
-                            if (!previewUrl.IsNullOrEmpty())
-                                getPreviewUrl = Task.FromResult(previewUrl);
-                            else if (MediaTypeExt.IsVisualMedia(fileProvider.Metadata.FileType)) {
-                                getPreviewUrl = GetPreviewUrl();
-                                async Task<string> GetPreviewUrl() {
-                                    var consentGranted = await whenUserConsentGrantedTask.ConfigureAwait(false);
-                                    if (!consentGranted)
-                                        return "";
-
-                                    var preview2 = await fileProvider.GetPreviewUrl().ConfigureAwait(false);
-                                    return preview2;
-                                }
-                            }
                             whenFilePermissionGranted = whenUserConsentGrantedTask;
-                            attachmentIsOk = true;
+                            attachmentPreviewTask = GetAttachmentPreviewUrl();
+
+                            async Task<AttachmentPreview> GetAttachmentPreviewUrl() {
+                                if (!previewUrl.IsNullOrEmpty())
+                                    return AttachmentPreview.Preview(previewUrl);
+
+                                var consentGranted = await whenUserConsentGrantedTask.ConfigureAwait(false);
+                                if (!consentGranted)
+                                    return AttachmentPreview.NoFileAccess;
+
+                                if (!MediaTypeExt.IsVisualMedia(fileProvider.Metadata.FileType))
+                                    return AttachmentPreview.Preview("");
+
+                                var previewUrl2 = await fileProvider.GetPreviewUrl().ConfigureAwait(false);
+                                return AttachmentPreview.Preview(previewUrl2);
+                            }
                         }
                     }
                 }
@@ -212,6 +205,8 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
                 Log.LogError(e, "Failed to get upload session '{UploadSessionId}'", uploadSessionId);
                 // Intended
             }
+
+            attachmentPreviewTask ??= Task.FromResult(AttachmentPreview.NoFileAccess);
 
             async Task CleanupRequest()
                 => await _requestsRepo.RemoveAttachRequest(entry.Uuid, attachEntry, CancellationToken.None).ConfigureAwait(false);
@@ -230,7 +225,7 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
             if (sourceAttachmentId is not null)
                 attachmentsState.Unregister(sourceAttachmentId.Value);
             attachmentsState.Register(attachment);
-            var attachmentInfo = new AttachmentInfo(attachment, !attachmentIsOk, whenFilePermissionGranted ?? Task.FromResult(false), getPreviewUrl);
+            var attachmentInfo = new AttachmentInfo(attachment, whenFilePermissionGranted ?? Task.FromResult(false), attachmentPreviewTask);
             attachmentInfos.Add(attachmentInfo);
         }
         if (attachmentInfos.Count == 0)
@@ -242,12 +237,7 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
         foreach (var attachmentInfo in attachmentInfos) {
             var attachment = attachmentInfo.Attachment;
             attachmentList.Add(attachment);
-            if (attachmentInfo.NoFileAccess) {
-                attachmentsState.SetPreview(attachment.Id, AttachmentPreview.NoFileAccess);
-                continue;
-            }
-            SubscribeFilePermissionsGranted(attachment.Id, attachmentInfo.WhenFilePermissionGranted);
-            SubscribePreviewResolved(attachment.Id, attachmentInfo.GetPreviewUrl);
+            SetAttachmentPreview(attachment.Id, attachmentInfo.WhenFilePermissionGranted, attachmentInfo.GetPreview);
             var attachmentProgress = await attachmentsState.GetProgress(attachment.Id, default).ConfigureAwait(false);
             if (attachmentProgress.IsReady || attachmentProgress.IsFailed)
                 continue;
@@ -256,24 +246,28 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
         return new AttachmentUploads(attachmentList, attachmentsState);
     }
 
-    private void SubscribePreviewResolved(AttachmentId attachmentId, Task<string> getPreviewUrl)
+    private void SetAttachmentPreview(
+        AttachmentId attachmentId,
+        Task<bool> whenFilePermissionGranted,
+        Task<AttachmentPreview> getPreview)
     {
-        _ =  getPreviewUrl.ContinueWith(t => {
+        if (getPreview.IsCompletedSuccessfully) {
+            var preview = getPreview.GetAwaiter().GetResult();
+            AttachmentsState.SetPreview(attachmentId, preview);
+            return;
+        }
+
+        if (!whenFilePermissionGranted.IsCompleted)
+            AttachmentsState.SetPreview(attachmentId, AttachmentPreview.PendingGetAccessRequest);
+
+        _ = getPreview.ContinueWith(_ => {
             // Preview resolved.
+            var preview = getPreview.GetAwaiter().GetResult();
 #pragma warning disable VSTHRD002
-            AttachmentsState.SetPreview(attachmentId, AttachmentPreview.Preview(t.GetAwaiter().GetResult()));
- #pragma warning restore VSTHRD002
+            AttachmentsState.SetPreview(attachmentId, preview);
+#pragma warning restore VSTHRD002
         }, TaskScheduler.Default);
     }
-
-    private void SubscribeFilePermissionsGranted(AttachmentId attachmentId, Task<bool> whenFilePermissionGranted)
-        => _ = whenFilePermissionGranted.ContinueWith(t => {
-            if (t.GetAwaiter().GetResult())
-                return;
-
-            // File permission was denied.
-            AttachmentsState.SetPreview(attachmentId, AttachmentPreview.NoFileAccess);
-        }, TaskScheduler.Default);
 
     private async Task CleanupAttachments(string postRequestUuid, IEnumerable<Attachment> attachments)
     {
@@ -521,7 +515,6 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
 
     private sealed record AttachmentInfo(
         Attachment Attachment,
-        bool NoFileAccess,
         Task<bool> WhenFilePermissionGranted,
-        Task<string> GetPreviewUrl);
+        Task<AttachmentPreview> GetPreview);
 }

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
@@ -148,102 +148,133 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
             throw StandardError.Internal("Source attachments count is not equal to attach file requests count.");
 
         var attachmentInfos = new List<AttachmentInfo>();
-        var attachmentsState = AttachmentsState;
-        for (var i = 0; i < attachEntries.Length; i++) {
-            var attachEntry = attachEntries[i];
-            var sourceAttachment = sourceAttachments?[i];
-            AttachmentId? sourceAttachmentId = sourceAttachment?.Id;
-            var previewUrl = sourceAttachment is SourceAttachment s ? s.PreviewUrl : "";
-            var uploadSessionId = attachEntry.UploadSessionId;
-            Task<bool>? whenFilePermissionGranted = null;
-            Task<AttachmentPreview>? attachmentPreviewTask = null;
-            try {
-                var session = await UploadSessions.TryGetSession(uploadSessionId).ConfigureAwait(false);
-                if (session is not null) {
-                    if (session.IsCompleted) {
-                        // If media was already uploaded, use it directly to display a preview.
-                        // Do not try to access the file.
-                        whenFilePermissionGranted = NeverGetFilePermission();
-                        async Task<bool> NeverGetFilePermission() {
-                            await TaskExt.NeverEnding(CancellationToken.None).ConfigureAwait(false);
-                            return false;
-                        }
-                        if (previewUrl.IsNullOrEmpty()) {
-                            var contentType = session.FileProvider.Metadata.FileType;
-                            if (MediaTypeExt.IsVisualMedia(contentType))
-                                previewUrl = UrlMapper.ContentUrl(session.MediaRef.BlobId);
-                        }
-                        attachmentPreviewTask = Task.FromResult(AttachmentPreview.Preview(previewUrl));
+        try {
+            for (var i = 0; i < attachEntries.Length; i++) {
+                var attachEntry = attachEntries[i];
+                var sourceAttachment = sourceAttachments?[i];
+                AttachmentId? sourceAttachmentId = sourceAttachment?.Id;
+                var previewUrl = sourceAttachment is SourceAttachment s ? s.PreviewUrl : "";
+                var uploadSessionId = attachEntry.UploadSessionId;
+                Task<bool>? whenFilePermissionGranted = null;
+                Task<AttachmentPreview>? attachmentPreviewTask = null;
+                UploadSession? session = null;
+                try {
+                    session = await UploadSessions.TryGetSession(uploadSessionId).ConfigureAwait(false);
+                }
+                catch (Exception e) {
+                    Log.LogError(e,
+                        "Failed to get upload session '{UploadSessionId}' for attachment '{Attachment}'",
+                        uploadSessionId,
+                        attachEntry.FileName);
+                }
+                // Skip this attachment.
+                if (session is null)
+                    continue;
+
+                if (session.IsCompleted) {
+                    // If media was already uploaded, use it directly to display a preview.
+                    // Do not try to access the file.
+                    whenFilePermissionGranted = NeverGetFilePermission();
+
+                    async Task<bool> NeverGetFilePermission()
+                    {
+                        await TaskExt.NeverEnding(CancellationToken.None).ConfigureAwait(false);
+                        return false;
                     }
-                    else {
-                        var fileProvider = session.FileProvider;
-                        var canAccess = await fileProvider.CheckAccess().ConfigureAwait(false);
-                        if (canAccess) {
-                            var whenUserConsentGrantedTask = fileProvider.WhenUserConsentGranted();
-                            whenFilePermissionGranted = whenUserConsentGrantedTask;
-                            attachmentPreviewTask = GetAttachmentPreviewUrl();
 
-                            async Task<AttachmentPreview> GetAttachmentPreviewUrl() {
-                                if (!previewUrl.IsNullOrEmpty())
-                                    return AttachmentPreview.Preview(previewUrl);
+                    if (previewUrl.IsNullOrEmpty()) {
+                        var contentType = session.FileProvider.Metadata.FileType;
+                        if (MediaTypeExt.IsVisualMedia(contentType))
+                            previewUrl = UrlMapper.ContentUrl(session.MediaRef.BlobId);
+                    }
+                    attachmentPreviewTask = Task.FromResult(AttachmentPreview.Preview(previewUrl));
+                }
+                else {
+                    var fileProvider = session.FileProvider;
+                    var canAccess = await fileProvider.CheckAccess().ConfigureAwait(false);
+                    if (canAccess) {
+                        var whenUserConsentGrantedTask = fileProvider.WhenUserConsentGranted();
+                        whenFilePermissionGranted = whenUserConsentGrantedTask;
+                        attachmentPreviewTask = GetAttachmentPreviewUrl();
 
-                                var consentGranted = await whenUserConsentGrantedTask.ConfigureAwait(false);
-                                if (!consentGranted)
-                                    return AttachmentPreview.NoFileAccess;
+                        async Task<AttachmentPreview> GetAttachmentPreviewUrl()
+                        {
+                            if (!previewUrl.IsNullOrEmpty())
+                                return AttachmentPreview.Preview(previewUrl);
 
-                                if (!MediaTypeExt.IsVisualMedia(fileProvider.Metadata.FileType))
-                                    return AttachmentPreview.Preview("");
+                            var consentGranted = await whenUserConsentGrantedTask.ConfigureAwait(false);
+                            if (!consentGranted)
+                                return AttachmentPreview.NoFileAccess;
 
-                                var previewUrl2 = await fileProvider.GetPreviewUrl().ConfigureAwait(false);
-                                return AttachmentPreview.Preview(previewUrl2);
-                            }
+                            if (!MediaTypeExt.IsVisualMedia(fileProvider.Metadata.FileType))
+                                return AttachmentPreview.Preview("");
+
+                            var previewUrl2 = await fileProvider.GetPreviewUrl().ConfigureAwait(false);
+                            return AttachmentPreview.Preview(previewUrl2);
                         }
                     }
                 }
+
+                attachmentPreviewTask ??= Task.FromResult(AttachmentPreview.NoFileAccess);
+
+                async Task CleanupRequest()
+                    => await _requestsRepo.RemoveAttachRequest(entry.Uuid, attachEntry, CancellationToken.None)
+                        .ConfigureAwait(false);
+
+                var attachment = new Attachment(
+                    attachEntry.FileName,
+                    attachEntry.FileType,
+                    attachEntry.FileLength,
+                    attachEntry.Width,
+                    attachEntry.Height) {
+                    UploadSessionId = uploadSessionId,
+                };
+                attachment.Cleanups.Add(new AttachmentCleanup(AttachmentCleanupKind.PersistedPostMessageRequest, CleanupRequest));
+                UploadSessions.AddReference(uploadSessionId);
+                attachment.Cleanups.Add(AttachmentCleanupFactory.ForUploadSession(UploadSessions, uploadSessionId));
+                if (sourceAttachmentId is not null)
+                    AttachmentsState.Unregister(sourceAttachmentId.Value);
+                AttachmentsState.Register(attachment);
+                var attachmentInfo = new AttachmentInfo(attachment,
+                    whenFilePermissionGranted ?? Task.FromResult(false),
+                    attachmentPreviewTask);
+                attachmentInfos.Add(attachmentInfo);
             }
-            catch (Exception e) {
-                Log.LogError(e, "Failed to get upload session '{UploadSessionId}'", uploadSessionId);
-                // Intended
+            if (attachmentInfos.Count == 0)
+                return null;
+
+            var attachmentsController = Services.GetRequiredService<AttachmentsController>();
+            var attachmentList = new AttachmentList();
+            attachmentList.Subscribe(attachmentsController);
+            foreach (var attachmentInfo in attachmentInfos) {
+                var attachment = attachmentInfo.Attachment;
+                attachmentList.Add(attachment);
+                SetAttachmentPreview(attachment.Id, attachmentInfo.WhenFilePermissionGranted, attachmentInfo.GetPreview);
+                var attachmentProgress = await AttachmentsState.GetProgress(attachment.Id, default).ConfigureAwait(false);
+                if (attachmentProgress.IsReady || attachmentProgress.IsFailed)
+                    continue;
+
+                attachmentsController.ResumeUpload(attachment);
             }
-
-            attachmentPreviewTask ??= Task.FromResult(AttachmentPreview.NoFileAccess);
-
-            async Task CleanupRequest()
-                => await _requestsRepo.RemoveAttachRequest(entry.Uuid, attachEntry, CancellationToken.None).ConfigureAwait(false);
-
-            var attachment = new Attachment(
-                attachEntry.FileName,
-                attachEntry.FileType,
-                attachEntry.FileLength,
-                attachEntry.Width,
-                attachEntry.Height) {
-                UploadSessionId = uploadSessionId,
-            };
-            attachment.Cleanups.Add(new AttachmentCleanup(AttachmentCleanupKind.PersistedPostMessageRequest, CleanupRequest));
-            UploadSessions.AddReference(uploadSessionId);
-            attachment.Cleanups.Add(AttachmentCleanupFactory.ForUploadSession(UploadSessions, uploadSessionId));
-            if (sourceAttachmentId is not null)
-                attachmentsState.Unregister(sourceAttachmentId.Value);
-            attachmentsState.Register(attachment);
-            var attachmentInfo = new AttachmentInfo(attachment, whenFilePermissionGranted ?? Task.FromResult(false), attachmentPreviewTask);
-            attachmentInfos.Add(attachmentInfo);
+            return new AttachmentUploads(attachmentList, AttachmentsState);
         }
-        if (attachmentInfos.Count == 0)
-            return null;
-
-        var attachmentsController = Services.GetRequiredService<AttachmentsController>();
-        var attachmentList = new AttachmentList();
-        attachmentList.Subscribe(attachmentsController);
-        foreach (var attachmentInfo in attachmentInfos) {
-            var attachment = attachmentInfo.Attachment;
-            attachmentList.Add(attachment);
-            SetAttachmentPreview(attachment.Id, attachmentInfo.WhenFilePermissionGranted, attachmentInfo.GetPreview);
-            var attachmentProgress = await attachmentsState.GetProgress(attachment.Id, default).ConfigureAwait(false);
-            if (attachmentProgress.IsReady || attachmentProgress.IsFailed)
-                continue;
-            attachmentsController.ResumeUpload(attachment);
+        catch (Exception e) {
+            Log.LogError(e, "Failed to create attachment uploads for post request '{Id}'", entry.Uuid);
+            foreach (var attachmentInfo in attachmentInfos) {
+                var attachment = attachmentInfo.Attachment;
+                try {
+                    AttachmentsState.Unregister(attachment.Id);
+                    // NOTE(DF): during starting stored requests, it might be that there multiple consumers for the same upload it.
+                    // So we can't delete the upload session until all stored requests are processed.
+                    UploadSessions.ReleaseReference(attachment.UploadSessionId, false);
+                }
+                catch (Exception e2) {
+                    Log.LogError(e2, "Failed to release attachment resources. Attachment: '{AttachmentId}', UploadSession: '{UploadSessionId}', File: '{FileName}'",
+                        attachment.Id, attachment.UploadSessionId, attachment.FileName);
+                }
+            }
+            throw;
         }
-        return new AttachmentUploads(attachmentList, attachmentsState);
     }
 
     private void SetAttachmentPreview(

--- a/tests/Chat.IntegrationTests/InMemoryUploadSessionRepo.cs
+++ b/tests/Chat.IntegrationTests/InMemoryUploadSessionRepo.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+public class InMemoryUploadSessionRepo : IUploadSessionRepo
+{
+    private readonly ConcurrentDictionary<string, UploadSessionSnapshot> _sessions = new();
+
+    public Task Save(UploadSessionSnapshot session, bool flush = true)
+    {
+        _sessions[session.SessionId] = session;
+        return Task.CompletedTask;
+    }
+
+    public Task<UploadSessionSnapshot?> Get(string sessionId)
+        => Task.FromResult(_sessions.GetValueOrDefault(sessionId));
+
+    public Task<IEnumerable<KeyValuePair<string, UploadSessionSnapshot>>> GetAll()
+        => Task.FromResult<IEnumerable<KeyValuePair<string, UploadSessionSnapshot>>>(_sessions.ToArray());
+
+    public Task Delete(string sessionId)
+    {
+        _sessions.TryRemove(sessionId, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task Flush() => Task.CompletedTask;
+}

--- a/tests/Chat.IntegrationTests/UploadSessionFlowTest.cs
+++ b/tests/Chat.IntegrationTests/UploadSessionFlowTest.cs
@@ -64,6 +64,78 @@ public class UploadSessionFlowTest(ChatCollection.AppHostFixture fixture, ITestO
         media.BlobId.Should().Be(uploadSession.MediaRef.BlobId);
     }
 
+    [Fact]
+    public async Task ShouldRestoreUploadSessionFromRepo()
+    {
+        await using var appHost = await NewAppHost("restore-session", options => options with {
+            ConfigureServices = (_, services) => {
+                services.AddScoped<IUploadSessionRepo, InMemoryUploadSessionRepo>();
+            },
+        });
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+
+        var hub = tester.ScopedAppServices.AppUIHub();
+        var repo = tester.ScopedAppServices.GetRequiredService<IUploadSessionRepo>();
+        var uploadSessions = hub.UploadSessions;
+
+        var testContent = "Test content for restore"u8.ToArray();
+        var fileProvider = new DataFileProvider(testContent, "restore-test.txt", "text/plain");
+        var metadata = new PropertyBag().Set("TestKey", "TestValue");
+
+        var uploadOperations = new UploadOperations(hub);
+        var snapshot = UploadSession.NewUploadSnapshot(fileProvider, metadata, uploadOperations.Now(), "restore-test");
+
+        // Save snapshot directly to repo (bypasses _sessions dictionary)
+        await repo.Save(snapshot);
+
+        // Act: TryGetSession should load from repo
+        var session = await uploadSessions.TryGetSession(snapshot.SessionId);
+
+        // Assert
+        session.Should().NotBeNull();
+        session.SessionId.Should().Be(snapshot.SessionId);
+        session.CurrentState.Should().Be(snapshot.CurrentState);
+        session.FileName.Should().Be("restore-test.txt");
+    }
+
+    [Fact]
+    public async Task ShouldDeleteStaleUploadSession()
+    {
+        await using var appHost = await NewAppHost("delete-stale-session", options => options with {
+            ConfigureServices = (_, services) => {
+                services.AddScoped<IUploadSessionRepo, InMemoryUploadSessionRepo>();
+            },
+        });
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+
+        var hub = tester.ScopedAppServices.AppUIHub();
+        var repo = tester.ScopedAppServices.GetRequiredService<IUploadSessionRepo>();
+        var uploadSessions = hub.UploadSessions;
+
+        var testContent = "Test content for stale delete"u8.ToArray();
+        var fileProvider = new DataFileProvider(testContent, "stale-test.txt", "text/plain");
+        var metadata = new PropertyBag().Set("TestKey", "TestValue");
+
+        var uploadOperations = new UploadOperations(hub);
+        var snapshot = UploadSession.NewUploadSnapshot(fileProvider, metadata, uploadOperations.Now(), "stale-test");
+
+        // Save snapshot directly to repo (bypasses _sessions dictionary — simulates stale session)
+        await repo.Save(snapshot);
+
+        // Act: DeleteSession should handle a session not in _sessions
+        await uploadSessions.DeleteStaleSession(snapshot.SessionId);
+
+        // Assert: session is deleted from repo
+        var repoSession = await repo.Get(snapshot.SessionId);
+        repoSession.Should().BeNull();
+
+        // Assert: TryGetSession also returns null
+        var session = await uploadSessions.TryGetSession(snapshot.SessionId);
+        session.Should().BeNull();
+    }
+
     // Test file provider that uploads data via ChunkedFileUploader
     private sealed class DataFileProvider : IFileProvider
     {


### PR DESCRIPTION
- Fixed stale uploads cleaning 
- Fixed: attachment status is not displayed correctly for some attachments (no file access, pending user grant access request)
- Get rid of IconOnly parameter in attachments (not used)
- Added locking to prevent concurrent updates of MediaProgress entries