### PR TITLE
fix(chat-audio-panel): cleanup recording-svg components

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/active-recording-svg.lit.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/active-recording-svg.lit.ts
@@ -10,7 +10,6 @@ interface Result {
     runningMax: RunningMax;
     runningEMA: RunningEMA;
     p: number;
-    i: number;
 }
 
 interface AudioPowerState {
@@ -119,11 +118,10 @@ export class ActiveRecordingSvg extends LitElement {
             runningMax: new RunningMax(SIGNAL_COUNT_TO_CALCULATE_MAX, 0.05),
             runningEMA: new RunningEMA(0, 10, 0.8),
             p: 0,
-            i: 0,
         };
         const recorderState$ = RecordingActivity.stateChanged$;
         const signalPower$ = RecordingActivity.audioPowerChanged$
-            .pipe(scan<number, Result, Result>((result, p, i) => {
+            .pipe(scan<number, Result, Result>((result, p) => {
                 const runningMax = result.runningMax;
                 const runningEMA = result.runningEMA;
                 // Fill the window first; once full, only advance it while voice is active
@@ -132,7 +130,7 @@ export class ActiveRecordingSvg extends LitElement {
                 if (shouldAppendMax)
                     runningMax.appendSample(p);
                 runningEMA.appendSample(p);
-                return { runningMax, runningEMA, p, i };
+                return { runningMax, runningEMA, p };
             }, initialResult));
 
         this.recorderStateChangedSubscription = recorderState$.subscribe(rs => {
@@ -168,6 +166,7 @@ export class ActiveRecordingSvg extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
 
+        this.observer.disconnect();
         this.recorderStateChangedSubscription.unsubscribe();
         this.signalPowerChangedSubscription.unsubscribe();
     }
@@ -206,9 +205,7 @@ export class ActiveRecordingSvg extends LitElement {
                 </svg>
             `;
         } else {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition,@typescript-eslint/no-non-null-asserted-optional-chain
-            const display = getComputedStyle(this.shadowRoot?.host!, null)?.display ?? 'none';
-            if (display === 'none')
+            if (getComputedStyle(this).display === 'none')
                 return html``;
 
             const shouldAnimate = isVoiceActive && isVisible;

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/narrow-recording-svg.lit.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/narrow-recording-svg.lit.ts
@@ -1,8 +1,6 @@
-// TODO: Fix ESLint errors
-/* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import { customElement, property, state } from 'lit/decorators.js';
 import { css, html, LitElement } from 'lit';
-import { scan,  Subscription } from 'rxjs';
+import { scan, Subscription } from 'rxjs';
 import { clamp, RunningMax, translate } from 'math';
 import { RecordingActivity } from '../AudioRecorder/recording-activity';
 
@@ -11,7 +9,6 @@ const SIGNAL_COUNT_TO_CALCULATE_MAX = 100; // 100 * 96ms ~ 10s
 interface Result {
     runningMax: RunningMax;
     p: number;
-    i: number;
 }
 
 @customElement('narrow-recording-svg')
@@ -63,17 +60,20 @@ export class NarrowRecordingSvg extends LitElement {
 
         const minOpacity = 60;
         const maxOpacity = 100;
+        const initialResult: Result = {
+            runningMax: new RunningMax(SIGNAL_COUNT_TO_CALCULATE_MAX, 0.05),
+            p: 0,
+        };
         const signalPower$ = RecordingActivity.audioPowerChanged$
-            .pipe(scan<number, Result, RunningMax>((runningMaxOrResult, p, i) => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const runningMax: RunningMax = runningMaxOrResult['runningMax'] ?? runningMaxOrResult;
+            .pipe(scan<number, Result, Result>((result, p) => {
+                const { runningMax } = result;
                 // Fill the window first; once full, only advance it while voice is active
                 const isWindowNotFull = runningMax.sampleCount < SIGNAL_COUNT_TO_CALCULATE_MAX;
                 const shouldAppend = isWindowNotFull || this.isVoiceActive;
                 if (shouldAppend)
                     runningMax.appendSample(p);
-                return { runningMax, p, i };
-            }, new RunningMax(SIGNAL_COUNT_TO_CALCULATE_MAX, 0.05)));
+                return { runningMax, p };
+            }, initialResult));
 
         this.recorderStateChangedSubscription = RecordingActivity.stateChanged$.subscribe(s => {
             this.isRecording = s.isRecording;
@@ -95,7 +95,7 @@ export class NarrowRecordingSvg extends LitElement {
             const opacity = translate(power, [0, 0.6*maxPower], [minOpacity, maxOpacity]) / maxOpacity;
             this.opacity = isNaN(opacity)
                 ? minOpacity / 100
-                : opacity
+                : opacity;
         });
     }
 
@@ -107,33 +107,27 @@ export class NarrowRecordingSvg extends LitElement {
     }
 
     protected render(): unknown {
-        if (!this._isRecording) {
-            return html`
-                <svg width='24' height='24' viewBox='0 0 24 32'
-                     fill='rgba(100,22,50)' fill-opacity='0.75'
-                     xmlns='http://www.w3.org/2000/svg'>
-                    <path fill='#FF3880' fill-rule='evenodd' clip-rule='evenodd'
-                          style='animation: wave 1.3s steps(10, start) infinite;'
-                          d='M8.62668 6.97296C8.62668 5.64058 9.8962 4.25461 11.8813 4.25461C13.8664 4.25461 15.1359 5.64058 15.1359 6.97296V14.6472C15.1359 15.866 13.8903 17.2731 11.8813 17.2731C9.8962 17.2731 8.62668 15.8871 8.62668 14.5547V6.97296ZM11.8813 1C8.46512 1 5.37207 3.49738 5.37207 6.97296V14.5547C5.37207 18.0303 8.46512 20.5277 11.8813 20.5277C15.2736 20.5277 18.3905 18.0514 18.3905 14.6472V6.97296C18.3905 3.49738 15.2975 1 11.8813 1ZM0.95509 17.4257C1.77346 17.0542 2.73803 17.4165 3.1095 18.2349C4.62287 21.5689 7.98144 23.886 11.8634 23.886C15.7134 23.886 19.0486 21.6069 20.5796 18.3167C20.9588 17.5019 21.9267 17.1487 22.7416 17.5279C23.5564 17.9071 23.9096 18.875 23.5304 19.6898C21.6619 23.7052 17.7755 26.6066 13.1745 27.0743V30.234C13.1745 31.1899 12.3996 31.9648 11.4437 31.9648C10.4878 31.9648 9.71289 31.1899 9.71289 30.234V26.9609C5.44063 26.2391 1.8819 23.4045 0.145911 19.5801C-0.225565 18.7617 0.136718 17.7972 0.95509 17.4257Z' />
-                </svg>
-            `;
-        } else {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            const display = getComputedStyle(this.shadowRoot?.host!, null)?.display ?? 'none';
-            if (display === 'none')
-                return html``;
+        if (!this._isRecording)
+            return this.renderIcon('animation: wave 1.3s steps(10, start) infinite;', 0.75);
 
-            const opacity = this.opacity ?? 70;
+        if (getComputedStyle(this).display === 'none')
+            return html``;
 
-            return html`
-                <svg width='24' height='24' viewBox='0 0 24 32' class='active'
-                     fill='#FF3880' fill-opacity='1'
-                     xmlns='http://www.w3.org/2000/svg'>
-                    <path fill='#FF3880' fill-rule='evenodd' clip-rule='evenodd'
-                          style='filter: drop-shadow(-2px -2px 4px rgba(179,77,174, ${opacity})) drop-shadow(2px 2px 4px rgba(255,0,92, ${opacity}));'
-                          d='M8.62668 6.97296C8.62668 5.64058 9.8962 4.25461 11.8813 4.25461C13.8664 4.25461 15.1359 5.64058 15.1359 6.97296V14.6472C15.1359 15.866 13.8903 17.2731 11.8813 17.2731C9.8962 17.2731 8.62668 15.8871 8.62668 14.5547V6.97296ZM11.8813 1C8.46512 1 5.37207 3.49738 5.37207 6.97296V14.5547C5.37207 18.0303 8.46512 20.5277 11.8813 20.5277C15.2736 20.5277 18.3905 18.0514 18.3905 14.6472V6.97296C18.3905 3.49738 15.2975 1 11.8813 1ZM0.95509 17.4257C1.77346 17.0542 2.73803 17.4165 3.1095 18.2349C4.62287 21.5689 7.98144 23.886 11.8634 23.886C15.7134 23.886 19.0486 21.6069 20.5796 18.3167C20.9588 17.5019 21.9267 17.1487 22.7416 17.5279C23.5564 17.9071 23.9096 18.875 23.5304 19.6898C21.6619 23.7052 17.7755 26.6066 13.1745 27.0743V30.234C13.1745 31.1899 12.3996 31.9648 11.4437 31.9648C10.4878 31.9648 9.71289 31.1899 9.71289 30.234V26.9609C5.44063 26.2391 1.8819 23.4045 0.145911 19.5801C-0.225565 18.7617 0.136718 17.7972 0.95509 17.4257Z' />
-                </svg>
-            `;
-        }
+        const opacity = this.opacity ?? 0.7;
+        const filter = `drop-shadow(-2px -2px 4px rgba(179,77,174, ${opacity})) drop-shadow(2px 2px 4px rgba(255,0,92, ${opacity}))`;
+        return this.renderIcon(`filter: ${filter};`, 1);
+    }
+
+    // Private methods
+
+    private renderIcon(pathStyle: string, fillOpacity: number): unknown {
+        return html`
+            <svg width='24' height='24' viewBox='0 0 24 32'
+                 xmlns='http://www.w3.org/2000/svg'>
+                <path fill='#FF3880' fill-opacity='${fillOpacity}' fill-rule='evenodd' clip-rule='evenodd'
+                      style='${pathStyle}'
+                      d='M8.62668 6.97296C8.62668 5.64058 9.8962 4.25461 11.8813 4.25461C13.8664 4.25461 15.1359 5.64058 15.1359 6.97296V14.6472C15.1359 15.866 13.8903 17.2731 11.8813 17.2731C9.8962 17.2731 8.62668 15.8871 8.62668 14.5547V6.97296ZM11.8813 1C8.46512 1 5.37207 3.49738 5.37207 6.97296V14.5547C5.37207 18.0303 8.46512 20.5277 11.8813 20.5277C15.2736 20.5277 18.3905 18.0514 18.3905 14.6472V6.97296C18.3905 3.49738 15.2975 1 11.8813 1ZM0.95509 17.4257C1.77346 17.0542 2.73803 17.4165 3.1095 18.2349C4.62287 21.5689 7.98144 23.886 11.8634 23.886C15.7134 23.886 19.0486 21.6069 20.5796 18.3167C20.9588 17.5019 21.9267 17.1487 22.7416 17.5279C23.5564 17.9071 23.9096 18.875 23.5304 19.6898C21.6619 23.7052 17.7755 26.6066 13.1745 27.0743V30.234C13.1745 31.1899 12.3996 31.9648 11.4437 31.9648C10.4878 31.9648 9.71289 31.1899 9.71289 30.234V26.9609C5.44063 26.2391 1.8819 23.4045 0.145911 19.5801C-0.225565 18.7617 0.136718 17.7972 0.95509 17.4257Z' />
+            </svg>
+        `;
     }
 }


### PR DESCRIPTION
- ActiveRecordingSvg: disconnect IntersectionObserver on disconnect (leak fix)
- NarrowRecordingSvg: fix scan() seed type, remove `runningMaxOrResult` workaround
- NarrowRecordingSvg: fix idle `fill-opacity` (was 0.75 via inheritance, regressed to 1) by moving onto <path>
- NarrowRecordingSvg: fix default opacity 70 -> 0.7 (rgba alpha clamp)
- NarrowRecordingSvg: dedupe two near-identical render branches via renderIcon()
- Both: simplify getComputedStyle(this) instead of shadowRoot host
- Both: drop unused `i` index from scan Result