### PR TITLE
fix(android): hardware Back closes modal without extra navigation step

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,7 +107,7 @@
     <Features>strict</Features>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <MauiVersion Condition="$(IsMauiProject)">10.0.30</MauiVersion>
+    <MauiVersion Condition="$(IsMauiProject)">10.0.51</MauiVersion>
 
     <!-- Globalization: must be invariant in every executable! -->
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidManifest.xml
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidManifest.xml
@@ -6,7 +6,8 @@
       android:dataExtractionRules="@xml/data_extraction_rules"
       android:icon="@mipmap/appicon_android"
       android:roundIcon="@mipmap/appicon_android_round"
-      android:supportsRtl="true">
+      android:supportsRtl="true"
+      android:enableOnBackInvokedCallback="false">
     <!-- Defines the fallback channel id when backend does not specify notification channel id -->
     <!-- Resource value should aligned with Constants.Notification.ChannelIds.Default -->
     <meta-data


### PR DESCRIPTION
## Summary

- Upgrade MAUI 10.0.30 → 10.0.51 to pick up dotnet/maui#33213 (BlazorWebView `BackNavigationHandled` flag) and unrelated patch-level fixes.
- Disable Android 13+ predictive back routing for the activity via `android:enableOnBackInvokedCallback="false"`, so all hardware back events traverse the legacy KeyEvent path.

## Root cause

Two parallel back-handling paths each called `window.history.back()`:

1. `BlazorAndroidWebView.OnKeyDown(KEYCODE_BACK)` → `webView.GoBack()` → popstate.
2. MAUI's `PredictiveBackCallback` → `AndroidLifecycle.OnBackPressed` handler → `History.TryStepBack()` → `window.history.back()` → second popstate.

Each popstate triggered a `LocationChange`, producing two consecutive state transitions — modal closed AND an extra back step ran (e.g., middle panel collapsed to chat list, or right panel closed).

## Fix

10.0.51 ships dotnet/maui#33213 which coordinates the two paths via `BackNavigationHandled`, but on Android 13+ the new `BlazorWebViewPredictiveBackCallback` bypasses `HandleBackNavigation` on `CanGoBack=false`, breaking the right-panel-reopen case. Disabling predictive-back routing for this activity keeps behaviour aligned with what shipped on 10.0.30 (legacy KeyEvent path + our `AndroidLifecycle.OnBackPressed` handler as fallback).

## Known follow-up

On Android 13+ at root (left panel visible) the first Back is swallowed by `BlazorAndroidWebView` and a second press is needed to minimise the app. Minor UX polish; not worse than 10.0.30 behaviour.

## Test plan

- [x] Manual: modal close on narrow screen (chat header and right panel) — single back closes only the modal.
- [x] Manual: right panel close by hardware Back after clicking the header icon.
- [x] Manual: right panel close by hardware Back after swipe-open (including repeat open → back → open → back).
- [ ] Manual: Android 9 regression check (legacy back path).

Fixes #3791

🤖 Generated with [Claude Code](https://claude.com/claude-code)