### PR TITLE
Feat/1xxx chat view jumps

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -45,30 +45,40 @@
     // Log.LogInformation("Rendering ChatEntryMessageInternalView for #{EntryId} (IsStreaming: {IsStreaming}, Translation: {TranslationState})",
     //     message.Entry.Id, m.IsStreaming, m.Translation);
 
+    var status = ChatMessageSendingStatus.MessageStatus.Default;
+    if (entry.IsSending) {
+        if (!entry.HasUploadingAttachments)
+            status = ChatMessageSendingStatus.MessageStatus.Sending;
+    }
+    else if (entry.HasUploadingAttachments) {
+        // Use default
+    }
+    else if (IsUnreadByOthers) {
+        if (entry.Attachments.Length == 0)
+            status = ChatMessageSendingStatus.MessageStatus.Unread;
+    }
+    var showTextStatus = status == ChatMessageSendingStatus.MessageStatus.Unread && IsUnreadByOthersBlockStart;
+
     // Should be named __builder
     // ReSharper disable once VariableHidesOuterVariable UnusedParameter.Local
     RenderFragment statusFragment = (__builder) => {
-        var status = ChatMessageSendingStatus.MessageStatus.Default;
-        if (entry.IsSending) {
-            if (!entry.HasUploadingAttachments)
-                status = ChatMessageSendingStatus.MessageStatus.Sending;
-        }
-        else if (entry.HasUploadingAttachments) {
-            // Use default
-        }
-        else if (IsUnreadByOthers) {
-            if (entry.Attachments.Length == 0)
-                status = ChatMessageSendingStatus.MessageStatus.Unread;
-        }
-        var showTextStatus = status == ChatMessageSendingStatus.MessageStatus.Unread && IsUnreadByOthersBlockStart;
         @* <span>@entry.Id.LocalId : @entry.Version</span> *@
         @TranslationFragments.TranslationMark(m.Translation)
         @if (status != ChatMessageSendingStatus.MessageStatus.Default) {
             <ChatMessageSendingStatus Status="@status" IsDotOnly="@(!showTextStatus)" />
         }
     };
+
+    // No visible content (no text, status icon, translation mark or entry-kind sign) → mark the markup
+    // empty so it renders hidden from the first frame. The JS used to add this one frame late, which made
+    // attachment-only messages render ~1 text line taller, then collapse — re-anchoring the list (a jump).
+    var isEmptyMarkup = !m.IsStreaming
+        && trimmedContent.IsNullOrEmpty()
+        && m.Translation == TranslationState.None
+        && status == ChatMessageSendingStatus.MessageStatus.Default
+        && !message.Flags.HasFlag(ChatMessageFlags.HasEntryKindSign);
 }
-<div @ref="Ref" class="chat-message-markup @translationCls @streamingCls">
+<div @ref="Ref" class="chat-message-markup @translationCls @streamingCls @(isEmptyMarkup ? "empty" : "")">
     @if (!isEmojiOnly && !isGifOnly && !isCodeBlockOnly && message.Flags.HasFlag(ChatMessageFlags.HasEntryKindSign)) {
         <ChatEntryKindView IsTranscribed="@entry.HasAudio"/>
     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -167,7 +167,6 @@
 
     private ElementReference Ref { get; set; }
     private IJSObjectReference JSRef { get; set; } = null!;
-    private DotNetObjectReference<ChatEntryMessageInternalView> BlazorRef { get; set; } = null!;
 
     [Parameter, EditorRequired] public ChatContext ChatContext { get; set; } = null!;
     [Parameter, EditorRequired] public ChatEntryMessage Message { get; set; } = null!;
@@ -180,8 +179,6 @@
     public override async ValueTask DisposeAsync() {
         await JSRef.DisposeSilentlyAsync("dispose");
         JSRef = null!;
-        BlazorRef.DisposeSilently();
-        BlazorRef = null!;
 
         // Log.LogInformation("ChatEntryMessageInternalView.DisposeAsync: {Id}", _textEntryId);
         TranscriptStreamReaderCache.TryGetValue(_textEntryId, out var cached);
@@ -219,10 +216,8 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender) {
         if (firstRender) {
-            BlazorRef = DotNetObjectReference.Create(this);
             JSRef = await JS.InvokeAsync<IJSObjectReference>(
                 JSCreateMethod,
-                BlazorRef,
                 Ref);
         }
     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/chat-entry-message-internal-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/chat-entry-message-internal-view.ts
@@ -12,7 +12,6 @@ const importantClasses = new Set([
 ]);
 
 export class ChatEntryMessageInternalView {
-    private blazorRef: DotNet.DotNetObject;
     private readonly messageMarkup: HTMLElement;
     private playableText: HTMLElement | null;
     private markupHeight = 0;
@@ -34,12 +33,11 @@ export class ChatEntryMessageInternalView {
     private slowDebouncedChangeSize: ResettableFunc<[height: number]>;
     private disposed$: Subject<void> = new Subject<void>();
 
-    static create(blazorRef: DotNet.DotNetObject, messageMarkup: HTMLElement): ChatEntryMessageInternalView {
-        return new ChatEntryMessageInternalView(blazorRef, messageMarkup);
+    static create(messageMarkup: HTMLElement): ChatEntryMessageInternalView {
+        return new ChatEntryMessageInternalView(messageMarkup);
     }
 
-    constructor(blazorRef: DotNet.DotNetObject, messageMarkup: HTMLElement) {
-        this.blazorRef = blazorRef;
+    constructor(messageMarkup: HTMLElement) {
         this.messageMarkup = messageMarkup;
         if (!this.messageMarkup)
             return;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/chat-entry-message-internal-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/chat-entry-message-internal-view.ts
@@ -44,11 +44,6 @@ export class ChatEntryMessageInternalView {
         if (!this.messageMarkup)
             return;
 
-        const content = this.messageMarkup.textContent;
-        const hasChildren = this.messageMarkup.querySelector('img, svg') !== null;
-        if (!content && !hasChildren && !this.messageMarkup.classList.contains('streaming'))
-            this.messageMarkup.classList.add('empty');
-
         const isStreaming = this.messageMarkup.classList.contains('streaming');
 
         this.classObserver = new MutationObserver(this.stateHandler);

--- a/src/dotnet/UI.Blazor/Components/VirtualList/ts/virtual-list-item.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/ts/virtual-list-item.ts
@@ -6,6 +6,7 @@ export class VirtualListItem {
         this.size = -1;
     }
 
+    public readonly createdAt = Date.now();
     public range?: NumberRange;
     public size?: number;
     public shouldSkipKey = false;

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list-debug.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list-debug.ts
@@ -15,6 +15,9 @@ type VlDebugGlobal = typeof globalThis & {
 const Eps = 8;
 const GapEps = 24;
 const JumpEps = 12;
+// An existing item that resizes within this window of first appearing is a layout-shift offender
+// (it didn't reserve its final height up-front); later resizes are usually genuine edits.
+const LateResizeMs = 2500;
 
 // What a live VirtualList exposes to the checker. Kept structural so the debug module stays
 // decoupled from the (large) VirtualList class; the instance is passed in via an `any` cast.
@@ -43,6 +46,31 @@ export interface VlViolation {
     message: string;
     detail: Record<string, unknown>;
     snapshot: VlSnapshot;
+}
+
+// A compact structural snapshot of a list item at a given measurement, for diffing what changed
+// between the first (pre-settle) and final layout. `rows` lists descendants with their heights.
+export interface ItemFingerprint {
+    h: number;
+    html: string;
+    rows: { tag: string; cls: string; h: number }[];
+}
+
+// A post-initial-measurement height change of a list item — i.e. a message that didn't settle on
+// its final height at first measurement. `late` ones (soon after the item appeared) are the offenders.
+// `before`/`after` capture the item's structure at the previous and current measurement.
+export interface ItemResize {
+    key: string;
+    chatEntryId: string | null;
+    kind: string;
+    from: number;
+    to: number;
+    delta: number;
+    ageMs: number;
+    late: boolean;
+    at: number;
+    before: ItemFingerprint;
+    after: ItemFingerprint;
 }
 
 export interface VlSnapshot {
@@ -88,8 +116,12 @@ export class VirtualListDebug {
     private timer: ReturnType<typeof setInterval> | null = null;
     private lastRequestSnapshot: VlSnapshot | null = null;
     private readonly recent: VlViolation[] = [];
+    private readonly itemResizes: ItemResize[] = [];
+    private readonly lastMeasure = new Map<string, { size: number; fp: ItemFingerprint }>();
     private lastLoggedSig = '';
     private lastLoggedAt = 0;
+    private lastResizeLogKey = '';
+    private lastResizeLogAt = 0;
     // No-jump tracking: a keyed item's viewport-relative position across consecutive checks.
     private lastAnchor: { key: string; top: number; scrollTop: number; time: number } | null = null;
     private lastRendering = false;
@@ -229,6 +261,49 @@ export class VirtualListDebug {
     public clear(): void { this.recent.length = 0; }
     public get lastRequest(): VlSnapshot | null { return this.lastRequestSnapshot; }
 
+    // Called by VirtualList on every item measurement. Snapshots the item's structure each time and,
+    // when the size changed vs the previous measurement, records a resize carrying the before/after
+    // snapshots — so the pre-settle (first-pass) DOM that caused the height change is captured.
+    public noteItemMeasure(key: string, size: number, createdAt: number, el: HTMLElement): void {
+        const fp = itemFingerprint(el);
+        const prev = this.lastMeasure.get(key);
+        this.lastMeasure.set(key, { size, fp });
+        if (!prev || prev.size === size)
+            return;
+
+        const ageMs = Math.max(0, Date.now() - createdAt);
+        const r: ItemResize = {
+            key,
+            chatEntryId: el.querySelector<HTMLElement>('[data-chat-entry-id]')?.dataset.chatEntryId
+                ?? el.dataset.chatEntryId ?? null,
+            kind: classifyItemContent(el),
+            from: prev.size,
+            to: size,
+            delta: size - prev.size,
+            ageMs: Math.round(ageMs),
+            late: ageMs < LateResizeMs,
+            at: Math.round(performance.now()),
+            before: prev.fp,
+            after: fp,
+        };
+        this.itemResizes.push(r);
+        if (this.itemResizes.length > 500)
+            this.itemResizes.shift();
+        // Deduped console log: same key within 1s logs once.
+        if (key === this.lastResizeLogKey && r.at - this.lastResizeLogAt < 1000)
+            return;
+
+        this.lastResizeLogKey = key;
+        this.lastResizeLogAt = r.at;
+        const sign = r.delta >= 0 ? '+' : '';
+        const tag = r.late ? ' LATE' : '';
+        warnLog?.log(
+            `⤡ resize "${key}" ${r.from}→${r.to} ${sign}${r.delta}px +${r.ageMs}ms${tag} ${r.kind}`);
+    }
+
+    public get itemResizeList(): ItemResize[] { return this.itemResizes; }
+    public clearItemResizes(): void { this.itemResizes.length = 0; }
+
     private report(v: VlViolation): void {
         this.recent.push(v);
         if (this.recent.length > 200)
@@ -314,6 +389,50 @@ export class VirtualListDebug {
 }
 
 // Helpers
+
+// Compact structural snapshot of an item: its height, a trimmed outerHTML, and a depth-first list
+// of descendants with heights (capped) — enough to diff which sub-block changed height.
+function itemFingerprint(el: HTMLElement): ItemFingerprint {
+    const rows: { tag: string; cls: string; h: number }[] = [];
+    const walk = (node: Element) => {
+        for (const c of Array.from(node.children)) {
+            if (rows.length >= 30)
+                return;
+            const r = c.getBoundingClientRect();
+            if (r.height > 0) {
+                const cls = (c.getAttribute('class') ?? '').slice(0, 40);
+                rows.push({ tag: c.tagName.toLowerCase(), cls, h: Math.round(r.height) });
+            }
+            walk(c);
+        }
+    };
+    walk(el);
+    return {
+        h: Math.round(el.getBoundingClientRect().height),
+        html: el.outerHTML.replace(/\s+/g, ' ').slice(0, 500),
+        rows,
+    };
+}
+
+// Best-effort content classification for a list item, for the resize tracker's `kind` field.
+function classifyItemContent(el: HTMLElement): string {
+    if (el.querySelector('.image-attachment'))
+        return 'image';
+    if (el.querySelector('.video-attachment, video'))
+        return 'video';
+    if (el.querySelector('.file-attachment'))
+        return 'file';
+    if (el.querySelector('.link-preview, link-preview'))
+        return 'link-preview';
+    if (el.querySelector('.audio-attachment, audio-player, audio'))
+        return 'audio';
+    if ((el.dataset.key ?? '').endsWith('-date-line'))
+        return 'date-line';
+    if (el.classList.contains('group') || el.querySelector('.chat-message-group'))
+        return 'message-group';
+
+    return 'text';
+}
 
 // Total px of [0, height] covered by the given (viewport-relative) intervals.
 function coveredPx(height: number, intervals: { top: number; bottom: number }[]): number {

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -820,6 +820,7 @@ export class VirtualList {
                 if (size == 0)
                     itemRefsWithWrongSize.push(itemRef);
                 else {
+                    this.debug?.noteItemMeasure(key, size, item.createdAt, itemRef);
                     const hasRemoved = this.unmeasuredItems.delete(key);
                     itemsWereMeasured ||= hasRemoved;
                     const oldSize = item.size;

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -35,6 +35,12 @@ const RequestDataTimeout = 800;
 // the wrapper is revealed regardless (e.g. an empty chat that never "places").
 const EdgePlacedEpsilon = 8;
 const RevealTimeout = 1500;
+// Min edge re-pin distance. A re-pin re-derives the target scrollTop from the DOM; when already flush
+// that target sits ~1 device px off the current scrollTop on fractional-DPI screens (scrollTop quantizes
+// to integer CSS px, which isn't a whole device px at e.g. dpr 2.5). Writing it re-snaps the scroll and
+// flips it ±1px on every re-pin — a visible jitter on each render that re-pins (e.g. a late avatar load).
+// The residual is unclosable, so skip re-pins below 1px; a real edge change is many px.
+const EdgeRepinEpsilon = 1;
 // Fixed scroll size of an infinite (scrollbar-less) list — its wrapper height. Kept well under the
 // browser's max element height (Firefox ≈ 17.9M); at ~50px/item that is still ~200k items of scroll.
 // Must match InfiniteSize in VirtualList.razor.cs.
@@ -1755,7 +1761,8 @@ export class VirtualList {
                 useSmoothScroll = useSmoothScroll && !isFarFromEdge;
             },
             write: () => {
-                this.scrollController.scrollTo(targetScrollTop, { smooth: useSmoothScroll });
+                if (Math.abs(this.ref.scrollTop - targetScrollTop) >= EdgeRepinEpsilon)
+                    this.scrollController.scrollTo(targetScrollTop, { smooth: useSmoothScroll });
                 if (edge == VirtualListEdge.End) {
                     void this.turnOnIsEndAnchorVisible();
                     this.turnOffIsEndAnchorVisibleDebounced.reset();

--- a/src/dotnet/UI.Blazor/Services/DebugUI/debug-ui.ts
+++ b/src/dotnet/UI.Blazor/Services/DebugUI/debug-ui.ts
@@ -277,6 +277,40 @@ export class DebugUI {
         return all;
     }
 
+    /** Returns message-item height changes (post-initial-measurement resizes) across all live lists —
+     *  use to find messages that don't reserve their final height up-front. Requires virtualListDebug(true).
+     *  Returns an offenders summary (by key, largest jump first) plus raw events. Pass clear=true to drain. */
+    public static listMessageResizes(clear = false): unknown {
+        interface Rec { key: string; kind: string; delta: number; ageMs: number; late: boolean }
+        const reg = ((globalThis as Record<string, unknown>).__vlDebugs ?? {}) as
+            Record<string, { itemResizeList?: Rec[]; clearItemResizes?: () => void }>;
+        const all: Rec[] = [];
+        for (const d of Object.values(reg)) {
+            if (d.itemResizeList)
+                all.push(...d.itemResizeList);
+            if (clear)
+                d.clearItemResizes?.();
+        }
+        const byKey = new Map<string, {
+            key: string; kind: string; count: number; totalDelta: number;
+            maxAbsDelta: number; firstAgeMs: number; late: boolean;
+        }>();
+        for (const r of all) {
+            const e = byKey.get(r.key) ?? {
+                key: r.key, kind: r.kind, count: 0, totalDelta: 0,
+                maxAbsDelta: 0, firstAgeMs: r.ageMs, late: false,
+            };
+            e.count++;
+            e.totalDelta += r.delta;
+            e.maxAbsDelta = Math.max(e.maxAbsDelta, Math.abs(r.delta));
+            e.firstAgeMs = Math.min(e.firstAgeMs, r.ageMs);
+            e.late = e.late || r.late;
+            byKey.set(r.key, e);
+        }
+        const offenders = [...byKey.values()].sort((a, b) => b.maxAbsDelta - a.maxAbsDelta);
+        return { total: all.length, offenders, raw: all };
+    }
+
     private static setVideoTraceKill(
         kind: VideoTraceKillKind,
         avgPeriod: VideoTraceKillPeriodInput,


### PR DESCRIPTION
Symptom

Switching between chats and scrolling to certain messages made content "float up" / jitter — most visible on messages with attachments and on dev (higher latency). The report actually covered two distinct effects: a jump on placement, and a small 1px jitter.

Root causes & what was done

1. Empty attachment-message markup collapsed one frame late → list re-pin, visible jump.
Attachment-only messages with no text rendered their chat-message-markup one text-line tall, and the empty class (which is hidden) was added by JS in OnAfterRenderAsync — a frame later. The list is End-anchored, so the late height collapse re-pinned it upward.
Fix: compute emptiness in Razor and emit empty from the first render; dropped the late JS fallback. Also removed an unused BlazorRef along the way.

2. 1px jitter on late loads (avatar/Picture) — sub-pixel no-op re-pin on fractional DPR.
On fractional-devicePixelRatio displays (e.g. 2.5×), scrollTop quantizes to integer CSS pixels, which isn't a whole number of device pixels. As a result the list's end can never sit perfectly flush — there's an unclosable residual of ~1 device pixel (0.4 CSS px). scrollToEdge re-derived that fractional target from the DOM and wrote it on every sticky re-pin (and a re-pin happens on any re-render — e.g. when an avatar photo loads late). The browser re-snapped the scroll, scrollTop flipped ±1px → content jittered.
Fix: don't write scrollTop when the target is within 1px of the current value (that range is just snapping noise; a real edge change is many px). Verified: post-reveal shift 1px → 0px across 6 runs, and pinning to new messages is unaffected.
Note: the bug doesn't appear at 100%/200% zoom — only at fractional scales (2.5×, 1.5×, etc.).

3. Debug tooling (supporting).
Added a tracker for late VirtualList item-height changes (toggled via debug UI: debugUI.virtualListDebug(true) → debugUI.listMessageResizes()); it records which messages change height after their first measurement, with before/after structural snapshots.