### PR TITLE
fix(android): dispose AudioTrack position listener after Release()

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
@@ -110,16 +110,13 @@ internal sealed class AndroidAudioPlaybackEngine(
         }
 
         lock (Lock) { // We must re-lock after await
-            // Deactivate and remove listener BEFORE stopping the track
-            // to prevent OnPeriodicNotification callbacks on a stopped/released track,
-            // which can cause stack overflow via JNI interop infinite recursion
+            // Detach the listener and fully release the track BEFORE disposing the listener.
+            // Disposing it while the native track is alive severs its managed peer, so a late
+            // OnPeriodicNotification callback resurrects it as the Invoker and recurses through
+            // JNI until the stack overflows.
             _positionListener?.Deactivate();
             if (_audioTrack.IsValid()) {
                 try { _audioTrack.SetPlaybackPositionUpdateListener(null); } catch { /* Ignore */ }
-            }
-            if (_positionListener.IsValid())
-                _positionListener.DisposeSilently();
-            if (_audioTrack.IsValid()) {
                 try {
                     if (_audioTrack.PlayState is PlayState.Playing or PlayState.Paused)
                         _audioTrack.Stop();
@@ -129,6 +126,10 @@ internal sealed class AndroidAudioPlaybackEngine(
                 _audioTrack.DisposeSilently();
             }
             _audioTrack = null;
+
+            if (_positionListener.IsValid())
+                _positionListener.DisposeSilently();
+            _positionListener = null;
 
             if (_positionListenerHandle.IsAllocated)
                 _positionListenerHandle.Free();
@@ -173,9 +174,10 @@ internal sealed class AndroidAudioPlaybackEngine(
         if (mustAbort) {
             try {
                 _positionListener?.Deactivate();
-                if (audioTrack?.PlayState is PlayState.Playing or PlayState.Paused) {
+                if (audioTrack is not null) {
                     try { audioTrack.SetPlaybackPositionUpdateListener(null); } catch { }
-                    audioTrack.Stop();
+                    if (audioTrack.PlayState is PlayState.Playing or PlayState.Paused)
+                        audioTrack.Stop();
                 }
             }
             catch {


### PR DESCRIPTION
DisposeAsyncCore disposed PlayPositionListener before releasing the AudioTrack. A periodic-notification callback firing in that window has no managed peer, so the runtime resurrects the listener as its Invoker, which re-calls the Java method through JNI and recurses until the stack overflows (SIGABRT, "Aborting process.").

Move the listener Dispose past AudioTrack.Release(), and make SetPlaybackPositionUpdateListener(null) unconditional in End().

Restores the disposal order from 9c6830287, lost in the 5261691c1 refactor.