### PR TITLE
feat: Limit non-contact messaging in peer chats to 3 text-only …

### DIFF
--- a/src/dotnet/Api.Contracts/Chat/ChatEntryReader.cs
+++ b/src/dotnet/Api.Contracts/Chat/ChatEntryReader.cs
@@ -24,9 +24,9 @@ public sealed class ChatEntryReader(
         return tile.Entries.SingleOrDefault(e => e.LocalId == id);
     }
 
-    public async ValueTask<ChatEntry?> GetFirst(Range<long> idRange, CancellationToken cancellationToken)
+    public async ValueTask<ChatEntry?> GetFirst(Range<long> lidRange, CancellationToken cancellationToken)
     {
-        var (minId, maxIdExclusive) = idRange;
+        var (minId, maxIdExclusive) = lidRange;
         while (minId < maxIdExclusive) {
             var idTile = IdTileLayer.GetTile(minId);
             var tile = await Chats.GetTile(Session, ChatId, idTile.Range, cancellationToken).ConfigureAwait(false);
@@ -41,9 +41,9 @@ public sealed class ChatEntryReader(
         return null;
     }
 
-    public async ValueTask<ChatEntry?> GetFirst(Range<long> idRange, Func<ChatEntry, bool> filter, int filterLimit, CancellationToken cancellationToken)
+    public async ValueTask<ChatEntry?> GetFirst(Range<long> lidRange, Func<ChatEntry, bool> filter, int filterLimit, CancellationToken cancellationToken)
     {
-        var (minId, maxIdExclusive) = idRange;
+        var (minId, maxIdExclusive) = lidRange;
         while (minId < maxIdExclusive) {
             var idTile = IdTileLayer.GetTile(minId);
             var tile = await Chats.GetTile(Session, ChatId, idTile.Range, cancellationToken).ConfigureAwait(false);
@@ -62,9 +62,9 @@ public sealed class ChatEntryReader(
         return null;
     }
 
-    public async ValueTask<ChatEntry?> GetLast(Range<long> idRange, CancellationToken cancellationToken)
+    public async ValueTask<ChatEntry?> GetLast(Range<long> lidRange, CancellationToken cancellationToken)
     {
-        var (minId, maxIdExclusive) = idRange;
+        var (minId, maxIdExclusive) = lidRange;
         while (minId < maxIdExclusive) {
             var idTile = IdTileLayer.GetTile(maxIdExclusive - 1);
             var tile = await Chats.GetTile(Session, ChatId, idTile.Range, cancellationToken).ConfigureAwait(false);
@@ -80,9 +80,9 @@ public sealed class ChatEntryReader(
         return null;
     }
 
-    public async ValueTask<ChatEntry?> GetLast(Range<long> idRange, Func<ChatEntry, bool> filter, int filterLimit, CancellationToken cancellationToken)
+    public async ValueTask<ChatEntry?> GetLast(Range<long> lidRange, Func<ChatEntry, bool> filter, int filterLimit, CancellationToken cancellationToken)
     {
-        var (minId, maxIdExclusive) = idRange;
+        var (minId, maxIdExclusive) = lidRange;
         var skippedCount = 0;
         while (minId < maxIdExclusive) {
             var idTile = IdTileLayer.GetTile(maxIdExclusive - 1);
@@ -122,14 +122,14 @@ public sealed class ChatEntryReader(
     }
 
     public async IAsyncEnumerable<ChatEntry> Read(
-        Range<long> idRange,
+        Range<long> lidRange,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var tile in ReadTiles(idRange, cancellationToken).ConfigureAwait(false)) {
+        await foreach (var tile in ReadTiles(lidRange, cancellationToken).ConfigureAwait(false)) {
             foreach (var entry in tile.Entries) {
-                if (entry.LocalId < idRange.Start)
+                if (entry.LocalId < lidRange.Start)
                     continue;
-                if (entry.LocalId >= idRange.End)
+                if (entry.LocalId >= lidRange.End)
                     yield break;
                 yield return entry;
             }
@@ -137,15 +137,15 @@ public sealed class ChatEntryReader(
     }
 
     public async IAsyncEnumerable<ChatEntry> ReadReverse(
-        Range<long> idRange,
+        Range<long> lidRange,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var tile in ReadTilesReverse(idRange, cancellationToken).ConfigureAwait(false)) {
+        await foreach (var tile in ReadTilesReverse(lidRange, cancellationToken).ConfigureAwait(false)) {
             for (var i = tile.Entries.Length - 1; i >= 0; i--) {
                 var entry = tile.Entries[i];
-                if (entry.LocalId >= idRange.End)
+                if (entry.LocalId >= lidRange.End)
                     continue;
-                if (entry.LocalId < idRange.Start)
+                if (entry.LocalId < lidRange.Start)
                     yield break;
                 yield return entry;
             }
@@ -154,14 +154,14 @@ public sealed class ChatEntryReader(
 
     // This method never returns empty tiles
     public async IAsyncEnumerable<ChatTile> ReadTiles(
-        Range<long> idRange,
+        Range<long> lidRange,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (idRange.Size() <= 0)
+        if (lidRange.Size() <= 0)
             yield break;
 
-        for (var idTile = IdTileLayer.GetTile(idRange.Start);
-             idTile.Start < idRange.End;
+        for (var idTile = IdTileLayer.GetTile(lidRange.Start);
+             idTile.Start < lidRange.End;
              idTile = idTile.Next())
         {
             var tile = await GetTile(idTile.Range, cancellationToken).ConfigureAwait(false);
@@ -173,14 +173,14 @@ public sealed class ChatEntryReader(
 
     // This method never returns empty tiles
     public async IAsyncEnumerable<ChatTile> ReadTilesReverse(
-        Range<long> idRange,
+        Range<long> lidRange,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (idRange.Size() <= 0)
+        if (lidRange.Size() <= 0)
             yield break;
 
-        for (var idTile = IdTileLayer.GetTile(idRange.End - 1);
-             idTile.End > idRange.Start;
+        for (var idTile = IdTileLayer.GetTile(lidRange.End - 1);
+             idTile.End > lidRange.Start;
              idTile = idTile.Prev())
         {
             var tile = await GetTile(idTile.Range, cancellationToken).ConfigureAwait(false);
@@ -211,7 +211,7 @@ public sealed class ChatEntryReader(
     {
         var idTile = IdTileLayer.GetTile(minEntryId);
         var cTileTask = CaptureTile(idTile.Range, cancellationToken);
-        var cIdRangeTask = CaptureIdRange(cancellationToken);
+        var cIdRangeTask = CaptureLidRange(cancellationToken);
         var cTile = await cTileTask.ConfigureAwait(false);
         var cIdRange = await cIdRangeTask.ConfigureAwait(false);
 
@@ -263,37 +263,37 @@ public sealed class ChatEntryReader(
 
     public async Task<ChatEntry?> FindByMinBeginsAt(
         Moment minBeginsAt,
-        Range<long> idRange,
+        Range<long> lidRange,
         CancellationToken cancellationToken)
     {
-        var entry = await FindByMinBeginsAtPrecise(minBeginsAt - MaxBeginsAtDisorder, idRange, cancellationToken)
+        var entry = await FindByMinBeginsAtPrecise(minBeginsAt - MaxBeginsAtDisorder, lidRange, cancellationToken)
             .ConfigureAwait(false);
         if (entry == null)
             return null;
-        return await GetFirst((entry.LocalId, idRange.End), e => e.BeginsAt >= minBeginsAt, MaxEntryCountDisorder, cancellationToken)
+        return await GetFirst((entry.LocalId, lidRange.End), e => e.BeginsAt >= minBeginsAt, MaxEntryCountDisorder, cancellationToken)
             .ConfigureAwait(false);
     }
 
     // Private methods
 
-    private Task<Range<long>> GetIdRange(CancellationToken cancellationToken)
+    private Task<Range<long>> GetLidRange(CancellationToken cancellationToken)
         => Chats.GetIdRange(Session, ChatId, cancellationToken);
 
-    private Task<ChatTile> GetTile(Range<long> idRange, CancellationToken cancellationToken)
-        => Chats.GetTile(Session, ChatId, idRange, cancellationToken);
+    private Task<ChatTile> GetTile(Range<long> lidRange, CancellationToken cancellationToken)
+        => Chats.GetTile(Session, ChatId, lidRange, cancellationToken);
 
-    private ValueTask<Computed<Range<long>>> CaptureIdRange(CancellationToken cancellationToken)
-        => Computed.Capture(() => GetIdRange(cancellationToken), cancellationToken);
+    private ValueTask<Computed<Range<long>>> CaptureLidRange(CancellationToken cancellationToken)
+        => Computed.Capture(() => GetLidRange(cancellationToken), cancellationToken);
 
     private ValueTask<Computed<ChatTile>> CaptureTile(Range<long> idRange, CancellationToken cancellationToken)
         => Computed.Capture(() => GetTile(idRange, cancellationToken), cancellationToken);
 
     private async Task<ChatEntry?> FindByMinBeginsAtPrecise(
         Moment beginsAt,
-        Range<long> idRange,
+        Range<long> lidRange,
         CancellationToken cancellationToken)
     {
-        var (minId, maxId) = idRange.MoveEnd(-1);
+        var (minId, maxId) = lidRange.MoveEnd(-1);
         ChatEntry? entry;
         while (minId < maxId) {
             var midId = minId + ((maxId - minId) >> 1);
@@ -308,7 +308,7 @@ public sealed class ChatEntryReader(
             else
                 minId = midId + 1;
         }
-        entry = await GetFirst((minId, idRange.End), e => e.BeginsAt >= beginsAt, MaxEntryCountDisorder, cancellationToken)
+        entry = await GetFirst((minId, lidRange.End), e => e.BeginsAt >= beginsAt, MaxEntryCountDisorder, cancellationToken)
             .ConfigureAwait(false);
         return entry;
     }

--- a/src/dotnet/Api.Contracts/Chat/IChats.cs
+++ b/src/dotnet/Api.Contracts/Chat/IChats.cs
@@ -43,7 +43,7 @@ public interface IChats : IComputeService
     Task<ChatTile> GetTile(
         Session session,
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
     [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]
@@ -52,7 +52,7 @@ public interface IChats : IComputeService
         Session session,
         ChatId chatId,
         int entryKind,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
     [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]

--- a/src/dotnet/Api.Contracts/Chat/IConversations.cs
+++ b/src/dotnet/Api.Contracts/Chat/IConversations.cs
@@ -9,7 +9,7 @@ public interface IConversations : IComputeService
     Task<Conversation[]> GetTile(
         Session session,
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
     [ComputeMethod]

--- a/src/dotnet/Api.Contracts/Chat/ILegacyChats.cs
+++ b/src/dotnet/Api.Contracts/Chat/ILegacyChats.cs
@@ -23,7 +23,7 @@ public interface ILegacyChats : IComputeService
     // route it here so they get a LegacyChatTile rather than the modern union shape.
     [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]
     Task<LegacyChatTile> GetTile(
-        Session session, ChatId chatId, int entryKind, Range<long> idTileRange, CancellationToken cancellationToken);
+        Session session, ChatId chatId, int entryKind, Range<long> lidTileRange, CancellationToken cancellationToken);
 
     [CommandHandler, RpcMethod(ConnectTimeout = double.PositiveInfinity)]
     Task<LegacyChatEntry> OnUpsertEntry(

--- a/src/dotnet/Api.Contracts/Chat/ITranslations.cs
+++ b/src/dotnet/Api.Contracts/Chat/ITranslations.cs
@@ -12,6 +12,6 @@ public interface ITranslations : IComputeService
     Task<ChatLanguageTile> GetLanguageTile(
         Session session,
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 }

--- a/src/dotnet/Api/Chat/AuthorRules.cs
+++ b/src/dotnet/Api/Chat/AuthorRules.cs
@@ -21,6 +21,11 @@ public sealed partial record AuthorRules(
 
     public bool CanRead() => Permissions.Has(ChatPermissions.Read);
     public bool CanWrite() => Permissions.Has(ChatPermissions.Write);
+    public bool CanUpload() => Permissions.Has(ChatPermissions.Upload);
+    public bool CanWriteAudio() => Permissions.Has(ChatPermissions.WriteAudio);
+    public bool CanWriteVideo() => Permissions.Has(ChatPermissions.WriteVideo);
+    public bool CanReadAudio() => Permissions.Has(ChatPermissions.ReadAudio);
+    public bool CanReadVideo() => Permissions.Has(ChatPermissions.ReadVideo);
     public bool CanSeeMembers() => Permissions.Has(ChatPermissions.SeeMembers);
     public bool CanJoin() => Permissions.Has(ChatPermissions.Join);
     public bool CanLeave() => Permissions.Has(ChatPermissions.Leave);

--- a/src/dotnet/Api/Chat/ChatEntryRangeMeta.cs
+++ b/src/dotnet/Api/Chat/ChatEntryRangeMeta.cs
@@ -4,9 +4,9 @@
 [method: SerializationConstructor]
 public sealed partial record ChatEntryRangeMeta(
     [property: DataMember, MemoryPackOrder(0), Key(0)] ChatId? ChatId,
-    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryRanges,
-    [property: DataMember, MemoryPackIgnore, Key(2)] long? PreviousEntryId,
-    [property: DataMember, MemoryPackIgnore, Key(3)] long? NextEntryId)
+    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryLidRange,
+    [property: DataMember, MemoryPackIgnore, Key(2)] long? PreviousEntryLid,
+    [property: DataMember, MemoryPackIgnore, Key(3)] long? NextEntryLid)
 {
     public static readonly ChatEntryRangeMeta None = new(null, [], null, null);
 
@@ -17,14 +17,14 @@ public sealed partial record ChatEntryRangeMeta(
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackInclude, MemoryPackOrder(2), IgnoreMember]
     private ApiNullable8<long> MemoryPackPreviousEntryId {
-        get => PreviousEntryId;
-        init => PreviousEntryId = value;
+        get => PreviousEntryLid;
+        init => PreviousEntryLid = value;
     }
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackInclude, MemoryPackOrder(3), IgnoreMember]
     private ApiNullable8<long> MemoryPackNextEntryId {
-        get => NextEntryId;
-        init => NextEntryId = value;
+        get => NextEntryLid;
+        init => NextEntryLid = value;
     }
 
     #endregion

--- a/src/dotnet/Api/Chat/ChatLanguageTile.cs
+++ b/src/dotnet/Api/Chat/ChatLanguageTile.cs
@@ -3,7 +3,7 @@
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject]
 public sealed partial class ChatLanguageTile
 {
-    [DataMember, MemoryPackOrder(0), Key(0)] public Range<long> IdTileRange { get; init; }
+    [DataMember, MemoryPackOrder(0), Key(0)] public Range<long> LidTileRange { get; init; }
     // Entries area always sorted by Id!
     [DataMember, MemoryPackOrder(1), Key(1)] public ChatEntryLanguage[] Entries { get; init; } = [];
 
@@ -13,23 +13,23 @@ public sealed partial class ChatLanguageTile
     [JsonConstructor, Newtonsoft.Json.JsonConstructor, MemoryPackConstructor, SerializationConstructor]
     public ChatLanguageTile() { }
 
-    public ChatLanguageTile(Range<long> idTileRange, ChatEntryLanguage[] entries)
+    public ChatLanguageTile(Range<long> lidTileRange, ChatEntryLanguage[] entries)
     {
-        IdTileRange = idTileRange;
+        LidTileRange = lidTileRange;
         Entries = entries;
     }
 
     public ChatLanguageTile(IEnumerable<ChatLanguageTile> tiles)
     {
         var entries = new List<ChatEntryLanguage>();
-        var idTile = new Range<long>(long.MaxValue, long.MinValue);
+        var lidTile = new Range<long>(long.MaxValue, long.MinValue);
         foreach (var tile in tiles) {
-            idTile = idTile.MinMaxWith(tile.IdTileRange);
+            lidTile = lidTile.MinMaxWith(tile.LidTileRange);
             foreach (var entry in tile.Entries)
                 entries.Add(entry);
         }
 
-        IdTileRange = idTile;
+        LidTileRange = lidTile;
         Entries = entries.ToArray();
     }
 }

--- a/src/dotnet/Api/Chat/ChatNews.cs
+++ b/src/dotnet/Api/Chat/ChatNews.cs
@@ -5,5 +5,5 @@ namespace ActualChat.Chat;
 [DataContract, MessagePackObject]
 [ParameterComparer(typeof(ByValueParameterComparer))]
 public sealed partial record ChatNews(
-    [property: DataMember, Key(0)] Range<long> TextEntryIdRange,
+    [property: DataMember, Key(0)] Range<long> TextEntryLidRange,
     [property: DataMember, Key(1)] ChatEntry? LastTextEntry = null);

--- a/src/dotnet/Api/Chat/ChatPermissions.cs
+++ b/src/dotnet/Api/Chat/ChatPermissions.cs
@@ -22,4 +22,11 @@ public enum ChatPermissions
     EditMembers    = 0x4000,
 
     Owner          = 0x10_000, // Implies EditProperties, EditRoles, Invite (-> Join, Read), Write (-> Read)
+
+    // Content-type capabilities (default-on; selectively stripped, e.g. for non-contact peer chats).
+    Upload         = 0x10_0000, // Attach files/media to entries; implied by Write.
+    WriteAudio     = 0x20_0000, // Record voice messages / start an audio stream; implied by Write.
+    WriteVideo     = 0x40_0000, // Start a video stream / screenshare; implied by Write.
+    ReadAudio      = 0x80_0000, // Receive audio streams; implied by Read.
+    ReadVideo      = 0x100_0000, // Receive video streams; implied by Read.
 }

--- a/src/dotnet/Api/Chat/ChatPermissionsExt.cs
+++ b/src/dotnet/Api/Chat/ChatPermissionsExt.cs
@@ -20,8 +20,17 @@ public static class ChatPermissionsExt
             permissions |=
                 ChatPermissions.Join
                 | ChatPermissions.SeeMembers;
+        if (permissions.Has(ChatPermissions.Write))
+            permissions |=
+                ChatPermissions.Upload
+                | ChatPermissions.WriteAudio
+                | ChatPermissions.WriteVideo;
         if (permissions.Has(ChatPermissions.Join) || permissions.Has(ChatPermissions.Write))
             permissions |= ChatPermissions.Read;
+        if (permissions.Has(ChatPermissions.Read))
+            permissions |=
+                ChatPermissions.ReadAudio
+                | ChatPermissions.ReadVideo;
         return permissions;
     }
 

--- a/src/dotnet/Api/Chat/ChatRangeMeta.cs
+++ b/src/dotnet/Api/Chat/ChatRangeMeta.cs
@@ -3,12 +3,12 @@
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject(AllowPrivate = true)]
 [method: SerializationConstructor]
 public sealed partial record ChatRangeMeta(
-    [property: DataMember, MemoryPackOrder(0), Key(0)] Range<long> IdRange,
-    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryIdRanges,
-    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long>[] ConversationIdRanges,
+    [property: DataMember, MemoryPackOrder(0), Key(0)] Range<long> LidRange,
+    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryLidRanges,
+    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long>[] ConversationLidRanges,
     [property: DataMember, MemoryPackOrder(3), Key(3)] int MinCount,
-    [property: DataMember, MemoryPackIgnore, Key(4)] long? PreviousIdTileStart,
-    [property: DataMember, MemoryPackIgnore, Key(5)] long? NextIdTileStart)
+    [property: DataMember, MemoryPackIgnore, Key(4)] long? PreviousLidTileStart,
+    [property: DataMember, MemoryPackIgnore, Key(5)] long? NextLidTileStart)
 {
     [MemoryPackConstructor]
     public ChatRangeMeta() : this(default, default!, default!, default, default, default) { }
@@ -16,15 +16,15 @@ public sealed partial record ChatRangeMeta(
     #region MemoryPackXxx properties
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackInclude, MemoryPackOrder(4), IgnoreMember]
-    private ApiNullable8<long> MemoryPackPreviousIdTileStart {
-        get => PreviousIdTileStart;
-        init => PreviousIdTileStart = value;
+    private ApiNullable8<long> MemoryPackPreviousLidTileStart {
+        get => PreviousLidTileStart;
+        init => PreviousLidTileStart = value;
     }
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackInclude, MemoryPackOrder(5), IgnoreMember]
-    private ApiNullable8<long> MemoryPackNextIdTileStart {
-        get => NextIdTileStart;
-        init => NextIdTileStart = value;
+    private ApiNullable8<long> MemoryPackNextLidTileStart {
+        get => NextLidTileStart;
+        init => NextLidTileStart = value;
     }
 
     #endregion

--- a/src/dotnet/Api/Chat/ChatTile.cs
+++ b/src/dotnet/Api/Chat/ChatTile.cs
@@ -1,9 +1,9 @@
-namespace ActualChat.Chat;
+﻿namespace ActualChat.Chat;
 
 [DataContract, MessagePackObject]
 public sealed partial class ChatTile
 {
-    [DataMember, Key(0)] public Range<long> IdTileRange { get; init; }
+    [DataMember, Key(0)] public Range<long> LidTileRange { get; init; }
     [DataMember, Key(1)] public bool IncludesRemoved { get; init; }
     [DataMember, Key(2)] public Range<Moment> BeginsAtRange { get; init; }
     // Entries area always sorted by Id!
@@ -15,13 +15,13 @@ public sealed partial class ChatTile
     [JsonConstructor, Newtonsoft.Json.JsonConstructor, SerializationConstructor]
     public ChatTile() { }
 
-    public ChatTile(Range<long> idTileRange, bool includesRemoved, ChatEntry[] entries)
+    public ChatTile(Range<long> lidTileRange, bool includesRemoved, ChatEntry[] entries)
     {
         var beginsAtRange = new Range<Moment>(Moment.MaxValue, Moment.MinValue);
         foreach (var entry in entries)
             beginsAtRange = beginsAtRange.MinMaxWith(entry.BeginsAt);
 
-        IdTileRange = idTileRange;
+        LidTileRange = lidTileRange;
         IncludesRemoved = includesRemoved;
         BeginsAtRange = (beginsAtRange.Start, beginsAtRange.End + TimeSpan.FromTicks(1));
         Entries = entries;
@@ -33,13 +33,13 @@ public sealed partial class ChatTile
         var idTile = new Range<long>(long.MaxValue, long.MinValue);
         var beginsAtRange = new Range<Moment>(Moment.MaxValue, Moment.MinValue);
         foreach (var tile in tiles) {
-            idTile = idTile.MinMaxWith(tile.IdTileRange);
+            idTile = idTile.MinMaxWith(tile.LidTileRange);
             beginsAtRange = beginsAtRange.MinMaxWith(tile.BeginsAtRange);
             foreach (var entry in tile.Entries)
                 entries.Add(entry);
         }
 
-        IdTileRange = idTile;
+        LidTileRange = idTile;
         IncludesRemoved = includesRemoved;
         BeginsAtRange = (beginsAtRange.Start, beginsAtRange.End + TimeSpan.FromTicks(1));
         Entries = entries.ToArray();

--- a/src/dotnet/Api/Chat/Conversation.cs
+++ b/src/dotnet/Api/Chat/Conversation.cs
@@ -22,7 +22,7 @@ public sealed partial record Conversation(
     [DataMember, MemoryPackOrder(2), Key(2)] public string Title { get; init; } = "";
     [DataMember, MemoryPackOrder(3), Key(3)] public string Description { get; init; } = "";
     [DataMember, MemoryPackOrder(4), Key(4)] public string Summary { get; init; } = "";
-    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember] public Range<long> EntryRange => new(Id.StartEntryLid, EndEntryLid + 1);
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember] public Range<long> EntryLidRange => new(Id.StartEntryLid, EndEntryLid + 1);
     [DataMember, MemoryPackOrder(5), Key(5)] public long EndEntryLid { get; init; } = Id.StartEntryLid;
     [DataMember, MemoryPackOrder(6), Key(6)] public Moment StartsAt { get; init; }
     [DataMember, MemoryPackOrder(7), Key(7)] public Moment EndsAt { get; init; }

--- a/src/dotnet/Api/Chat/ConversationRangeMeta.cs
+++ b/src/dotnet/Api/Chat/ConversationRangeMeta.cs
@@ -3,11 +3,11 @@
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject]
 public sealed partial record ConversationRangeMeta(
     [property: DataMember, MemoryPackOrder(0), Key(0)] ChatId ChatId,
-    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] ConversationRanges,
-    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long>? PreviousConversationRange,
-    [property: DataMember, MemoryPackOrder(3), Key(3)] Range<long>? NextConversationRange)
+    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] ConversationLidRanges,
+    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long>? PreviousConversationLidRange,
+    [property: DataMember, MemoryPackOrder(3), Key(3)] Range<long>? NextConversationLidRange)
 {
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public ConversationId[] ConversationIds
-        => field ??= ConversationRanges.Select(r => ConversationId.New(ChatId, r.Start)).ToArray();
+        => field ??= ConversationLidRanges.Select(r => ConversationId.New(ChatId, r.Start)).ToArray();
 }

--- a/src/dotnet/Api/Chat/LegacyChatNews.cs
+++ b/src/dotnet/Api/Chat/LegacyChatNews.cs
@@ -8,13 +8,13 @@ namespace ActualChat.Chat;
 [DataContract, MemoryPackable(GenerateType.VersionTolerant)]
 [ParameterComparer(typeof(ByValueParameterComparer))]
 public sealed partial record LegacyChatNews(
-    [property: DataMember, MemoryPackOrder(0)] Range<long> TextEntryIdRange,
+    [property: DataMember, MemoryPackOrder(0)] Range<long> TextEntryLidRange,
     [property: DataMember, MemoryPackOrder(1)] LegacyChatEntry? LastTextEntry = null)
 {
     public static LegacyChatNews? From(ChatNews? news)
         => news is null
             ? null
             : new LegacyChatNews(
-                news.TextEntryIdRange,
+                news.TextEntryLidRange,
                 news.LastTextEntry is { } entry ? LegacyChatEntry.From(entry) : null);
 }

--- a/src/dotnet/Api/Chat/LegacyChatTile.cs
+++ b/src/dotnet/Api/Chat/LegacyChatTile.cs
@@ -6,7 +6,7 @@ namespace ActualChat.Chat;
 [DataContract, MemoryPackable(GenerateType.VersionTolerant)]
 public sealed partial class LegacyChatTile
 {
-    [DataMember, MemoryPackOrder(0)] public Range<long> IdTileRange { get; init; }
+    [DataMember, MemoryPackOrder(0)] public Range<long> LidTileRange { get; init; }
     [DataMember, MemoryPackOrder(1)] public bool IncludesRemoved { get; init; }
     [DataMember, MemoryPackOrder(2)] public Range<Moment> BeginsAtRange { get; init; }
     [DataMember, MemoryPackOrder(3)] public LegacyChatEntry[] Entries { get; init; } = [];
@@ -19,7 +19,7 @@ public sealed partial class LegacyChatTile
 
     public LegacyChatTile(Range<long> idTileRange, bool includesRemoved, Range<Moment> beginsAtRange, LegacyChatEntry[] entries)
     {
-        IdTileRange = idTileRange;
+        LidTileRange = idTileRange;
         IncludesRemoved = includesRemoved;
         BeginsAtRange = beginsAtRange;
         Entries = entries;
@@ -27,7 +27,7 @@ public sealed partial class LegacyChatTile
 
     public static LegacyChatTile From(ChatTile tile)
         => new(
-            tile.IdTileRange,
+            tile.LidTileRange,
             tile.IncludesRemoved,
             tile.BeginsAtRange,
             tile.Entries.Select(LegacyChatEntry.From).ToArray());

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -73,10 +73,10 @@ public static partial class Constants
         public static readonly TileStack<long> ViewIdTileStack = TileStacks.Long5To20;
         public static readonly TileStack<int> ChatTileStack = TileStacks.Int5To20;
         public static readonly TimeSpan MaxEntryDuration = TimeSpan.FromMinutes(3);
-        public const int MaxSearchFilterLength = 100;
+        public const int NonContactPeerMessageLimit = 2;
         public const int ReactionFirstAuthorIdsLimit = 10;
+        public const int MaxSearchFilterLength = 100;
         public const int MinChatPageMapSize = 100;
-        public const int ImageRowCapacity = 4;
 
         public static class SystemTags
         {

--- a/src/dotnet/Api/Contacts/Contact.cs
+++ b/src/dotnet/Api/Contacts/Contact.cs
@@ -24,6 +24,7 @@ public sealed partial record Contact(
     [DataMember, MemoryPackOrder(7), Key(7)] public string PeerContactName { get; init; } = "";
     [DataMember, MemoryPackOrder(8), Key(8)] public Symbol SystemTag { get; init; }
     [DataMember, MemoryPackOrder(9), Key(9)] public string ExternalContactName { get; init; } = "";
+    [DataMember, MemoryPackOrder(10), Key(10)] public ContactState State { get; init; }
 
     // Computed
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
@@ -34,6 +35,8 @@ public sealed partial record Contact(
     public ChatId ChatId => Id.ChatId;
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public string? PeerRename => PeerContactName.NullIfWhiteSpace() ?? ExternalContactName.NullIfWhiteSpace();
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public bool IsStoredContact => State == ContactState.Regular;
 
     // Populated on backend on reads
     [DataMember, MemoryPackOrder(5), Key(5)] public Account? Account { get; init; }

--- a/src/dotnet/Api/Contacts/ContactState.cs
+++ b/src/dotnet/Api/Contacts/ContactState.cs
@@ -1,0 +1,14 @@
+namespace ActualChat.Contacts;
+
+#pragma warning disable CA1027
+
+/// <summary>
+/// Describes how a contact should participate in contact-list and peer-chat rules.
+/// </summary>
+public enum ContactState
+{
+    Temporary = 0,
+    Regular = 0x10,
+    // Archieved = 0x100,
+    Blocked = 0x1000,
+}

--- a/src/dotnet/Api/Invite/ChatInvite.cs
+++ b/src/dotnet/Api/Invite/ChatInvite.cs
@@ -4,14 +4,12 @@ namespace ActualChat.Invite;
 /// Invite link for joining a specific chat.
 /// </summary>
 [DataContract, MessagePackObject]
-public sealed partial record ChatInvite : Invite
+[method: SerializationConstructor]
+public sealed partial record ChatInvite(Symbol Id, long Version = 0) : Invite(Id, Version)
 {
-    [DataMember, Key(10)] public ChatId ChatId { get; init; }
+    [DataMember, Key(10)] public ChatId ChatId { get; init; } = null!;
 
-    public ChatInvite() : base(Symbol.Empty) { }
-
-    [SerializationConstructor]
-    public ChatInvite(Symbol id, long version = 0) : base(id, version) { }
+    public ChatInvite() : this(Symbol.Empty) { }
 
     public static ChatInvite New(int remaining, ChatId chatId)
         => new(Symbol.Empty) { Remaining = remaining, ChatId = chatId };

--- a/src/dotnet/Api/Invite/PlaceInvite.cs
+++ b/src/dotnet/Api/Invite/PlaceInvite.cs
@@ -4,14 +4,12 @@ namespace ActualChat.Invite;
 /// Invite link for joining a specific place.
 /// </summary>
 [DataContract, MessagePackObject]
-public sealed partial record PlaceInvite : Invite
+[method: SerializationConstructor]
+public sealed partial record PlaceInvite(Symbol Id, long Version = 0) : Invite(Id, Version)
 {
-    [DataMember, Key(10)] public PlaceId PlaceId { get; init; }
+    [DataMember, Key(10)] public PlaceId PlaceId { get; init; } = null!;
 
-    public PlaceInvite() : base(Symbol.Empty) { }
-
-    [SerializationConstructor]
-    public PlaceInvite(Symbol id, long version = 0) : base(id, version) { }
+    public PlaceInvite() : this(Symbol.Empty) { }
 
     public static PlaceInvite New(int remaining, PlaceId placeId)
         => new(Symbol.Empty) { Remaining = remaining, PlaceId = placeId };

--- a/src/dotnet/Chat.Contracts/ChatsBackendExt.cs
+++ b/src/dotnet/Chat.Contracts/ChatsBackendExt.cs
@@ -115,11 +115,11 @@ public static class ChatsBackendExt
     public static async Task<IReadOnlyList<ChatEntry>> ListEntries(
         this IChatsBackend chatsBackend,
         ChatId chatId,
-        Range<long> idRange,
+        Range<long> lidRange,
         bool includeRemoved = false,
         CancellationToken cancellationToken = default)
     {
-        var idTiles = Constants.Chat.ViewIdTileStack.FirstLayer.GetCoveringTiles(idRange);
+        var idTiles = Constants.Chat.ViewIdTileStack.FirstLayer.GetCoveringTiles(lidRange);
         var tiles = await idTiles.Select(t => chatsBackend.GetTile(
                 chatId,
                 t.Range,
@@ -140,7 +140,7 @@ public static class ChatsBackendExt
         // We don't want callers of this method to be dependent on whatever it fetches
         using var _ = Computed.BeginIsolation();
 
-        var idRange = await chatsBackend.GetIdRange(chatId, true, cancellationToken).ConfigureAwait(false);
+        var idRange = await chatsBackend.GetLidRange(chatId, true, cancellationToken).ConfigureAwait(false);
         if (idRange.Size() <= 0)
             return [];
 
@@ -178,11 +178,11 @@ public static class ChatsBackendExt
     public static async IAsyncEnumerable<ChatEntry> ReadEntries(
         this IChatsBackend chatsBackend,
         ChatId chatId,
-        Range<long> idRange,
+        Range<long> lidRange,
         bool includeRemoved = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var idTiles = Constants.Chat.ViewIdTileStack.FirstLayer.GetCoveringTiles(idRange);
+        var idTiles = Constants.Chat.ViewIdTileStack.FirstLayer.GetCoveringTiles(lidRange);
         foreach (var idTile in idTiles) {
             var tile = await chatsBackend.GetTile(
                 chatId,

--- a/src/dotnet/Chat.Contracts/IChatEntryLanguagesBackend.cs
+++ b/src/dotnet/Chat.Contracts/IChatEntryLanguagesBackend.cs
@@ -11,7 +11,7 @@ public interface IChatEntryLanguagesBackend : IComputeService, IBackendService
     [ComputeMethod]
     Task<ChatLanguageTile> GetTile(
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
     // Command handlers

--- a/src/dotnet/Chat.Contracts/IChatsBackend.cs
+++ b/src/dotnet/Chat.Contracts/IChatsBackend.cs
@@ -27,14 +27,14 @@ public interface IChatsBackend : IComputeService, IBackendService
     [ComputeMethod]
     Task<ChatTile> GetTile(
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         bool includeRemoved,
         CancellationToken cancellationToken);
 
     [ComputeMethod]
     Task<ChatRangeMeta> GetChatRangeMeta(
         ChatId chatId,
-        long idTileStart,
+        long lidTileStart,
         CancellationToken cancellationToken);
 
     [ComputeMethod]
@@ -45,16 +45,26 @@ public interface IChatsBackend : IComputeService, IBackendService
 
     // Note that it returns (firstId, lastId + 1) range!
     [ComputeMethod]
-    Task<Range<long>> GetIdRange(
+    Task<Range<long>> GetLidRange(
         ChatId chatId,
         bool includeRemoved,
         CancellationToken cancellationToken);
 
     [ComputeMethod]
-    Task<long?> GetMaxEntryVersion(ChatId chatId, CancellationToken cancellationToken);
+    Task<long> GetMinLid(ChatId chatId, CancellationToken cancellationToken);
 
     [ComputeMethod]
-    Task<long> GetEntryCount(ChatId chatId, AuthorId authorId, CancellationToken cancellationToken);
+    Task<long> GetMaxLid(ChatId chatId, bool includeRemoved, CancellationToken cancellationToken);
+
+    [ComputeMethod]
+    Task<ApiSet<AuthorId>> GetFirstEntryAuthors(
+        ChatId chatId,
+        int entryCount,
+        bool includeRemoved,
+        CancellationToken cancellationToken);
+
+    [ComputeMethod]
+    Task<long?> GetMaxEntryVersion(ChatId chatId, CancellationToken cancellationToken);
 
     [ComputeMethod]
     Task<ChatId[]> GetPublicChatIdsFor(

--- a/src/dotnet/Chat.Contracts/IChatsBackend.cs
+++ b/src/dotnet/Chat.Contracts/IChatsBackend.cs
@@ -54,6 +54,9 @@ public interface IChatsBackend : IComputeService, IBackendService
     Task<long?> GetMaxEntryVersion(ChatId chatId, CancellationToken cancellationToken);
 
     [ComputeMethod]
+    Task<long> GetEntryCount(ChatId chatId, AuthorId authorId, CancellationToken cancellationToken);
+
+    [ComputeMethod]
     Task<ChatId[]> GetPublicChatIdsFor(
         PlaceId? placeId,
         CancellationToken cancellationToken);

--- a/src/dotnet/Chat.Contracts/IConversationsBackend.cs
+++ b/src/dotnet/Chat.Contracts/IConversationsBackend.cs
@@ -15,7 +15,7 @@ public interface IConversationsBackend : IComputeService, IBackendService
     [ComputeMethod]
     Task<Conversation[]> GetTile(
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
     [ComputeMethod]
@@ -55,7 +55,7 @@ public sealed partial record ConversationBackend_Change(
 // ReSharper disable once InconsistentNaming
 public sealed partial record ConversationBackend_Summarize(
     [property: DataMember, MemoryPackOrder(0), Key(0)] ChatId ChatId,
-    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryIdRanges
+    [property: DataMember, MemoryPackOrder(1), Key(1)] Range<long>[] EntryLidRanges
     ) : ICommand<Conversation>, IBackendCommand, IHasShardKey<ChatId>, IHasDelayUntil, IHasTimeout
 {
     [DataMember, MemoryPackOrder(2), Key(2)]
@@ -65,7 +65,7 @@ public sealed partial record ConversationBackend_Summarize(
     TimeSpan? IHasTimeout.Timeout => TimeSpan.FromMinutes(5);
 
     public override string ToString()
-        => $"ConversationBackend_Summarize {{ ChatId={ChatId}, EntryIdRanges=[{string.Join(", ", EntryIdRanges.Select(r => r.Format()))}], DelayUntil={DelayUntil} }}";
+        => $"ConversationBackend_Summarize {{ ChatId={ChatId}, EntryLidRanges=[{string.Join(", ", EntryLidRanges.Select(r => r.Format()))}], DelayUntil={DelayUntil} }}";
 }
 
 /// <summary>
@@ -76,7 +76,7 @@ public sealed partial record ConversationBackend_Summarize(
 public sealed partial record ConversationBackend_AppendReply(
     [property: DataMember, MemoryPackOrder(0), Key(0)] ChatId ChatId,
     [property: DataMember, MemoryPackOrder(1), Key(1)] long EntryLid,
-    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long> ReplySequence
+    [property: DataMember, MemoryPackOrder(2), Key(2)] Range<long> ReplyLidRange
 ) : ICommand<Conversation>, IBackendCommand, IHasShardKey<ChatId>, IHasDelayUntil, IHasTimeout
 {
     [DataMember, MemoryPackOrder(3), Key(3)]

--- a/src/dotnet/Chat.ML/ConversationSummarizer.cs
+++ b/src/dotnet/Chat.ML/ConversationSummarizer.cs
@@ -163,12 +163,12 @@ public class ConversationSummarizer(ConversationSummarizer.Options settings, ISe
 
         var localIds = chatEntries.Select(ce => ce.LocalId).ToList();
         // Determine the minimal tile range that covers all provided local IDs
-        var minId = localIds.Min();
-        var maxId = localIds.Max();
-        var range = new Range<long>(minId, maxId + 1);
-        var idTiles = Constants.Chat.ServerIdTileStack.FirstLayer.GetCoveringTiles(range);
+        var minLid = localIds.Min();
+        var maxLid = localIds.Max();
+        var lidRange = new Range<long>(minLid, maxLid + 1);
+        var lidTiles = Constants.Chat.ServerIdTileStack.FirstLayer.GetCoveringTiles(lidRange);
 
-        var tiles = await idTiles
+        var tiles = await lidTiles
             .Select(idTile => ChatEntryLanguagesBackend.GetTile(chatId, idTile.Range, cancellationToken))
             .Collect(cancellationToken)
             .ConfigureAwait(false);

--- a/src/dotnet/Chat.ML/EntryGroupExtractor.cs
+++ b/src/dotnet/Chat.ML/EntryGroupExtractor.cs
@@ -10,21 +10,21 @@ public record EntryGroup(IReadOnlyList<ChatEntrySlim> Entries, int WordCount = 0
             return [];
 
         var idRanges = new List<Range<long>>();
-        long? startId = null, endId = null;
+        long? startLid = null, endLid = null;
         foreach (var lid in Entries.Select(e => e.LocalId).OrderBy(id => id).EnsureMonotonic())
-            if (startId is null) {
-                startId = lid;
-                endId = lid;
+            if (startLid is null) {
+                startLid = lid;
+                endLid = lid;
             }
-            else if (lid == endId + 1)
-                endId = lid;
+            else if (lid == endLid + 1)
+                endLid = lid;
             else {
-                idRanges.Add(new Range<long>(startId.Value, endId!.Value + 1));
-                startId = lid;
-                endId = lid;
+                idRanges.Add(new Range<long>(startLid.Value, endLid!.Value + 1));
+                startLid = lid;
+                endLid = lid;
             }
-        if (startId != null && endId != null)
-            idRanges.Add(new Range<long>(startId.Value, endId.Value + 1));
+        if (startLid != null && endLid != null)
+            idRanges.Add(new Range<long>(startLid.Value, endLid.Value + 1));
 
         return idRanges;
     }

--- a/src/dotnet/Chat.Service/AuthorsBackend.cs
+++ b/src/dotnet/Chat.Service/AuthorsBackend.cs
@@ -281,7 +281,7 @@ public class AuthorsBackend(IServiceProvider services) : DbServiceBase<ChatDbCon
             if (existingAuthor == null) {
                 // Set the read position to the very end
                 var chatTextIdRange = await ChatsBackend
-                    .GetIdRange(command.ChatId, false, cancellationToken)
+                    .GetLidRange(command.ChatId, false, cancellationToken)
                     .ConfigureAwait(false);
                 var readPosition = new ChatPosition(chatTextIdRange.End - 1);
                 context.Operation.AddEvent(

--- a/src/dotnet/Chat.Service/ChatEntryLanguagesBackend.cs
+++ b/src/dotnet/Chat.Service/ChatEntryLanguagesBackend.cs
@@ -22,10 +22,10 @@ public class ChatEntryLanguagesBackend(IServiceProvider services)
     // [ComputeMethod]
     public virtual async Task<ChatLanguageTile> GetTile(
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken)
     {
-        var idTile = IdTileStack.GetTile(idTileRange);
+        var idTile = IdTileStack.GetTile(lidTileRange);
         var smallerIdTiles = idTile.Smaller();
         if (smallerIdTiles.Length != 0) {
             var smallerChatTiles = await smallerIdTiles

--- a/src/dotnet/Chat.Service/ChatThreads.cs
+++ b/src/dotnet/Chat.Service/ChatThreads.cs
@@ -103,7 +103,7 @@ public class ChatThreads(IServiceProvider services) : IChatThreads
         var messageCount = 0;
         var topAuthorIds = new List<AuthorId>();
         var authorIds = new HashSet<AuthorId>();
-        var range = await ChatsBackend.GetIdRange(threadChatId, false, cancellationToken).ConfigureAwait(false);
+        var range = await ChatsBackend.GetLidRange(threadChatId, false, cancellationToken).ConfigureAwait(false);
         var entries = ChatsBackend.ReadEntries(threadChatId, range, false, cancellationToken);
         var entryCount = 0;
         var attachmentList = new List<ChatEntryAttachment>();
@@ -169,6 +169,14 @@ public class ChatThreads(IServiceProvider services) : IChatThreads
         var parentChat = await Chats.Get(session, parentChatId, cancellationToken).Require().ConfigureAwait(false);
         parentChat.Rules.Permissions.Require(ChatPermissions.Write);
         var ownerId = parentChat.Rules.Account!.Id;
+        if (parentChatId is PeerChatId peerChatId) {
+            var peerUserId = peerChatId.AnotherUserId(ownerId);
+            var peerContactId = ContactId.NewUser(peerUserId, ownerId);
+            var peerContact = await ContactsBackend.Get(peerUserId, peerContactId, cancellationToken)
+                .ConfigureAwait(false);
+            if (!peerContact.IsStoredContact)
+                throw StandardError.Constraint("Threads can be started only after this user adds you to their contacts or replies.");
+        }
 
         var isFirst = true;
         Chat? threadChat = null;

--- a/src/dotnet/Chat.Service/Chats.AdminCommands.cs
+++ b/src/dotnet/Chat.Service/Chats.AdminCommands.cs
@@ -104,7 +104,7 @@ public partial class Chats
             await CreateTestBot(session, userId, cancellationToken).ConfigureAwait(false);
 
             var contactId = ContactId.NewUser(myId, userId);
-            var contact = new Contact(contactId);
+            var contact = new Contact(contactId) { State = ContactState.Regular };
             var createCmd = new ContactsBackend_Change(contactId, null, Change.Create(contact));
             await Commander.Call(createCmd, cancellationToken).ConfigureAwait(false);
         }

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -12,8 +12,6 @@ public partial class Chats(IServiceProvider services) : IChats
     public static readonly TileStack<long> ServerIdTileStack = Constants.Chat.ServerIdTileStack;
     public static readonly TileStack<long> ViewIdTileStack = Constants.Chat.ViewIdTileStack;
 
-    private const int NonContactPeerMessageCap = 3;
-
     private IAccounts Accounts { get; } = services.GetRequiredService<IAccounts>();
     private IAuthors Authors { get; } = services.GetRequiredService<IAuthors>();
     private IAvatars Avatars { get; } = services.GetRequiredService<IAvatars>();
@@ -427,15 +425,16 @@ public partial class Chats(IServiceProvider services) : IChats
             textEntry = await Commander.Call(upsertCommand, true, cancellationToken).ConfigureAwait(false);
         }
         else { // Create
-            // In peer chats, when the caller isn't in the recipient's contacts,
-            // ChatPermissions.WriteAudio (and other content-type flags) are stripped.
-            // Use that as the cheap signal to enforce a 3-message creation cap.
-            // Edits remain unaffected since this branch only runs on create.
+            // In peer chats, when the caller isn't in the recipient's contacts and
+            // the recipient hasn't replied, ChatPermissions.WriteAudio (and other
+            // content-type flags) are stripped. Use that as the cheap signal to
+            // enforce the creation cap. Edits remain unaffected since this branch
+            // only runs on create.
             if (chatId is PeerChatId && !chat.Rules.Has(ChatPermissions.WriteAudio)) {
                 var existingCount = await Backend.GetEntryCount(chatId, author.Id, cancellationToken).ConfigureAwait(false);
-                if (existingCount >= NonContactPeerMessageCap)
+                if (existingCount >= Constants.Chat.NonContactPeerMessageLimit)
                     throw StandardError.Constraint(
-                        $"You can send up to {NonContactPeerMessageCap} messages until this user adds you to their contacts.");
+                        $"You can send up to {Constants.Chat.NonContactPeerMessageLimit} messages until this user adds you to their contacts or replies.");
             }
 
             var commandResult = await TryHandleAdminCommand(session, chatId, author, text, cancellationToken)

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -77,18 +77,18 @@ public partial class Chats(IServiceProvider services) : IChats
     public virtual async Task<ChatTile> GetTile(
         Session session,
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken)
     {
         await RequireCanRead(session, chatId, cancellationToken).ConfigureAwait(false);
-        return await Backend.GetTile(chatId, idTileRange, false, cancellationToken).ConfigureAwait(false);
+        return await Backend.GetTile(chatId, lidTileRange, false, cancellationToken).ConfigureAwait(false);
     }
 
     // Legacy compat: old clients send ChatEntryKind parameter
     [Obsolete("2026.03: Use GetTile without entryKind")]
     public virtual Task<ChatTile> GetTile(
-        Session session, ChatId chatId, int entryKind, Range<long> idTileRange, CancellationToken cancellationToken)
-        => GetTile(session, chatId, idTileRange, cancellationToken);
+        Session session, ChatId chatId, int entryKind, Range<long> lidTileRange, CancellationToken cancellationToken)
+        => GetTile(session, chatId, lidTileRange, cancellationToken);
 
     // [ComputeMethod]
     public virtual async Task<ChatRangeMeta> GetChatRangeMeta(
@@ -109,7 +109,7 @@ public partial class Chats(IServiceProvider services) : IChats
         CancellationToken cancellationToken)
     {
         await RequireCanRead(session, chatId, cancellationToken).ConfigureAwait(false);
-        return await Backend.GetIdRange(chatId, false, cancellationToken).ConfigureAwait(false);
+        return await Backend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
     }
 
     // Legacy compat: old clients send ChatEntryKind parameter
@@ -431,8 +431,9 @@ public partial class Chats(IServiceProvider services) : IChats
             // enforce the creation cap. Edits remain unaffected since this branch
             // only runs on create.
             if (chatId is PeerChatId && !chat.Rules.Has(ChatPermissions.WriteAudio)) {
-                var existingCount = await Backend.GetEntryCount(chatId, author.Id, cancellationToken).ConfigureAwait(false);
-                if (existingCount >= Constants.Chat.NonContactPeerMessageLimit)
+                var hasReachedLimit = await HasReachedNonContactPeerLimit(chatId, author.Id, cancellationToken)
+                    .ConfigureAwait(false);
+                if (hasReachedLimit)
                     throw StandardError.Constraint(
                         $"You can send up to {Constants.Chat.NonContactPeerMessageLimit} messages until this user adds you to their contacts or replies.");
             }
@@ -455,6 +456,9 @@ public partial class Chats(IServiceProvider services) : IChats
                     ClientId = command.ClientId,
                 }));
             textEntry = await Commander.Call(upsertCommand, true, cancellationToken).ConfigureAwait(false);
+            if (chatId is PeerChatId peerChatId)
+                await EnsureOwnPeerContactStored(peerChatId, chat.Rules.Account.Require().Id, cancellationToken)
+                    .ConfigureAwait(false);
         }
 
         return textEntry;
@@ -770,14 +774,16 @@ public partial class Chats(IServiceProvider services) : IChats
                 var contactId = ContactId.NewAny(userId, newChatId);
                 var contact = await ContactsBackend.Get(userId, contactId, cancellationToken).ConfigureAwait(false);
                 if (!contact.IsStored()) {
-                    var change = new Change<Contact> { Create = new Contact(contactId) };
+                    var change = new Change<Contact> {
+                        Create = new Contact(contactId) { State = ContactState.Regular },
+                    };
                     var backendCmd4 = new ContactsBackend_Change(contactId, null, change);
                     await Commander.Call(backendCmd4, true, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
         {
-            var textEntryRange = await Backend.GetIdRange(newChatId, false, cancellationToken).ConfigureAwait(false);
+            var textEntryRange = await Backend.GetLidRange(newChatId, false, cancellationToken).ConfigureAwait(false);
             var maxEntryId = textEntryRange.End > 0 ? textEntryRange.End - 1 : 0;
             var userIds = await AuthorsBackend.ListUserIds(newChatId, cancellationToken).ConfigureAwait(false);
             var updateUserChatSettingCount = 0;
@@ -945,6 +951,33 @@ public partial class Chats(IServiceProvider services) : IChats
     {
         var rules = await GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
         return rules.CanRead();
+    }
+
+    private async Task<bool> HasReachedNonContactPeerLimit(
+        ChatId chatId,
+        AuthorId authorId,
+        CancellationToken cancellationToken)
+    {
+        var messageLimit = Constants.Chat.NonContactPeerMessageLimit;
+        var firstAuthors = await Backend.GetFirstEntryAuthors(chatId, messageLimit, true, cancellationToken).ConfigureAwait(false);
+        return firstAuthors.Count == 1 && firstAuthors.Contains(authorId);
+    }
+
+    private async Task EnsureOwnPeerContactStored(
+        PeerChatId chatId,
+        UserId ownerId,
+        CancellationToken cancellationToken)
+    {
+        var contactId = ContactId.NewUser(ownerId, chatId.AnotherUserId(ownerId));
+        var contact = await ContactsBackend.Get(ownerId, contactId, cancellationToken).ConfigureAwait(false);
+        if (contact.IsStoredContact)
+            return;
+
+        var command = new ContactsBackend_Change(
+            contactId,
+            contact.IsStored() ? contact.Version : null,
+            Change.Upsert(contact with { State = ContactState.Regular }));
+        await Commander.Call(command, true, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<PrincipalId> GetOwnPrincipalId(

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -12,6 +12,8 @@ public partial class Chats(IServiceProvider services) : IChats
     public static readonly TileStack<long> ServerIdTileStack = Constants.Chat.ServerIdTileStack;
     public static readonly TileStack<long> ViewIdTileStack = Constants.Chat.ViewIdTileStack;
 
+    private const int NonContactPeerMessageCap = 3;
+
     private IAccounts Accounts { get; } = services.GetRequiredService<IAccounts>();
     private IAuthors Authors { get; } = services.GetRequiredService<IAuthors>();
     private IAvatars Avatars { get; } = services.GetRequiredService<IAvatars>();
@@ -359,6 +361,8 @@ public partial class Chats(IServiceProvider services) : IChats
         var chat = await Get(session, chatId, cancellationToken).Require().ConfigureAwait(false);
         chat.Rules.Permissions.Require(ChatPermissions.Write);
         var attachments = command.Attachments;
+        if (attachments.Length > 0 || command.HasUploadingAttachments)
+            chat.Rules.Permissions.Require(ChatPermissions.Upload);
         if (string.IsNullOrWhiteSpace(text) && attachments.Length == 0 && !command.HasUploadingAttachments)
             throw StandardError.Constraint("Sorry, you can't post empty messages.");
 
@@ -423,6 +427,17 @@ public partial class Chats(IServiceProvider services) : IChats
             textEntry = await Commander.Call(upsertCommand, true, cancellationToken).ConfigureAwait(false);
         }
         else { // Create
+            // In peer chats, when the caller isn't in the recipient's contacts,
+            // ChatPermissions.WriteAudio (and other content-type flags) are stripped.
+            // Use that as the cheap signal to enforce a 3-message creation cap.
+            // Edits remain unaffected since this branch only runs on create.
+            if (chatId is PeerChatId && !chat.Rules.Has(ChatPermissions.WriteAudio)) {
+                var existingCount = await Backend.GetEntryCount(chatId, author.Id, cancellationToken).ConfigureAwait(false);
+                if (existingCount >= NonContactPeerMessageCap)
+                    throw StandardError.Constraint(
+                        $"You can send up to {NonContactPeerMessageCap} messages until this user adds you to their contacts.");
+            }
+
             var commandResult = await TryHandleAdminCommand(session, chatId, author, text, cancellationToken)
                 .ConfigureAwait(false);
             if (commandResult != null)

--- a/src/dotnet/Chat.Service/ChatsBackend.CopyChat.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.CopyChat.cs
@@ -24,8 +24,9 @@ public partial class ChatsBackend
                     ChatEntryId.Parse(invLastEntrySid).LocalId,
                     ChangeKind.Create,
                     false);
-                _ = GetIdRange(newChatId, true, default);
-                _ = GetIdRange(newChatId, false, default);
+                _ = GetMinLid(newChatId, default);
+                _ = GetMaxLid(newChatId, true, default);
+                _ = GetMaxLid(newChatId, false, default);
             }
             return default!;
         }
@@ -44,7 +45,7 @@ public partial class ChatsBackend
         var commandTimeout = TimeSpan.FromSeconds(30);
 
         MigratedAuthors migratedAuthors;
-        var textEntryRange = new Range<long>();
+        var entryLidRange = new Range<long>();
         (RoleId Id, RoleId NewId)[] rolesMap;
         long maxAuthorLocalId;
         ChatCopyState chatCopyState;
@@ -70,17 +71,17 @@ public partial class ChatsBackend
                         cancellationToken)
                     .ConfigureAwait(false);
 
-            var sourceChatRange = await GetIdRange(chatId, true, cancellationToken).ConfigureAwait(false);
+            var sourceChatRange = await GetLidRange(chatId, true, cancellationToken).ConfigureAwait(false);
             if (!sourceChatRange.IsEmpty) {
-                var newChatRange = await GetIdRange(newChatId, true, cancellationToken).ConfigureAwait(false);
+                var newChatRange = await GetLidRange(newChatId, true, cancellationToken).ConfigureAwait(false);
                 var startEntryId = !newChatRange.IsEmpty ? newChatRange.End : 1;
                 var endEntryId = sourceChatRange.End;
                 if (endEntryId > startEntryId)
-                    textEntryRange = new Range<long>(startEntryId, endEntryId);
+                    entryLidRange = new Range<long>(startEntryId, endEntryId);
             }
 
             Log.LogInformation("OnCopyChat({CorrelationId}: text range is [{Start},{End})",
-                correlationId, textEntryRange.Start, textEntryRange.End);
+                correlationId, entryLidRange.Start, entryLidRange.End);
 
             var migratedRoles = new List<MigratedRole>();
             var hasChanges1 = await CreateOrUpdateRoles(dbContext,
@@ -120,13 +121,13 @@ public partial class ChatsBackend
         var proceed = true;
         var hasErrors = false;
         var lastProcessedEntryId = (ChatEntryId?)null;
-        if (!textEntryRange.IsEmpty) {
-            var startEntryId = textEntryRange.Start;
+        if (!entryLidRange.IsEmpty) {
+            var startEntryId = entryLidRange.Start;
             var copyContext = new CopyChatEntriesContext(chatId, newChatId, correlationId, migratedAuthors);
             const int batchLimit = 500;
 
             while (proceed) {
-                var batchRange = new Range<long>(startEntryId, textEntryRange.End);
+                var batchRange = new Range<long>(startEntryId, entryLidRange.End);
                 try {
                     var result = await CopyChatEntries(copyContext,
                             batchRange,
@@ -321,16 +322,16 @@ public partial class ChatsBackend
 
     private async Task<CopyChatEntriesResult> CopyChatEntries(
         CopyChatEntriesContext context,
-        Range<long> entryIdRange,
+        Range<long> entryLidRange,
         int batchLimit,
         CancellationToken cancellationToken)
     {
-        if (entryIdRange.IsEmpty)
+        if (entryLidRange.IsEmpty)
             return new CopyChatEntriesResult(0, null);
 
         Log.LogInformation(
             "-> CopyChatEntries({CorrelationId}), entry Id range is [{Start},{End})",
-            context.CorrelationId, entryIdRange.Start, entryIdRange.End);
+            context.CorrelationId, entryLidRange.Start, entryLidRange.End);
 
         var dbContext = await DbHub.CreateDbContext(readWrite: true, cancellationToken).ConfigureAwait(false);
         dbContext.Database.SetCommandTimeout(TimeSpan.FromSeconds(30));
@@ -340,7 +341,7 @@ public partial class ChatsBackend
 
         var result = await CopyChatEntries(dbContext,
                 context,
-                entryIdRange,
+                entryLidRange,
                 batchLimit,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -350,7 +351,7 @@ public partial class ChatsBackend
 
         Log.LogInformation(
             "<- CopyChatEntries({CorrelationId}), entry Id range is [{Start},{End})",
-            context.CorrelationId, entryIdRange.Start, entryIdRange.End);
+            context.CorrelationId, entryLidRange.Start, entryLidRange.End);
 
         return result;
     }
@@ -358,7 +359,7 @@ public partial class ChatsBackend
     private async Task<CopyChatEntriesResult> CopyChatEntries(
         ChatDbContext dbContext,
         CopyChatEntriesContext context,
-        Range<long> entryIdRange,
+        Range<long> entryLidRange,
         int batchLimit,
         CancellationToken cancellationToken)
     {
@@ -371,8 +372,8 @@ public partial class ChatsBackend
         var mentionUpdatesInsideContent = 0;
         var mentionUpdatesInSystemEntries = 0;
 
-        var minLocalId = entryIdRange.Start;
-        var maxLocalId = entryIdRange.End;
+        var minLocalId = entryLidRange.Start;
+        var maxLocalId = entryLidRange.End;
         var attachmentIds = new List<long>();
         var reactionIds = new List<long>();
 
@@ -399,7 +400,7 @@ public partial class ChatsBackend
                 chatSid,
                 newChatId,
                 correlationId,
-                new Range<long>(entryIdRange.Start, lastFetchedEntry.LocalId + 1),
+                new Range<long>(entryLidRange.Start, lastFetchedEntry.LocalId + 1),
                 migratedAuthors,
                 chatEntryWithMentionIds,
                 cancellationToken)

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -2408,17 +2408,22 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
 
         var permissions = (ChatPermissions.Write | ChatPermissions.SeeMembers | ChatPermissions.Join | ChatPermissions.EditProperties).AddImplied();
 
-        // Strip stream + upload capabilities if the caller isn't in the recipient's contacts.
-        // The 3-message cap on creates is enforced separately in Chats.OnUpsertEntry.
+        // Strip stream + upload capabilities if the caller isn't in the recipient's contacts
+        // AND the recipient hasn't replied yet. Either event lifts the restriction.
+        // The message-count cap on creates is enforced separately in Chats.OnUpsertEntry.
         var peerUserId = otherUserId!;
         var peerContactId = ContactId.NewUser(peerUserId, account.Id);
         var peerContact = await ContactsBackend.Get(peerUserId, peerContactId, cancellationToken).ConfigureAwait(false);
-        if (!peerContact.IsStored())
-            permissions &= ~(ChatPermissions.Upload
-                | ChatPermissions.WriteAudio
-                | ChatPermissions.WriteVideo
-                | ChatPermissions.ReadAudio
-                | ChatPermissions.ReadVideo);
+        if (!peerContact.IsStored()) {
+            var peerAuthorId = chatId.AnotherAuthorId(account.Id);
+            var peerEntryCount = await GetEntryCount(chatId, peerAuthorId, cancellationToken).ConfigureAwait(false);
+            if (peerEntryCount == 0)
+                permissions &= ~(ChatPermissions.Upload
+                    | ChatPermissions.WriteAudio
+                    | ChatPermissions.WriteVideo
+                    | ChatPermissions.ReadAudio
+                    | ChatPermissions.ReadVideo);
+        }
 
         return new(chatId, author, account, permissions);
     }

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -14,6 +14,7 @@ using ActualChat.Transcription;
 using Microsoft.EntityFrameworkCore;
 using ActualLab.Fusion.EntityFramework;
 using ActualLab.Resilience;
+using ActualLab.Rpc;
 
 namespace ActualChat.Chat;
 
@@ -113,20 +114,6 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
     }
 
     // [ComputeMethod]
-    public virtual async Task<long> GetEntryCount(ChatId chatId, AuthorId authorId, CancellationToken cancellationToken)
-    {
-        var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
-        await using var _ = dbContext.ConfigureAwait(false);
-
-        var sChatId = chatId.Value;
-        var sAuthorId = authorId.Value;
-        return await dbContext.ChatEntries
-            .Where(e => e.ChatId == sChatId && e.Kind == 0 && e.AuthorId == sAuthorId && !e.IsRemoved)
-            .LongCountAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    // [ComputeMethod]
     public virtual async Task<ChatId[]> GetPublicChatIdsFor(PlaceId? placeId, CancellationToken cancellationToken)
     {
         var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
@@ -187,7 +174,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             var threadPermissions = ChatPermissions.Read;
             if (parentChatRules.CanWrite() && threadChatAuthor is not null)
                 threadPermissions |= ChatPermissions.Write;
-            return new AuthorRules(chatId, threadChatAuthor, account, threadPermissions);
+            return new AuthorRules(chatId, threadChatAuthor, account, threadPermissions.AddImplied());
         }
 
         AuthorRules chatRules;
@@ -227,7 +214,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         if (chat == null)
             return null;
 
-        var idRange = await GetIdRange(chatId, false, cancellationToken).ConfigureAwait(false);
+        var idRange = await GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
         var idTile = IdTileStack.FirstLayer.GetTile(idRange.End - 1);
         var tile = await GetTile(chatId, idTile.Range, false, cancellationToken).ConfigureAwait(false);
         var lastEntry = tile.Entries.Length != 0 ? tile.Entries[^1] : null;
@@ -236,13 +223,39 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
 
     // Note that it returns (firstId, lastId + 1) range!
     // [ComputeMethod]
-    public virtual async Task<Range<long>> GetIdRange(
+    [LegacyName("GetIdRange", "2.7.9999")]
+    public virtual async Task<Range<long>> GetLidRange(
         ChatId chatId,
         bool includeRemoved,
         CancellationToken cancellationToken)
     {
-        var minId = await GetMinId(chatId, cancellationToken).ConfigureAwait(false);
+        var minLid = await GetMinLid(chatId, cancellationToken).ConfigureAwait(false);
+        var maxLid = await GetMaxLid(chatId, includeRemoved, cancellationToken).ConfigureAwait(false);
+        return (minLid, Math.Max(minLid, maxLid) + 1);
+    }
 
+    [ComputeMethod]
+    public virtual async Task<long> GetMinLid(
+        ChatId chatId,
+        CancellationToken cancellationToken)
+    {
+        var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
+        await using var _ = dbContext.ConfigureAwait(false);
+
+        return await dbContext.ChatEntries
+            .Where(e => e.ChatId == chatId.Value && e.Kind == 0)
+            .OrderBy(e => e.LocalId)
+            .Select(e => e.LocalId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    // [ComputeMethod]
+    public virtual async Task<long> GetMaxLid(
+        ChatId chatId,
+        bool includeRemoved,
+        CancellationToken cancellationToken)
+    {
         var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
         await using var _ = dbContext.ConfigureAwait(false);
 
@@ -251,23 +264,53 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             .Where(e => !e.IsThreadEntry);
         if (!includeRemoved)
             dbChatEntries = dbChatEntries.Where(e => !e.IsRemoved);
-        var maxId = await dbChatEntries
+        return await dbChatEntries
             .OrderByDescending(e => e.LocalId)
             .Select(e => e.LocalId)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
+    }
 
-        return (minId, Math.Max(minId, maxId) + 1);
+    // [ComputeMethod]
+    public virtual async Task<ApiSet<AuthorId>> GetFirstEntryAuthors(
+        ChatId chatId,
+        int entryCount,
+        bool includeRemoved,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(entryCount, 64);
+        if (entryCount <= 0)
+            return ApiSet<AuthorId>.Empty;
+
+        var minLid = await GetMinLid(chatId, cancellationToken).ConfigureAwait(false);
+        var authors = new ApiSet<AuthorId>();
+        var remainingCount = entryCount;
+        for (var idTile = IdTileStack.FirstLayer.GetTile(minLid); remainingCount > 0; idTile = idTile.Next()) {
+            var tile = await GetTile(chatId, idTile.Range, true, cancellationToken).ConfigureAwait(false);
+            if (tile.Entries.Length == 0)
+                break;
+
+            foreach (var entry in tile.Entries) {
+                if (!includeRemoved && entry.IsRemoved)
+                    continue;
+
+                authors.Add(entry.AuthorId);
+                remainingCount--;
+                if (remainingCount == 0)
+                    break;
+            }
+        }
+        return remainingCount == 0 ? authors : ApiSet<AuthorId>.Empty;
     }
 
     // [ComputeMethod]
     public virtual async Task<ChatTile> GetTile(
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         bool includeRemoved,
         CancellationToken cancellationToken)
     {
-        var idTile = IdTileStack.GetTile(idTileRange);
+        var idTile = IdTileStack.GetTile(lidTileRange);
         var smallerIdTiles = idTile.Smaller();
         if (smallerIdTiles.Length != 0) {
             var smallerChatTiles = await smallerIdTiles
@@ -280,8 +323,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             return new ChatTile(smallerChatTiles, includeRemoved);
         }
         if (!includeRemoved) {
-            var fullTile = await GetTile(chatId, idTileRange, true, cancellationToken).ConfigureAwait(false);
-            return new ChatTile(idTileRange, false, fullTile.Entries.Where(e => !e.IsRemoved).ToArray());
+            var fullTile = await GetTile(chatId, lidTileRange, true, cancellationToken).ConfigureAwait(false);
+            return new ChatTile(lidTileRange, false, fullTile.Entries.Where(e => !e.IsRemoved).ToArray());
         }
 
         // If we're here, it's the smallest tile & includeRemoved = true
@@ -322,7 +365,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                 entry = entry with { Audio = resolvedAudio with { TimeMap = entry.Audio.TimeMap } };
             return entry;
         });
-        return new ChatTile(idTileRange, true, entries.ToArray());
+        return new ChatTile(lidTileRange, true, entries.ToArray());
 
         Task<IReadOnlyDictionary<Symbol, LinkPreview>> GetLinkPreviews()
         {
@@ -346,28 +389,28 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
     }
 
     // [ComputeMethod]
-    public virtual async Task<ChatRangeMeta> GetChatRangeMeta(ChatId chatId, long idTileStart, CancellationToken cancellationToken)
+    public virtual async Task<ChatRangeMeta> GetChatRangeMeta(ChatId chatId, long lidTileStart, CancellationToken cancellationToken)
     {
-        var tile = IdTileStack.LastLayer.AssertIsTileStart(idTileStart);
+        var tile = IdTileStack.LastLayer.AssertIsTileStart(lidTileStart);
 
-        Range<long> chatIdRange;
+        Range<long> chatLidRange;
         using (Computed.BeginIsolation())
-            chatIdRange = await GetIdRange(chatId, false, cancellationToken).ConfigureAwait(false);
-        var start = tile.Start;
-        var end = tile.End;
-        var entryIdRanges = new List<Range<long>>();
+            chatLidRange = await GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
+        var startLid = tile.Start;
+        var endLid = tile.End;
+        var entryLidRanges = new List<Range<long>>();
         var conversationIdRanges = new List<Range<long>>();
         var minCount = 0;
-        var entryRangeMetaTask = GetEntryRangeMeta(chatId, idTileStart, cancellationToken);
-        var conversationRangeMetaTask = ConversationsBackend.GetRangeMeta(chatId, idTileStart, cancellationToken);
+        var entryRangeMetaTask = GetEntryRangeMeta(chatId, lidTileStart, cancellationToken);
+        var conversationRangeMetaTask = ConversationsBackend.GetRangeMeta(chatId, lidTileStart, cancellationToken);
         await Task.WhenAll(entryRangeMetaTask, conversationRangeMetaTask).ConfigureAwait(false);
 
         var entryRangeMeta = await entryRangeMetaTask.ConfigureAwait(false);
         var conversationRangeMeta = await conversationRangeMetaTask.ConfigureAwait(false);
-        entryIdRanges.AddRange(entryRangeMeta.EntryRanges);
-        conversationIdRanges.AddRange(conversationRangeMeta.ConversationRanges);
+        entryLidRanges.AddRange(entryRangeMeta.EntryLidRange);
+        conversationIdRanges.AddRange(conversationRangeMeta.ConversationLidRanges);
         minCount += EstimateMinimumCount(entryRangeMeta, conversationRangeMeta);
-        var hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(start, end).Contains(chatIdRange);
+        var hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(startLid, endLid).Contains(chatLidRange);
 
         var previousEntryRangeMeta = entryRangeMeta;
         var previousConversationRangeMeta = conversationRangeMeta;
@@ -376,8 +419,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         long previousId;
         long nextId;
         while (!hasFulfilled) {
-            previousId = Math.Max(previousEntryRangeMeta?.PreviousEntryId ?? 0, (previousConversationRangeMeta?.PreviousConversationRange?.End ?? 1) - 1);
-            nextId = Math.Min(nextEntryRangeMeta?.NextEntryId ?? long.MaxValue, nextConversationRangeMeta?.NextConversationRange?.Start ?? long.MaxValue);
+            previousId = Math.Max(previousEntryRangeMeta?.PreviousEntryLid ?? 0, (previousConversationRangeMeta?.PreviousConversationLidRange?.End ?? 1) - 1);
+            nextId = Math.Min(nextEntryRangeMeta?.NextEntryLid ?? long.MaxValue, nextConversationRangeMeta?.NextConversationLidRange?.Start ?? long.MaxValue);
             if (previousId == 0 && nextId == long.MaxValue)
                 break;
 
@@ -406,16 +449,16 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                 : null;
 
             if (previousEntryRangeMeta is not null && previousConversationRangeMeta is not null) {
-                start = previousTile.Start;
-                entryIdRanges = [..previousEntryRangeMeta.EntryRanges, ..entryIdRanges];
-                conversationIdRanges = [..previousConversationRangeMeta.ConversationRanges, ..conversationIdRanges];
+                startLid = previousTile.Start;
+                entryLidRanges = [..previousEntryRangeMeta.EntryLidRange, ..entryLidRanges];
+                conversationIdRanges = [..previousConversationRangeMeta.ConversationLidRanges, ..conversationIdRanges];
                 minCount += EstimateMinimumCount(previousEntryRangeMeta, previousConversationRangeMeta);
-                hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(start, end).Contains(chatIdRange);
+                hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(startLid, endLid).Contains(chatLidRange);
                 if (hasFulfilled)
                     break;
             }
             else
-                start = IdTileStack.LastLayer.GetTile(chatIdRange.Start).Start;
+                startLid = IdTileStack.LastLayer.GetTile(chatLidRange.Start).Start;
 
             nextEntryRangeMeta = nextEntryRangeMetaTask is not null
                 ? await nextEntryRangeMetaTask.ConfigureAwait(false)
@@ -424,25 +467,25 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                 ? await nextConversationRangeMetaTask.ConfigureAwait(false)
                 : null;
             if (nextEntryRangeMeta is null || nextConversationRangeMeta is null) {
-                end = chatIdRange.End;
+                endLid = chatLidRange.End;
                 continue;
             }
 
-            end = nextTile.End;
-            entryIdRanges.AddRange(nextEntryRangeMeta.EntryRanges);
-            conversationIdRanges.AddRange(nextConversationRangeMeta.ConversationRanges);
+            endLid = nextTile.End;
+            entryLidRanges.AddRange(nextEntryRangeMeta.EntryLidRange);
+            conversationIdRanges.AddRange(nextConversationRangeMeta.ConversationLidRanges);
             minCount += EstimateMinimumCount(nextEntryRangeMeta, nextConversationRangeMeta);
-            hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(start, end).Contains(chatIdRange);
+            hasFulfilled = minCount >= Constants.Chat.MinChatPageMapSize || new Range<long>(startLid, endLid).Contains(chatLidRange);
         }
 
-        previousId = Math.Max(previousEntryRangeMeta?.PreviousEntryId ?? 0, (previousConversationRangeMeta?.PreviousConversationRange?.End ?? 1) - 1);
-        nextId = Math.Min(nextEntryRangeMeta?.NextEntryId ?? long.MaxValue, nextConversationRangeMeta?.NextConversationRange?.Start ?? long.MaxValue);
-        entryIdRanges.Sort((a, b) => a.Start.CompareTo(b.Start));
+        previousId = Math.Max(previousEntryRangeMeta?.PreviousEntryLid ?? 0, (previousConversationRangeMeta?.PreviousConversationLidRange?.End ?? 1) - 1);
+        nextId = Math.Min(nextEntryRangeMeta?.NextEntryLid ?? long.MaxValue, nextConversationRangeMeta?.NextConversationLidRange?.Start ?? long.MaxValue);
+        entryLidRanges.Sort((a, b) => a.Start.CompareTo(b.Start));
         conversationIdRanges.Sort((a, b) => a.Start.CompareTo(b.Start));
 
         // Merge adjacent entryIdRanges into a new collection
         // to avoid duplicates and reduce the number of ranges
-        var mergedEntryIdRanges = entryIdRanges
+        var mergedEntryIdRanges = entryLidRanges
             .MergeAdjacentRanges()
             .ToList();
 
@@ -452,7 +495,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             .ToList();
 
         return new ChatRangeMeta(
-            new Range<long>(start, end),
+            new Range<long>(startLid, endLid),
             mergedEntryIdRanges.EnsureMonotonic().ToArray(),
             mergedConversationIdRanges.EnsureMonotonic().ToArray(),
             minCount,
@@ -463,8 +506,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         {
             var count = 0;
             var lastRange = new Range<long>(0, 0);
-            var merged = entryRangeMeta1.EntryRanges
-                .Merge(conversationRangeMeta1.ConversationRanges, (ce, co) => ce.IntersectWith(co).IsEmpty ? (int)(ce.Start - co.Start) : 0)
+            var merged = entryRangeMeta1.EntryLidRange
+                .Merge(conversationRangeMeta1.ConversationLidRanges, (ce, co) => ce.IntersectWith(co).IsEmpty ? (int)(ce.Start - co.Start) : 0)
                 .ToList();
 
             Range<long>? pendingRight = null; // right part of the current entryRange
@@ -1184,14 +1227,14 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         if (Invalidation.IsActive) {
             var invChatEntry = context.Operation.Items.KeylessGet<ChatEntry>();
             var invBoundToThreadHasChanged = context.Operation.Items.Get<bool>(boundToThreadHasChangedKey);
+            var previousEntryId = context.Operation.Items.Get<long>(nameof(ChatEntryRangeMeta.PreviousEntryLid));
+            var nextEntryId = context.Operation.Items.Get<long>(nameof(ChatEntryRangeMeta.NextEntryLid));
             if (invChatEntry != null) {
                 InvalidateTiles(chatId, invChatEntry.LocalId, changeKind, invBoundToThreadHasChanged);
 
                 var entryTile = IdTileStack.LastLayer.GetTile(invChatEntry.LocalId);
                 _ = GetEntryRangeMeta(chatId, entryTile.Range.Start, default);
 
-                var previousEntryId = context.Operation.Items.Get<long>(nameof(ChatEntryRangeMeta.PreviousEntryId));
-                var nextEntryId = context.Operation.Items.Get<long>(nameof(ChatEntryRangeMeta.NextEntryId));
                 if (previousEntryId != 0 && !entryTile.Range.Contains(previousEntryId)) {
                     var previousEntryIdTile = IdTileStack.LastLayer.GetTile(previousEntryId);
                     _ = GetEntryRangeMeta(chatId, previousEntryIdTile.Range.Start, default);
@@ -1205,18 +1248,18 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             // Invalidate min-max Id range at last
             switch (changeKind) {
             case ChangeKind.Create:
-                var createdChatEntry = context.Operation.Items.Get<ChatEntryId>(CreatedChatEntryId);
-                if (createdChatEntry is { LocalId: <= 1 })
-                    _ = GetMinId(createdChatEntry.ChatId, default);
-                _ = GetIdRange(chatId, true, default);
-                _ = GetIdRange(chatId, false, default);
+                var createdChatEntryId = context.Operation.Items.Get<ChatEntryId>(CreatedChatEntryId);
+                if (createdChatEntryId is not null && previousEntryId == 0)
+                    _ = GetMinLid(createdChatEntryId.ChatId, default);
+                _ = GetMaxLid(chatId, true, default);
+                _ = GetMaxLid(chatId, false, default);
                 break;
             case ChangeKind.Update when invBoundToThreadHasChanged:
-                _ = GetIdRange(chatId, true, default);
-                _ = GetIdRange(chatId, false, default);
+                _ = GetMaxLid(chatId, true, default);
+                _ = GetMaxLid(chatId, false, default);
                 break;
             case ChangeKind.Remove:
-                _ = GetIdRange(chatId, false, default);
+                _ = GetMaxLid(chatId, false, default);
                 break;
             }
             return null!;
@@ -1416,9 +1459,9 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                 .ConfigureAwait(false);
 
             if (previousEntryId != 0)
-                context.Operation.Items.Set(nameof(ChatEntryRangeMeta.PreviousEntryId), previousEntryId);
+                context.Operation.Items.Set(nameof(ChatEntryRangeMeta.PreviousEntryLid), previousEntryId);
             if (nextEntryId != 0)
-                context.Operation.Items.Set(nameof(ChatEntryRangeMeta.NextEntryId), nextEntryId);
+                context.Operation.Items.Set(nameof(ChatEntryRangeMeta.NextEntryLid), nextEntryId);
         }
     }
 
@@ -1811,7 +1854,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             }
         }
         else {
-            var idRange = await GetIdRange(chatId, false, cancellationToken).ConfigureAwait(false);
+            var idRange = await GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
             var lastEntryId = idRange.End - 1; // Start tracking positions stat since this entry
             var shouldTrackPosition = entryLid >= lastEntryId;
             dbContext.Add(new DbReadPositionsStat() {
@@ -2101,24 +2144,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         }
     }
 
-
     // Protected methods
-
-    [ComputeMethod]
-    protected virtual async Task<long> GetMinId(
-        ChatId chatId,
-        CancellationToken cancellationToken)
-    {
-        var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
-        await using var _ = dbContext.ConfigureAwait(false);
-
-        return await dbContext.ChatEntries
-            .Where(e => e.ChatId == chatId.Value && e.Kind == 0)
-            .OrderBy(e => e.LocalId)
-            .Select(e => e.LocalId)
-            .FirstOrDefaultAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
 
     protected void InvalidateTiles(
         ChatId chatId,
@@ -2126,7 +2152,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         ChangeKind changeKind,
         bool boundToThreadHasChanged)
     {
-        // Invalidate GetTile & GetEntryCount for chat tiles
+        // Invalidate GetTile for chat tiles
         foreach (var idTile in IdTileStack.GetAllTiles(entryId)) {
             if (idTile.Layer.Smaller != null)
                 continue;
@@ -2408,22 +2434,18 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
 
         var permissions = (ChatPermissions.Write | ChatPermissions.SeeMembers | ChatPermissions.Join | ChatPermissions.EditProperties).AddImplied();
 
-        // Strip stream + upload capabilities if the caller isn't in the recipient's contacts
-        // AND the recipient hasn't replied yet. Either event lifts the restriction.
+        // Strip stream + upload capabilities if the recipient hasn't explicitly stored
+        // the caller's contact. A recipient reply stores this contact automatically.
         // The message-count cap on creates is enforced separately in Chats.OnUpsertEntry.
         var peerUserId = otherUserId!;
         var peerContactId = ContactId.NewUser(peerUserId, account.Id);
         var peerContact = await ContactsBackend.Get(peerUserId, peerContactId, cancellationToken).ConfigureAwait(false);
-        if (!peerContact.IsStored()) {
-            var peerAuthorId = chatId.AnotherAuthorId(account.Id);
-            var peerEntryCount = await GetEntryCount(chatId, peerAuthorId, cancellationToken).ConfigureAwait(false);
-            if (peerEntryCount == 0)
-                permissions &= ~(ChatPermissions.Upload
-                    | ChatPermissions.WriteAudio
-                    | ChatPermissions.WriteVideo
-                    | ChatPermissions.ReadAudio
-                    | ChatPermissions.ReadVideo);
-        }
+        if (!peerContact.IsStoredContact)
+            permissions &= ~(ChatPermissions.Upload
+                | ChatPermissions.WriteAudio
+                | ChatPermissions.WriteVideo
+                | ChatPermissions.ReadAudio
+                | ChatPermissions.ReadVideo);
 
         return new(chatId, author, account, permissions);
     }

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -2,6 +2,7 @@ using ActualChat.Chat.Db;
 using ActualChat.Chat.Flows;
 using ActualChat.Chat.ML;
 using ActualChat.Chat.Module;
+using ActualChat.Contacts;
 using ActualChat.Db;
 using ActualChat.Diagnostics;
 using ActualChat.Flows;
@@ -47,6 +48,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
     private IInvitesBackend InvitesBackend => field ??= Services.GetRequiredService<IInvitesBackend>();
     private IPlacesBackend PlacesBackend => field ??= Services.GetRequiredService<IPlacesBackend>();
     private IConversationsBackend ConversationsBackend => field ??= Services.GetRequiredService<IConversationsBackend>();
+    private IContactsBackend ContactsBackend => field ??= Services.GetRequiredService<IContactsBackend>();
     private IServerKvasBackend ServerKvasBackend => field ??= Services.GetRequiredService<IServerKvasBackend>();
     private HostInfo HostInfo => field ??= Services.HostInfo();
     private IMarkupParser MarkupParser => field ??= Services.GetRequiredService<IMarkupParser>();
@@ -107,6 +109,20 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         var sid = chatId.Value;
         return await dbContext.ChatEntries.Where(x => x.Id == sid && x.Kind == 0)
             .MaxAsync(x => (long?)x.Version, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    // [ComputeMethod]
+    public virtual async Task<long> GetEntryCount(ChatId chatId, AuthorId authorId, CancellationToken cancellationToken)
+    {
+        var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
+        await using var _ = dbContext.ConfigureAwait(false);
+
+        var sChatId = chatId.Value;
+        var sAuthorId = authorId.Value;
+        return await dbContext.ChatEntries
+            .Where(e => e.ChatId == sChatId && e.Kind == 0 && e.AuthorId == sAuthorId && !e.IsRemoved)
+            .LongCountAsync(cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -2391,6 +2407,19 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         }
 
         var permissions = (ChatPermissions.Write | ChatPermissions.SeeMembers | ChatPermissions.Join | ChatPermissions.EditProperties).AddImplied();
+
+        // Strip stream + upload capabilities if the caller isn't in the recipient's contacts.
+        // The 3-message cap on creates is enforced separately in Chats.OnUpsertEntry.
+        var peerUserId = otherUserId!;
+        var peerContactId = ContactId.NewUser(peerUserId, account.Id);
+        var peerContact = await ContactsBackend.Get(peerUserId, peerContactId, cancellationToken).ConfigureAwait(false);
+        if (!peerContact.IsStored())
+            permissions &= ~(ChatPermissions.Upload
+                | ChatPermissions.WriteAudio
+                | ChatPermissions.WriteVideo
+                | ChatPermissions.ReadAudio
+                | ChatPermissions.ReadVideo);
+
         return new(chatId, author, account, permissions);
     }
 

--- a/src/dotnet/Chat.Service/ChatsUpgradeBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsUpgradeBackend.cs
@@ -137,7 +137,7 @@ public partial class ChatsUpgradeBackend : DbServiceBase<ChatDbContext>, IChatsU
                 if (position.EntryLid <= 0)
                     continue;
 
-                var idRange = await ChatsBackend.GetIdRange(chatId, false, cancellationToken).ConfigureAwait(false);
+                var idRange = await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
                 var lastEntryLid = idRange.End - 1;
                 if (lastEntryLid >= position.EntryLid)
                     continue;

--- a/src/dotnet/Chat.Service/Conversations.cs
+++ b/src/dotnet/Chat.Service/Conversations.cs
@@ -11,13 +11,13 @@ public class Conversations(IServiceProvider services) : IConversations
     private ICommander Commander { get; } = services.GetRequiredService<ICommander>();
 
     // [Computed]
-    public virtual async Task<Conversation[]> GetTile(Session session, ChatId chatId, Range<long> idTileRange, CancellationToken cancellationToken)
+    public virtual async Task<Conversation[]> GetTile(Session session, ChatId chatId, Range<long> lidTileRange, CancellationToken cancellationToken)
     {
         var rules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
         if (!rules.CanRead())
             return [];
 
-        return await Backend.GetTile(chatId, idTileRange, cancellationToken).ConfigureAwait(false);
+        return await Backend.GetTile(chatId, lidTileRange, cancellationToken).ConfigureAwait(false);
     }
 
     public virtual async Task<Conversation?> Get(Session session, ConversationId conversationId, CancellationToken cancellationToken)
@@ -41,7 +41,7 @@ public class Conversations(IServiceProvider services) : IConversations
         if (conversation == null)
             throw new NotFoundException<Conversation>();
 
-        var entryIdRange = conversation.EntryRange;
+        var entryIdRange = conversation.EntryLidRange;
         var reSummarizeCommand = new ConversationBackend_Summarize(chatId, [entryIdRange]);
         await Commander.Call(reSummarizeCommand, cancellationToken).ConfigureAwait(false);
     }

--- a/src/dotnet/Chat.Service/ConversationsBackend.cs
+++ b/src/dotnet/Chat.Service/ConversationsBackend.cs
@@ -85,9 +85,9 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
     }
 
     // [Computed]
-    public virtual async Task<Conversation[]> GetTile(ChatId chatId, Range<long> idTileRange, CancellationToken cancellationToken)
+    public virtual async Task<Conversation[]> GetTile(ChatId chatId, Range<long> lidTileRange, CancellationToken cancellationToken)
     {
-        var idTiles = IdTileStack.LastLayer.GetCoveringTiles(idTileRange);
+        var idTiles = IdTileStack.LastLayer.GetCoveringTiles(lidTileRange);
         var conversationTiles = await idTiles
             .Select(idTile => GetRangeMeta(chatId, idTile.Range.Start, cancellationToken))
             .Collect(cancellationToken)
@@ -100,8 +100,8 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
             .ConfigureAwait(false);
 
         return conversations
-            .Where(c => c != null && !c.EntryRange.IntersectWith(idTileRange).IsEmpty)
-            .OrderBy(c => c!.EntryRange.Start)
+            .Where(c => c != null && !c.EntryLidRange.IntersectWith(lidTileRange).IsEmpty)
+            .OrderBy(c => c!.EntryLidRange.Start)
             .ToArray()!;
     }
 
@@ -117,10 +117,10 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
             var invConversation = context.Operation.Items.KeylessGet<Conversation>();
             if (invConversation != null) {
                 _ = Get(invConversation.Id, default);
-                foreach (var idTile in IdTileStack.LastLayer.GetCoveringTiles(invConversation.EntryRange))
+                foreach (var idTile in IdTileStack.LastLayer.GetCoveringTiles(invConversation.EntryLidRange))
                     _ = GetRangeMeta(chatId, idTile.Range.Start, default);
-                var previousConversationId = context.Operation.Items.Get<long>(nameof(ConversationRangeMeta.PreviousConversationRange));
-                var nextConversationId = context.Operation.Items.Get<long>(nameof(ConversationRangeMeta.NextConversationRange));
+                var previousConversationId = context.Operation.Items.Get<long>(nameof(ConversationRangeMeta.PreviousConversationLidRange));
+                var nextConversationId = context.Operation.Items.Get<long>(nameof(ConversationRangeMeta.NextConversationLidRange));
                 if (previousConversationId != default) {
                     var previousIdTile = IdTileStack.LastLayer.GetTile(previousConversationId);
                     _ = GetRangeMeta(chatId, previousIdTile.Range.Start, default);
@@ -218,7 +218,7 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
             var newConversation = DiffEngine.Patch(originalConversation, diff) with {
                 Version = VersionGenerator.NextVersion(originalConversation.Version),
             };
-            if (newConversation.EntryRange.Start != originalConversation.EntryRange.Start)
+            if (newConversation.EntryLidRange.Start != originalConversation.EntryLidRange.Start)
                 throw StandardError.Constraint("EntryRange.Start can't be changed.");
 
             // Validation
@@ -246,9 +246,9 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
                 .ConfigureAwait(false);
 
             if (previousConversationId != 0)
-                context.Operation.Items.Set(nameof(ConversationRangeMeta.PreviousConversationRange), previousConversationId);
+                context.Operation.Items.Set(nameof(ConversationRangeMeta.PreviousConversationLidRange), previousConversationId);
             if (nextConversationId != 0)
-                context.Operation.Items.Set(nameof(ConversationRangeMeta.NextConversationRange), nextConversationId);
+                context.Operation.Items.Set(nameof(ConversationRangeMeta.NextConversationLidRange), nextConversationId);
         }
     }
 
@@ -340,7 +340,7 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
         var conversation = await Get(conversationId, cancellationToken).ConfigureAwait(false);
         conversation.Require();
 
-        var entriesInfo = await GetTextEntries(chatId, [conversation.EntryRange, replyIdRange], cancellationToken).ConfigureAwait(false);
+        var entriesInfo = await GetTextEntries(chatId, [conversation.EntryLidRange, replyIdRange], cancellationToken).ConfigureAwait(false);
         var entries = entriesInfo.TextEntries;
         var summaryResult = await ConversationSummarizer.Summarize(entries, cancellationToken).ConfigureAwait(false);
         if (!summaryResult.HasResult)
@@ -368,10 +368,10 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
 
     // Private methods
 
-    private async Task<ConversationEntriesInfo> GetTextEntries(ChatId chatId, Range<long>[] entryIdRanges, CancellationToken cancellationToken)
+    private async Task<ConversationEntriesInfo> GetTextEntries(ChatId chatId, Range<long>[] entryLidRanges, CancellationToken cancellationToken)
     {
-        Log.LogInformation("-> GetTextEntries: {Ranges}", entryIdRanges.Select(c => c.ToString()).ToCommaPhrase());
-        var idTiles = entryIdRanges
+        Log.LogInformation("-> GetTextEntries: {Ranges}", entryLidRanges.Select(c => c.ToString()).ToCommaPhrase());
+        var idTiles = entryLidRanges
             .SelectMany(idRange => IdTileStack.GetOptimalCoveringTiles(idRange))
             .ToList();
 
@@ -385,7 +385,7 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
         var attachmentCount = 0;
         var chatEntries = tiles
             .SelectMany(tile => tile.Entries)
-            .Where(e => entryIdRanges.Any(r => r.Contains(e.LocalId)))
+            .Where(e => entryLidRanges.Any(r => r.Contains(e.LocalId)))
             .ToArray();
         foreach (var entry in chatEntries) {
             textEntries.Add(new ChatEntrySlim(entry));

--- a/src/dotnet/Chat.Service/Db/DbChatEntry.cs
+++ b/src/dotnet/Chat.Service/Db/DbChatEntry.cs
@@ -8,7 +8,7 @@ namespace ActualChat.Chat.Db;
 
 [Table("ChatEntries")]
 [Index(nameof(ChatId), nameof(Kind), nameof(LocalId), IsUnique = true)]
-[Index(nameof(ChatId), nameof(Kind), nameof(IsRemoved), nameof(LocalId))] // For GetEntryCount queries
+[Index(nameof(ChatId), nameof(Kind), nameof(IsRemoved), nameof(LocalId))] // For GetMaxLid queries
 [Index(nameof(ChatId), nameof(Kind), nameof(BeginsAt), nameof(EndsAt))]
 [Index(nameof(ChatId), nameof(Kind), nameof(EndsAt), nameof(BeginsAt))]
 [Index(nameof(ChatId), nameof(Kind), nameof(Version))]

--- a/src/dotnet/Chat.Service/Flows/ConversationSplitFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/ConversationSplitFlow.cs
@@ -30,7 +30,7 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
     [DataMember(Order = 3), MemoryPackOrder(3), Key(3)]
     public Moment LastSummaryAt { get; set; }
     [DataMember(Order = 4), MemoryPackOrder(4), Key(4)]
-    public Range<long>[] LastSummaryRanges { get; set; } = [];
+    public Range<long>[] LastSummaryLidRanges { get; set; } = [];
     [DataMember(Order = 5), MemoryPackOrder(5), Key(5)]
     public FlowReadiness LastReadiness { get; set; }
 
@@ -121,7 +121,7 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
             }
 
             var idRanges = group.LocalIdRanges;
-            if (LastSummaryRanges.SequenceEqual(idRanges)) {
+            if (LastSummaryLidRanges.SequenceEqual(idRanges)) {
                 Console.Log("Skipping group: ranges match LastSummaryRanges");
                 continue;
             }
@@ -130,7 +130,7 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
             var summarize = new ConversationBackend_Summarize(ChatId, [.. idRanges]);
             await Services.Queues().Enqueue(summarize, cancellationToken).ConfigureAwait(false);
             LastSummaryAt = now;
-            LastSummaryRanges = idRanges.ToArray();
+            LastSummaryLidRanges = idRanges.ToArray();
         }
 
         if (hasEntries)
@@ -138,7 +138,7 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
 
         // If we reached the end of the entries, we might want to summarize the last group
         if (!hasMore) {
-            var lastRanges = LastSummaryRanges;
+            var lastRanges = LastSummaryLidRanges;
             var currentRanges = new EntryGroupBuilder(state.CurrentGroup)
                 .AddRange(state.CurrentChunk?.Entries ?? [])
                 .Build().LocalIdRanges;
@@ -159,12 +159,12 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
                 var group = groupBuilder.Build();
 
                 var idRanges = group.LocalIdRanges;
-                if (!LastSummaryRanges.SequenceEqual(idRanges)) {
+                if (!LastSummaryLidRanges.SequenceEqual(idRanges)) {
                     Console.Log($"Enqueuing end-of-stream summarize: {group.Entries.Count} entries, {group.WordCount} words");
                     var summarize = new ConversationBackend_Summarize(ChatId, [.. idRanges]);
                     await Services.Queues().Enqueue(summarize, cancellationToken).ConfigureAwait(false);
                     LastSummaryAt = now;
-                    LastSummaryRanges = idRanges.ToArray();
+                    LastSummaryLidRanges = idRanges.ToArray();
                 }
 
                 // Keep the group if there are immature items, otherwise clear the chunk

--- a/src/dotnet/Chat.Service/LegacyChats.cs
+++ b/src/dotnet/Chat.Service/LegacyChats.cs
@@ -18,9 +18,9 @@ public class LegacyChats(IServiceProvider services) : ILegacyChats
     }
 
     public virtual async Task<LegacyChatTile> GetTile(
-        Session session, ChatId chatId, Range<long> idTileRange, CancellationToken cancellationToken)
+        Session session, ChatId chatId, Range<long> lidTileRange, CancellationToken cancellationToken)
     {
-        var tile = await Chats.GetTile(session, chatId, idTileRange, cancellationToken).ConfigureAwait(false);
+        var tile = await Chats.GetTile(session, chatId, lidTileRange, cancellationToken).ConfigureAwait(false);
         return LegacyChatTile.From(tile);
     }
 

--- a/src/dotnet/Chat.Service/Translations.cs
+++ b/src/dotnet/Chat.Service/Translations.cs
@@ -24,10 +24,10 @@ public class Translations(IServiceProvider services) : ITranslations
     public virtual async Task<ChatLanguageTile> GetLanguageTile(
         Session session,
         ChatId chatId,
-        Range<long> idTileRange,
+        Range<long> lidTileRange,
         CancellationToken cancellationToken)
     {
         _ = await Chats.Get(session, chatId, cancellationToken).Require().ConfigureAwait(false);
-        return await ChatEntryLanguagesBackend.GetTile(chatId, idTileRange, cancellationToken).ConfigureAwait(false);
+        return await ChatEntryLanguagesBackend.GetTile(chatId, lidTileRange, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/dotnet/Contacts.Service.Migration/Migrations/20260428185646_AddContactState.Designer.cs
+++ b/src/dotnet/Contacts.Service.Migration/Migrations/20260428185646_AddContactState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ActualChat.Contacts.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ActualChat.Contacts.Migrations
 {
     [DbContext(typeof(ContactsDbContext))]
-    partial class ContactsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428185646_AddContactState")]
+    partial class AddContactState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/dotnet/Contacts.Service.Migration/Migrations/20260428185646_AddContactState.cs
+++ b/src/dotnet/Contacts.Service.Migration/Migrations/20260428185646_AddContactState.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActualChat.Contacts.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContactState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "state",
+                table: "contacts",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+            migrationBuilder.Sql("UPDATE contacts SET state = 16;"); // 0x10 = ContactState.Regular
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "state",
+                table: "contacts");
+        }
+    }
+}

--- a/src/dotnet/Contacts.Service/ContactLinker.cs
+++ b/src/dotnet/Contacts.Service/ContactLinker.cs
@@ -87,10 +87,10 @@ public class ContactLinker(IServiceProvider services) : ActivatedWorkerBase(serv
         var contactId = ContactId.NewUser(ownerId, userId);
         // check existing contact since command always performs db request
         var contact = await ContactsBackend.Get(ownerId, contactId, cancellationToken).ConfigureAwait(false);
-        if (!contact.IsStored()) {
-            contact = new Contact(contactId);
+        if (!contact.IsStored() || !contact.IsStoredContact) {
+            contact = contact with { State = ContactState.Regular };
             // This command doesn't throw an exception in case contact already exists
-            var createCmd = new ContactsBackend_Change(contactId, null, Change.Create(contact));
+            var createCmd = new ContactsBackend_Change(contactId, null, Change.Upsert(contact));
             await Commander.Call(createCmd, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/dotnet/Contacts.Service/Contacts.cs
+++ b/src/dotnet/Contacts.Service/Contacts.cs
@@ -101,6 +101,7 @@ public class Contacts(IServiceProvider services) : IContacts
         if (id.OwnerId != account.Id)
             throw Unauthorized();
 
+        change = EnsureStoredContactState(change);
         var changeCommand = new ContactsBackend_Change(id, expectedVersion, change);
         return await Commander.Call(changeCommand, true, cancellationToken).ConfigureAwait(false);
     }
@@ -135,6 +136,20 @@ public class Contacts(IServiceProvider services) : IContacts
     }
 
     // Private methods
+
+    private static Change<Contact> EnsureStoredContactState(Change<Contact> change)
+    {
+        if (change.IsCreate(out var create))
+            return Change.Create(EnsureStored(create));
+        if (change.IsUpdate(out var update))
+            return Change.Update(EnsureStored(update));
+        return change;
+
+        static Contact EnsureStored(Contact contact)
+            => contact.State == ContactState.Temporary
+                ? contact with { State = ContactState.Regular }
+                : contact;
+    }
 
     private static Exception Unauthorized()
         => StandardError.Unauthorized("You can access only your own contacts.");

--- a/src/dotnet/Contacts.Service/ContactsBackend.cs
+++ b/src/dotnet/Contacts.Service/ContactsBackend.cs
@@ -317,8 +317,22 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
         var existing = dbContact?.ToModel();
 
         if (change.IsCreate(out var contact)) {
-            if (dbContact != null)
-                return dbContact.ToModel(); // Already exists, so we don't recreate one
+            if (dbContact != null) {
+                var existingContact = existing.Require();
+                if (contact.State != ContactState.Regular || existingContact.State == ContactState.Regular)
+                    return existingContact; // Already exists, so we don't recreate one
+
+                contact = existingContact with {
+                    Version = VersionGenerator.NextVersion(dbContact.Version),
+                    State = ContactState.Regular,
+                    TouchedAt = Clocks.SystemClock.Now,
+                };
+                dbContact.UpdateFrom(contact);
+                await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                context.Operation.Items.KeylessSet((long)oldContactIds.IndexOf(id));
+                context.Operation.AddEvent(new ContactChangedEvent(contact, existing, ChangeKind.Update));
+                return contact;
+            }
 
             // Original UserId is ignored here - it's set based on Id
             var userId = id.ChatId is PeerChatId peerChatId
@@ -538,6 +552,7 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
             }
             var contact = new Contact(ContactId.NewUser(ownerId, account.Id)) {
                 ExternalContactName = externalContactName,
+                State = ContactState.Regular,
             };
             var cmd = new ContactsBackend_Change(contact.Id, null, Change.Create(contact));
             return await Commander.Call(cmd, true, cancellationToken).ConfigureAwait(false);
@@ -623,7 +638,7 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
             if (contact.IsStored())
                 continue; // No need to make any changes
 
-            var change = Change.Create(new Contact(contactId));
+            var change = Change.Create(new Contact(contactId) { State = ContactState.Regular });
             var createContact = new ContactsBackend_Change(contactId, null, change);
             await Commander.Call(createContact, false, cancellationToken).ConfigureAwait(false);
         }
@@ -821,8 +836,9 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
             return;
         }
 
+        var contactState = chatId.Kind == ChatKind.Peer ? ContactState.Temporary : ContactState.Regular;
         var change = new Change<Contact> {
-            Create = new Contact(contactId),
+            Create = new Contact(contactId) { State = contactState },
         };
         var command = new ContactsBackend_Change(contactId, null, change);
         await Commander.Call(command, true, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/Contacts.Service/Db/DbContact.cs
+++ b/src/dotnet/Contacts.Service/Db/DbContact.cs
@@ -20,6 +20,7 @@ public class DbContact : IHasId<string>, IHasVersion<long>, IRequirementTarget
     public string? PlaceId { get; set; }
     public string PeerContactName { get; set; } = "";
     public string ExternalContactName { get; set; } = "";
+    public ContactState State { get; set; }
     public bool IsPinned { get; set; }
 
     public DateTime TouchedAt {
@@ -37,6 +38,7 @@ public class DbContact : IHasId<string>, IHasVersion<long>, IRequirementTarget
             IsPinned = IsPinned,
             PeerContactName = PeerContactName,
             ExternalContactName = ExternalContactName,
+            State = State,
         };
 
     public void UpdateFrom(Contact model)
@@ -50,6 +52,7 @@ public class DbContact : IHasId<string>, IHasVersion<long>, IRequirementTarget
         IsPinned = model.IsPinned;
         PeerContactName = model.PeerContactName;
         ExternalContactName = model.ExternalContactName;
+        State = model.State;
         if (!Id.IsNullOrEmpty())
             return; // Only the above properties can be changed for already existing contacts
 

--- a/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
+++ b/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
@@ -76,6 +76,7 @@ public partial class AudioStreamingBackend
             chatId, record.ClientStartOffset, clockDelta.TotalMilliseconds);
         var rules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
         rules.Require(ChatPermissions.Write);
+        rules.Require(ChatPermissions.WriteAudio);
 
         var languages = await GetTranscriptionLanguage(record, cancellationToken).ConfigureAwait(false);
 

--- a/src/dotnet/Streaming.Service/Backend/VideoStreamingBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/VideoStreamingBackend.cs
@@ -183,6 +183,7 @@ public class VideoStreamingBackend : IVideoStreamingBackend, IDisposable
         var rules = await Chats.GetRules(record.Session, record.ChatId, cancellationToken)
             .ConfigureAwait(false);
         rules.Require(ChatPermissions.Write);
+        rules.Require(ChatPermissions.WriteVideo);
 
         var author = await Authors
             .EnsureJoined(record.Session, record.ChatId, cancellationToken)

--- a/src/dotnet/Streaming.Service/Services/LiveAudioStreams.cs
+++ b/src/dotnet/Streaming.Service/Services/LiveAudioStreams.cs
@@ -25,6 +25,8 @@ public class LiveAudioStreams(IServiceProvider services) : ILiveAudioStreams
     {
         var chat = await Chats.Get(session, chatId, cancellationToken).ConfigureAwait(false);
         chat.Require();
+        if (!chat.Rules.Has(ChatPermissions.ReadAudio))
+            return [];
         return await LiveBackend.List(chatId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -36,6 +38,7 @@ public class LiveAudioStreams(IServiceProvider services) : ILiveAudioStreams
     {
         var chat = await Chats.Get(session, chatId, cancellationToken).ConfigureAwait(false);
         chat.Require();
+        chat.Rules.Require(ChatPermissions.ReadAudio);
 
         LiveStreamMuxer muxer;
         var key = (session, chatId);
@@ -63,6 +66,7 @@ public class LiveAudioStreams(IServiceProvider services) : ILiveAudioStreams
     {
         var chat = await Chats.Get(session, chatId, cancellationToken).ConfigureAwait(false);
         chat.Require();
+        chat.Rules.Require(ChatPermissions.ReadAudio);
 
         if (_liveMuxers.TryGetValue((session, chatId), out var muxer))
             muxer.UpdateConfig(settings);
@@ -78,6 +82,7 @@ public class LiveAudioStreams(IServiceProvider services) : ILiveAudioStreams
     {
         var chat = await Chats.Get(session, chatId, cancellationToken).ConfigureAwait(false);
         chat.Require();
+        chat.Rules.Require(ChatPermissions.ReadAudio);
 
         ReplayStreamMuxer muxer;
         var key = (session, chatId);

--- a/src/dotnet/Streaming.Service/Services/LiveVideoStreams.cs
+++ b/src/dotnet/Streaming.Service/Services/LiveVideoStreams.cs
@@ -18,7 +18,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         CancellationToken cancellationToken)
     {
         var chatRules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
-        if (!chatRules.Has(ChatPermissions.Read))
+        if (!chatRules.Has(ChatPermissions.ReadVideo))
             return [];
 
         var result = await Backend.List(chatId, cancellationToken).ConfigureAwait(false);
@@ -33,7 +33,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         CancellationToken cancellationToken)
     {
         var chatRules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
-        if (!chatRules.Has(ChatPermissions.Read))
+        if (!chatRules.Has(ChatPermissions.ReadVideo))
             return 0;
 
         return await Backend.GetVideoStreamMemberCount(chatId, cancellationToken).ConfigureAwait(false);
@@ -46,7 +46,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         CancellationToken cancellationToken)
     {
         var chatRules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
-        chatRules.Require(ChatPermissions.Read);
+        chatRules.Require(ChatPermissions.ReadVideo);
         await Backend.RegisterMember(chatId, session.Id, supportedDecoderCodecs, cancellationToken).ConfigureAwait(false);
     }
 
@@ -56,7 +56,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         CancellationToken cancellationToken)
     {
         var chatRules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
-        chatRules.Require(ChatPermissions.Read);
+        chatRules.Require(ChatPermissions.ReadVideo);
         await Backend.UnregisterMember(chatId, session.Id, cancellationToken).ConfigureAwait(false);
     }
 
@@ -67,7 +67,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         CancellationToken cancellationToken)
     {
         var chatRules = await Chats.GetRules(session, chatId, cancellationToken).ConfigureAwait(false);
-        chatRules.Require(ChatPermissions.Read);
+        chatRules.Require(ChatPermissions.ReadVideo);
         return await Backend.GetSupportedCodecs(chatId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -77,6 +77,7 @@ public class LiveVideoStreams(IServiceProvider services) : ILiveVideoStreams
         TimeSpan skipTo,
         CancellationToken cancellationToken)
     {
+        // Note: stream-level access is gated upstream via List/RegisterMember.
         var peerId = RpcInboundContext.Current?.Peer.Id.ToString() ?? "rpc-unknown";
         var remoteStream = await VideoStreamingBackend.GetVideo(streamId, skipTo, peerId, cancellationToken).ConfigureAwait(false);
         return remoteStream is null

--- a/src/dotnet/Streaming.Service/Services/ReplayStreamMuxer.cs
+++ b/src/dotnet/Streaming.Service/Services/ReplayStreamMuxer.cs
@@ -310,8 +310,8 @@ public sealed class ReplayStreamMuxer : WorkerBase
         if (startEntry == null)
             return null;
 
-        Range<long> idRange = (startEntry.LocalId, fullIdRange.End);
-        var entries = entryReader.Read(idRange, cancellationToken);
+        Range<long> lidRange = (startEntry.LocalId, fullIdRange.End);
+        var entries = entryReader.Read(lidRange, cancellationToken);
         ChatEntry? lastEntry = null;
         await foreach (var entry in entries.ConfigureAwait(false)) {
             if (!entry.HasAudio || entry.IsContentStreaming)
@@ -324,8 +324,8 @@ public sealed class ReplayStreamMuxer : WorkerBase
         if (lastEntry == null)
             return null;
 
-        idRange = ((Range<long>)(fullIdRange.Start, lastEntry.LocalId)).MoveEnd(1);
-        var reverseEntries = entryReader.ReadReverse(idRange, cancellationToken);
+        lidRange = ((Range<long>)(fullIdRange.Start, lastEntry.LocalId)).MoveEnd(1);
+        var reverseEntries = entryReader.ReadReverse(lidRange, cancellationToken);
         var remainingOffset = offset;
         var lastPlayingAt = playingAt;
         await foreach (var entry in reverseEntries.ConfigureAwait(false)) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -37,13 +37,15 @@
                  data-bubble-priority="150"
                  data-bubble-placement="@(FloatingPosition.Top.ToPositionString())">
                 <div class="c-left-buttons">
-                    <ButtonRound
-                        data-menu="@(MenuRef.New<ChatMessageEditorMenu>(_editorId))"
-                        data-menu-trigger="@MenuTrigger.Primary"
-                        data-menu-placement="@(FloatingPosition.Top.ToPositionString())"
-                        Class="post-panel-btn attach-btn btn-transparent btn-xxs">
-                        <i class="icon-plus-circle text-2.5xl"></i>
-                    </ButtonRound>
+                    @if (Chat.Rules.CanUpload()) {
+                        <ButtonRound
+                            data-menu="@(MenuRef.New<ChatMessageEditorMenu>(_editorId))"
+                            data-menu-trigger="@MenuTrigger.Primary"
+                            data-menu-placement="@(FloatingPosition.Top.ToPositionString())"
+                            Class="post-panel-btn attach-btn btn-transparent btn-xxs">
+                            <i class="icon-plus-circle text-2.5xl"></i>
+                        </ButtonRound>
+                    }
                 </div>
                 <label for="message-input" class="message-input-label">
                     <MarkupEditor
@@ -76,7 +78,9 @@
                 </div>
                 <RelatedChatEntryPanel/>
             }
-            <ChatAudioPanel Chat="@Chat" IsNarrow="@ScreenSize.IsNarrow()"/>
+            @if (Chat.Rules.CanWriteAudio() || Chat.Rules.CanWriteVideo() || Chat.Rules.CanReadAudio() || Chat.Rules.CanReadVideo()) {
+                <ChatAudioPanel Chat="@Chat" IsNarrow="@ScreenSize.IsNarrow()"/>
+            }
         </div>
     </MentionListManager>
 </div>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -233,7 +233,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         async Task UpdateReadPositionToTheLastId(ChatId chatId)
         {
             var chatInfo = await ChatUI.Get(chatId, DisposeToken).ConfigureAwait(true);
-            var lastId = chatInfo?.News?.TextEntryIdRange.End - 1;
+            var lastId = chatInfo?.News?.TextEntryLidRange.End - 1;
             if (lastId is not > 0)
                 return;
 
@@ -269,8 +269,8 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
         // Getting the very last chat entry
         var chatNews = await Chats.GetNews(Session, chatId, cancellationToken).ConfigureAwait(false);
-        var chatIdGap = new Range<long>(chatNews?.TextEntryIdRange.End ?? 0, chatIdRange.End);
-        var lastEntry = await entryReader.ReadReverse(chatIdGap, cancellationToken)
+        var chatLidGap = new Range<long>(chatNews?.TextEntryLidRange.End ?? 0, chatIdRange.End);
+        var lastEntry = await entryReader.ReadReverse(chatLidGap, cancellationToken)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
         lastEntry ??= chatNews?.LastTextEntry;
@@ -369,7 +369,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             renderedData,
             nav,
             chatIdRange);
-        if (dataQuery.ExistingIdRange.End + dataQuery.EndOffset + ChatUI.HalfLoadLimit >= chatIdRange.End)
+        if (dataQuery.ExistingLidRange.End + dataQuery.EndOffset + ChatUI.HalfLoadLimit >= chatIdRange.End)
             await cChatIdRange.Use(cancellationToken); // Add dependency on chatIdRange
 
         DebugLog?.LogDebug(
@@ -517,7 +517,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         VirtualListDataQuery query,
         VirtualListData<ChatMessage> oldData,
         ChatViewNavigation? navigation,
-        Range<long> chatIdRange)
+        Range<long> chatLidRange)
     {
         var firstLayer = ChatUI.IdTileStack.FirstLayer;
         var secondLayer = ChatUI.IdTileStack.LastLayer;
@@ -527,7 +527,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         var keyRange = query.IsNone
             ? firstItem != null
                 ? new Range<long>(firstItem.Id, lastItem!.Id + 1)
-                : chatIdRange.EnsureNonEmpty()
+                : chatLidRange.EnsureNonEmpty()
             : query.KeyRange.ToLongRange(true).EnsureNonEmpty();
         var caseName = (!query.IsNone, firstItem != null) switch {
             (false, false) => "no-query+no-data",
@@ -540,7 +540,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
             // No query, no data -> initial load
             (false, false) => new ChatDataQuery(
-                secondLayer.GetTile(chatIdRange.End - firstLayer.TileSize).Range,
+                secondLayer.GetTile(chatLidRange.End - firstLayer.TileSize).Range,
                 -ChatUI.HalfLoadLimit,
                 ChatUI.HalfLoadLimit),
 
@@ -567,7 +567,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         };
 
         // If we are scrolling somewhere within idRange, let's extend the range to navigation & nearby entries.
-        if (navigation != null && chatIdRange.Contains(navigation.EntryLid)) {
+        if (navigation != null && chatLidRange.Contains(navigation.EntryLid)) {
             caseName += "+navigation";
             dataQuery = new ChatDataQuery(
                 secondLayer.GetTile(navigation.EntryLid).Range,
@@ -579,7 +579,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
         DebugLog?.LogDebug(
             "GetChatDataQuery: case={Case}, result={DataQuery}, chatIdRange={IdRange}",
-            caseName, dataQuery.Format(), chatIdRange.Format());
+            caseName, dataQuery.Format(), chatLidRange.Format());
 
         return dataQuery;
     }
@@ -674,11 +674,9 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     {
         var chatId = ChatId;
         var entryReader = new ChatEntryReader(Chats, Session, chatId);
-        var chatIdRange = await Chats
-            .GetIdRange(Session, chatId, cancellationToken)
-            .ConfigureAwait(false);
+        var chatLidRange = await Chats.GetIdRange(Session, chatId, cancellationToken).ConfigureAwait(false);
         var range = new Range<long>(minEntryLid, minEntryLid + (20 * ChatUI.IdTileStack.MinTileSize))
-            .IntersectWith(chatIdRange);
+            .IntersectWith(chatLidRange);
         return await entryReader.GetFirst(range, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/LogView/LogList.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/LogView/LogList.razor.cs
@@ -30,12 +30,11 @@ public partial class LogList : IVirtualListDataSource<LogEntry>
 
         Range<long> GetIdRange()
         {
-            if (query.IsNone) {
-                var start = (fullIdRange.End - 40).Clamp(fullIdRange.Start, fullIdRange.End - 1);
-                return new (start, fullIdRange.End);
-            }
+            if (!query.IsNone)
+                return query.KeyRange.ToLongRange().Move(query.MoveRange);
 
-            return query.KeyRange.ToLongRange().Move(query.MoveRange);
+            var start = (fullIdRange.End - 40).Clamp(fullIdRange.Start, fullIdRange.End - 1);
+            return new (start, fullIdRange.End);
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatDataQuery.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatDataQuery.cs
@@ -3,15 +3,15 @@ namespace ActualChat.UI.Blazor.App.Services;
 /// <summary>
 /// Contains an inclusive range of existing chat IDs and offsets for querying chat data.
 /// </summary>
-/// <param name="ExistingIdRange">Inclusive range!</param>
+/// <param name="ExistingLidRange">Inclusive range!</param>
 /// <param name="StartOffset">How many items to load before the ExistingIdRange</param>
 /// <param name="EndOffset">How many items to load after the ExistingIdRange</param>
-public record ChatDataQuery(Range<long> ExistingIdRange, int StartOffset, int EndOffset)
+public record ChatDataQuery(Range<long> ExistingLidRange, int StartOffset, int EndOffset)
 {
     public ChatViewNavigation? Navigation { get; init; }
 
     public string Format()
- #pragma warning disable MA0076
-        => $"{ExistingIdRange}@[{StartOffset}-{EndOffset}]";
- #pragma warning restore MA0076
+#pragma warning disable MA0076
+        => $"{ExistingLidRange}@[{StartOffset}-{EndOffset}]";
+#pragma warning restore MA0076
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
@@ -250,7 +250,7 @@ public partial class ChatUI
                         var lastReadEntryLid = chatInfo.ReadEntryLid;
                         var prefetchNearTo = lastReadEntryLid != 0
                             ? lastReadEntryLid
-                            : chatInfo.News?.TextEntryIdRange.End ?? 0;
+                            : chatInfo.News?.TextEntryLidRange.End ?? 0;
 
                             var secondLayer = IdTileStack.LastLayer;
                             var idTile = secondLayer.GetTile(prefetchNearTo).Range;

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -51,7 +51,7 @@ public partial class ChatUI
         if (chat == null)
             return ChatItems.Empty;
 
-        var metaIdTiles = ServerIdTileStack.LastLayer.GetCoveringTiles(dataQuery.ExistingIdRange.Expand(LoadLimit))
+        var metaIdTiles = ServerIdTileStack.LastLayer.GetCoveringTiles(dataQuery.ExistingLidRange.Expand(LoadLimit))
             .Where(t => t.Start >= 0)
             .ToList();
         var chatRangeMetaList = (await metaIdTiles
@@ -59,15 +59,15 @@ public partial class ChatUI
                     => Chats.GetChatRangeMeta(Session, chatId, metaIdTile.Range.Start, cancellationToken))
                 .Collect(cancellationToken)
                 .ConfigureAwait(false))
-            .OrderBy(m => m.IdRange.Start)
-            .ThenByDescending(m => m.IdRange.Size()) // ChatRangeMeta can be overlapping, so we need to keep the largest
-            .EnsureMonotonic(Comparer<ChatRangeMeta>.Create((a, b) => a.IdRange.Start.CompareTo(b.IdRange.Start)))
+            .OrderBy(m => m.LidRange.Start)
+            .ThenByDescending(m => m.LidRange.Size()) // ChatRangeMeta can be overlapping, so we need to keep the largest
+            .EnsureMonotonic(Comparer<ChatRangeMeta>.Create((a, b) => a.LidRange.Start.CompareTo(b.LidRange.Start)))
             .ToList();
 
         var showConversations = chat.IsSummarized ?? false;
         if (showConversations && dataQuery.Navigation is { ShouldRestoreViewPosition: false }) {
             var conversationRanges = chatRangeMetaList
-                .SelectMany(rm => rm.ConversationIdRanges)
+                .SelectMany(rm => rm.ConversationLidRanges)
                 .EnsureMonotonic()
                 .ToList();
             var navigateToId = dataQuery.Navigation.EntryLid;
@@ -103,9 +103,9 @@ public partial class ChatUI
                     HalfLoadLimit);
         }
 
-        Range<long> chatIdRange;
+        Range<long> chatLidRange;
         using (Computed.BeginIsolation())
-            chatIdRange = await Chats.GetIdRange(Session, chatId, cancellationToken).ConfigureAwait(false);
+            chatLidRange = await Chats.GetIdRange(Session, chatId, cancellationToken).ConfigureAwait(false);
 
         if (chatRangeMetaList.Count == 0)
             return ChatItems.Empty;
@@ -113,8 +113,8 @@ public partial class ChatUI
         List<Range<long>> idTiles;
         bool hasMoreBefore, hasMoreAfter;
         while (!TryGetIdTilesToLoad(dataQuery, chatRangeMetaList, out idTiles, out hasMoreBefore, out hasMoreAfter)) {
-            var prevIdTileStart = chatRangeMetaList[0].PreviousIdTileStart;
-            var nextIdTileStart = chatRangeMetaList[^1].NextIdTileStart;
+            var prevIdTileStart = chatRangeMetaList[0].PreviousLidTileStart;
+            var nextIdTileStart = chatRangeMetaList[^1].NextLidTileStart;
             var prevChatRangeMetaTask = prevIdTileStart.HasValue
                 ? Chats.GetChatRangeMeta(Session, chatId, prevIdTileStart.Value, cancellationToken)
                 : Task.FromResult<ChatRangeMeta?>(null)!;
@@ -157,7 +157,7 @@ public partial class ChatUI
         var chatSendingMessages = Hub.SendingMessages.GetSendingMessages(chatId);
         var chatSendingMessagesWrapper = new IgnoreComputeArg<ChatSendingMessagesAccessor>(chatSendingMessages);
         var tiles = new List<VirtualListTile<ChatMessage>>();
-        var hasVeryFirstItem = idTiles.Count > 0 && idTiles[0].Start <= chatIdRange.Start;
+        var hasVeryFirstItem = idTiles.Count > 0 && idTiles[0].Start <= chatLidRange.Start;
         var prevMessage = hasVeryFirstItem ? ChatMessage.Welcome(chatId) : null;
         var alreadyAddedConversationHeaders = new HashSet<ConversationId>();
         foreach (var idTile in idTiles) {
@@ -166,7 +166,7 @@ public partial class ChatUI
                 lastReadEntryLid = 0;
             else if (shownReadyEntryLid >= idTile.End - 1)
                 lastReadEntryLid = long.MaxValue;
-            var isLastTile = idTile.Contains(chatIdRange.End - 1);
+            var isLastTile = idTile.Contains(chatLidRange.End - 1);
             var tile = await GetTile(
                     chatId,
                     chat.Rules.Author?.Id,
@@ -175,7 +175,7 @@ public partial class ChatUI
                     expandedConversations,
                     prevMessage,
                     lastReadEntryLid,
-                    isLastTile ? chatIdRange.End : null,
+                    isLastTile ? chatLidRange.End : null,
                     chatSendingMessagesWrapper,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -275,13 +275,13 @@ public partial class ChatUI
                 return true;
             }
 
-            var hasPreviousIdTile = chatRangeMeta1[0].PreviousIdTileStart.HasValue;
-            var hasNextIdTile = chatRangeMeta1[^1].NextIdTileStart.HasValue;
+            var hasPreviousIdTile = chatRangeMeta1[0].PreviousLidTileStart.HasValue;
+            var hasNextIdTile = chatRangeMeta1[^1].NextLidTileStart.HasValue;
             var entryIdRanges = chatRangeMeta1
-                .SelectMany(m => m.EntryIdRanges)
+                .SelectMany(m => m.EntryLidRanges)
                 .EnsureMonotonic();
             var conversationIdRanges = chatRangeMeta1
-                .SelectMany(m => m.ConversationIdRanges)
+                .SelectMany(m => m.ConversationLidRanges)
                 .EnsureMonotonic();
 
             var excludedRanges = conversationIdRanges
@@ -340,12 +340,12 @@ public partial class ChatUI
             var resultIdRangesSpan = resultIdRanges.AsSpan();
             var startIdWithOffset = GetIdWithOffset(
                 resultIdRangesSpan,
-                dataQuery1.ExistingIdRange.Start,
+                dataQuery1.ExistingLidRange.Start,
                 dataQuery1.StartOffset);
 
             var endIdWithOffset = GetIdWithOffset(
                 resultIdRangesSpan,
-                dataQuery1.ExistingIdRange.End,
+                dataQuery1.ExistingLidRange.End,
                 dataQuery1.EndOffset);
 
             var hasFulfilledStart = (startIdWithOffset != null && HasOffsetReached(dataQuery1.StartOffset, startIdWithOffset.Value.ActualOffset)) || !hasPreviousIdTile;
@@ -388,7 +388,7 @@ public partial class ChatUI
     protected virtual async Task<VirtualListTile<ChatMessage>> GetTile(
         ChatId chatId,
         AuthorId? currentAuthorId,
-        Range<long> idRange,
+        Range<long> lidRange,
         bool showConversations,
         IImmutableSet<ConversationId> expandedConversations,
         ChatMessage? prevMessage,
@@ -398,28 +398,28 @@ public partial class ChatUI
         CancellationToken cancellationToken = default)
     {
         // DebugLog?.LogDebug("GetTile: {ChatId} {IdRange} {LastReadEntryId}", chatId, idRange, lastReadEntryId);
-        if (idRange.IsEmptyOrNegative)
-            throw new ArgumentOutOfRangeException(nameof(idRange));
+        if (lidRange.IsEmptyOrNegative)
+            throw new ArgumentOutOfRangeException(nameof(lidRange));
 
         var chatSendingMessages = chatSendingMessagesWrapper.Value;
         var requestedIdRange = prevMessage == null
-            ? idRange.MoveStart(-IdTileStack.FirstLayer
+            ? lidRange.MoveStart(-IdTileStack.FirstLayer
                 .TileSize) // to request previous item of requested range to properly render block star - we will drop it off
-            : idRange;
+            : lidRange;
         var idRangesToSkip = Array.Empty<Range<long>>();
         var conversations = Array.Empty<Conversation>();
         var alreadyAddedConversationHeaders = new HashSet<ConversationId>();
         if (showConversations) {
-            var conversationIdTile = ServerIdTileStack.LastLayer.GetTile(idRange.Start); // Get largest tile that contains the requested range
+            var conversationIdTile = ServerIdTileStack.LastLayer.GetTile(lidRange.Start); // Get largest tile that contains the requested range
             var conversationTile = await Conversations
                 .GetTile(Session, chatId, conversationIdTile.Range, cancellationToken)
                 .ConfigureAwait(false);
             conversations = conversationTile
-                .Where(c => !c.EntryRange.IntersectWith(requestedIdRange).IsEmpty)
+                .Where(c => !c.EntryLidRange.IntersectWith(requestedIdRange).IsEmpty)
                 .ToArray();
             idRangesToSkip = conversations
                 .Where(c => !expandedConversations.Contains(c.Id))
-                .Select(c => c.EntryRange)
+                .Select(c => c.EntryLidRange)
                 .ToArray();
         }
         var entryIdTiles = IdTileStack.FirstLayer
@@ -434,7 +434,7 @@ public partial class ChatUI
             .Collect(ApiConstants.Concurrency.High, cancellationToken)
             .ConfigureAwait(false);
         var entries = new List<ChatEntry>();
-        foreach (var tile in tiles.OrderBy(t => t.IdTileRange.Start)) {
+        foreach (var tile in tiles.OrderBy(t => t.LidTileRange.Start)) {
             foreach (var e in tile.Entries) {
                 if (idRangesToSkip.Any(range => range.Contains(e.Id.LocalId)))
                     continue;
@@ -462,7 +462,7 @@ public partial class ChatUI
             }
         }
         if (entries.Count == 0 && conversations.Length == 0)
-            return new VirtualListTile<ChatMessage>(idRange);
+            return new VirtualListTile<ChatMessage>(lidRange);
 
         IReadOnlyDictionary<ChatEntryId, string> indexDocIds = ImmutableDictionary<ChatEntryId, string>.Empty;
 
@@ -501,7 +501,7 @@ public partial class ChatUI
             else if (entry != null) {
                 // Ignore matched conversation
                 var isClientMsg = entry.Version == 0;
-                var expandedConversation = conversations.FirstOrDefault(c => c.EntryRange.Contains(entry.LocalId));
+                var expandedConversation = conversations.FirstOrDefault(c => c.EntryLidRange.Contains(entry.LocalId));
                 var isBlockStart = IsBlockStart(prevEntry, entry);
                 var isForward = entry.Forwarded is not null;
                 var isPrevForward = prevEntry is not null && prevEntry.Forwarded is not null;
@@ -512,7 +512,7 @@ public partial class ChatUI
                 var isForwardAuthorBlockStart = isForwardBlockStart || (isForward && isForwardFromOtherAuthor);
                 var isEntryUnread = entry.LocalId > lastReadEntryId && !isClientMsg;
                 var isAudio = entry.HasAudio;
-                var shouldAddToResult = idRange.Contains(entry.LocalId) || entry.IsSending; // add sending entries
+                var shouldAddToResult = lidRange.Contains(entry.LocalId) || entry.IsSending; // add sending entries
                 var flags = default(ChatMessageFlags);
                 if (isBlockStart)
                     flags |= ChatMessageFlags.BlockStart;
@@ -639,12 +639,12 @@ public partial class ChatUI
             }
             prevDate = date;
         }
-        if (messages.Count > 0 && !idRange.Contains(messages[0].Id))
+        if (messages.Count > 0 && !lidRange.Contains(messages[0].Id))
             // Remove messages that are outside requested range
             messages.RemoveAll(m =>
-                (m is ChatEntryMessage && !idRange.Contains(m.Id))
-                || (m is ConversationMessage cm && idRange.IntersectWith(cm.Conversation!.EntryRange).IsEmpty));
-        return new VirtualListTile<ChatMessage>($"tile:{idRange.Format()}", messages);
+                (m is ChatEntryMessage && !lidRange.Contains(m.Id))
+                || (m is ConversationMessage cm && lidRange.IntersectWith(cm.Conversation!.EntryLidRange).IsEmpty));
+        return new VirtualListTile<ChatMessage>($"tile:{lidRange.Format()}", messages);
     }
 
     [ComputeMethod]

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -534,7 +534,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         var unreadCount = 0;
         if (chatNews is not null && (readEntryLid > 0 || (chatId.Kind == ChatKind.Peer && readEntryLid == 0))) {
             // Otherwise the chat wasn't ever opened
-            var lastId = chatNews.TextEntryIdRange.End - 1;
+            var lastId = chatNews.TextEntryLidRange.End - 1;
             unreadCount = (int)(lastId - readEntryLid).Clamp(0, ChatInfo.MaxUnreadCount);
         }
         return new Trimmed<int>(unreadCount, ChatInfo.MaxUnreadCount);

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListTile.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListTile.cs
@@ -19,7 +19,6 @@ public sealed record VirtualListTile<TItem>(string Key, IReadOnlyList<TItem> Ite
                     : Items[^1].Key)
             : default;
 
-
     public VirtualListTile(Range<long> idRange, IReadOnlyList<TItem>? Items = null)
         : this($"tile:{idRange.Format()}", Items ?? []) { }
 

--- a/src/dotnet/Users.Service/EmailsBackend.cs
+++ b/src/dotnet/Users.Service/EmailsBackend.cs
@@ -142,7 +142,7 @@ public class EmailsBackend(IServiceProvider services) : IEmailsBackend
                 return default;
 
             var textEntryRange = await ChatsBackend
-                .GetIdRange(chatId, false, cancellationToken)
+                .GetLidRange(chatId, false, cancellationToken)
                 .ConfigureAwait(false);
             var maxEntryId = textEntryRange.End > 0 ? textEntryRange.End - 1 : 0;
             if (maxEntryId <= 0)

--- a/tests/Chat.IntegrationTests/ApiEvolutionTest.cs
+++ b/tests/Chat.IntegrationTests/ApiEvolutionTest.cs
@@ -118,7 +118,7 @@ public class ApiEvolutionTest(ITestOutputHelper @out) : TestBase(@out)
             v.CanWrite().Should().BeTrue();
         });
         DeserializeOne<ChatNews>(dir, errors, v => {
-            v.TextEntryIdRange.Should().Be(new Range<long>(1, 100));
+            v.TextEntryLidRange.Should().Be(new Range<long>(1, 100));
             v.LastTextEntry.Should().NotBeNull();
         });
         DeserializeOne<ChatEntry>(dir, errors, v => {
@@ -127,7 +127,7 @@ public class ApiEvolutionTest(ITestOutputHelper @out) : TestBase(@out)
         });
         DeserializeOne<ChatTile>(dir, errors, v => {
             v.Entries.Length.Should().Be(1);
-            v.IdTileRange.Should().Be(new Range<long>(0, 100));
+            v.LidTileRange.Should().Be(new Range<long>(0, 100));
         });
         DeserializeOne<AuthorFull>(dir, errors, v => {
             v.UserId.Should().Be(TestUserId);

--- a/tests/Chat.IntegrationTests/ChatThreadOperationsTest.cs
+++ b/tests/Chat.IntegrationTests/ChatThreadOperationsTest.cs
@@ -276,5 +276,13 @@ public class ChatThreadOperationsTest(ChatCollection.AppHostFixture fixture, ITe
         canReadThreadChat.Should().Be(canReadParentChat);
         var canWriteToThreadChat = threadChat2 is not null && threadChat2.Rules.Permissions.Has(ChatPermissions.Write);
         canWriteToThreadChat.Should().Be(canWriteToParentChat);
+        if (parentChat2 is null || threadChat2 is null)
+            return;
+
+        threadChat2.Rules.CanUpload().Should().Be(parentChat2.Rules.CanUpload());
+        threadChat2.Rules.CanWriteAudio().Should().Be(parentChat2.Rules.CanWriteAudio());
+        threadChat2.Rules.CanWriteVideo().Should().Be(parentChat2.Rules.CanWriteVideo());
+        threadChat2.Rules.CanReadAudio().Should().Be(parentChat2.Rules.CanReadAudio());
+        threadChat2.Rules.CanReadVideo().Should().Be(parentChat2.Rules.CanReadVideo());
     }
 }

--- a/tests/Chat.IntegrationTests/NonContactPeerLimitTest.cs
+++ b/tests/Chat.IntegrationTests/NonContactPeerLimitTest.cs
@@ -1,0 +1,225 @@
+using ActualChat.Contacts;
+using ActualChat.Testing.Host;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+[Collection(nameof(ChatCollection))]
+public class NonContactPeerLimitTest(ChatCollection.AppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
+{
+    [Fact]
+    public async Task RulesShouldStripContentFlagsForNonContactPeer()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var chats = aliceTester.AppServices.GetRequiredService<IChats>();
+
+        // act
+        var rules = await chats.GetRules(aliceTester.Session, peerChatId, CancellationToken.None);
+
+        // assert
+        rules.CanRead().Should().BeTrue();
+        rules.CanWrite().Should().BeTrue();
+        rules.CanUpload().Should().BeFalse();
+        rules.CanWriteAudio().Should().BeFalse();
+        rules.CanWriteVideo().Should().BeFalse();
+        rules.CanReadAudio().Should().BeFalse();
+        rules.CanReadVideo().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RulesShouldGrantContentFlagsWhenSenderIsInRecipientContacts()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+
+        // Bob adds Alice to his contacts - restrictions on Alice should lift.
+        await bobTester.CreatePeerContact(bob, alice);
+
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var chats = aliceTester.AppServices.GetRequiredService<IChats>();
+
+        // act
+        var rules = await chats.GetRules(aliceTester.Session, peerChatId, CancellationToken.None);
+
+        // assert
+        rules.CanWrite().Should().BeTrue();
+        rules.CanUpload().Should().BeTrue();
+        rules.CanWriteAudio().Should().BeTrue();
+        rules.CanWriteVideo().Should().BeTrue();
+        rules.CanReadAudio().Should().BeTrue();
+        rules.CanReadVideo().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RulesShouldGrantContentFlagsAfterRecipientReplies()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var chats = aliceTester.AppServices.GetRequiredService<IChats>();
+
+        // Alice sends a message; Bob (the recipient) replies.
+        await aliceTester.CreateTextEntry(peerChatId, "Hi");
+        await bobTester.CreateTextEntry(peerChatId, "Hi back");
+
+        // act, assert - Alice's restrictions should have lifted.
+        await ComputedTest.When(async ct => {
+            var rules = await chats.GetRules(aliceTester.Session, peerChatId, ct);
+            rules.CanUpload().Should().BeTrue();
+            rules.CanWriteAudio().Should().BeTrue();
+            rules.CanWriteVideo().Should().BeTrue();
+            rules.CanReadAudio().Should().BeTrue();
+            rules.CanReadVideo().Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task ShouldCapNonContactSenderAtMessageLimit()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var cap = Constants.Chat.NonContactPeerMessageLimit;
+
+        // act - Alice posts up to the cap successfully.
+        for (var i = 0; i < cap; i++)
+            await aliceTester.CreateTextEntry(peerChatId, $"msg {i + 1}");
+
+        // assert - the next create must fail.
+        var send = () => aliceTester.CreateTextEntry(peerChatId, "should be blocked");
+        await send.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task EditsShouldRemainAllowedAtCap()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var cap = Constants.Chat.NonContactPeerMessageLimit;
+
+        var entries = new List<ChatEntry>();
+        for (var i = 0; i < cap; i++)
+            entries.Add(await aliceTester.CreateTextEntry(peerChatId, $"msg {i + 1}"));
+
+        // act - editing the first entry should still succeed even though the cap is reached.
+        var firstEntryId = ChatEntryId.New(peerChatId, entries[0].LocalId);
+        var edited = await aliceTester.UpdateTextEntry(firstEntryId, "edited!");
+
+        // assert
+        edited.Content.Should().Be("edited!");
+    }
+
+    [Fact]
+    public async Task CapShouldLiftAfterRecipientReplies()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var cap = Constants.Chat.NonContactPeerMessageLimit;
+
+        for (var i = 0; i < cap; i++)
+            await aliceTester.CreateTextEntry(peerChatId, $"msg {i + 1}");
+
+        // Recipient replies - restrictions should lift.
+        await bobTester.CreateTextEntry(peerChatId, "Replying");
+
+        // act, assert - Alice can now post freely.
+        await ComputedTest.When(async _ => {
+            var entry = await aliceTester.CreateTextEntry(peerChatId, "post-reply message");
+            entry.Content.Should().Be("post-reply message");
+        });
+    }
+
+    [Fact]
+    public async Task SenderMessageShouldNotStoreRecipientContact()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var contactsBackend = aliceTester.AppServices.GetRequiredService<IContactsBackend>();
+
+        // act
+        await aliceTester.CreateTextEntry(peerChatId, "Hi");
+
+        // assert
+        var aliceContact = await contactsBackend.Get(alice.Id, ContactId.NewUser(alice.Id, bob.Id), CancellationToken.None);
+        aliceContact.State.Should().Be(ContactState.Regular);
+        var bobContact = await contactsBackend.Get(bob.Id, ContactId.NewUser(bob.Id, alice.Id), CancellationToken.None);
+        bobContact.State.Should().Be(ContactState.Temporary);
+    }
+
+    [Fact]
+    public async Task ThreadStartShouldBeBlockedForNonContactPeer()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        var bob = await bobTester.SignInAsUniqueBob();
+        var peerChatId = PeerChatId.New(alice.Id, bob.Id);
+        var entry = await aliceTester.CreateTextEntry(peerChatId, "Hi");
+
+        // act, assert
+        var command = new ChatThreads_Start(
+            aliceTester.Session,
+            peerChatId,
+            "Thread",
+            "",
+            [entry.Id]);
+        var startThread = () => aliceTester.Commander.Call(command);
+        await startThread.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task GroupChatShouldNotBeAffectedByNonContactCap()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsBob();
+        var (chatId, _) = await tester.CreateChat(true);
+
+        // act - post more than the peer-chat cap; group chat must permit it.
+        for (var i = 0; i < Constants.Chat.NonContactPeerMessageLimit + 1; i++)
+            await tester.CreateTextEntry(chatId, $"msg {i + 1}");
+
+        // assert - last post observable.
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var rules = await chats.GetRules(tester.Session, chatId, CancellationToken.None);
+        rules.CanUpload().Should().BeTrue();
+        rules.CanWriteAudio().Should().BeTrue();
+        rules.CanWriteVideo().Should().BeTrue();
+    }
+}

--- a/tests/Chat.UnitTests/ChatModelSerializationTest.cs
+++ b/tests/Chat.UnitTests/ChatModelSerializationTest.cs
@@ -185,7 +185,7 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
         var tile = new ChatTile(new Range<long>(0, 100), false, entries);
 
         var s = tile.PassThroughModernSerializers(Out);
-        s.IdTileRange.Should().Be(tile.IdTileRange);
+        s.LidTileRange.Should().Be(tile.LidTileRange);
         s.IncludesRemoved.Should().Be(tile.IncludesRemoved);
         s.Entries.Length.Should().Be(tile.Entries.Length);
     }
@@ -209,12 +209,12 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
             100);
 
         var s = meta.PassThroughAllSerializers(Out);
-        s.IdRange.Should().Be(meta.IdRange);
-        s.EntryIdRanges.Should().BeEquivalentTo(meta.EntryIdRanges);
-        s.ConversationIdRanges.Should().BeEquivalentTo(meta.ConversationIdRanges);
+        s.LidRange.Should().Be(meta.LidRange);
+        s.EntryLidRanges.Should().BeEquivalentTo(meta.EntryLidRanges);
+        s.ConversationLidRanges.Should().BeEquivalentTo(meta.ConversationLidRanges);
         s.MinCount.Should().Be(meta.MinCount);
-        s.PreviousIdTileStart.Should().Be(meta.PreviousIdTileStart);
-        s.NextIdTileStart.Should().Be(meta.NextIdTileStart);
+        s.PreviousLidTileStart.Should().Be(meta.PreviousLidTileStart);
+        s.NextLidTileStart.Should().Be(meta.NextLidTileStart);
     }
 
     [Fact]
@@ -229,9 +229,9 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
 
         var s = meta.PassThroughAllSerializers(Out);
         s.ChatId.Should().Be(meta.ChatId);
-        s.EntryRanges.Should().BeEquivalentTo(meta.EntryRanges);
-        s.PreviousEntryId.Should().Be(meta.PreviousEntryId);
-        s.NextEntryId.Should().Be(meta.NextEntryId);
+        s.EntryLidRange.Should().BeEquivalentTo(meta.EntryLidRange);
+        s.PreviousEntryLid.Should().Be(meta.PreviousEntryLid);
+        s.NextEntryLid.Should().Be(meta.NextEntryLid);
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
             [new ChatEntryLanguage(entryId, 1) { Languages = [Languages.English] }]);
 
         tile.AssertPassesThroughAllSerializers(v => {
-            v.IdTileRange.Should().Be(tile.IdTileRange);
+            v.LidTileRange.Should().Be(tile.LidTileRange);
             v.Entries.Length.Should().Be(tile.Entries.Length);
             v.Entries[0].Id.Should().Be(tile.Entries[0].Id);
         }, Out);
@@ -348,9 +348,9 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
 
         var s = meta.PassThroughAllSerializers(Out);
         s.ChatId.Should().Be(meta.ChatId);
-        s.ConversationRanges.Should().BeEquivalentTo(meta.ConversationRanges);
-        s.PreviousConversationRange.Should().Be(meta.PreviousConversationRange);
-        s.NextConversationRange.Should().Be(meta.NextConversationRange);
+        s.ConversationLidRanges.Should().BeEquivalentTo(meta.ConversationLidRanges);
+        s.PreviousConversationLidRange.Should().Be(meta.PreviousConversationLidRange);
+        s.NextConversationLidRange.Should().Be(meta.NextConversationLidRange);
     }
 
     [Fact]

--- a/tests/Chat.UnitTests/ChatPermissionsExtTest.cs
+++ b/tests/Chat.UnitTests/ChatPermissionsExtTest.cs
@@ -1,0 +1,73 @@
+namespace ActualChat.Chat.UnitTests;
+
+public class ChatPermissionsExtTest
+{
+    [Fact]
+    public void WriteImpliesContentTypeFlags()
+    {
+        // act
+        var permissions = ChatPermissions.Write.AddImplied();
+
+        // assert
+        permissions.Has(ChatPermissions.Read).Should().BeTrue();
+        permissions.Has(ChatPermissions.Upload).Should().BeTrue();
+        permissions.Has(ChatPermissions.WriteAudio).Should().BeTrue();
+        permissions.Has(ChatPermissions.WriteVideo).Should().BeTrue();
+        permissions.Has(ChatPermissions.ReadAudio).Should().BeTrue();
+        permissions.Has(ChatPermissions.ReadVideo).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadImpliesAudioVideoReadFlags()
+    {
+        // act
+        var permissions = ChatPermissions.Read.AddImplied();
+
+        // assert
+        permissions.Has(ChatPermissions.ReadAudio).Should().BeTrue();
+        permissions.Has(ChatPermissions.ReadVideo).Should().BeTrue();
+        permissions.Has(ChatPermissions.WriteAudio).Should().BeFalse();
+        permissions.Has(ChatPermissions.WriteVideo).Should().BeFalse();
+        permissions.Has(ChatPermissions.Upload).Should().BeFalse();
+        permissions.Has(ChatPermissions.Write).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OwnerImpliesAllContentTypeFlags()
+    {
+        // act
+        var permissions = ChatPermissions.Owner.AddImplied();
+
+        // assert
+        permissions.Has(ChatPermissions.Read).Should().BeTrue();
+        permissions.Has(ChatPermissions.Write).Should().BeTrue();
+        permissions.Has(ChatPermissions.Upload).Should().BeTrue();
+        permissions.Has(ChatPermissions.WriteAudio).Should().BeTrue();
+        permissions.Has(ChatPermissions.WriteVideo).Should().BeTrue();
+        permissions.Has(ChatPermissions.ReadAudio).Should().BeTrue();
+        permissions.Has(ChatPermissions.ReadVideo).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StrippingContentFlagsKeepsReadAndWrite()
+    {
+        // arrange
+        var full = ChatPermissions.Write.AddImplied();
+
+        // act - same masking used by GetPeerChatRules for non-contact peer chats
+        var stripped = full & ~(ChatPermissions.Upload
+            | ChatPermissions.WriteAudio
+            | ChatPermissions.WriteVideo
+            | ChatPermissions.ReadAudio
+            | ChatPermissions.ReadVideo);
+
+        // assert
+        stripped.Has(ChatPermissions.Read).Should().BeTrue();
+        stripped.Has(ChatPermissions.Write).Should().BeTrue();
+        stripped.Has(ChatPermissions.Upload).Should().BeFalse();
+        stripped.Has(ChatPermissions.WriteAudio).Should().BeFalse();
+        stripped.Has(ChatPermissions.WriteVideo).Should().BeFalse();
+        stripped.Has(ChatPermissions.ReadAudio).Should().BeFalse();
+        stripped.Has(ChatPermissions.ReadVideo).Should().BeFalse();
+    }
+}

--- a/tests/Chat.UnitTests/Flows/SerializationTests.cs
+++ b/tests/Chat.UnitTests/Flows/SerializationTests.cs
@@ -50,7 +50,7 @@ public class ConversationSplitFlowSerializationTest(ITestOutputHelper @out)
         LastLid = 100,
         LastRunAt = new Moment(new DateTime(2026, 4, 16, 12, 0, 0, DateTimeKind.Utc)),
         LastSummaryAt = new Moment(new DateTime(2026, 4, 16, 13, 0, 0, DateTimeKind.Utc)),
-        LastSummaryRanges = [new Range<long>(1, 10), new Range<long>(20, 30)],
+        LastSummaryLidRanges = [new Range<long>(1, 10), new Range<long>(20, 30)],
         LastReadiness = "test-suspension",
     };
 }

--- a/tests/Chat.UnitTests/LegacyChatCompatTest.cs
+++ b/tests/Chat.UnitTests/LegacyChatCompatTest.cs
@@ -134,7 +134,7 @@ public class LegacyChatCompatTest(ITestOutputHelper @out) : TestBase(@out)
 
         var legacy = LegacyChatNews.From(modernNews);
         legacy.Should().NotBeNull();
-        legacy!.TextEntryIdRange.Should().Be(modernNews.TextEntryIdRange);
+        legacy.TextEntryLidRange.Should().Be(modernNews.TextEntryLidRange);
         legacy.LastTextEntry.Should().NotBeNull();
         legacy.LastTextEntry!.Content.Should().Be("tail");
     }

--- a/tests/Contacts.UnitTests/ContactSerializationTest.cs
+++ b/tests/Contacts.UnitTests/ContactSerializationTest.cs
@@ -21,6 +21,7 @@ public class ContactSerializationTest(ITestOutputHelper @out) : TestBase(@out)
             TouchedAt = new Moment(DateTime.UtcNow),
             IsPinned = true,
             PeerContactName = "Friend",
+            State = ContactState.Regular,
             Chat = new Chat.Chat(TestChatId) { Title = "Test Chat" },
         };
 
@@ -30,6 +31,7 @@ public class ContactSerializationTest(ITestOutputHelper @out) : TestBase(@out)
         s.TouchedAt.Should().Be(contact.TouchedAt);
         s.IsPinned.Should().Be(contact.IsPinned);
         s.PeerContactName.Should().Be(contact.PeerContactName);
+        s.State.Should().Be(contact.State);
     }
 
     [Fact]

--- a/tests/Streaming.IntegrationTests/AudioBackendTest.cs
+++ b/tests/Streaming.IntegrationTests/AudioBackendTest.cs
@@ -155,7 +155,7 @@ public class StreamingBackendTest(AppHostFixture fixture, ITestOutputHelper @out
         transcribed.Should().BeGreaterThan(0);
         readSize.Should().BeLessThanOrEqualTo(writtenSize);
 
-        var idRange = await chats.GetIdRange(chat.Id, true, CancellationToken.None);
+        var idRange = await chats.GetLidRange(chat.Id, true, CancellationToken.None);
         var lastIdTile = Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(idRange.End - 1);
         var lastTile = await chats.GetTile(
             chat.Id,
@@ -226,7 +226,7 @@ public class StreamingBackendTest(AppHostFixture fixture, ITestOutputHelper @out
         transcribed.Should().BeGreaterThan(0);
         readSize.Should().BeLessThanOrEqualTo(writtenSize);
 
-        var idRange = await chats.GetIdRange(chat.Id, true, CancellationToken.None);
+        var idRange = await chats.GetLidRange(chat.Id, true, CancellationToken.None);
         var lastIdTile = Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(idRange.End - 1);
         var lastTile = await chats.GetTile(
             chat.Id,


### PR DESCRIPTION
…messages

Restrict outreach from users who aren't in the recipient's contact list: text + edits only, capped at 3 created entries; no voice messages, no audio/video streams in either direction, no uploads. Once added to contacts, all restrictions lift. Applies to peer chats only.

Implemented by extending ChatPermissions with content-type capability flags (Upload, WriteAudio, WriteVideo, ReadAudio, ReadVideo). The flags are default-on (implied by Write/Read) and selectively stripped in ChatsBackend.GetPeerChatRules when the caller isn't in the peer's contacts. The 3-message creation cap is enforced separately in Chats.OnUpsertEntry's create branch via a new IChatsBackend.GetEntryCount compute method, so edits remain unaffected. Stream send/receive paths in Streaming.Service now require the matching Write/Read* flag, and the ChatMessageEditor hides the attach button and audio panel when the corresponding capabilities are absent.