### PR TITLE
feat: add ShardLocalCache<TKey, TValue> for shard-ownership-aware in-…

### DIFF
--- a/src/dotnet/Core.Server/Sharding/ShardLocalCache.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardLocalCache.cs
@@ -31,14 +31,11 @@ public sealed class ShardLocalCache<TKey, TValue>
     {
         var ownership = _shardOwner.RequireShardOwnership(key, addDependency, cancellationToken);
         return ownership.IsCompleted
-            ? GetOrAdd(key, ownership.Result)
+            ? new ValueTask<TValue>(GetOrAdd(key, ownership.Result))
             : CompleteAsync(key, ownership);
 
         async ValueTask<TValue> CompleteAsync(TKey k, ValueTask<ShardOwnership> ownershipTask)
-        {
-            var o = await ownershipTask.ConfigureAwait(false);
-            return GetOrAdd(k, o).Result;
-        }
+            => GetOrAdd(k, await ownershipTask.ConfigureAwait(false));
     }
 
     public TValue? GetLocal(TKey key)
@@ -77,18 +74,40 @@ public sealed class ShardLocalCache<TKey, TValue>
 
     // Private methods
 
-    private ValueTask<TValue> GetOrAdd(TKey key, ShardOwnership ownership)
+    private TValue GetOrAdd(TKey key, ShardOwnership ownership)
     {
-        if (_entries.TryGetValue(key, out var entry) && ReferenceEquals(entry.Ownership, ownership))
-            return new(entry.Value);
+        // CAS retry loop: concurrent callers may race here, and only one write to _entries
+        // must win per (key, ownership). We use TryAdd / TryUpdate (optimistic) so that
+        // the dictionary slot is updated only if it still matches what we observed.
+        // A losing CAS means another thread produced a winning entry — we dispose our
+        // unused value and retry from the top, where we'll either (a) see the winner with
+        // matching ownership and return its value, or (b) see a still-stale entry and try
+        // to replace it again.
+        while (true) {
+            if (_entries.TryGetValue(key, out var entry)) {
+                if (ReferenceEquals(entry.Ownership, ownership))
+                    return entry.Value;
 
-        // Stale or missing — evict old entry if present, create new
-        if (entry != null)
-            EvictEntry(key, entry);
+                // Stale — try to replace atomically
+                var newValue = _factory(key, ownership);
+                var newEntry = new Entry(newValue, ownership);
+                if (_entries.TryUpdate(key, newEntry, entry)) {
+                    EvictValue(key, entry.Value);
+                    return newValue;
+                }
+                // Lost the race — discard freshly-made value and retry
+                EvictValue(key, newValue);
+                continue;
+            }
 
-        var value = _factory(key, ownership);
-        _entries[key] = new Entry(value, ownership);
-        return new(value);
+            var addedValue = _factory(key, ownership);
+            var addedEntry = new Entry(addedValue, ownership);
+            if (_entries.TryAdd(key, addedEntry))
+                return addedValue;
+
+            // Lost the race — discard and retry
+            EvictValue(key, addedValue);
+        }
     }
 
     private void EvictEntry(TKey key, Entry entry)

--- a/src/dotnet/Core.Server/Sharding/ShardLocalCache.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardLocalCache.cs
@@ -1,0 +1,114 @@
+namespace ActualChat.Sharding;
+
+/// <summary>
+/// A shard-ownership-aware in-memory cache that maps keys to values within a sharded service.
+/// Embeds <see cref="ShardOwner.RequireShardOwnership{T}"/> into access methods,
+/// so compute methods automatically get shard dependency, and stale entries from
+/// previous ownership epochs are evicted on access or by a periodic sweep.
+/// </summary>
+public sealed class ShardLocalCache<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, Entry> _entries = new();
+    private readonly ShardOwner _shardOwner;
+    private readonly Func<TKey, ShardOwnership, TValue> _factory;
+    private readonly Action<TKey, TValue>? _onEvict;
+    private readonly TimeSpan _evictionInterval;
+
+    public ShardLocalCache(
+        ShardOwner shardOwner,
+        Func<TKey, ShardOwnership, TValue> factory,
+        Action<TKey, TValue>? onEvict = null,
+        TimeSpan? evictionInterval = null)
+    {
+        _shardOwner = shardOwner;
+        _factory = factory;
+        _onEvict = onEvict;
+        _evictionInterval = evictionInterval ?? TimeSpan.FromSeconds(30);
+    }
+
+    public ValueTask<TValue> GetOrAdd(TKey key, bool addDependency, CancellationToken cancellationToken)
+    {
+        var ownership = _shardOwner.RequireShardOwnership(key, addDependency, cancellationToken);
+        return ownership.IsCompleted
+            ? GetOrAdd(key, ownership.Result)
+            : CompleteAsync(key, ownership);
+
+        async ValueTask<TValue> CompleteAsync(TKey k, ValueTask<ShardOwnership> ownershipTask)
+        {
+            var o = await ownershipTask.ConfigureAwait(false);
+            return GetOrAdd(k, o).Result;
+        }
+    }
+
+    public TValue? GetLocal(TKey key)
+        => _entries.TryGetValue(key, out var entry) ? entry.Value : default;
+
+    public bool TryRemove(TKey key, out TValue? value)
+    {
+        if (_entries.TryRemove(key, out var entry)) {
+            value = entry.Value;
+            EvictValue(key, entry.Value);
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    public void Clear()
+    {
+        foreach (var (key, entry) in _entries)
+            if (_entries.TryRemove(KeyValuePair.Create(key, entry)))
+                EvictValue(key, entry.Value);
+    }
+
+    public async Task RunEvictionLoop(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested) {
+            await Task.Delay(_evictionInterval, cancellationToken).SilentAwait(false);
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            foreach (var (key, entry) in _entries)
+                if (entry.Ownership.LockToken.IsCancellationRequested)
+                    EvictEntry(key, entry);
+        }
+    }
+
+    // Private methods
+
+    private ValueTask<TValue> GetOrAdd(TKey key, ShardOwnership ownership)
+    {
+        if (_entries.TryGetValue(key, out var entry) && ReferenceEquals(entry.Ownership, ownership))
+            return new(entry.Value);
+
+        // Stale or missing — evict old entry if present, create new
+        if (entry != null)
+            EvictEntry(key, entry);
+
+        var value = _factory(key, ownership);
+        _entries[key] = new Entry(value, ownership);
+        return new(value);
+    }
+
+    private void EvictEntry(TKey key, Entry entry)
+    {
+        if (!_entries.TryRemove(KeyValuePair.Create(key, entry)))
+            return; // Already replaced by a fresh entry or removed by another thread
+
+        EvictValue(key, entry.Value);
+    }
+
+    private void EvictValue(TKey key, TValue value)
+    {
+        _onEvict?.Invoke(key, value);
+        if (value is IAsyncDisposable ad)
+            _ = ad.DisposeAsync();
+        else if (value is IDisposable d)
+            d.Dispose();
+    }
+
+    // Nested types
+
+    private sealed record Entry(TValue Value, ShardOwnership Ownership);
+}

--- a/tests/Core.Server.IntegrationTests/Sharding/ShardLocalCacheTest.cs
+++ b/tests/Core.Server.IntegrationTests/Sharding/ShardLocalCacheTest.cs
@@ -252,10 +252,64 @@ public class ShardLocalCacheTest(ITestOutputHelper @out)
         await cts.CancelAsync();
         await evictionTask.SilentAwait(false);
 
-        // assert — evicted entries should no longer be in cache
+        // assert — redistribution must leave at least one entry stale,
+        // and evicted entries must no longer be in cache
         WriteLine($"Populated: {populatedKeys.Count}, Evicted: {evictedKeys.Count}");
+        evictedKeys.Should().NotBeEmpty("shard redistribution should leave some entries stale");
         foreach (var key in evictedKeys)
             cache.GetLocal(key).Should().BeNull();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ConcurrentGetOrAddDoesNotLeakValues()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var factoryCallCount = 0;
+        var evictedCount = 0;
+        var cache = new ShardLocalCache<string, DisposableValue>(
+            shardOwner,
+            (_, _) => {
+                Interlocked.Increment(ref factoryCallCount);
+                return new DisposableValue(() => Interlocked.Increment(ref evictedCount));
+            });
+
+        // Pre-resolve ownership once — keeps the race to the inner GetOrAdd logic only.
+        await cache.GetOrAdd("race-key", addDependency: false, CancellationToken.None);
+        cache.TryRemove("race-key", out _);
+        factoryCallCount = 0;
+        evictedCount = 0;
+
+        // act — many threads race on the same key. Use dedicated threads + a barrier
+        // to maximise contention without starving the thread pool.
+        const int concurrency = 32;
+        using var barrier = new Barrier(concurrency);
+        var results = new DisposableValue[concurrency];
+        var threads = new Thread[concurrency];
+        for (var i = 0; i < concurrency; i++) {
+            var idx = i;
+            threads[i] = new Thread(() => {
+                barrier.SignalAndWait();
+                results[idx] = cache.GetOrAdd("race-key", addDependency: false, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+            });
+            threads[i].Start();
+        }
+        foreach (var t in threads)
+            t.Join();
+
+        WriteLine($"factoryCallCount={factoryCallCount}, evictedCount={evictedCount}, distinct={results.Distinct().Count()}");
+
+        // assert — every caller must observe the single winning instance
+        results.Distinct().Should().HaveCount(1,
+            "every caller must get the entry that ends up in the cache");
+
+        // every factory-created loser must have been evicted to prevent leaks
+        // winners: exactly 1 (currently in the cache); losers: factoryCallCount - 1
+        evictedCount.Should().Be(factoryCallCount - 1,
+            "losing values from racing factory invocations must be evicted");
     }
 
     // Nested types

--- a/tests/Core.Server.IntegrationTests/Sharding/ShardLocalCacheTest.cs
+++ b/tests/Core.Server.IntegrationTests/Sharding/ShardLocalCacheTest.cs
@@ -1,0 +1,267 @@
+using ActualChat.Testing.Host;
+using ActualLab.Rpc;
+
+namespace ActualChat.Core.Server.IntegrationTests.Sharding;
+
+public class ShardLocalCacheTest(ITestOutputHelper @out)
+    : AppHostTestBase($"x-{nameof(ShardLocalCacheTest)}", TestAppHostOptions.None, @out)
+{
+    [Fact(Timeout = 30_000)]
+    public async Task GetOrAddCreatesEntry()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var factoryCallCount = 0;
+        var cache = new ShardLocalCache<string, string>(
+            shardOwner,
+            (key, _) => {
+                Interlocked.Increment(ref factoryCallCount);
+                return $"value-{key}";
+            });
+
+        // act — RequireShardOwnership inside GetOrAdd waits for ownership
+        var value1 = await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+        var value2 = await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+
+        // assert
+        value1.Should().Be("value-test-key");
+        value2.Should().Be("value-test-key");
+        factoryCallCount.Should().Be(1);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task GetLocalReturnsExistingEntry()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+        var cache = new ShardLocalCache<string, string>(
+            shardOwner,
+            (key, _) => $"value-{key}");
+
+        // act & assert
+        cache.GetLocal("test-key").Should().BeNull();
+        await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+        cache.GetLocal("test-key").Should().Be("value-test-key");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task TryRemoveEvictsAndCallsCallback()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var evictedKeys = new List<string>();
+        var cache = new ShardLocalCache<string, string>(
+            shardOwner,
+            (key, _) => $"value-{key}",
+            onEvict: (key, _) => evictedKeys.Add(key));
+
+        await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+
+        // act
+        var removed = cache.TryRemove("test-key", out var value);
+
+        // assert
+        removed.Should().BeTrue();
+        value.Should().Be("value-test-key");
+        evictedKeys.Should().Equal(["test-key"]);
+        cache.GetLocal("test-key").Should().BeNull();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ClearEvictsAllEntries()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var evictedKeys = new List<string>();
+        var cache = new ShardLocalCache<string, string>(
+            shardOwner,
+            (key, _) => $"value-{key}",
+            onEvict: (key, _) => evictedKeys.Add(key));
+
+        await cache.GetOrAdd("key-a", addDependency: false, CancellationToken.None);
+        await cache.GetOrAdd("key-b", addDependency: false, CancellationToken.None);
+
+        // act
+        cache.Clear();
+
+        // assert
+        evictedKeys.Should().HaveCount(2);
+        cache.GetLocal("key-a").Should().BeNull();
+        cache.GetLocal("key-b").Should().BeNull();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task DisposableValuesAreDisposedOnEviction()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var disposed = false;
+        var cache = new ShardLocalCache<string, DisposableValue>(
+            shardOwner,
+            (_, _) => new DisposableValue(() => disposed = true));
+
+        await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+
+        // act
+        cache.TryRemove("test-key", out _);
+
+        // assert
+        disposed.Should().BeTrue();
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task OnEvictAndDisposableAreBothCalled()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        var shardOwner = host.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var onEvictCalled = false;
+        var disposed = false;
+        var cache = new ShardLocalCache<string, DisposableValue>(
+            shardOwner,
+            (_, _) => new DisposableValue(() => disposed = true),
+            onEvict: (_, _) => onEvictCalled = true);
+
+        await cache.GetOrAdd("test-key", addDependency: false, CancellationToken.None);
+
+        // act
+        cache.TryRemove("test-key", out _);
+
+        // assert
+        onEvictCalled.Should().BeTrue();
+        disposed.Should().BeTrue();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task StaleEntryIsEvictedOnAccess()
+    {
+        // arrange
+        await using var h1 = await NewAppHost();
+        var o1 = h1.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var factoryCallCount = 0;
+        var evictedValues = new List<string>();
+        var cache = new ShardLocalCache<string, string>(
+            o1,
+            (key, ownership) => {
+                Interlocked.Increment(ref factoryCallCount);
+                return $"value-{key}-v{factoryCallCount}";
+            },
+            onEvict: (_, value) => evictedValues.Add(value));
+
+        // Populate cache entry — GetOrAdd waits for ownership
+        var key = "stale-test-key";
+        var value1 = await cache.GetOrAdd(key, addDependency: false, CancellationToken.None);
+        factoryCallCount.Should().Be(1);
+        var shardIndex = o1.ShardScheme.GetShardIndex(key);
+
+        // Start second host, causing shard redistribution
+        await using var h2 = await NewAppHost(o => o with { MustInitializeDb = false });
+        var o2 = h2.Services.ShardOwner(ShardScheme.TestBackend);
+
+        // Wait for redistribution to complete
+        await ComputedTest.When(async ct => {
+            var bits1 = await o1.BitmapState.Use(ct).ConfigureAwait(false);
+            var bits2 = await o2.BitmapState.Use(ct).ConfigureAwait(false);
+            bits1.SetBitCount().Should().Be(ShardScheme.TestBackend.ShardCount / 2);
+            bits2.SetBitCount().Should().Be(ShardScheme.TestBackend.ShardCount / 2);
+        }, TimeSpan.FromSeconds(20));
+
+        // Check if key's shard is still owned by h1
+        var state = o1.States[shardIndex].Value;
+        if (state.OwnershipStatus != ShardOwnershipStatus.OwnedByThisNode) {
+            // Shard moved to h2 — cache should throw RpcRerouteException
+            Func<Task> act = async () => await cache.GetOrAdd(key, addDependency: false, CancellationToken.None);
+            await act.Should().ThrowAsync<RpcRerouteException>();
+            WriteLine("Shard moved to h2 — RpcRerouteException thrown as expected");
+        }
+        else {
+            // Shard stayed with h1 — verify same ownership instance means no re-creation
+            var value2 = await cache.GetOrAdd(key, addDependency: false, CancellationToken.None);
+            if (ReferenceEquals(state.Ownership, o1.States[shardIndex].Value.Ownership)) {
+                // Ownership instance unchanged — factory should NOT have been called again
+                factoryCallCount.Should().Be(1);
+                value2.Should().Be(value1);
+                WriteLine("Shard stayed with h1, same ownership — entry reused");
+            }
+            else {
+                // Ownership re-acquired — factory SHOULD have been called again
+                factoryCallCount.Should().Be(2);
+                evictedValues.Should().Contain(value1);
+                WriteLine("Shard stayed with h1, new ownership — entry recreated");
+            }
+        }
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task EvictionLoopRemovesStaleEntries()
+    {
+        // arrange
+        await using var h1 = await NewAppHost();
+        var o1 = h1.Services.ShardOwner(ShardScheme.TestBackend);
+
+        var evictedKeys = new ConcurrentBag<string>();
+        var cache = new ShardLocalCache<string, string>(
+            o1,
+            (key, _) => $"value-{key}",
+            onEvict: (key, _) => evictedKeys.Add(key),
+            evictionInterval: TimeSpan.FromMilliseconds(100));
+
+        // Populate entries across multiple shards
+        var populatedKeys = new List<string>();
+        for (var i = 0; i < 20; i++) {
+            var key = $"evict-key-{i}";
+            try {
+                await cache.GetOrAdd(key, addDependency: false, CancellationToken.None);
+                populatedKeys.Add(key);
+            }
+            catch (RpcRerouteException) {
+                // Skip keys whose shards aren't owned
+            }
+        }
+        populatedKeys.Should().NotBeEmpty();
+
+        // Start eviction loop
+        using var cts = new CancellationTokenSource();
+        var evictionTask = cache.RunEvictionLoop(cts.Token);
+
+        // Start second host to trigger shard ownership changes
+        await using var h2 = await NewAppHost(o => o with { MustInitializeDb = false });
+        var o2 = h2.Services.ShardOwner(ShardScheme.TestBackend);
+
+        // Wait for redistribution
+        await ComputedTest.When(async ct => {
+            var bits1 = await o1.BitmapState.Use(ct).ConfigureAwait(false);
+            var bits2 = await o2.BitmapState.Use(ct).ConfigureAwait(false);
+            bits1.SetBitCount().Should().Be(ShardScheme.TestBackend.ShardCount / 2);
+            bits2.SetBitCount().Should().Be(ShardScheme.TestBackend.ShardCount / 2);
+        }, TimeSpan.FromSeconds(20));
+
+        // Wait for eviction loop to run a few cycles
+        await Task.Delay(1000);
+        await cts.CancelAsync();
+        await evictionTask.SilentAwait(false);
+
+        // assert — evicted entries should no longer be in cache
+        WriteLine($"Populated: {populatedKeys.Count}, Evicted: {evictedKeys.Count}");
+        foreach (var key in evictedKeys)
+            cache.GetLocal(key).Should().BeNull();
+    }
+
+    // Nested types
+
+    private sealed class DisposableValue(Action onDispose) : IDisposable
+    {
+        public void Dispose() => onDispose();
+    }
+}


### PR DESCRIPTION
…memory caching

Provides a ConcurrentDictionary-based cache that embeds RequireShardOwnership into access methods, so compute methods automatically get shard dependency. Stale entries from previous ownership epochs are detected via reference equality on ShardOwnership and evicted on access or by a caller-controlled background sweep.