### PR TITLE
fix(chat): don't draw avatar when group exists only due to a separator

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryAuthorGroupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryAuthorGroupView.razor
@@ -2,7 +2,11 @@
 @{
     var m = Message;
     var firstItem = m.Items.FirstOrDefault();
-    var showAuthorBadge = !(firstItem?.Entry.IsSystemEntry ?? false);
+    var isSystem = firstItem?.Entry.IsSystemEntry ?? false;
+    // No BlockStart => the group exists only because a separator (e.g. NewMessagesLine) split a
+    // same-author run; the inner header is suppressed too, so a lone avatar would look orphaned.
+    var isBlockStart = firstItem?.Flags.HasFlag(ChatMessageFlags.BlockStart) ?? false;
+    var showAuthorBadge = !isSystem && isBlockStart;
     // Log.LogInformation("Render ChatEntryAuthorGroupView: {Id}, Count = {Count}", firstItem?.Entry.Id, m.Items.Count);
 }
 


### PR DESCRIPTION
After 94db1e87 every author block is wrapped in ChatEntryAuthorGroup, including continuation messages that became a fresh group only because a NewMessagesLine (or other separator) split a same-author run. The inner ChatEntryMessageView is invoked with ShowAuthorBadge=false and, since the first item is not a BlockStart, its author header is suppressed too — leaving the c-left avatar as an orphan and pushing the LI to the wrong height (the bottom-most one ends up clipped by the input bar).

Gate the c-left avatar on the first item being a BlockStart, matching the visibility rule the inner header already uses. Continuation blocks render as plain text again, like before 94db1e87.