### PR TITLE
fix(chat): drop duplicate tail conversation header (@key crash)

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -160,13 +160,18 @@ public partial class ChatUI
         var hasVeryFirstItem = idTiles.Count > 0 && idTiles[0].Start <= chatLidRange.Start;
         var prevMessage = hasVeryFirstItem ? ChatMessage.Welcome(chatId) : null;
         var alreadyAddedConversationHeaders = new HashSet<ConversationId>();
-        foreach (var idTile in idTiles) {
+        for (var tileIndex = 0; tileIndex < idTiles.Count; tileIndex++) {
+            var idTile = idTiles[tileIndex];
             var lastReadEntryLid = shownReadyEntryLid;
             if (lastReadEntryLid < idTile.Start)
                 lastReadEntryLid = 0;
             else if (shownReadyEntryLid >= idTile.End - 1)
                 lastReadEntryLid = long.MaxValue;
-            var isLastTile = idTile.Contains(chatLidRange.End - 1);
+            // When we're at the chat's newest end, the last loaded tile is the tail even if a trailing
+            // run of removed entries leaves chatLidRange.End-1 outside it - and it's where the optimistic
+            // "sending"/new messages must be merged.
+            var isLastTile = idTile.Contains(chatLidRange.End - 1)
+                || (!hasMoreAfter && tileIndex == idTiles.Count - 1);
             var tile = await GetTile(
                     chatId,
                     chat.Rules.Author?.Id,
@@ -216,11 +221,12 @@ public partial class ChatUI
             tiles[^1].Items[^1].NextMessage = null;
         }
 
-        // When the chat's tail isn't carried by any loaded tile (e.g. an empty chat whose only entries
-        // are removed), no GetTile call merges the optimistic "sending" messages. Build the tail tile
-        // explicitly so they still surface - and so this query depends on OnNewMessagesChanged.
-        var isTailLoaded = idTiles.Any(t => t.Contains(chatLidRange.End - 1));
-        if (!isTailLoaded && !hasMoreAfter) {
+        // A chat whose only entries are removed loads zero id-tiles, so the per-tile loop above never
+        // runs and never merges the optimistic "sending" messages. Build the tail tile explicitly for
+        // that case so they still surface - and so this query depends on OnNewMessagesChanged. When tiles
+        // *are* loaded, the loop's last tile already carries this merge (see isLastTile above), so we must
+        // not append a second tail tile here - doing so duplicated the trailing conversation header's @key.
+        if (idTiles.Count == 0 && !hasMoreAfter) {
             var tailRange = IdTileStack.FirstLayer.GetTile(chatLidRange.End).Range;
             var tailTile = await GetTile(
                     chatId,
@@ -235,10 +241,8 @@ public partial class ChatUI
                     cancellationToken)
                 .ConfigureAwait(false);
             if (tailTile.Items.Count > 0) {
-                if (tiles.Count > 0)
-                    tiles[^1].Items[^1].NextMessage = tailTile.Items[0];
                 tiles.Add(tailTile);
-                hasVeryFirstItem = idTiles.Count == 0 || hasVeryFirstItem;
+                hasVeryFirstItem = true;
             }
         }
 

--- a/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
@@ -2,6 +2,7 @@ using ActualChat.Hashing;
 using ActualChat.Testing.Host;
 using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.Components;
 
 namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
 
@@ -56,5 +57,58 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
         items.Items.OfType<ChatEntryMessage>()
             .Select(m => m.Entry.Content)
             .Should().Contain("TEST_SENDING");
+    }
+
+    // Each chat-items entry renders with a @key; duplicate sibling keys throw inside Blazor's keyed
+    // render-tree diff and tear down the circuit. A conversation at the chat tail used to be emitted
+    // twice - once by the last loaded tile, once by the explicit tail-tile fallback - producing a
+    // duplicate ConversationStart @key. This guards the "GetChatItems yields unique render keys"
+    // invariant while still surfacing the tail merge. The exact prod trigger (a summarized chat whose
+    // tail ids are all removed, so no tile carries the tail) isn't reproducible in-process - the test
+    // host keeps removed entries as tombstone tiles - so this exercises the invariant on the normal path.
+    [Fact]
+    public async Task ShouldNotProduceDuplicateRenderKeysAtChatTail()
+    {
+        // arrange: a chat with several messages and a removed tail entry
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "dup-key-test");
+        for (var i = 0; i < 5; i++)
+            await Tester.CreateTextEntry(chat.Id, $"msg-{i}");
+        var tailEntry = await Tester.CreateTextEntry(chat.Id, "tail-to-remove");
+        await Tester.RemoveTextEntry(tailEntry.Id);
+
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var sendingMessages = Tester.ScopedAppServices.GetRequiredService<SendingMessages>();
+        var now = Tester.AppServices.Clocks().SystemClock.Now;
+
+        // act: register an optimistic "sending" message, then load the chat at its tail
+        var accessor = sendingMessages.GetSendingMessages(chat.Id);
+        accessor.ChatSendingMessages.AddSendingMessage(new SendingMessage(
+            Guid.NewGuid().ToString(),
+            chat.Id,
+            null,
+            now,
+            "TAIL_SENDING",
+            HashString.None,
+            null,
+            () => { }));
+
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert: the tail merge still surfaces the optimistic message
+        items.Items.OfType<ChatEntryMessage>()
+            .Select(m => m.Entry.Content)
+            .Should().Contain("TAIL_SENDING");
+
+        // assert: no duplicate @key among siblings - top-level items and each conversation's children
+        items.Items
+            .Select(i => ((IVirtualListItem)i).RenderKey)
+            .Should().OnlyHaveUniqueItems();
+        foreach (var conversation in items.Items.OfType<ExpandedConversationMessage>())
+            conversation.Items
+                .Select(i => ((IVirtualListItem)i).RenderKey)
+                .Should().OnlyHaveUniqueItems();
     }
 }


### PR DESCRIPTION
## Problem

Since last Friday (06-05) the dev/build server started logging render errors (and the page kept reloading) in chat:

```
System.ArgumentException: Attempting to return wrong pooled instance. Get/Return calls must form a stack.
   at Microsoft.AspNetCore.Components.RenderTree.StackObjectPool`1.Return(T instance)
   at ...RenderTreeDiffBuilder.AppendDiffEntriesForRange(...)
```

This is a **secondary** symptom: two sibling elements sharing the same `@key` throw inside Blazor's keyed render-tree diff, leave its `StackObjectPool` unbalanced, and tear down the circuit.

## Root cause

Commit `1ba488979` (06-05, *show optimistic "sending" messages in empty chats*) added an explicit **tail-tile** build to `GetChatItemsInternal`. It is appended **after** every loaded tile but — unlike the tiles in the loop — never passes through their conversation-header dedup. When a conversation starts at the chat tail, its `ConversationHeader` is emitted twice → duplicate `@key` (`{lid}-conversation`, kind `ConversationStart`).

The guard (`!isTailLoaded && !hasMoreAfter`) was too broad: the commit message describes the "zero id-tiles" (empty chat) case, but the condition also fires for loaded chats whose trailing ids are all removed, so `chatLidRange.End-1` lands in no loaded tile.

## Fix

- **`isLastTile`** is now true for the last loaded tile when we're at the chat's newest end (`!hasMoreAfter`), even if `chatLidRange.End-1` points at a removed entry outside it. The sending/new-message merge happens in that tile (as it did before the commit on normal chats).
- The explicit **tail-tile fallback** is restricted to the genuinely empty case (`idTiles.Count == 0`). No second tail tile is appended for loaded chats, so the duplicate `@key` is never produced.

## Verification

Reproduced on the local Windows client (which talks to the dev backend), chat `s-P7oRNDTeHM-052w3sgrad`:
- **before:** `dropped duplicate render key '194872-conversation' (kind ConversationStart)` when loading the tail;
- **after:** the same chat loads to its tail (`loaded 34 items, last=194872, hasAfter=False`), sending messages still surface, no duplicate / `pooled instance`.

## Test

`SendingMessagesDisplayTest.ShouldNotProduceDuplicateRenderKeysAtChatTail` — guards the "GetChatItems yields unique `@key`s" invariant (top-level items + each conversation's children) and that the optimistic message still surfaces at the tail. The exact prod trigger (a summarized chat with a conversation at the tail plus a trailing run of removed entries) isn't reproducible in-process — the test host keeps removed entries as tombstone tiles — so the test exercises the invariant on the normal path.

Build is clean, both tests in the class pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)