### PR TITLE
fix: show message menu for entries with uploading attachments and empty ClientUid

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatEntryEx.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatEntryEx.cs
@@ -10,7 +10,7 @@ public static class ChatEntryEx
             return chatEntry.Id.Value;
 
         var useClientId = chatEntry.IsSending || chatEntry.HasUploadingAttachments && isOwnMessage;
-        if (useClientId)
+        if (useClientId && !chatEntry.ClientUid.IsNullOrEmpty())
             return chatEntry.ClientUid;
 
         return chatEntry.Id.Value;


### PR DESCRIPTION
When a message with attachments was already posted but HasUploadingAttachments flag was still true, GetClientId returned empty ClientUid causing MessageMenu to render empty (Model.None). Now falls back to entry Id when ClientUid is empty.