### PR TITLE
feat(chat): attach large pasted text as a .txt file (#3763)

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -62,6 +62,13 @@
                         Cancel="@(() => OnCancel())"
                         OpenPrevious="OnOpenPrevious"/>
                 </label>
+                <button class="post-panel-btn convert-to-file-btn btn btn-round btn-transparent btn-xs unhovered"
+                        data-tooltip="Send text as file"
+                        data-tooltip-position="@(FloatingPosition.Top.ToPositionString())"
+                        @onmousedown="@(_ => OnConvertToFileClick())"
+                        @onmousedown:preventDefault="true">
+                    <i class="icon-file-text"></i>
+                </button>
                 <div class="c-right-buttons">
                     <NotifyAllButton Chat="@Chat"/>
                     <div class="c-incut"></div>
@@ -283,6 +290,11 @@
     private async Task OnMentionButtonClick() {
         await MarkupEditorRef.WhenReady;
         await MarkupEditorRef.JSRef.InvokeVoidAsync("beginMention");
+    }
+
+    private async Task OnConvertToFileClick() {
+        await JSRef.InvokeVoidAsync("convertCurrentTextToAttachment");
+        await MarkupEditorRef.Clear();
     }
 
     private async Task OnAttachClick(string acceptTypes) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -62,13 +62,6 @@
                         Cancel="@(() => OnCancel())"
                         OpenPrevious="OnOpenPrevious"/>
                 </label>
-                <button class="post-panel-btn convert-to-file-btn btn btn-round btn-transparent btn-xs unhovered"
-                        data-tooltip="Send text as file"
-                        data-tooltip-position="@(FloatingPosition.Top.ToPositionString())"
-                        @onmousedown="@(_ => OnConvertToFileClick())"
-                        @onmousedown:preventDefault="true">
-                    <i class="icon-file-text"></i>
-                </button>
                 <div class="c-right-buttons">
                     <NotifyAllButton Chat="@Chat"/>
                     <div class="c-incut"></div>
@@ -292,9 +285,19 @@
         await MarkupEditorRef.JSRef.InvokeVoidAsync("beginMention");
     }
 
-    private async Task OnConvertToFileClick() {
-        await JSRef.InvokeVoidAsync("convertCurrentTextToAttachment");
-        await MarkupEditorRef.Clear();
+    [JSInvokable]
+    public async Task<bool> OnLargeTextPasted(int textLength) {
+        var text = $"The pasted text is {textLength:N0} characters long. "
+            + "Do you want to send it as a .txt file or keep it as a regular text message?";
+        var confirmed = false;
+        var model = new ConfirmModal.Model(false, text, () => confirmed = true) {
+            Title = "Large text pasted",
+            ConfirmButtonText = "Send as file",
+            CancelButtonText = "Keep as text",
+        };
+        var modalRef = await ModalUI.Show(model);
+        await modalRef.WhenClosed;
+        return confirmed;
     }
 
     private async Task OnAttachClick(string acceptTypes) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
@@ -237,28 +237,6 @@ body.narrow .notify-call-panel.panel-open {
     @apply text-primary-title;
 }
 
-/* Convert-text-to-file button (appears when editor text is large enough to suggest attaching) */
-.convert-to-file-btn.post-panel-btn {
-    @apply absolute right-0 md:right-2 top-2;
-    @apply flex-none;
-    @apply opacity-0 pointer-events-none;
-    @apply text-03;
-    transition: opacity 150ms ease;
-}
-.convert-to-file-btn > i {
-    @apply text-2.5xl md:text-2xl;
-}
-.chat-message-editor.text-can-convert-to-file .convert-to-file-btn.post-panel-btn {
-    @apply opacity-100 pointer-events-auto;
-}
-body.hoverable .convert-to-file-btn.post-panel-btn:hover {
-    @apply text-02;
-}
-body.narrow .convert-to-file-btn.post-panel-btn {
-    @apply right-auto top-auto;
-    @apply left-12 bottom-3;
-}
-
 /* Post button */
 .post-panel-btn.post-message {
     @apply hidden;

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
@@ -237,6 +237,28 @@ body.narrow .notify-call-panel.panel-open {
     @apply text-primary-title;
 }
 
+/* Convert-text-to-file button (appears when editor text is large enough to suggest attaching) */
+.convert-to-file-btn.post-panel-btn {
+    @apply absolute right-0 md:right-2 top-2;
+    @apply flex-none;
+    @apply opacity-0 pointer-events-none;
+    @apply text-03;
+    transition: opacity 150ms ease;
+}
+.convert-to-file-btn > i {
+    @apply text-2.5xl md:text-2xl;
+}
+.chat-message-editor.text-can-convert-to-file .convert-to-file-btn.post-panel-btn {
+    @apply opacity-100 pointer-events-auto;
+}
+body.hoverable .convert-to-file-btn.post-panel-btn:hover {
+    @apply text-02;
+}
+body.narrow .convert-to-file-btn.post-panel-btn {
+    @apply right-auto top-auto;
+    @apply left-12 bottom-3;
+}
+
 /* Post button */
 .post-panel-btn.post-message {
     @apply hidden;

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
@@ -1,5 +1,5 @@
 // TODO: remove eslint-disables and fix errors
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unnecessary-condition,@typescript-eslint/require-await,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-misused-promises,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unnecessary-condition,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-misused-promises,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
 import { DeviceInfo } from 'device-info';
 import {
     Subject,
@@ -21,7 +21,6 @@ const { debugLog, warnLog } = getLogs('MessageEditor');
 const LargeTextSuggestFileThreshold = 4_000;
 const LargeTextAutoFileThreshold = 32_000;
 const LargeTextPasteFileName = 'pasted.txt';
-const CanConvertToFileClass = 'text-can-convert-to-file';
 
 export type PanelMode = 'Normal' | 'Narrow';
 
@@ -33,6 +32,7 @@ export class ChatMessageEditor {
     private readonly postPanelDiv: HTMLDivElement;
     private readonly input: HTMLDivElement;
     private readonly filePickerInput: HTMLInputElement;
+    private readonly blazorRef: DotNet.DotNetObject;
     private readonly filePickerBackend: AttachmentWebFilePickerBackend;
     private readonly filePicker: AttachmentWebFilePicker;
     private readonly postPanelHeightObserver: ResizeObserver;
@@ -61,6 +61,7 @@ export class ChatMessageEditor {
         this.editorDiv = editorDiv;
         this.postPanelDiv = this.editorDiv.querySelector(':scope .post-panel')!;
         this.input = this.postPanelDiv.querySelector(':scope .message-input')!;
+        this.blazorRef = filePickerBlazorRef;
         this.filePickerBackend = new AttachmentWebFilePickerBackend(filePickerBlazorRef);
         this.filePickerInput = this.editorDiv.querySelector(':scope .attachment-web-file-picker')!;
         this.filePicker = new AttachmentWebFilePicker(this.filePickerBackend, this.filePickerInput);
@@ -245,29 +246,13 @@ export class ChatMessageEditor {
             .pipe(takeUntil(this.disposed$))
             .subscribe((event: ClipboardEvent) => this.onInputPaste(event));
 
-        this.markupEditor.changed = (_html, text) => {
+        this.markupEditor.changed = () => {
             this.backupRequired$.next();
             this.updateHasContent();
-            this.updateCanConvertToFile(text);
         }
         this.updateHasContent();
-        this.updateCanConvertToFile(this.markupEditor.getText());
         if (this.isNarrowScreen)
             this.markupEditor.contentDiv.blur(); // We want to see the placeholder on mobile when you open a chat
-    }
-
-    /** Called by Blazor */
-    public convertCurrentTextToAttachment(): void {
-        const text = this.markupEditor?.getText() ?? '';
-        if (text.length < LargeTextSuggestFileThreshold)
-            return;
-        const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
-        void this.filePickerBackend.add([{ file: file, fileHandle: null }]);
-    }
-
-    private updateCanConvertToFile(text: string) {
-        const canConvert = text.length >= LargeTextSuggestFileThreshold;
-        this.editorDiv.classList.toggle(CanConvertToFileClass, canConvert);
     }
 
     /** Called by Blazor */
@@ -319,23 +304,37 @@ export class ChatMessageEditor {
             }
         }
 
-        if (fileResults.length === 0) {
-            const text = clipboardData.getData('text');
-            if (text && text.length >= LargeTextAutoFileThreshold) {
-                const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
-                fileResults.push({ file: file, fileHandle: null });
-                // Capture-phase + stopImmediatePropagation keeps MarkupEditor.onPaste
-                // from inserting the same text into the editor.
-                event.stopImmediatePropagation();
-            }
+        if (fileResults.length > 0) {
+            preventDefaultForEvent(event); // Must run sync — async tail can't preventDefault
+            void this.filePickerBackend.add(fileResults);
+            return;
         }
 
-        if (fileResults.length === 0)
+        const text = clipboardData.getData('text');
+        if (!text || text.length < LargeTextSuggestFileThreshold)
             return;
 
-        preventDefaultForEvent(event); // Must run sync — async tail can't preventDefault
-        void this.filePickerBackend.add(fileResults);
+        // Capture-phase + stopImmediatePropagation keeps MarkupEditor.onPaste
+        // from inserting the same text into the editor.
+        preventDefaultForEvent(event);
+        event.stopImmediatePropagation();
+
+        if (text.length >= LargeTextAutoFileThreshold) {
+            this.addTextAsAttachment(text);
+            return;
+        }
+
+        const asFile = await this.blazorRef.invokeMethodAsync<boolean>('OnLargeTextPasted', text.length);
+        if (asFile)
+            this.addTextAsAttachment(text);
+        else
+            this.markupEditor.insertText(text);
     };
+
+    private addTextAsAttachment(text: string) {
+        const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
+        void this.filePickerBackend.add([{ file: file, fileHandle: null }]);
+    }
 
     // Drag-and-drop handlers
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
@@ -18,6 +18,9 @@ import { AttachmentWebFilePicker, AttachmentWebFilePickerBackend, PickFileResult
 
 const { debugLog, warnLog } = getLogs('MessageEditor');
 
+const LargeTextPasteThreshold = 4000;
+const LargeTextPasteFileName = 'pasted.txt';
+
 export type PanelMode = 'Normal' | 'Narrow';
 
 export class ChatMessageEditor {
@@ -236,7 +239,7 @@ export class ChatMessageEditor {
         fromEvent(this.postPanelDiv, 'click')
             .pipe(takeUntil(this.disposed$))
             .subscribe((event: MouseEvent) => this.onPostPanelClick(event));
-        fromEvent(this.input, 'paste')
+        fromEvent<ClipboardEvent>(this.input, 'paste', { capture: true })
             .pipe(takeUntil(this.disposed$))
             .subscribe((event: ClipboardEvent) => this.onInputPaste(event));
 
@@ -280,20 +283,16 @@ export class ChatMessageEditor {
     });
 
     private onInputPaste = async (event: ClipboardEvent) => {
-        // Get pasted data via clipboard API
-        // We need to handle only files pasting.
-        // Text pasting is controlled by markup editor.
+        // We handle clipboard files here, and route large plain-text pastes
+        // through the same attachment pipeline. Small text pastes fall through
+        // to MarkupEditor (bubble phase on the inner .editor-content).
         const clipboardData = event.clipboardData;
         if (!clipboardData)
             return;
 
-        let isAdding = false;
         const fileResults : PickFileResult[] = [];
         for (const item of clipboardData.items) {
             if (item.kind === 'file') {
-                if (!isAdding)
-                    preventDefaultForEvent(event); // We can do it only in the sync part of async handler
-                isAdding = true;
                 const file = item.getAsFile();
                 if (!file)
                     continue; // Should not happen, but just in case
@@ -301,6 +300,22 @@ export class ChatMessageEditor {
                 fileResults.push({ file: file, fileHandle: null });
             }
         }
+
+        if (fileResults.length === 0) {
+            const text = clipboardData.getData('text');
+            if (text && text.length >= LargeTextPasteThreshold) {
+                const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
+                fileResults.push({ file: file, fileHandle: null });
+                // Capture-phase + stopImmediatePropagation keeps MarkupEditor.onPaste
+                // from inserting the same text into the editor.
+                event.stopImmediatePropagation();
+            }
+        }
+
+        if (fileResults.length === 0)
+            return;
+
+        preventDefaultForEvent(event); // Must run sync — async tail can't preventDefault
         void this.filePickerBackend.add(fileResults);
     };
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.ts
@@ -18,8 +18,10 @@ import { AttachmentWebFilePicker, AttachmentWebFilePickerBackend, PickFileResult
 
 const { debugLog, warnLog } = getLogs('MessageEditor');
 
-const LargeTextPasteThreshold = 4000;
+const LargeTextSuggestFileThreshold = 4_000;
+const LargeTextAutoFileThreshold = 32_000;
 const LargeTextPasteFileName = 'pasted.txt';
+const CanConvertToFileClass = 'text-can-convert-to-file';
 
 export type PanelMode = 'Normal' | 'Narrow';
 
@@ -243,13 +245,29 @@ export class ChatMessageEditor {
             .pipe(takeUntil(this.disposed$))
             .subscribe((event: ClipboardEvent) => this.onInputPaste(event));
 
-        this.markupEditor.changed = () => {
+        this.markupEditor.changed = (_html, text) => {
             this.backupRequired$.next();
             this.updateHasContent();
+            this.updateCanConvertToFile(text);
         }
         this.updateHasContent();
+        this.updateCanConvertToFile(this.markupEditor.getText());
         if (this.isNarrowScreen)
             this.markupEditor.contentDiv.blur(); // We want to see the placeholder on mobile when you open a chat
+    }
+
+    /** Called by Blazor */
+    public convertCurrentTextToAttachment(): void {
+        const text = this.markupEditor?.getText() ?? '';
+        if (text.length < LargeTextSuggestFileThreshold)
+            return;
+        const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
+        void this.filePickerBackend.add([{ file: file, fileHandle: null }]);
+    }
+
+    private updateCanConvertToFile(text: string) {
+        const canConvert = text.length >= LargeTextSuggestFileThreshold;
+        this.editorDiv.classList.toggle(CanConvertToFileClass, canConvert);
     }
 
     /** Called by Blazor */
@@ -303,7 +321,7 @@ export class ChatMessageEditor {
 
         if (fileResults.length === 0) {
             const text = clipboardData.getData('text');
-            if (text && text.length >= LargeTextPasteThreshold) {
+            if (text && text.length >= LargeTextAutoFileThreshold) {
                 const file = new File([text], LargeTextPasteFileName, { type: 'text/plain' });
                 fileResults.push({ file: file, fileHandle: null });
                 // Capture-phase + stopImmediatePropagation keeps MarkupEditor.onPaste

--- a/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.ts
@@ -468,6 +468,16 @@ export class MarkupEditor {
         ok();
     }
 
+    public insertText(text: string) {
+        if (!this.hasFocus()) {
+            this.focus();
+            this.restoreSelection();
+        }
+        this.transaction('insertText', () => {
+            this.insertTextAtCursor(text);
+        });
+    }
+
     private insertTextAtCursor(text)
     {
         const selection = window.getSelection()!;


### PR DESCRIPTION
Closes #3763

A multi-KB paste rendered inline destroys chat history readability. When the clipboard carries plain text ≥4000 chars (and no file items), synthesize a File('pasted.txt', text/plain) and route it through the existing attachment pipeline instead of letting MarkupEditor insert it into the editor.

Done by switching the existing paste subscription to capture phase on .message-input so we run before MarkupEditor.onPaste, and using stopImmediatePropagation in the large-text branch to keep the editor empty. File-paste behavior is unchanged.