### PR TITLE
feat(chat): show video duration in right-panel media gallery

### DIFF
--- a/src/dotnet/Api/Chat/VisualMediaItem.cs
+++ b/src/dotnet/Api/Chat/VisualMediaItem.cs
@@ -21,4 +21,5 @@ public sealed partial record VisualMediaItem : IChatContentItem
     [DataMember, MemoryPackOrder(9), Key(9)] public string ContentType { get; init; } = "";
     [DataMember, MemoryPackOrder(10), Key(10)] public string FileName { get; init; } = "";
     [DataMember, MemoryPackOrder(11), Key(11)] public long Size { get; init; }
+    [DataMember, MemoryPackOrder(12), Key(12)] public long DurationMs { get; init; }
 }

--- a/src/dotnet/Chat.Service/ChatsBackend.ContentItems.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.ContentItems.cs
@@ -48,7 +48,12 @@ public partial class ChatsBackend
         var dbItems = await QueryPeriodPage(
                 dbContext.ChatVisualMediaItems, chatId.Value, periodKey, pageIndex, cancellationToken)
             .ConfigureAwait(false);
-        return dbItems.Select(x => x.ToModel()).ToArray();
+        if (dbItems.Count == 0)
+            return [];
+        return await dbItems
+            .Select(x => ResolveVisualMediaItem(x.ToModel(), cancellationToken))
+            .Collect(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     // [ComputeMethod]
@@ -211,6 +216,19 @@ public partial class ChatsBackend
     }
 
     // Private members
+
+    // DurationMs lives only on the Media record (its metadata bag), not on the
+    // denormalized visual-media projection — so the badge value is resolved here
+    // at read time. Only videos carry a duration; older uploads predate it and
+    // resolve to 0, which the client treats as "unknown" and recovers client-side.
+    private async Task<VisualMediaItem> ResolveVisualMediaItem(VisualMediaItem item, CancellationToken cancellationToken)
+    {
+        if (!MediaTypeExt.IsSupportedVideo(item.ContentType))
+            return item;
+
+        var media = await MediaBackend.Get(item.MediaId, cancellationToken).ConfigureAwait(false);
+        return media is { DurationMs: > 0 } ? item with { DurationMs = media.DurationMs } : item;
+    }
 
     private async Task<LinkItem> ResolveLinkItem(LinkItem item, CancellationToken cancellationToken)
     {

--- a/src/dotnet/Core/Time/TimeSpanFormatExt.cs
+++ b/src/dotnet/Core/Time/TimeSpanFormatExt.cs
@@ -7,6 +7,8 @@ public enum TimeSpanFormat
 {
     Default = 0,
     Short,
+    // m:ss, switching to h:mm:ss past an hour — media-player style (e.g. 0:05, not 5s)
+    Clock,
 }
 
 /// <summary>
@@ -18,6 +20,7 @@ public static class TimeSpanFormatExt
         => format switch {
             "Default" => FormatDefault(value),
             "Short" => value.ToShortString(),
+            "Clock" => FormatClock(value),
             _ => value.ToString(format),
         };
 
@@ -25,10 +28,20 @@ public static class TimeSpanFormatExt
         => format switch {
             TimeSpanFormat.Default => FormatDefault(value),
             TimeSpanFormat.Short => value.ToShortString(),
+            TimeSpanFormat.Clock => FormatClock(value),
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
         };
 
     // Private methods
+
+    private static string FormatClock(TimeSpan value)
+    {
+        value = TimeSpan.FromTicks(Math.Abs(value.Ticks));
+        var totalHours = (int)value.TotalHours;
+        return totalHours > 0
+            ? $"{totalHours}:{value.Minutes:D2}:{value.Seconds:D2}"
+            : $"{value.Minutes}:{value.Seconds:D2}";
+    }
 
     private static string FormatDefault(TimeSpan value)
     {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/attachment.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/attachment.css
@@ -27,7 +27,7 @@ body.hoverable .image-line .image-item:hover {
    even when a vertical video shares a row with wider tiles. Scoped to video
    so plain images keep their justified proportions. */
 .image-line .image-item:has(.video-thumbnail) {
-    @apply min-w-12;
+    @apply min-w-12 md:min-w-14;
 }
 /* Single image: respect aspect ratio, no cropping.
    `w-full` (inherited from .image-line) + inline `max-width` give a definite

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
@@ -1,15 +1,19 @@
 @namespace ActualChat.UI.Blazor.App.Components
 @inherits FusionComponentBase<AppUIHub>
 @implements IVirtualListDataSource<ContentListItem>
+@implements IAsyncDisposable
 @using ActualChat.Media
+@using ActualChat.Time
+@using ActualChat.UI.Blazor.App.Module
 
-<div class="content-list-with-visor">
+<div class="content-list-with-visor" @ref="Ref">
 <ContentListDateVisor/>
 <VirtualList
     @key="@Identity"
     Class="content-list-tab content-list-grid"
     Identity="@Identity"
     DataSource="@this"
+    ItemVisibilityChanged="@OnItemVisibilityChanged"
     SkeletonCount="8">
     <Item>
         @{ var item = context; }
@@ -33,6 +37,12 @@
                                 <image-skeleton class="show-image-skeleton" src="@thumb"/>
                             }
                             <i class="icon-play-fill c-play-icon"></i>
+                            @if (media.DurationMs > 0) {
+                                <div class="c-duration">@TimeSpan.FromMilliseconds(media.DurationMs).Format(TimeSpanFormat.Clock)</div>
+                            }
+                            else {
+                                <div class="c-duration" data-duration-url="@url" data-media-id="@media.MediaId.Value"></div>
+                            }
                         </a>
                     }
                     else {
@@ -54,15 +64,44 @@
 </div>
 
 @code {
+    private static readonly string JSCreateMethod = $"{BlazorUIAppModule.ImportName}.VisualMediaDuration.create";
+
     private const int GridColumns = 3;
     private const int GalleryRadius = 12;
 
     private IChats Chats => Hub.Chats;
     private VisualMediaViewerUI VisualMediaViewerUI => Hub.VisualMediaViewerUI;
 
+    private IJSObjectReference? JSRef { get; set; }
+    private ElementReference Ref { get; set; }
+    private string[] _lastVisibleKeys = [];
+
     [Parameter, EditorRequired] public ChatId ChatId { get; set; } = null!;
 
     private string Identity => $"visualMedia:{ChatId}";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!firstRender)
+            return;
+
+        JSRef = await Hub.JS.InvokeAsync<IJSObjectReference>(JSCreateMethod, Ref);
+        // Visibility may have been reported before JSRef existed (those events are
+        // dropped below); flush the last known set so a static first paint resolves
+        // without waiting for a scroll to fire the next ItemVisibilityChanged.
+        if (_lastVisibleKeys.Length > 0)
+            await JSRef.InvokeVoidAsync("setVisibleKeys", (object)_lastVisibleKeys);
+    }
+
+    public async ValueTask DisposeAsync() {
+        await JSRef.DisposeSilentlyAsync("dispose");
+        JSRef = null;
+    }
+
+    private void OnItemVisibilityChanged(VirtualListItemVisibility visibility) {
+        _lastVisibleKeys = visibility.VisibleKeys.ToArray();
+        if (JSRef is {} jsRef)
+            _ = jsRef.InvokeVoidAsync("setVisibleKeys", (object)_lastVisibleKeys);
+    }
 
     public Task<VirtualListData<ContentListItem>> GetData(
         VirtualListDataQuery query,

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/visual-media-duration.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/visual-media-duration.ts
@@ -1,0 +1,118 @@
+// Fills duration badges for *old* videos in the right-panel Media grid — the ones
+// whose duration wasn't persisted server-side (VisualMediaItem.DurationMs == 0).
+// Reuses VirtualList's own visibility signal (no extra IntersectionObserver): the
+// Blazor side forwards the set of visible row keys, and a row's metadata is only
+// fetched once it has dwelled in view past DwellMs, so fast scrolling costs nothing.
+const DwellMs = 1000;
+
+export class VisualMediaDuration {
+    private readonly container: HTMLElement;
+    private readonly cache = new Map<string, string>();
+    private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+    private isDisposed = false;
+
+    static create(container: HTMLElement): VisualMediaDuration {
+        return new VisualMediaDuration(container);
+    }
+
+    constructor(container: HTMLElement) {
+        this.container = container;
+    }
+
+    public setVisibleKeys(keys: string[]) {
+        if (this.isDisposed)
+            return;
+        const next = new Set(keys);
+        for (const key of [...this.timers.keys()])
+            if (!next.has(key)) {
+                clearTimeout(this.timers.get(key));
+                this.timers.delete(key);
+            }
+        for (const key of next) {
+            this.fillCached(key);
+            if (this.timers.has(key) || !this.hasPending(key))
+                continue;
+            this.timers.set(key, setTimeout(() => {
+                this.timers.delete(key);
+                this.resolveRow(key);
+            }, DwellMs));
+        }
+    }
+
+    public dispose() {
+        if (this.isDisposed)
+            return;
+        this.isDisposed = true;
+        for (const timer of this.timers.values())
+            clearTimeout(timer);
+        this.timers.clear();
+    }
+
+    private pendingTiles(key: string): HTMLElement[] {
+        const row = this.container.querySelector<HTMLElement>(`li.item[data-key="${CSS.escape(key)}"]`);
+        if (!row)
+            return [];
+        return [...row.querySelectorAll<HTMLElement>('.c-duration[data-duration-url]:not([data-resolved])')];
+    }
+
+    private hasPending(key: string): boolean {
+        return this.pendingTiles(key).length > 0;
+    }
+
+    private fillCached(key: string) {
+        for (const tile of this.pendingTiles(key)) {
+            const cached = this.cache.get(tile.dataset.mediaId ?? '');
+            if (cached !== undefined)
+                this.write(tile, cached);
+        }
+    }
+
+    private resolveRow(key: string) {
+        for (const tile of this.pendingTiles(key))
+            this.resolveTile(tile);
+    }
+
+    private resolveTile(tile: HTMLElement) {
+        const mediaId = tile.dataset.mediaId ?? '';
+        const url = tile.dataset.durationUrl;
+        if (!url)
+            return;
+        const cached = this.cache.get(mediaId);
+        if (cached !== undefined) {
+            this.write(tile, cached);
+            return;
+        }
+        const video = document.createElement('video');
+        video.preload = 'metadata';
+        video.muted = true;
+        video.onloadedmetadata = () => {
+            const text = formatDuration(video.duration);
+            video.removeAttribute('src');
+            video.load();
+            if (!text)
+                return;
+            this.cache.set(mediaId, text);
+            this.write(tile, text);
+        };
+        video.onerror = () => {
+            video.removeAttribute('src');
+        };
+        video.src = url;
+    }
+
+    private write(tile: HTMLElement, text: string) {
+        tile.textContent = text;
+        tile.setAttribute('data-resolved', '');
+    }
+}
+
+function formatDuration(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds <= 0)
+        return '';
+    const total = Math.round(seconds);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
@@ -484,6 +484,16 @@ body.hoverable .content-list-grid .image-attachment:hover image-skeleton {
     @apply flex items-center justify-center;
     @apply text-3xl text-white;
 }
+.content-list-grid .c-video .c-duration {
+    @apply absolute bottom-1 left-1;
+    @apply px-1.5 py-0.5;
+    @apply rounded-md border border-[var(--white-20)];
+    @apply bg-[var(--black-90)] text-white;
+    @apply text-xxs font-medium leading-none whitespace-nowrap;
+}
+.content-list-grid .c-video .c-duration:empty {
+    @apply hidden;
+}
 .content-list-rows .c-file-row {
     @apply flex items-center gap-2;
     @apply w-full px-3 py-1;

--- a/src/dotnet/UI.Blazor.App/exports.ts
+++ b/src/dotnet/UI.Blazor.App/exports.ts
@@ -31,6 +31,7 @@ export * from './Components/ChatView/EmptyChatContent/empty-search-chat-svg.lit'
 export * from './Components/ChatView/Items/ChatEntryMessageInternalView/chat-entry-message-internal-view';
 export * from './Components/ClientUpgradeCover/upgrade-app-cat-svg.lit';
 export * from './Components/ContentList/content-list-date-visor';
+export * from './Components/ContentList/visual-media-duration';
 export * from './Components/DateVisor/date-visor';
 export * from './Components/FontSizeSlider/font-size-slider';
 export * from './Components/InaccessiblePlace/not-member-yet-svg.lit';

--- a/src/dotnet/UI.Blazor/Components/VideoAttachmentThumbnail/VideoAttachmentThumbnail.razor
+++ b/src/dotnet/UI.Blazor/Components/VideoAttachmentThumbnail/VideoAttachmentThumbnail.razor
@@ -1,4 +1,5 @@
 @using ActualChat.Chat
+@using ActualChat.Time
 @namespace ActualChat.UI.Blazor.Components
 @{
     var urls = GetUrls();
@@ -23,7 +24,7 @@
         <i class="c-play icon-play-fill"></i>
     </div>
     @if (Attachment.Media.DurationMs > 0) {
-        <div class="c-duration">@FormatDuration(Attachment.Media.DurationMs)</div>
+        <div class="c-duration">@TimeSpan.FromMilliseconds(Attachment.Media.DurationMs).Format(TimeSpanFormat.Clock)</div>
     }
 </div>
 @code {
@@ -31,15 +32,6 @@
 
     [Parameter] public ChatEntryAttachment Attachment { get; set; } = null!;
     [Parameter] public string Class { get; set; } = "";
-
-    private static string FormatDuration(long durationMs)
-    {
-        var t = TimeSpan.FromMilliseconds(durationMs);
-        var hours = (int)t.TotalHours;
-        return hours > 0
-            ? $"{hours}:{t.Minutes:D2}:{t.Seconds:D2}"
-            : $"{t.Minutes}:{t.Seconds:D2}";
-    }
 
     private (string OriginalUrl, string ThumbnailUrl) GetUrls()
     {


### PR DESCRIPTION
- Persist Media.DurationMs on VisualMediaItem; populate it in ChatsBackend
- Add shared TimeSpanFormat.Clock; reuse in VideoAttachmentThumbnail
- Render duration badge in VisualMediaList; lazy client-side probe (visual-media-duration.ts) for legacy media without DurationMs
- Badge styles in right-panel.css; min-width tweak in attachment.css