### PR TITLE
fix(ci): pin Xcode 26.3 + .NET-iOS 26.2.10233 to bypass startup crash #3839

### DIFF
--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -566,7 +566,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.4.1
+          xcode-version: 26.3
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -629,8 +629,8 @@ jobs:
       - name: Setup dotnet
         uses: ./.github/actions/setup-dotnet
 
-      - name: Install workloads
-        run: dotnet workload install maui ios maui-ios
+      - name: Install workloads (pinned to Xcode 26.3 / .NET-iOS 26.2.10233 — see #3839)
+        run: dotnet workload install maui ios maui-ios --from-rollback-file ${{github.workspace}}/.github/workloads-26.3.json
 
       - name: Replace git+ssh://git@ to https://
         run: sed -i -E 's/git+ssh:\/\/git@/https:\/\//g' package-lock.json

--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -697,6 +697,14 @@ jobs:
           compression-level: 0
           retention-days: 10
 
+      - name: Upload dSYMs to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{env.APP_ID}}.${{steps.nbgv.outputs.SemVer2}}.dSYMs
+          path: artifacts/bin/App.Maui/release_net10.0-ios_ios-arm64/*.dSYM
+          if-no-files-found: error
+          retention-days: 90
+
   deploy-ios-to-appstore:
     name: Deploy ios app package to apple app store for ${{ github.ref_name }}
     # release branch can build for both dev and prod envs while other branches can build only for dev env

--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -16,6 +16,11 @@ on:
           - auto
           - dev
           - prod
+      skipTests:
+        type: boolean
+        required: false
+        default: false
+        description: Skip unit and integration tests
   create:
   push:
     branches:
@@ -50,8 +55,9 @@ jobs:
         id: check
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          SKIP_TESTS_INPUT: ${{ github.event.inputs.skipTests }}
         run: |
-          if echo "$COMMIT_MESSAGE" | grep -qiw '#tested'; then
+          if [[ "$SKIP_TESTS_INPUT" == "true" ]] || echo "$COMMIT_MESSAGE" | grep -qiw '#tested'; then
             echo "skip-tests=true" | tee -a $GITHUB_OUTPUT
           else
             echo "skip-tests=false" | tee -a $GITHUB_OUTPUT

--- a/.github/workloads-26.3.json
+++ b/.github/workloads-26.3.json
@@ -1,0 +1,18 @@
+{
+  "microsoft.net.workload.emscripten.current": "10.0.107/10.0.100",
+  "microsoft.net.workload.emscripten.net6": "10.0.107/10.0.100",
+  "microsoft.net.workload.emscripten.net7": "10.0.107/10.0.100",
+  "microsoft.net.workload.emscripten.net8": "10.0.107/10.0.100",
+  "microsoft.net.workload.emscripten.net9": "10.0.107/10.0.100",
+  "microsoft.net.sdk.android": "36.1.53/10.0.100",
+  "microsoft.net.sdk.ios": "26.2.10233/10.0.100",
+  "microsoft.net.sdk.maccatalyst": "26.2.10233/10.0.100",
+  "microsoft.net.sdk.macos": "26.2.10233/10.0.100",
+  "microsoft.net.sdk.maui": "10.0.20/10.0.100",
+  "microsoft.net.sdk.tvos": "26.2.10233/10.0.100",
+  "microsoft.net.workload.mono.toolchain.current": "10.0.107/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net6": "10.0.107/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net7": "10.0.107/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net8": "10.0.107/10.0.100",
+  "microsoft.net.workload.mono.toolchain.net9": "10.0.107/10.0.100"
+}


### PR DESCRIPTION
iOS Release builds shipped to TestFlight from 2.8.1154 onward crashed at launch in mono_runtime_invoke -> mono_error_convert_to_exception.cold.1 -> g_assert_not_reached, before any UI rendered. Bisected to commit 3e3126e34 (height 1151), which bumped CI Xcode 26.3 -> 26.4 and forced dotnet workload install to pull microsoft.net.sdk.ios 26.4.10259 instead of 26.2.10233. Builds with the 26.4 workload show the crash on real devices regardless of subsequent code; build 1188 with the 26.3 toolchain launches cleanly.

Changes:
- Pin xcode-version 26.4.1 -> 26.3.
- New .github/workloads-26.3.json freezing all manifests (iOS/macCat/ macOS/tvOS at 26.2.10233, MAUI 10.0.20, Android 36.1.53, mono/ emscripten 10.0.107) at feature band 10.0.100.
- Switch the iOS pkg job's workload install to --from-rollback-file.
- Add skipTests workflow_dispatch input (workflow_dispatch can't read head_commit.message, so the existing #tested flag didn't apply to manual runs — needed to validate the fix without flaky unit tests).
- Upload iOS dSYMs as a separate CI artifact (90-day retention) so TestFlight .ips reports can be symbolicated via atos.