### PR TITLE
Feat/1xxx historical playback

### DIFF
--- a/src/dotnet/Api/MediaPlayback/TrackInfo.cs
+++ b/src/dotnet/Api/MediaPlayback/TrackInfo.cs
@@ -7,4 +7,5 @@ public record TrackInfo(Symbol TrackId, bool IsStreaming)
 {
     public Moment RecordedAt { get; init; }
     public Moment ClientSideRecordedAt { get; init; }
+    public double Speed { get; init; } = 1.0;
 }

--- a/src/dotnet/UI.Blazor.App/Components/AudioPlayer/AudioTrackPlayer.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioPlayer/AudioTrackPlayer.cs
@@ -41,7 +41,7 @@ public sealed class AudioTrackPlayer : TrackPlayer, IAudioPlayerBackend
             "[AudioTrackPlayer #{AudioTrackPlayerId}] OnPlayingAt: {Offset}, {IsPaused}, buffer: {IsBufferLow}",
             _id, offset, isPaused ? "paused" : "playing", isBufferLow ? "low" : "ok");
         UpdateBufferState(isBufferLow);
-        SetPlaybackState(TimeSpan.FromSeconds(offset), isPaused);
+        SetPlaybackState(TimeSpan.FromSeconds(offset * TrackInfo.Speed), isPaused);
         if (_reportSyncToJs) {
             var state = isPaused ? "paused" : "playing";
             _ = Services.JSRuntime().InvokeVoidAsync(

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlayableTextMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlayableTextMarkupView.razor
@@ -265,10 +265,12 @@
         return "";
     }
 
-    public override ValueTask DisposeAsync() {
+    public override async ValueTask DisposeAsync() {
         var m = State.Value;
         m.ColorLease?.Release();
-        return base.DisposeAsync();
+        await JSRef.DisposeSilentlyAsync("dispose");
+        BlazorRef.DisposeSilently();
+        await base.DisposeAsync();
     }
 
     private static string InsertBreaks(string lastWord, int interval) {

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/playable-text-markup-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/playable-text-markup-view.ts
@@ -165,8 +165,9 @@ export class PlayableTextMarkupView {
 
         setTimeout(() => {
             floatSpan.remove();
-            void this.blazorRef.invokeMethodAsync('OnMarkupClick', word.textRange);
         }, 400);
+
+        void this.blazorRef.invokeMethodAsync('OnMarkupClick', word.textRange);
     }
 }
 

--- a/src/dotnet/UI.Blazor.App/Services/Playback/ChatReplayer.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Playback/ChatReplayer.cs
@@ -70,7 +70,7 @@ public sealed class ChatReplayer : ChatPlayer
             if (playbackStartedAt == default)
                 playbackStartedAt = CpuTimestamp.Now;
             var trackTask = OnStreamStarted(
-                entryPlayer, info, playsAt, frames,
+                entryPlayer, info, playsAt, frames, speed,
                 playbackStartedAt, sleepDurationAtStart, pauseDurationAtStart,
                 cancellationToken);
             trackTasks.Add(trackTask);
@@ -88,6 +88,7 @@ public sealed class ChatReplayer : ChatPlayer
         LiveStreamInfo streamInfo,
         TimeSpan playsAt,
         IAsyncEnumerable<byte[]> audioFrames,
+        double speed,
         CpuTimestamp playbackStartedAt,
         TimeSpan sleepDurationAtStart,
         TimeSpan pauseDurationAtStart,
@@ -127,10 +128,12 @@ public sealed class ChatReplayer : ChatPlayer
                     ? new ChatAudioTrackInfo(audioEntry, chat, author!) {
                         RecordedAt = streamInfo.BeginsAt,
                         ClientSideRecordedAt = streamInfo.BeginsAt,
+                        Speed = speed,
                     }
                     : new ChatAudioTrackInfo(ChatId, streamInfo.EntryId, chat, author) {
                         RecordedAt = streamInfo.BeginsAt,
                         ClientSideRecordedAt = streamInfo.BeginsAt,
+                        Speed = speed,
                     };
                 var playAt = Clocks.CpuClock.Now;
                 var process = entryPlayer.Playback.Play(trackInfo, audioSource, playAt, cancellationToken);


### PR DESCRIPTION
- fix: properly dispose JS and Blazor references in PlayableTextMarkupView
- fix: eliminate 400ms delay between PlayableTextMarkupView click and OnMarkupClick invocation
- fix: PlayerState.PlayingAt is incorrect when Replay with speed different from 1.0 is performing