### PR TITLE
fix(video): stop "Computed.Current is null" crash in live stream List

### DIFF
--- a/src/dotnet/Streaming.Service/Backend/LiveAudioBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveAudioBackend.cs
@@ -100,6 +100,9 @@ public partial class LiveAudioBackend : ShardComputeService, ILiveAudioBackend
     [ComputeMethod]
     protected virtual async Task<State> ListRaw(ChatId chatId, CancellationToken cancellationToken)
     {
+        // Fusion keeps Computed.Current set only for the synchronous prefix of a compute
+        // method, so capture it here — reading it past an await throws "Computed.Current is null".
+        var computed = Computed.GetCurrent();
         var now = Clocks.SystemClock.Now;
         if (_listRawPrimer.TryUsePrimed(chatId, out var primed))
             return WithAutoInvalidation(primed);
@@ -154,7 +157,7 @@ public partial class LiveAudioBackend : ShardComputeService, ILiveAudioBackend
 
             var minBeginsAt = state.Streams.Min(x => x.BeginsAt);
             var delay = (minBeginsAt + StreamTtl - now + MinInvDelay).Clamp(MinInvDelay, StreamTtl);
-            Computed.GetCurrent().Invalidate(delay);
+            computed.Invalidate(delay);
             return state;
         }
     }

--- a/src/dotnet/Streaming.Service/Backend/LiveVideoBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveVideoBackend.cs
@@ -191,6 +191,9 @@ public partial class LiveVideoBackend : ShardComputeService, ILiveVideoBackend
     [ComputeMethod]
     protected virtual async Task<ApiArray<VideoStreamInfo>> ListRaw(ChatId chatId, CancellationToken cancellationToken)
     {
+        // Fusion keeps Computed.Current set only for the synchronous prefix of a compute
+        // method, so capture it here — reading it past the await below throws "Computed.Current is null".
+        var computed = Computed.GetCurrent();
         if (_listRawPrimer.TryUsePrimed(chatId, out var primed))
             return WithAutoInvalidation(primed);
 
@@ -198,10 +201,10 @@ public partial class LiveVideoBackend : ShardComputeService, ILiveVideoBackend
         var result = streams.Values.ToApiArray();
         return WithAutoInvalidation(result);
 
-        static ApiArray<VideoStreamInfo> WithAutoInvalidation(ApiArray<VideoStreamInfo> result)
+        ApiArray<VideoStreamInfo> WithAutoInvalidation(ApiArray<VideoStreamInfo> result)
         {
             if (result.Count != 0)
-                Computed.GetCurrent().Invalidate(Constants.Video.SilenceGracePeriod / 2);
+                computed.Invalidate(Constants.Video.SilenceGracePeriod / 2);
             return result;
         }
     }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanelLayoutCalculator.cs
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanelLayoutCalculator.cs
@@ -116,7 +116,12 @@ public class VideoPanelLayoutCalculator : UIWorkerBase<AppUIHub>, IComputeServic
             .Capture(() => GetActiveSpeakerState(cancellationToken), cancellationToken)
             .ConfigureAwait(false);
 
-        await foreach (var (state, _) in cState.Changes(cancellationToken).ConfigureAwait(false)) {
+        await foreach (var (state, error) in cState.Changes(cancellationToken).ConfigureAwait(false)) {
+            // Changes yields error snapshots too, with a null value — skip them
+            // instead of NRE-ing on the deconstruct below.
+            if (error is not null)
+                continue;
+
             var (speakersWithVideo, screenCastAuthorIds) = state;
             lock (_trackFocusLock) {
                 // ScreenCasts are primary-only. Backend/client gates allow only
@@ -149,7 +154,12 @@ public class VideoPanelLayoutCalculator : UIWorkerBase<AppUIHub>, IComputeServic
             .Capture(() => GetLayoutInputs(cancellationToken), cancellationToken)
             .ConfigureAwait(false);
 
-        await foreach (var (inputs, _) in cState.Changes(cancellationToken).ConfigureAwait(false)) {
+        await foreach (var (inputs, error) in cState.Changes(cancellationToken).ConfigureAwait(false)) {
+            // Changes yields error snapshots too, with a null value — skip them
+            // instead of NRE-ing on the deconstruct below.
+            if (error is not null)
+                continue;
+
             var layout = BuildLayout(inputs);
             if (layout != _layout.Value)
                 _layout.Value = layout;


### PR DESCRIPTION
Computed.Current is only valid in a compute method's synchronous prefix; Fusion tears the context down before post-await continuations. LiveVideo/ AudioBackend.ListRaw called Computed.GetCurrent() in WithAutoInvalidation after `await SafeGetAll`, so a chat with active streams threw on the Redis- read path. The error propagated over RPC into GetActiveVideoStreams and crashed ChatActivityPanel/ChatAudioPanel via ErrorBarrier. Capture the computed up front and invalidate that.

Also harden VideoPanelLayoutCalculator: CalculateLayout/TrackFocusedSpeaker discarded the deconstructed error and fed Computed<T>'s null ValueOrDefault into BuildLayout, NRE-ing on every errored upstream snapshot. Skip error snapshots instead.