### PR TITLE
fix(virtual-list): content-list placement, headers as skip-key items

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ContentList/ContentListItem.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/ContentListItem.cs
@@ -9,7 +9,7 @@ namespace ActualChat.UI.Blazor.App.Components;
 public sealed class ContentListItem : IVirtualListItem, IEquatable<ContentListItem>
 {
     public required string Key { get; init; }
-    public bool IsGroup { get; init; }
+    public bool IsHeader { get; init; }
     public bool IsEmptyPlaceholder { get; init; }
     public long Version { get; init; }
 
@@ -18,7 +18,11 @@ public sealed class ContentListItem : IVirtualListItem, IEquatable<ContentListIt
     public IReadOnlyList<IChatContentItem> Items { get; init; } = [];
     public ChatEntry? LinkEntry { get; init; }
 
-    public bool ShouldSkipKey => IsGroup;
+    // Date headers are ordinary list items (so they occupy space in the scroll geometry) that merely skip
+    // the key protocol: their synthetic "g:" key must never anchor a load query or a sticky edge. They are
+    // not VirtualList groups — those wrap child items, headers don't.
+    public bool IsGroup => false;
+    public bool ShouldSkipKey => IsHeader;
 
     public bool Equals(ContentListItem? other)
         => other is not null && Key == other.Key && Version == other.Version;

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/ContentListPlumbing.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/ContentListPlumbing.cs
@@ -69,7 +69,7 @@ internal static class ContentListPlumbing
         };
 
     public static ContentListItem GroupHeader(string key, string title)
-        => new() { Key = $"g:{key}", IsGroup = true, GroupTitle = title };
+        => new() { Key = $"g:{key}", IsHeader = true, GroupTitle = title };
 
     public static long SumVersion(IReadOnlyList<IChatContentItem> items)
     {

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/FileList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/FileList.razor
@@ -15,7 +15,7 @@
         @if (item.IsEmptyPlaceholder) {
             <div class="c-empty">No files yet</div>
         }
-        else if (item.IsGroup) {
+        else if (item.IsHeader) {
             <div class="c-group-header">@item.GroupTitle</div>
         }
         else {

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/LinkList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/LinkList.razor
@@ -15,7 +15,7 @@
         @if (item.IsEmptyPlaceholder) {
             <div class="c-empty">No links yet</div>
         }
-        else if (item.IsGroup) {
+        else if (item.IsHeader) {
             <div class="c-group-header">@item.GroupTitle</div>
         }
         else {

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
@@ -16,7 +16,7 @@
         @if (item.IsEmptyPlaceholder) {
             <div class="c-empty">No media yet</div>
         }
-        else if (item.IsGroup) {
+        else if (item.IsHeader) {
             <div class="c-group-header">@item.GroupTitle</div>
         }
         else {

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
@@ -503,6 +503,9 @@ body.hoverable .content-list-rows .c-file-row:hover,
 .content-list-links .item {
     @apply px-2 py-1;
 }
+.content-list-links .item:has(.c-empty) {
+    @apply py-0;
+}
 .content-list-links .message-link-preview {
     @apply w-full;
     @apply truncate;

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -1081,8 +1081,15 @@ export class VirtualList {
 
         this.updateState('endAnchor: on', this.state, { isEndAnchorVisible: true });
         if (this.state.renderState.hasVeryLastItem) {
-            const edgeKey = this.getLastItemKey()!;
-            this.setStickyEdge({ itemKey: edgeKey, edge: VirtualListEdge.End });
+            // Both edges visible (content shorter than viewport) → defaultEdge wins, mirroring updateVisibleItems.
+            // Without this a Start-edge list (media/files/links) gets pinned to End the moment its end anchor
+            // scrolls in, dropping a single item or the empty placeholder to the bottom instead of the top.
+            const firstRef = this.getFirstItemRef();
+            const firstVisible = firstRef != null && this.isItemPartiallyVisible(firstRef);
+            if (this.defaultEdge === VirtualListEdge.End || !firstVisible) {
+                const edgeKey = this.getLastItemKey()!;
+                this.setStickyEdge({ itemKey: edgeKey, edge: VirtualListEdge.End });
+            }
         }
         this.updateVisibleKeysThrottled();
     }
@@ -1970,8 +1977,11 @@ export class VirtualList {
                     reCenter();
 
                 // Bottom cap: clip the wrapper to the newest so scrolling down hard-stops there natively (no
-                // chain reposition — safe, unlike a top cap). After re-center so `end` is final.
-                if (this.isInfinite && rs.hasVeryLastItem && CutVirtualSpaceAtBottom) {
+                // chain reposition — safe, unlike a top cap). After re-center so `end` is final. End-edge only:
+                // on a Start-edge list this cap leaves no room below short content to scroll its first item up
+                // to the viewport top, stranding a single item / the empty placeholder at the bottom.
+                if (this.isInfinite && rs.hasVeryLastItem && CutVirtualSpaceAtBottom
+                    && this.defaultEdge === VirtualListEdge.End) {
                     totalSize = end + endAnchorSize;
                     bottomCapped = true;
                 }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -1328,7 +1328,9 @@ export class VirtualList {
         this.visibilityObserver.observe(itemRef);
         itemRef.addEventListener('touchend', this.onInteractiveEvent, { passive: true });
         itemRef.addEventListener('click', this.onInteractiveEvent, { passive: true });
-        newItem.shouldSkipKey = itemRef.dataset.skip === 'true';
+        // Blazor renders a true bool attribute as a valueless boolean attribute (data-skip=""), not
+        // data-skip="true"; treat any present, non-"false" value as skip so the flag isn't silently lost.
+        newItem.shouldSkipKey = itemRef.dataset.skip != null && itemRef.dataset.skip !== 'false';
         return newItem;
     }
 


### PR DESCRIPTION
## Summary

Three fixes for the content-list tabs (Media / Files / Links), which wrap `VirtualList` with `DefaultEdge=Start`, plus the underlying VirtualList model issue they exposed.

- **Start-edge short content** (`2aa03c88c`): an empty placeholder or a single item rendered at the *bottom* of the viewport instead of the top. Two End-biased spots in the infinite-mode layout (`turnOnIsEndAnchorVisible` and the bottom cap) are now gated to `DefaultEdge=End`, so Start-edge lists flush to the top. No-ops for chat.

- **Placeholder alignment** (`563152501`): "No links yet" sat lower than "No files/media yet" because the links list gives its rows extra vertical padding, which the empty placeholder inherited. Zero it for the `.c-empty` case.

- **Header model + latent skip-key bug** (`0a9fe8506`): date headers were rendered as keyless `<li class="group">`, which excluded them from `orderedItems`/`itemRange` entirely. `class="group"` is for VirtualList groups that *wrap* child items (chat author groups); content-list headers are leaf rows. The misuse left the bottom scroll limit a group-height short (last rows unreachable) and broke `getFirstItemRef` / `isContentPlaced` for Start-edge lists. They are now modeled like ChatView's synthetic rows (date-lines, "new messages"): an ordinary `<li class="item" data-key>` that merely skips the key protocol (`ShouldSkipKey`). This also fixes a latent detection bug — Blazor renders a true bool attribute as the minimized `data-skip=""` (not `"true"`), but the TS checked `=== "true"`, so `shouldSkipKey` was silently always false everywhere (including chat date-lines / welcome blocks).

This last commit makes two earlier band-aids unnecessary (a measured `contentBottomPx` bottom-scroll patch and a reveal gate), so they were dropped rather than kept.

## Verification

Verified in-browser on ws3:
- Content lists render content + skeletons immediately, the bottom is fully reachable, the empty placeholder sits at the top.
- Chat (End-edge) unaffected: opens at the bottom, genuine author groups still render as `li.group`, date-lines now correctly skip the key protocol, date visor works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)