### PR TITLE
fix(time-sync): bind MAUI ServerTimeSync to the WebView page scope

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
+++ b/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
@@ -117,10 +117,10 @@ public sealed class AppScopedServiceStarter
 
             // Starting less important UI services
             await Task.Delay(baseDelay, cancellationToken).ConfigureAwait(false);
-            if (hostKind.IsServer())
-                // Server mode registers ServerTimeSync scoped (per-circuit IJSRuntime), not hosted,
-                // so its background sync loop must be started here — otherwise viewers never sync
-                // and recorders sync only once (see BlazorUICoreModule).
+            if (hostKind.IsServer() || hostKind.IsMauiApp())
+                // Server & MAUI register ServerTimeSync scoped (bound to the per-circuit / per-WebView-page
+                // IJSRuntime), not hosted, so its background sync loop must be started here — once first
+                // render guarantees JS is ready (see BlazorUICoreModule).
                 Hub.Services.GetService<ServerTimeSync>()?.Start();
             Hub.Services.GetRequiredService<SessionTokens>().Start();
             Hub.Services.GetRequiredService<BackgroundActivityUI>().Start();

--- a/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
+++ b/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
@@ -67,17 +67,20 @@ public sealed class BlazorUICoreModule(IServiceProvider moduleServices)
         if (isServer) {
             services.AddScoped<DateTimeConverter>(c => new ServerSideDateTimeConverter(c));
             MomentClockSet.Default.ServerClock.Offset = TimeSpan.Zero;
-            // In Server mode, register as scoped (IJSRuntime is scoped per Blazor circuit).
-            // Its background loop is started per-circuit by AppScopedServiceStarter.AfterFirstRender;
-            // EnsureSynced() additionally forces an immediate sync before the first recording.
+        }
+        else
+            services.AddScoped<DateTimeConverter>(c => new ClientSizeDateTimeConverter(c)); // WASM & MAUI
+        // ServerTimeSync needs the IJSRuntime bound to the active scope:
+        // - Server: the per-circuit IJSRuntime;
+        // - MAUI: the per-WebView-page IJSRuntime — the root (non-scoped) one isn't attached to a
+        //   WebView, so its JS calls throw "Cannot invoke JavaScript outside of a WebView context".
+        // Both start the background loop from AppScopedServiceStarter.AfterFirstRender, once JS is ready;
+        // EnsureSynced() additionally forces an immediate sync before the first recording.
+        // WASM has a single, always-ready IJSRuntime, so a hosted service is fine there.
+        if (isServer || isMauiApp)
             services.AddScoped(c => new ServerTimeSync(c));
-        }
-        else {
-            services.AddScoped<DateTimeConverter>(c => new ClientSizeDateTimeConverter(c)); // WASM
-            // In WASM, hosted service auto-starts the background sync loop.
-            // Also makes ServerTimeSync resolvable via GetService<ServerTimeSync>().
+        else
             services.AddHostedService(c => new ServerTimeSync(c));
-        }
         services.AddScoped(c => new FontSizeUI(c.UIHub()));
 
         // UI events


### PR DESCRIPTION
## Problem

~770 Sentry events (FCE) of `InvalidOperationException: "Cannot invoke JavaScript outside of a WebView context."` coming from the `ServerTimeSync.Sync` background loop in the **MAUI** app ([ACTUAL-CHAT-UI-ZV0](https://actual-chat.sentry.io/issues/7486388276/)).

Root cause is the **service scope**:
- On MAUI `ServerTimeSync` was registered via `AddHostedService` and started from the **root** provider (`AppNonScopedServiceStarter`) — before the WebView creates its page scope.
- Its constructor resolved `IJSRuntime` from the root scope and got the `WrappedJSRuntime` that **isn't attached to any WebView**, so every JS offset push (`ServerTimeSync.cs:173`) threw.
- Side effect: `GetService<ServerTimeSync>()` for the `EnsureSynced` callers (VideoTrackPlayer / AudioRecorder / ChatVideoUI) returned `null` on MAUI — the forced pre-recording sync never ran there.

The JS-side offset matters (`ServerClock` in `clocks.ts` → `SharedSettings` → audio/video workers), so swallowing the error is not an option — TimeSync must actually reach the WebView's JS runtime.

## Fix

Register `ServerTimeSync` as `scoped` on MAUI (same as Server mode) and start its background loop from `AppScopedServiceStarter.AfterFirstRender`, once the page-bound, ready `IJSRuntime` exists. This fixes both the background loop and `EnsureSynced`. WASM stays on a hosted service (single always-ready `IJSRuntime`).

## Changes
- `BlazorUICoreModule.cs` — `ServerTimeSync` is now `scoped` for Server **and** MAUI; hosted service only for WASM.
- `AppScopedServiceStarter.cs` — background loop is started from `AfterFirstRender` for Server **and** MAUI.

Fixes ACTUAL-CHAT-UI-ZV0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
