### PR TITLE
fix(ios): disable Crashlytics dSYM upload for share ext and Maui lib #3905

### DIFF
--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -36,6 +36,7 @@
     <CodesignEntitlements Condition="'$(IsDevMaui)' == 'true'">Entitlements.dev.plist</CodesignEntitlements>
     <CodesignEntitlements Condition="'$(IsDevMaui)' != 'true'">Entitlements.prod.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
+    <FirebaseCrashlyticsUploadSymbolsEnabled>false</FirebaseCrashlyticsUploadSymbolsEnabled>
   </PropertyGroup>
 
   <!-- Debug configuration -->

--- a/src/dotnet/Maui/Maui.csproj
+++ b/src/dotnet/Maui/Maui.csproj
@@ -23,6 +23,11 @@
     <DefineConstants>$(DefineConstants);IS_DEV_MAUI</DefineConstants>
   </PropertyGroup>
 
+  <!-- Library, not a shippable app: no dSYM to upload to Crashlytics. -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <FirebaseCrashlyticsUploadSymbolsEnabled>false</FirebaseCrashlyticsUploadSymbolsEnabled>
+  </PropertyGroup>
+
   <!-- Platform-specific files to compile -->
 
   <!-- NOT iOS -->


### PR DESCRIPTION
## Problem

The iOS Release build logs (e.g. dev-branch run `26407665532`) show:

error: Unable to read Google Service plist at path .../ActualChat.App.Maui.IosShareExt.app/GoogleService-Info.plist
warning MSB3073: '.../upload-symbols.sh' ... exited with code 13

This is a **build-time** step (not runtime): `AdamE.Firebase.iOS.Crashlytics` auto-enables dSYM symbol upload in Release for *every* referencing iOS project. The CI log shows `upload-symbols.sh` fired only for `ActualChat.Maui.app`
(the library) and `ActualChat.App.Maui.IosShareExt.app` (the extension) — never for the main `ActualChat.app`. Neither has an assembled `.app` + bundled `GoogleService-Info.plist` at that build stage, so the script can't read the
plist. The build still succeeds (`ContinueOnError`), but the errors pollute the log.

## Fix

Set `FirebaseCrashlyticsUploadSymbolsEnabled=false` for the two projects that produced the error:

- **`Maui`** — a library, not a shippable app → no dSYM to upload.
- **`App.Maui.IosShareExt`** — reports crashes via **Sentry**, not Crashlytics (never calls `CrossFirebase.Initialize`), and the upload runs against the standalone build output before the `.appex` is assembled.

`App.Maui` is untouched — it genuinely uses Crashlytics and uploads its dSYM successfully. The extension keeps bundling `GoogleService-Info.plist` (runtime concern for the linked native Firebase frameworks); only the build-time
symbol upload is disabled.

## Verification

- Local Debug build of `App.Maui.IosShareExt`: ✅ 0 errors, no `Unable to read Google Service plist`, no `upload-symbols` invocation.
- `FirebaseCrashlyticsUploadSymbolsEnabled` resolves to `false` for ShareExt (Debug+Release) and Maui lib (Release) → the upload target is skipped.

