### PR TITLE
feat(replay): treat replay restart as new, keep content on resume

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ReplaySubHeader/ReplaySubHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ReplaySubHeader/ReplaySubHeader.razor
@@ -51,7 +51,7 @@
                 Class="c-authors"
                 MaxCount="@slotCount"
                 Size="@size"
-                AuthorIds="@m?.AuthorIds"
+                AuthorIds="@m.AuthorIds"
                 IsListening="true"/>
         </div>
         @if (showDivider) {
@@ -63,9 +63,7 @@
             } else {
                 <div class="c-title">@titleLabel</div>
             }
-            @if (isLoading) {
-                <div class="c-date-skeleton" aria-hidden="true"></div>
-            } else if (dateLabel.Length > 0) {
+            @if (dateLabel.Length > 0) {
                 <div class="c-date">@dateLabel</div>
             }
         </div>
@@ -142,21 +140,13 @@
         var chatTitle = chat?.Title ?? "";
         var participantCount = await GetParticipantCount(chatId, cancellationToken).ConfigureAwait(false);
 
-        Model Loading() => new() {
-            ChatId = chatId,
-            IsLoading = true,
-            ChatTitle = chatTitle,
-            ShowChatTitle = chatId != selectedChatId,
-            Speed = replayState.Speed,
-            ParticipantCount = participantCount,
-            AuthorIds = [],
-        };
-
         // Paused state: player is stopped, but we still show the banner
         if (replayState.PausedAt is { } pausedAt)
             return new() {
                 ChatId = chatId,
                 PlayingAt = pausedAt,
+                StartAt = replayState.StartAt,
+                RewindOffset = replayState.RewindOffset,
                 Player = null,
                 IsPaused = true,
                 Speed = replayState.Speed,
@@ -170,7 +160,7 @@
         if (player is null) {
             // This happens when player is being disposed, which means this method
             // will soon recompute anyway.
-            return lastState ?? Loading(); // Keep the last state to avoid blinking
+            return SameReplay(lastState) || IsResume(lastState) ? lastState! : Loading(); // Keep the last state to avoid blinking
         }
         var isPaused = await player.Playback.IsPaused.Use(cancellationToken).ConfigureAwait(false);
         var playback = player.Playback;
@@ -189,10 +179,18 @@
 
             playingAt ??= trackInfo.RecordedAt + actualPlaybackState.PlayingAt;
         }
-        if (playingAt.HasValue)
+
+        // The replay player is reused across replays, so it may still be winding down
+        // a previous run with stale tracks. Trust its position only once it has
+        // (re)started for the current replay; until then we stay in Loading.
+        var runMatches = player.CurrentStartAt == replayState.StartAt
+            && player.CurrentRewindOffset == replayState.RewindOffset;
+        if (runMatches && playingAt.HasValue)
             return new() {
                 ChatId = chatId,
                 PlayingAt = playingAt,
+                StartAt = replayState.StartAt,
+                RewindOffset = replayState.RewindOffset,
                 Player = player,
                 IsPaused = isPaused,
                 Speed = replayState.Speed,
@@ -202,10 +200,48 @@
                 ParticipantCount = participantCount,
             };
 
-        // No playing tracks yet (e.g. resuming) — keep last state to avoid blinking
-        if (lastState is not null && lastState.ChatId == chatId)
-            return lastState with { Player = player, IsPaused = isPaused };
+        // No playing tracks yet — keep last state within the same replay (e.g. an
+        // inter-entry gap) or while resuming from pause; a new replay falls back to
+        // Loading. Re-stamp the replay key so the next recompute still matches.
+        if (SameReplay(lastState) || IsResume(lastState))
+            return lastState! with {
+                StartAt = replayState.StartAt,
+                RewindOffset = replayState.RewindOffset,
+                Player = player,
+                IsPaused = isPaused,
+            };
         return Loading();
+
+        // A change of (ChatId, StartAt, RewindOffset) means a new replay was started,
+        // so the previous banner state must not be reused — we show Loading until the
+        // new playback reaches the requested position.
+        bool SameReplay(Model? s)
+            => s is { } m
+               && m.ChatId == chatId
+               && m.StartAt == replayState.StartAt
+               && m.RewindOffset == replayState.RewindOffset;
+
+        // Resuming from pause continues from the position already shown on the banner,
+        // so it's not a position jump — keep the current content instead of flashing
+        // Loading while the stream is re-established.
+        bool IsResume(Model? s)
+            => s is { IsPaused: true, PlayingAt: { } pausedAt }
+               && s.ChatId == chatId
+               && replayState.PausedAt is null
+               && pausedAt == replayState.StartAt;
+
+        Model Loading() => new() {
+            ChatId = chatId,
+            IsLoading = true,
+            PlayingAt = replayState.StartAt,
+            StartAt = replayState.StartAt,
+            RewindOffset = replayState.RewindOffset,
+            ChatTitle = chatTitle,
+            ShowChatTitle = chatId != selectedChatId,
+            Speed = replayState.Speed,
+            ParticipantCount = participantCount,
+            AuthorIds = [],
+        };
     }
 
     private async Task<int> GetParticipantCount(ChatId chatId, CancellationToken cancellationToken) {
@@ -276,6 +312,8 @@
         public ChatReplayPlayer? Player { get; init; }
         public string ChatTitle { get; init; } = "";
         public required ChatId ChatId { get; init; }
+        public Moment StartAt { get; init; }
+        public TimeSpan RewindOffset { get; init; }
         public bool ShowChatTitle { get; init; }
         public IReadOnlyList<AuthorId> AuthorIds { get; init; } = [];
         public int ParticipantCount { get; init; }

--- a/src/dotnet/UI.Blazor.App/Components/ReplaySubHeader/replay-subheader.css
+++ b/src/dotnet/UI.Blazor.App/Components/ReplaySubHeader/replay-subheader.css
@@ -77,10 +77,6 @@ a.c-title {
     @apply truncate;
     @apply text-caption-8 text-03;
 }
-.replay-subheader .c-date-skeleton {
-    @apply mt-0.5 h-2.5 w-20 rounded-full;
-    background-color: var(--border-replay);
-}
 .replay-subheader .c-playback {
     @apply flex-none flex-x items-center gap-x-0.5 md:gap-x-1;
     @apply p-0.5;

--- a/src/dotnet/UI.Blazor.App/Services/Playback/ChatReplayPlayer.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Playback/ChatReplayPlayer.cs
@@ -6,6 +6,12 @@ namespace ActualChat.UI.Blazor.App.Services;
 
 public sealed class ChatReplayPlayer : ChatPlayer
 {
+    // Identifies the replay currently being played by this (reused) player.
+    // ReplaySubHeader trusts the playback position only once this matches the
+    // active ReplayState — otherwise the player is still winding down a previous run.
+    public Moment CurrentStartAt { get; private set; }
+    public TimeSpan CurrentRewindOffset { get; private set; }
+
     public ChatReplayPlayer(AppUIHub hub, ChatId chatId)
         : base(hub, chatId)
         => PlayerKind = ChatPlayerKind.Replaying;
@@ -48,6 +54,8 @@ public sealed class ChatReplayPlayer : ChatPlayer
             speed = replayState.Speed;
             rewindOffset = replayState.RewindOffset;
         }
+        CurrentStartAt = startAt;
+        CurrentRewindOffset = rewindOffset;
         var sleepDurationAtStart = SleepDuration.Value;
         var pauseDurationAtStart = Playback.TotalPauseDuration.Value;
 


### PR DESCRIPTION
Show Loading when (ChatId, StartAt, RewindOffset) changes (a new replay / rewind), using ReplayState.StartAt as the initial PlayingAt so the banner renders the target time immediately instead of a date skeleton. Gate the playing model on ChatReplayPlayer's current run so the reused player's stale tracks can't flash an old position. Resume-from-pause continues from the shown position, so it keeps the current content instead of flashing Loading while the stream re-establishes.