### PR TITLE
fix(digest): pin summary language to the chat's dominant language

### DIFF
--- a/src/dotnet/Chat.ML/ChatDigestSummarizer.cs
+++ b/src/dotnet/Chat.ML/ChatDigestSummarizer.cs
@@ -9,6 +9,7 @@ public interface IChatDigestSummarizer
 {
     Task<IReadOnlyCollection<string>> Summarize(
         IReadOnlyCollection<ChatEntry> chatEntries,
+        Language language,
         CancellationToken cancellationToken);
 
     Task<string?> SummarizeMediaShares(
@@ -37,6 +38,7 @@ public class ChatDigestSummarizer(ChatDigestSummarizer.Options settings, IServic
 
     public async Task<IReadOnlyCollection<string>> Summarize(
         IReadOnlyCollection<ChatEntry> chatEntries,
+        Language language,
         CancellationToken cancellationToken)
     {
         if (Prompt.IsNullOrEmpty())
@@ -47,6 +49,7 @@ public class ChatDigestSummarizer(ChatDigestSummarizer.Options settings, IServic
             Prompt,
             new Dictionary<string, string>() {
                 { "DOCUMENT", text.Substring(0, Math.Min(text.Length, 1_000_000)) },
+                { "LANGUAGE", language.Title },
             });
         try {
             var response = await Ask(prompt, cancellationToken).ConfigureAwait(false);
@@ -143,7 +146,7 @@ public class ChatDigestSummarizer(ChatDigestSummarizer.Options settings, IServic
 
 public class ChatDigestSummarizerStub : IChatDigestSummarizer
 {
-    public Task<IReadOnlyCollection<string>> Summarize(IReadOnlyCollection<ChatEntry> chatEntries, CancellationToken cancellationToken)
+    public Task<IReadOnlyCollection<string>> Summarize(IReadOnlyCollection<ChatEntry> chatEntries, Language language, CancellationToken cancellationToken)
         => Task.FromResult<IReadOnlyCollection<string>>([]);
 
     public Task<string?> SummarizeMediaShares(IReadOnlyCollection<ChatEntry> mediaEntries, Language language, CancellationToken cancellationToken)

--- a/src/dotnet/Users.Service/EmailsBackend.cs
+++ b/src/dotnet/Users.Service/EmailsBackend.cs
@@ -13,6 +13,7 @@ public class EmailsBackend(IServiceProvider services) : IEmailsBackend
     private IChatPositionsBackend ChatPositionsBackend { get; } = services.GetRequiredService<IChatPositionsBackend>();
     private IContactsBackend ContactsBackend { get; } = services.GetRequiredService<IContactsBackend>();
     private IChatsBackend ChatsBackend { get; } = services.GetRequiredService<IChatsBackend>();
+    private IChatEntryLanguagesBackend ChatEntryLanguagesBackend { get; } = services.GetRequiredService<IChatEntryLanguagesBackend>();
     private IEmailSender EmailSender { get; } = services.GetRequiredService<IEmailSender>();
     private IServerKvasBackend ServerKvasBackend { get; } = services.GetRequiredService<IServerKvasBackend>();
     private IChatDigestSummarizer ChatDigestSummarizer { get; } = services.GetRequiredService<IChatDigestSummarizer>();
@@ -208,8 +209,10 @@ public class EmailsBackend(IServiceProvider services) : IEmailsBackend
                 .Select(WithMediaHint)
                 .Where(x => !x.Content.IsNullOrEmpty())
                 .ToList();
+            var digestLanguage = await GetDominantLanguage(chatId, summarizable, cancellationToken).ConfigureAwait(false)
+                ?? userLanguage;
             bulletPoints = await ChatDigestSummarizer
-                .Summarize(summarizable, cancellationToken)
+                .Summarize(summarizable, digestLanguage, cancellationToken)
                 .ConfigureAwait(false);
         }
         else {
@@ -230,6 +233,32 @@ public class EmailsBackend(IServiceProvider services) : IEmailsBackend
             UnreadCount = unreadCount,
             BulletPoints = bulletPoints,
         };
+    }
+
+    private async Task<Language?> GetDominantLanguage(
+        ChatId chatId, IReadOnlyCollection<ChatEntry> entries, CancellationToken cancellationToken)
+    {
+        var idTileLayer = Constants.Chat.ServerIdTileStack.FirstLayer;
+        var tileRanges = entries
+            .Select(e => idTileLayer.GetTile(e.LocalId).Range)
+            .Distinct()
+            .ToList();
+
+        var languagesByEntryId = new Dictionary<ChatEntryId, Language[]>();
+        foreach (var range in tileRanges) {
+            var tile = await ChatEntryLanguagesBackend.GetTile(chatId, range, cancellationToken).ConfigureAwait(false);
+            foreach (var entryLanguage in tile.Entries)
+                languagesByEntryId[entryLanguage.Id] = entryLanguage.Languages;
+        }
+
+        return entries
+            .Select(e => languagesByEntryId.GetValueOrDefault(e.Id))
+            .Where(languages => languages is { Length: > 0 })
+            .Select(languages => languages![0])
+            .GroupBy(language => language)
+            .OrderByDescending(g => g.Count())
+            .Select(g => g.Key)
+            .FirstOrDefault();
     }
 
     private async Task<Language> GetUserLanguage(UserId userId, CancellationToken cancellationToken)


### PR DESCRIPTION
## Problem

A chat digest generated on May 29 came out in **German** even though every source message was in **English** (a technical Q&A about Fusion / EF / `ConfigureAwait`).

Root cause: the chat-digest prompt instructed the model to write the summary *"in the original language of the document"*. This abstract, self-referential language instruction makes `gpt-4.1` **systematically** pick the wrong language — in empirical testing it produced German **12/12 times** on the English input (and drifted to Spanish / Chinese in other variants). Removing the instruction made the model naturally mirror English, but that is not a guarantee. Only injecting a **concrete language name** into the prompt is reliable (`"... in English"` → English 4/4).

## Fix

Resolve a concrete language and pass it into the summarizer instead of asking the model to infer it:

- `ChatDigestSummarizer.Summarize` now takes a `Language` and fills the prompt's `{{LANGUAGE}}` placeholder with `Language.Title`. This mirrors the existing `SummarizeMediaShares` path, which already pinned the language.
- `EmailsBackend` resolves the chat's **dominant language** from the already-stored per-entry languages via `IChatEntryLanguagesBackend.GetTile` — **no extra LLM call** (these are persisted/computed by the existing language-detection pipeline). Falls back to the user's primary language when no entry languages are available (e.g. translation disabled).

## Verification

- `Chat.ML` and `Users.Service` build clean.
- Empirical, same English document that previously produced German 8/8:
  - `{{LANGUAGE}} = "English (USA)"` → English **6/6**
  - `{{LANGUAGE}} = "Russian"` → Russian **3/3** (confirms the lever controls the output)
- `DigestFlowTest` — **5/5 passed**.

## Deployment note

The prompt template (`summarize-chat-digest.md`) lives outside this repo (`CoreSettings__PromptsDir`). It must be updated to use the `{{LANGUAGE}}` placeholder. Deploy **code first, then the prompt**: new code + old prompt is safe (the extra value is ignored), but the new prompt + old code throws because `{{LANGUAGE}}` would be unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
