### PR TITLE
fix(virtual-list): kill translation sub-header jitter and bottom-edge shift

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/TranslationSubHeader/translation-sub-header.css
+++ b/src/dotnet/UI.Blazor.App/Components/TranslationSubHeader/translation-sub-header.css
@@ -26,3 +26,37 @@ sub-header.translation-sub-header .c-language {
 sub-header.translation-sub-header .c-right {
     @apply flex-none;
 }
+/* Reserve the full height in a single step (one viewport resize → one synchronous re-pin in the list) and
+   reveal via opacity only. The shared showSubHeader animation grows max-height frame-by-frame, shrinking
+   the chat viewport every frame, which the list can't track without jitter. */
+sub-header.translation-sub-header.enter {
+    animation: showTranslationSubHeader 150ms ease-out forwards;
+}
+/* Release the height in one step immediately on close (single viewport resize, re-pinned cleanly), kept
+   separate from the unmount. Collapsing height gradually, or together with the unmount, races the list's
+   re-pin against ResizeObserver delivery and strands the bottom edge a few px off. The animation only
+   carries the lifecycle (its end unmounts the element, which is already zero-height by then — a no-op). */
+sub-header.translation-sub-header.exit {
+    max-height: 0;
+    margin-top: 0;
+    border-width: 0;
+    animation: hideTranslationSubHeader 150ms linear forwards;
+}
+@keyframes showTranslationSubHeader {
+    from {
+        max-height: var(--subheader-height, 3.5rem);
+        opacity: 0;
+    }
+    to {
+        max-height: var(--subheader-height, 3.5rem);
+        opacity: 1;
+    }
+}
+@keyframes hideTranslationSubHeader {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 0;
+    }
+}

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -1733,12 +1733,20 @@ export class VirtualList {
         this.updateState('scrollToEdge', this.state, { scrollTime: Date.now() });
 
         let targetScrollTop = 0;
-        fastRaf({
-            read: () => {
+        const read = () => {
+            const vr = this.ref.getBoundingClientRect();
+            const maxScrollTop = Math.max(0, this.ref.scrollHeight - this.ref.clientHeight);
+            // The End edge has a deterministic flush position — the model's max limit. Prefer it: the
+            // relative DOM nudge below assumes 1 scrollTop unit == 1px, but in infinite mode container.top
+            // is recomputed on scroll, so near the edge that ratio drifts (~1.75x) and a one-shot nudge
+            // undershoots the edge, leaving the newest item a few px high. The model edge is exact, and
+            // ScrollController already clamps to this same limit — so aiming at it can't overshoot.
+            const modelMax = edge === VirtualListEdge.End ? this.computeScrollLimits().max : null;
+            if (modelMax != null)
+                targetScrollTop = clamp(modelMax, 0, maxScrollTop);
+            else {
                 // Position from the ACTUAL DOM (robust to model/DOM size drift): bring the end anchor
                 // flush to the viewport bottom (End) or the first item to the viewport top (Start).
-                const vr = this.ref.getBoundingClientRect();
-                const maxScrollTop = Math.max(0, this.ref.scrollHeight - this.ref.clientHeight);
                 let delta: number;
                 if (edge === VirtualListEdge.Start) {
                     const first = this.getFirstItemRef();
@@ -1756,20 +1764,30 @@ export class VirtualList {
                     }
                 }
                 targetScrollTop = clamp(this.ref.scrollTop + delta, 0, maxScrollTop);
+            }
 
-                const isFarFromEdge = Math.abs(this.ref.scrollTop - targetScrollTop) > this.ref.offsetHeight;
-                useSmoothScroll = useSmoothScroll && !isFarFromEdge;
-            },
-            write: () => {
-                if (Math.abs(this.ref.scrollTop - targetScrollTop) >= EdgeRepinEpsilon)
-                    this.scrollController.scrollTo(targetScrollTop, { smooth: useSmoothScroll });
-                if (edge == VirtualListEdge.End) {
-                    void this.turnOnIsEndAnchorVisible();
-                    this.turnOffIsEndAnchorVisibleDebounced.reset();
-                }
-                debugLog?.log('scrollToEdge: complete', edge, useSmoothScroll, reason);
-            },
-        });
+            const isFarFromEdge = Math.abs(this.ref.scrollTop - targetScrollTop) > this.ref.offsetHeight;
+            useSmoothScroll = useSmoothScroll && !isFarFromEdge;
+        };
+        const write = () => {
+            if (Math.abs(this.ref.scrollTop - targetScrollTop) >= EdgeRepinEpsilon)
+                this.scrollController.scrollTo(targetScrollTop, { smooth: useSmoothScroll });
+            if (edge == VirtualListEdge.End) {
+                void this.turnOnIsEndAnchorVisible();
+                this.turnOffIsEndAnchorVisibleDebounced.reset();
+            }
+            debugLog?.log('scrollToEdge: complete', edge, useSmoothScroll, reason);
+        };
+        // A viewport resize arrives inside a ResizeObserver callback — after layout, before paint — so a
+        // synchronous re-pin lands the correction in the same frame the viewport shrank. The fastRaf path
+        // defers read→write by a frame, which lets the edge visibly drift (jitter) while a sub-header or
+        // panel animates the viewport height.
+        if (reason === 'viewport-resize') {
+            read();
+            write();
+        }
+        else
+            fastRaf({ read, write });
     }
 
     // True when the viewport is still flush with the current sticky edge (End: end anchor visible;

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -70,8 +70,16 @@ export class ScrollController {
             const onTouchEnd = (e: TouchEvent) => { if (e.touches.length === 0) this.onTouchEnd(); };
             element.addEventListener('touchend', onTouchEnd, opts);
             element.addEventListener('touchcancel', onTouchEnd, opts);
-            // A resize (e.g. mobile keyboard hiding) changes limits without firing a scroll event.
-            this.resizeObserver = new ResizeObserver(() => this.clampToLimits());
+            // A resize (e.g. mobile keyboard hiding, or a sub-header opening/closing) changes limits without
+            // firing a scroll event. It re-pins authoritatively, so any boundary it crosses isn't a user
+            // gesture: suppress the rubber-band spring (and cancel one in flight) and snap to the new limits
+            // instead of animating a return — otherwise a viewport growth springs the edge back over ~400ms.
+            this.resizeObserver = new ResizeObserver(() => {
+                this.suppressUntil = Date.now() + ProgrammaticScrollSuppressMs;
+                if (this.isReturning)
+                    this.finishOverscrollReturn();
+                this.clampToLimits();
+            });
             this.resizeObserver.observe(element);
         }
         ScrollController.all.add(this);

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -99,6 +99,11 @@ export class ScrollController {
                 const limits = this.getEffectiveScrollLimits();
                 top = clamp(top, limits.min, limits.max);
             }
+            // An authoritative scroll to a new position supersedes a settling overscroll bounce; without this
+            // the spring's per-frame boundary write keeps yanking scrollTop back to its now-stale edge (e.g.
+            // the content grew and we re-pinned past it), stranding the list above the edge.
+            if (this.isReturning && Math.abs(top - this.overscrollBoundary) > FixPrecisionPx)
+                this.finishOverscrollReturn();
             if (options.smooth === false) {
                 this.element.scrollTop = top;
                 void this.element.offsetHeight; // Triggers reflow


### PR DESCRIPTION
## Problem

Opening the translation sub-header trembled the chat-view. Once the tremble was gone, two further issues surfaced: the bottom edge of the conversation **moved between open/closed states**, and **sprang back over ~400ms on close**.

## Root causes (three layers)

1. **Open jitter** — the viewport-resize re-pin went through `fastRaf` (read→write deferred a frame), so the edge correction landed one frame after the viewport shrank, drifting per frame while the sub-header animated `max-height`.
2. **Bottom-edge shift open↔closed** — `scrollToEdge` aimed the End re-pin via a *relative* DOM nudge that assumes `1 scrollTop unit == 1px`. In infinite mode `container.top` is recomputed on scroll, so near the edge the ratio drifts (~1.75×) and the nudge undershoots the flush position by a few px.
3. **Spring-back on close** — a growing viewport (sub-header closing) pushes `scrollTop` past the now-smaller max limit; `onScroll` mistook that for a touch overscroll and ran the rubber-band spring, sliding the edge back over ~400ms.

## Changes

- **`virtual-list.ts` · `scrollToEdge`** — aim the End re-pin at the deterministic model edge (`itemRange.end + endAnchorSize - clientHeight`) instead of the relative DOM nudge. `ScrollController` already clamps to this same limit, so aiming at it can't overshoot; the DOM fallback stays for when the last item isn't loaded yet.
- **`virtual-list.ts` · `scrollToEdge`** — re-pin synchronously for `viewport-resize`. The `ResizeObserver` callback runs after layout but before paint, so the correction lands in the same frame the viewport changed.
- **`scroll-controller.ts`** — on resize, suppress the rubber-band spring (and cancel one in flight) and snap to the new limits. A resize re-pins authoritatively; the boundary it crosses isn't a user gesture. Touch gestures are untouched.
- **`translation-sub-header.css`** — reserve the full height in one step on open (single resize, revealed via opacity) and release it in one step on close, separate from the unmount, so the chat viewport resizes once instead of frame-by-frame or racing the re-pin.

## Verification

Measured over CDP on the live chat (fresh bundle):
- Open **and** close settle identically: `d = -1.41`, `scrollTop == modelMax`, last-message bottom constant across 6 cycles.
- RO-painted samples: the bottom edge stays put at every painted frame through open and close (3 runs).
- Open jitter: 0 sustained oscillation, 0 checker violations.
- Scroll up/down ×4: re-pins flush every time (`scrollTop == max`), 0 violations — general scroll-to-bottom unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)