### PR TITLE
fix(incoming-share): make Android share of >10 files work reliably

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/AndroidContentDownloader.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidContentDownloader.cs
@@ -17,7 +17,7 @@ public sealed class AndroidContentDownloader(IServiceProvider services)
     public static string CreateWebRequestUri(string url)
         => Prefix + System.Uri.EscapeDataString(url);
 
-    public AttachFileInfo[] ConvertToAttachFileInfos(IEnumerable<Uri> uris)
+    public AttachFileInfo[] ConvertToAttachFileInfos(IEnumerable<Uri> uris, bool canPersistGrant = false)
     {
         var fileInfos = new List<AttachFileInfo>();
         foreach (var uri in uris) {
@@ -30,11 +30,22 @@ public sealed class AndroidContentDownloader(IServiceProvider services)
             if (!TryExtractFileName(sUri, out var fileName))
                 fileName = "unknown";
 
-            // Copy now while the transient share grant is alive — the source URI dies with this process,
-            // so later uploads and post-restart retries must read our local copy instead.
-            var fileRef = CopyToCache(stream, fileName, out var fileLength);
-            if (fileRef.IsNullOrEmpty())
-                continue;
+            string fileRef;
+            long fileLength;
+            if (canPersistGrant) {
+                // The grant is persistable, so the content:// URI survives process death once
+                // AndroidFileProviderImpl takes a persistable read permission — no local copy needed.
+                using (stream)
+                    fileLength = TryGetStreamLength(stream);
+                fileRef = sUri;
+            }
+            else {
+                // Copy now while the transient share grant is alive — the source URI dies with this process,
+                // so later uploads and post-restart retries must read our local copy instead.
+                fileRef = CopyToCache(stream, fileName, out fileLength);
+                if (fileRef.IsNullOrEmpty())
+                    continue;
+            }
 
             var fileProvider = new MauiFileProvider {
                 FileRef = fileRef,
@@ -61,6 +72,16 @@ public sealed class AndroidContentDownloader(IServiceProvider services)
         }
         catch {
             // Best-effort cleanup; the OS evicts the cache directory under storage pressure anyway.
+        }
+    }
+
+    private static long TryGetStreamLength(Stream stream)
+    {
+        try {
+            return stream.Length;
+        }
+        catch {
+            return 0;
         }
     }
 

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidContentDownloader.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidContentDownloader.cs
@@ -1,5 +1,6 @@
 using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
+using ActualLab.IO;
 using Uri = Android.Net.Uri;
 
 namespace ActualChat.App.Maui;
@@ -7,7 +8,7 @@ namespace ActualChat.App.Maui;
 public sealed class AndroidContentDownloader(IServiceProvider services)
 {
     private const string Prefix = "/in/content/";
-
+    private static readonly FilePath IncomingShareCacheDir = new FilePath(FileSystem.CacheDirectory) | "incoming-share";
     private ILogger Log => field ??= services.LogFor(GetType());
 
     public static bool CanHandleWebRequestUri(string? relativeUrl)
@@ -28,9 +29,15 @@ public sealed class AndroidContentDownloader(IServiceProvider services)
             mimeType ??= "";
             if (!TryExtractFileName(sUri, out var fileName))
                 fileName = "unknown";
-            var fileLength = stream.Length;
+
+            // Copy now while the transient share grant is alive — the source URI dies with this process,
+            // so later uploads and post-restart retries must read our local copy instead.
+            var fileRef = CopyToCache(stream, fileName, out var fileLength);
+            if (fileRef.IsNullOrEmpty())
+                continue;
+
             var fileProvider = new MauiFileProvider {
-                FileRef = sUri,
+                FileRef = fileRef,
                 Metadata = new() {
                     FileName = fileName,
                     FileType = mimeType,
@@ -43,7 +50,41 @@ public sealed class AndroidContentDownloader(IServiceProvider services)
         return fileInfos.ToArray();
     }
 
-    public bool TryExtractFileName(string url, out string fileName)
+    public static void DeleteCachedShareFile(string uri)
+    {
+        if (!uri.StartsWith(System.Uri.UriSchemeFile))
+            return;
+        try {
+            var path = (FilePath)new System.Uri(uri).LocalPath;
+            if (path.IsSubPathOf(IncomingShareCacheDir) && File.Exists(path))
+                File.Delete(path);
+        }
+        catch {
+            // Best-effort cleanup; the OS evicts the cache directory under storage pressure anyway.
+        }
+    }
+
+    private string CopyToCache(Stream source, FilePath fileName, out long length)
+    {
+        length = 0;
+        try {
+            Directory.CreateDirectory(IncomingShareCacheDir);
+            var localName = fileName.ToUnique();
+            var localPath = IncomingShareCacheDir | localName;
+            using (source)
+            using (var target = File.Create(localPath)) {
+                source.CopyTo(target);
+                length = target.Length;
+            }
+            return Uri.FromFile(new Java.IO.File(localPath.Value))!.ToString()!;
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to copy shared file '{FileName}' to app-private storage", fileName);
+            return "";
+        }
+    }
+
+    public bool TryExtractFileName(string url, out FilePath fileName)
     {
         fileName = "";
         try {

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidFileProviderImpl.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidFileProviderImpl.cs
@@ -34,6 +34,7 @@ public class AndroidFileProviderImpl : IMauiFileProviderImpl
     public Task ClearBeforeRemoving()
     {
         AndroidFilePermissionsKeeper.ReleaseReadPermission(Uri, this);
+        AndroidContentDownloader.DeleteCachedShareFile(Uri);
         return Task.CompletedTask;
     }
 

--- a/src/dotnet/App.Maui/Platforms/Android/IncomingShareHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/IncomingShareHandler.cs
@@ -35,10 +35,11 @@ public static class IncomingShareHandler
         }
 
         var mimeType = intent.Type ?? "";
+        var canPersistGrant = intent.Flags.HasFlag(ActivityFlags.GrantPersistableUriPermission);
         var hasExtraStream = intent.Extras?.ContainsKey(Intent.ExtraStream) ?? false;
         if (action == Intent.ActionSend) {
             if (hasExtraStream)
-                HandleFilesSend(mimeType, GetStreams(intent, false), targetChatId);
+                HandleFilesSend(mimeType, GetStreams(intent, false), targetChatId, canPersistGrant);
             else if (mimeType == System.Net.Mime.MediaTypeNames.Text.Plain)
                 HandlePlainTextSend(intent.GetStringExtra(Intent.ExtraText), targetChatId);
             else
@@ -46,7 +47,7 @@ public static class IncomingShareHandler
         }
         else {
             if (hasExtraStream)
-                HandleFilesSend(mimeType, GetStreams(intent, true), targetChatId);
+                HandleFilesSend(mimeType, GetStreams(intent, true), targetChatId, canPersistGrant);
             else
                 Log.LogWarning("No extra streams for SendMultiple action. Mime type: '{MimiType}'", mimeType);
         }
@@ -72,7 +73,7 @@ public static class IncomingShareHandler
             .SuppressExceptions();
     }
 
-    private static void HandleFilesSend(string mimeType, IList? streams, ChatId? targetChatId)
+    private static void HandleFilesSend(string mimeType, IList? streams, ChatId? targetChatId, bool canPersistGrant)
     {
         if (streams == null || streams.Count == 0) {
             Log.LogWarning("No file streams provided");
@@ -84,15 +85,15 @@ public static class IncomingShareHandler
                 streams[0]?.GetType().FullName ?? "<null>");
             return;
         }
-        BeginInvokeOnMainThreadAsync(() => HandleFilesSendInternal(mimeType, uris, targetChatId));
+        BeginInvokeOnMainThreadAsync(() => HandleFilesSendInternal(mimeType, uris, targetChatId, canPersistGrant));
     }
 
-    private static void HandleFilesSendInternal(string mimeType, Uri[] uris, ChatId? targetChatId)
+    private static void HandleFilesSendInternal(string mimeType, Uri[] uris, ChatId? targetChatId, bool canPersistGrant)
     {
         Log.LogInformation("About to send {Count} files of type '{MimeType}'", uris.Length, mimeType);
         _ = DispatchToBlazor(scopedServices => {
                     var downloader = scopedServices.GetRequiredService<AndroidContentDownloader>();
-                    var fileInfos = downloader.ConvertToAttachFileInfos(uris);
+                    var fileInfos = downloader.ConvertToAttachFileInfos(uris, canPersistGrant);
                     var incomingShareUI = scopedServices.GetRequiredService<IncomingShareUI>();
                     incomingShareUI.ShareFiles(fileInfos, targetChatId);
                 },

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSession.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSession.cs
@@ -21,7 +21,7 @@ public class UploadSession
     public event EventHandler<double>? UploadProgressChanged;
     public event EventHandler<double>? ServerProcessingProgressChanged;
 
-    private readonly Func<UploadSessionSnapshot, CancellationToken, Task>? _storage;
+    private readonly Func<UploadSessionSnapshot, bool, CancellationToken, Task>? _storage;
     private readonly SemaphoreSlim _stateLock = new(1, 1);
     private readonly TaskCompletionSource<MediaId> _whenMediaIdReserved = TaskCompletionSourceExt.New<MediaId>();
     private volatile CancellationTokenSource? _cts;
@@ -48,7 +48,7 @@ public class UploadSession
 
     public UploadSession(UploadSessionSnapshot snapshot,
         UploadOperations uploadOperations,
-        Func<UploadSessionSnapshot, CancellationToken, Task>? storage = null)
+        Func<UploadSessionSnapshot, bool, CancellationToken, Task>? storage = null)
     {
         _uploadOperations = uploadOperations;
         _storage = storage;
@@ -142,7 +142,7 @@ public class UploadSession
         var mediaId = await _uploadOperations.ReserveMediaId(_snapshot, cancellationToken).ConfigureAwait(false);
         await UpdateState(s => s with {
             ReservedMediaId = mediaId
-        }, save:false, cancellationToken).ConfigureAwait(false);
+        }, save: false, cancellationToken: cancellationToken).ConfigureAwait(false);
         _whenMediaIdReserved.TrySetResult(mediaId);
         await TransitionTo(UploadSessionState.ClientProcessing).ConfigureAwait(false);
     }, cancellationToken);
@@ -177,14 +177,14 @@ public class UploadSession
 
     private Task UploadData(CancellationToken cancellationToken) => ExecuteStep(async () =>
     {
-        var progress = new Progress<double>(p => {
+        using var progress = new ThrottledProgress<double>(p => {
             _ = UpdateState(s => {
                 if (s.CurrentState != UploadSessionState.Uploading)
                     return s;
                 return s with { StageProgress = p };
-            }, cancellationToken: cancellationToken);
+            }, save: false, cancellationToken: cancellationToken);
             UploadProgressChanged?.Invoke(this, p);
-        });
+        }, TimeSpan.FromMilliseconds(250));
         var snapshotAccessor = new UploadSessionSnapshotAccessor(
             () => _snapshot,
             (update, ct) => UpdateState(update, cancellationToken: ct));
@@ -215,7 +215,8 @@ public class UploadSession
         });
         var result = await _uploadOperations.WaitForProcessingCompletion(_snapshot, progress, cancellationToken).ConfigureAwait(false);
 
-        await UpdateState(s => s with { MediaRef = result }, save:false, cancellationToken).ConfigureAwait(false);
+        await UpdateState(s => s with { MediaRef = result },
+            save: false, cancellationToken: cancellationToken).ConfigureAwait(false);
         await TransitionTo(UploadSessionState.Completed).ConfigureAwait(false);
     }, cancellationToken);
 
@@ -243,7 +244,10 @@ public class UploadSession
         await UpdateState(s => s with { IsFailed = true }, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task UpdateState(Func<UploadSessionSnapshot, UploadSessionSnapshot> update, bool save = true, CancellationToken cancellationToken = default)
+    private async Task UpdateState(
+        Func<UploadSessionSnapshot, UploadSessionSnapshot> update,
+        bool save = true,
+        CancellationToken cancellationToken = default)
     {
         await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
@@ -253,8 +257,8 @@ public class UploadSession
                 return;
 
             _snapshot = _snapshot with { LastUpdatedAt = _uploadOperations.Now() };
-            if (save && _storage != null)
-                await _storage.Invoke(_snapshot, cancellationToken).ConfigureAwait(false);
+            if (_storage != null)
+                await _storage.Invoke(_snapshot, save, cancellationToken).ConfigureAwait(false);
         }
         finally {
             _stateLock.Release();

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.Cleanup.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.Cleanup.cs
@@ -23,6 +23,7 @@ partial class UploadSessions
                     continue;
                 }
 
+                // Stale = persisted but with no in-memory session, i.e. an orphan left by a prior run.
                 if (!CheckIfActive(uploadSession.SessionId))
                     staleItems.Add(item);
             }

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
@@ -31,8 +31,9 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         var now = _uploadOperations.Now();
         var snapshot = UploadSession.NewUploadSnapshot(fileProvider, metadata, now, mediaScope);
         var session = new UploadSession(snapshot, _uploadOperations, _storage);
-        await _repo.Save(snapshot).ConfigureAwait(false);
+        // Register in memory before persisting, so cleanup never reclaims it before the caller references it.
         _sessions[session.SessionId] = new SessionRef(session);
+        await _repo.Save(snapshot).ConfigureAwait(false);
         return session.SessionId;
     }
 
@@ -176,7 +177,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         => UploadSessionsState.SetProgress(sessionId, progress);
 
     private bool CheckIfActive(string sessionId)
-        => _sessions.TryGetValue(sessionId, out var sessionRef) && sessionRef.ReferenceCount > 0;
+        => _sessions.ContainsKey(sessionId);
 
     private async Task DeleteSessionResources(string sessionId, IFileProvider fileProvider, string? transcodedFilePath, UploadId? uploadId)
     {

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
@@ -8,7 +8,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
     private readonly IUploadSessionRepo _repo;
     private readonly UploadOperations _uploadOperations;
     private readonly ConcurrentDictionary<string, SessionRef> _sessions = new ();
-    private readonly Func<UploadSessionSnapshot, CancellationToken, Task> _storage;
+    private readonly Func<UploadSessionSnapshot, bool, CancellationToken, Task> _storage;
 
     private UploadSessionsState UploadSessionsState => Hub.UploadSessionsState;
 
@@ -138,10 +138,11 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         Log.LogDebug("Deleted session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
     }
 
-    private Func<UploadSessionSnapshot, CancellationToken, Task> CreateStorage()
+    private Func<UploadSessionSnapshot, bool, CancellationToken, Task> CreateStorage()
     {
-        Func<UploadSessionSnapshot, CancellationToken, Task> storage = async (s, _) => {
-            await _repo.Save(s).ConfigureAwait(false);
+        Func<UploadSessionSnapshot, bool, CancellationToken, Task> storage = async (s, save, _) => {
+            if (save)
+                await _repo.Save(s).ConfigureAwait(false);
             if (s.CurrentState != UploadSessionState.Cancelled)
                 SetProgress(s.SessionId, GetProgressFromSnapshot(s));
         };

--- a/src/dotnet/UI.Blazor.App/Services/IncomingShareUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/IncomingShareUI.cs
@@ -31,7 +31,7 @@ public class IncomingShareUI(AppUIHub hub)
                 }
             }
 
-            await  ShowShareModal(new IncomingShareModal.Model(plainText)).ConfigureAwait(true);
+            await ShowShareModal(new IncomingShareModal.Model(plainText)).ConfigureAwait(true);
         }
     }
 
@@ -86,21 +86,30 @@ public class IncomingShareUI(AppUIHub hub)
 
         try {
             var postTasks = new List<(Task, ChatId, int)>();
+            var uploadHandles = new List<FilesUploadHandle>();
             var commentToSend = comment;
             var mediaScope = chatIds.Count == 1 ? chatIds.First().Value : "";
             foreach (var filesChunk in files.Chunk(Constants.Attachments.FileCountLimit)) {
                 var attachments = await CreateAttachmentList(filesChunk).ConfigureAwait(true);
                 var uploads = (await SendingMessages.Upload(attachments, mediaScope).ConfigureAwait(true))!;
+                uploadHandles.Add(uploads);
                 foreach (var chatId in chatIds) {
 #pragma warning disable CA2025
                     var postTask = PostMessage(chatId, commentToSend, uploads, attachments.Length);
 #pragma warning restore CA2025
                     postTasks.Add((postTask, chatId, filesChunk.Length));
                 }
-                uploads.Dispose();
                 commentToSend = "";
             }
-            await Task.WhenAll(postTasks.Select(c => c.Item1)).ConfigureAwait(true);
+            try {
+                await Task.WhenAll(postTasks.Select(c => c.Item1)).ConfigureAwait(true);
+            }
+            finally {
+                // Dispose only after the posts have run: an earlier release deletes the upload sessions
+                // out from under the in-flight posts, which then arrive empty and are rejected.
+                foreach (var uploads in uploadHandles)
+                    uploads.Dispose();
+            }
             var failedTasks = postTasks
                 .Where(c => !c.Item1.IsCompletedSuccessfully)
                 .ToArray();


### PR DESCRIPTION
Sharing more than 10 files from another app (e.g. Google Photos) via the Android incoming-share intent failed. The intent delivered every file; the bug was in the >10 / multi-chat chunk-and-post path:

- IncomingShareUI.SendFiles disposed each upload handle inside the chunk loop, releasing the upload-session references before the queued posts read them, so the sessions were deleted and the posts arrived empty (server rejected them with "you can't post empty messages"). Handles are now disposed only after Task.WhenAll, once each post owns its own references.
- AndroidContentDownloader copies each shared file into app-private cache while the transient URI grant is alive and references the local file:// copy, so uploads and post-restart retries survive process death (the share grant is non-persistable). Cached copies are deleted after a successful send.
- UploadSessions startup cleanup no longer reclaims a freshly created session that is still mid-setup (refcount 0 between CreateSession and AddReference): CheckIfActive treats any in-memory session as active and CreateSession registers in memory before persisting.