### PR TITLE
feat(notifications): skip devices inactive 30+ days in push fan-out

### DIFF
--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -279,6 +279,7 @@ public static partial class Constants
         public static readonly TimeSpan PermissionRequestDismissPeriod = TimeSpan.FromDays(7);
         public static readonly TimeSpan EntryWaitTimeout = TimeSpan.FromSeconds(0.5);
         public static readonly TimeSpan OnlineCheckDelay = TimeSpan.FromMinutes(1);
+        public static readonly TimeSpan ActiveDevicePeriod = TimeSpan.FromDays(30);
     }
 
     public static class Media

--- a/src/dotnet/Notification.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notification.Service/NotificationsBackend.cs
@@ -64,7 +64,7 @@ public class NotificationsBackend(IServiceProvider services)
 
     // [ComputeMethod]
     public virtual Task<IReadOnlyList<Device>> ListDevices(UserId userId, CancellationToken cancellationToken)
-        => ListDevices(userId, Symbol.Empty, cancellationToken);
+        => ListDevices(userId, Symbol.Empty, null, cancellationToken);
 
     // [ComputeMethod]
     public virtual async Task<IReadOnlyList<UserId>> ListSubscribedUserIds(ChatId chatId, CancellationToken cancellationToken)
@@ -486,7 +486,7 @@ public class NotificationsBackend(IServiceProvider services)
             return; // It just spawns other commands, so nothing to do here
 
         var session = eventCommand.Session;
-        var devices = await ListDevices(eventCommand.UserId, session.Hash, cancellationToken).ConfigureAwait(false);
+        var devices = await ListDevices(eventCommand.UserId, session.Hash, null, cancellationToken).ConfigureAwait(false);
         if (devices.Count == 0)
             return;
 
@@ -538,7 +538,8 @@ public class NotificationsBackend(IServiceProvider services)
 
     private async Task Send(UserId userId, Notification notification, CancellationToken cancellationToken1)
     {
-        var devices = await ListDevices(userId, cancellationToken1).ConfigureAwait(false);
+        var minActiveAt = Clocks.SystemClock.Now - Constants.Notification.ActiveDevicePeriod;
+        var devices = await ListDevices(userId, Symbol.Empty, minActiveAt, cancellationToken1).ConfigureAwait(false);
         if (devices.Count == 0) {
             Log.LogInformation("No recipient devices found for notification #{NotificationId}", notification.Id);
             return;
@@ -629,14 +630,18 @@ public class NotificationsBackend(IServiceProvider services)
         return null;
     }
 
-    private async Task<IReadOnlyList<Device>> ListDevices(UserId userId, Symbol sessionHash, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<Device>> ListDevices(
+        UserId userId, Symbol sessionHash, Moment? minActiveAt, CancellationToken cancellationToken)
     {
         var dbContext = await DbHub.CreateDbContext(cancellationToken).ConfigureAwait(false);
         await using var _ = dbContext.ConfigureAwait(false);
 
+        // AccessedAt is null until the same token re-registers, so freshness falls back to CreatedAt.
+        var minActiveAtValue = minActiveAt?.ToDateTime() ?? default;
         var dbDevices = await dbContext.Devices
             .Where(d => d.UserId == userId.Value)
             .WhereIf(d => d.SessionHash == sessionHash.Value, !sessionHash.IsEmpty)
+            .WhereIf(d => (d.AccessedAt ?? d.CreatedAt) >= minActiveAtValue, minActiveAt.HasValue)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
         var devices = dbDevices.Select(d => d.ToModel()).ToList();


### PR DESCRIPTION
Send only targets devices whose COALESCE(AccessedAt, CreatedAt) is within the new Constants.Notification.ActiveDevicePeriod (30d). Stale-but-valid tokens accumulate (FCM accepts them, so they're never pruned) and dominate the send list, dragging Android delivery down. The filter is applied only on the send path; ListDevices for deregistration and sign-out still see all devices, and nothing is deleted.