### PR TITLE
fix(audio): finalize + save partial audio on client network drop

### DIFF
--- a/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
+++ b/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
@@ -53,10 +53,17 @@ public partial class AudioStreamingBackend
         CancellationToken cancellationToken)
     {
         using var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var requestToken = cancellationToken; // real request/processing token, before the watchdog overlays it
         cancellationToken = watchdogCts.Token;
         // Cadence first so it observes raw inbound timing, before the silence watchdog can short-circuit it.
         frames = WithIngressCadenceLog(record.StreamId.Value, frames, Log, cancellationToken);
-        frames = WithFrameSilenceWatchdog(record.StreamId.Value, Constants.Audio.FrameSilenceTimeout, frames, watchdogCts, cancellationToken);
+        frames = WithFrameSilenceWatchdog(
+            record.StreamId.Value,
+            Constants.Audio.FrameSilenceTimeout,
+            frames,
+            watchdogCts,
+            requestToken,
+            cancellationToken);
 
         var session = record.Session;
         var chatId = record.ChatId;
@@ -188,48 +195,56 @@ public partial class AudioStreamingBackend
             await publishAudioTask.ConfigureAwait(false);
 
         // Close an open audio segment when the duration becomes available.
-        // WhenDurationAvailable throws "Duration wasn't parsed" when the producer's
-        // RPC stream disconnects mid-recording — we treat that as end-of-audio (not
-        // an error) and let FinalizeTextEntry close the entry with whatever transcript
-        // we have. The finally must run: it unregisters the live stream and unblocks
-        // audioMediaIdTcs — without that, FinalizeTextEntry hangs forever and the
-        // entry is stuck in the streaming state.
+        // WhenDurationAvailable ends two ways: "Duration wasn't parsed" when the producer's
+        // RPC stream disconnects cleanly mid-recording (non-OCE, caught below), or OCE when
+        // the frame-silence watchdog fires because the client lost the network and stopped
+        // sending without closing the stream. Both are end-of-audio, not errors: we let
+        // FinalizeTextEntry close the entry with whatever transcript we have.
         MediaId? audioMediaId = null;
         ClosedAudioSegment? closedSegment = null;
         try {
-            await openSegment.Source.WhenDurationAvailable.ConfigureAwait(false);
-            Log.LogInformation(
-                "ProcessAudio: stream #{StreamId} ended normally, duration={Duration:F1}s",
-                openSegment.StreamId, openSegment.Source.Duration.TotalSeconds);
-            openSegment.Close(openSegment.Source.Duration);
-            closedSegment = await openSegment.ClosedSegment.ConfigureAwait(false);
-
-            if (mustStreamVoice && mustTranscribe) {
-                // Save audio blob and create Media record - use CancellationToken.None to ensure cleanup
-                audioMediaId = await AudioSegmentSaver
-                    .SaveAndCreateMedia(closedSegment, chatId, beginsAt, recordedAt, CancellationToken.None)
-                    .ConfigureAwait(false);
-            }
-        }
-        catch (Exception e) when (e is not OperationCanceledException) {
-            Log.LogWarning(e,
-                "ProcessAudio: stream #{StreamId} ended unexpectedly; finalizing with available transcript",
-                openSegment.StreamId);
-        }
-        finally {
             try {
-                if (mustStreamVoice)
-                    await LiveAudioBackend.Unregister(chatId, openSegment.StreamId.Value, CancellationToken.None).ConfigureAwait(false);
+                await openSegment.Source.WhenDurationAvailable.ConfigureAwait(false);
+                Log.LogInformation(
+                    "ProcessAudio: stream #{StreamId} ended normally, duration={Duration:F1}s",
+                    openSegment.StreamId, openSegment.Source.Duration.TotalSeconds);
+                openSegment.Close(openSegment.Source.Duration);
+                closedSegment = await openSegment.ClosedSegment.ConfigureAwait(false);
+
+                if (mustStreamVoice && mustTranscribe) {
+                    // Save audio blob and create Media record - use CancellationToken.None to ensure cleanup
+                    audioMediaId = await AudioSegmentSaver
+                        .SaveAndCreateMedia(closedSegment, chatId, beginsAt, recordedAt, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (Exception e) when (e is not OperationCanceledException) {
+                Log.LogWarning(e,
+                    "ProcessAudio: stream #{StreamId} ended unexpectedly; finalizing with available transcript",
+                    openSegment.StreamId);
             }
             finally {
-                audioMediaIdTcs.TrySetResult(audioMediaId);
+                try {
+                    if (mustStreamVoice)
+                        await LiveAudioBackend
+                            .Unregister(chatId, openSegment.StreamId.Value, CancellationToken.None)
+                            .ConfigureAwait(false);
+                }
+                finally {
+                    audioMediaIdTcs.TrySetResult(audioMediaId);
+                }
             }
         }
-
-        if (mustTranscribe) {
-            DispatchRefineTranscription(
-                openSegment, closedSegment, mustStreamVoice, refineTranscriptLanguageTcs.Task, refinedTranscriptTcs);
-            await transcribeTask!.ConfigureAwait(false);
+        finally {
+            // Must run even when WhenDurationAvailable threw OCE (watchdog): DispatchRefineTranscription
+            // is the only place refinedTranscriptTcs is completed, and FinalizeTextEntry awaits it —
+            // skipping it hangs finalization and strands the entry in the streaming state. Awaiting
+            // transcribeTask also keeps `audio` alive until transcription and finalization finish.
+            if (mustTranscribe) {
+                DispatchRefineTranscription(
+                    openSegment, closedSegment, mustStreamVoice, refineTranscriptLanguageTcs.Task, refinedTranscriptTcs);
+                await transcribeTask!.ConfigureAwait(false);
+            }
         }
     }
 
@@ -271,17 +286,37 @@ public partial class AudioStreamingBackend
         TimeSpan silenceTimeout,
         IAsyncEnumerable<AudioFrame> source,
         CancellationTokenSource watchdogCts,
+        CancellationToken requestToken,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         _ = streamId; // reserved for diagnostics
         // Frame-silence watchdog: cancels watchdogCts if no frame arrives within silenceTimeout.
         // Each frame resets the deadline; CancellationTokenSource reuses a single internal timer.
+        // On a pure silence timeout (watchdog fired but the request itself wasn't cancelled — i.e. the
+        // client dropped the network without closing the stream) we end the stream gracefully instead of
+        // surfacing OCE, so the audio that did arrive is saved and the entry finalizes like a short recording.
         watchdogCts.CancelAfter(silenceTimeout);
-        await foreach (var frame in source.WithCancellation(cancellationToken).ConfigureAwait(false)) {
-            watchdogCts.CancelAfter(silenceTimeout);
-            yield return frame;
+        var enumerator = source.GetAsyncEnumerator(cancellationToken);
+        try {
+            while (true) {
+                try {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        yield break;
+                }
+                catch (OperationCanceledException) when (IsSilenceTimeout(watchdogCts, requestToken)) {
+                    yield break;
+                }
+                watchdogCts.CancelAfter(silenceTimeout);
+                yield return enumerator.Current;
+            }
+        }
+        finally {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    private static bool IsSilenceTimeout(CancellationTokenSource watchdogCts, CancellationToken requestToken)
+        => watchdogCts.IsCancellationRequested && !requestToken.IsCancellationRequested;
 
     private static async IAsyncEnumerable<AudioFrame> WithIngressCadenceLog(
         string streamId,

--- a/tests/Chat.IntegrationTests/StreamingEntryNetworkLossTest.cs
+++ b/tests/Chat.IntegrationTests/StreamingEntryNetworkLossTest.cs
@@ -1,0 +1,124 @@
+using System.Runtime.CompilerServices;
+using ActualChat.Audio;
+using ActualChat.Streaming;
+using ActualChat.Streaming.Module;
+using ActualChat.Testing.Host;
+using ActualLab.Rpc;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+[Collection(nameof(StreamingEntryNetworkLossCollection))]
+public class StreamingEntryNetworkLossTest(
+    StreamingEntryNetworkLossCollection.AppHostFixture fixture,
+    ITestOutputHelper @out)
+    : SharedAppHostTestBase<StreamingEntryNetworkLossCollection.AppHostFixture>(fixture, @out)
+{
+    private WebClientTester Tester => field ??= AppHost.NewWebClientTester(Out);
+
+    [Fact]
+    public async Task WatchdogEndSavesPartialAudioAndFinalizes()
+    {
+        // arrange
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(false);
+
+        var services = Tester.AppServices;
+        var session = Tester.Session;
+        var userSettingsUI = services.UserSettingsUI(session);
+        await userSettingsUI.UserLanguageSettings()
+            .Set(new UserLanguageSettings { Primary = Languages.English }, CancellationToken.None);
+        await userSettingsUI.ChatUserSettings(chatId)
+            .Update(x => x with { Language = Languages.English, VoiceMode = VoiceMode.TextAndVoice }, CancellationToken.None);
+
+        var streaming = services.GetRequiredService<IAudioStreamingBackend>();
+        var chatsBackend = services.GetRequiredService<IChatsBackend>();
+        var thisNode = services.MeshWatcher().ThisNode;
+        var recordStreamId = StreamId.New(thisNode.Ref);
+        // Mirrors OpenAudioSegment.GetStreamId(record, 0): the transcript stream id of segment #0.
+        var segmentStreamId = StreamId.New(recordStreamId.NodeRef, $"{recordStreamId.LocalId}-0000");
+        var record = new AudioRecord(
+            recordStreamId,
+            session,
+            chatId,
+            services.Clocks().SystemClock.Now.EpochOffset.TotalSeconds,
+            null);
+
+        // act
+        // Simulate the client losing the network mid-recording: frames stop arriving but the stream is
+        // never closed. The frame-silence watchdog must end the stream gracefully, so the audio that did
+        // reach the server is saved and the entry finalizes like a short recording — not discarded, and
+        // not left content-streaming forever (the pre-fix behaviour on the OCE path).
+        var recordTask = streaming.ProcessAudio(record, 0,
+            new RpcStream<AudioFrame>(FramesThenHang(80)),
+            CancellationToken.None);
+
+        var streamingEntry = await WhenStreamingEntry(chatsBackend, chatId, segmentStreamId);
+        var entryId = streamingEntry.Id;
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var entry = await chatsBackend.GetEntry(entryId, ct);
+            entry.Should().NotBeNull();
+            entry!.IsRemoved.Should().BeFalse();
+            entry.IsContentStreaming.Should().BeFalse(
+                because: "the frame-silence watchdog must finalize a streaming entry on network drop");
+            entry.EndsAt.Should().NotBeNull();
+            entry.Audio?.MediaId.Should().NotBeNull(
+                because: "the audio that reached the server before the drop must still be saved");
+        }, TimeSpan.FromSeconds(30));
+
+        // A pure silence timeout is not a cancellation: ProcessAudio completes normally.
+        await recordTask;
+    }
+
+    // Private methods
+
+    private static Task<ChatEntry> WhenStreamingEntry(IChatsBackend chatsBackend, ChatId chatId, StreamId segmentStreamId)
+        => ComputedTest.When(async ct => {
+            var range = await chatsBackend.GetLidRange(chatId, true, ct);
+            var idTile = Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(Math.Max(range.End - 1, 0));
+            var tile = await chatsBackend.GetTile(chatId, idTile.Range, false, ct);
+            var entry = tile.Entries.LastOrDefault(e => e.ContentStreamId == segmentStreamId.Value && e.IsContentStreaming);
+            entry.Should().NotBeNull();
+            return entry!;
+        }, TimeSpan.FromSeconds(20));
+
+    // Emits frameCount ~20ms frames with small real-time gaps so a transcript entry is created,
+    // then blocks until the enumerator is cancelled — i.e. never closes the stream. This is the
+    // client-lost-the-network case; the server's frame-silence watchdog cancels the read.
+    private static async IAsyncEnumerable<AudioFrame> FramesThenHang(
+        int frameCount,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var offset = TimeSpan.Zero;
+        var frameDuration = TimeSpan.FromMilliseconds(20);
+        for (var i = 0; i < frameCount; i++) {
+            var data = new byte[100];
+            Array.Fill(data, (byte)(i % 256));
+            yield return new AudioFrame {
+                Data = data,
+                Offset = offset,
+                Duration = frameDuration,
+            };
+            offset += frameDuration;
+            await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+        }
+        // -1ms == infinite for Task.Delay: block until the enumerator's token is cancelled.
+        await Task.Delay(TimeSpan.FromMilliseconds(-1), cancellationToken).ConfigureAwait(false);
+    }
+}
+
+[CollectionDefinition(nameof(StreamingEntryNetworkLossCollection))]
+public sealed class StreamingEntryNetworkLossCollection
+    : ICollectionFixture<StreamingEntryNetworkLossCollection.AppHostFixture>
+{
+    public sealed class AppHostFixture(IMessageSink messageSink)
+        : ActualChat.Testing.Host.AppHostFixture(
+            "streaming-entry-network-loss",
+            messageSink,
+            TestAppHostOptions.Default with {
+                ConfigureHost = (_, cfg) => {
+                    cfg.AddInMemory<StreamingSettings>((x => x.UseFakeTranscriber, "true"));
+                },
+            });
+}


### PR DESCRIPTION
When the client loses the network mid-recording it stops sending audio frames without closing the RPC stream. The frame-silence watchdog then cancelled its token, so WhenDurationAvailable threw OCE, which bypassed the catch and skipped DispatchRefineTranscription — the only place refinedTranscriptTcs is completed. FinalizeTextEntry awaits it unconditionally, so finalization hung and the entry stayed content-streaming forever ("hanging transcribing").

Two complementary changes in ProcessAudio.cs:

1. WithFrameSilenceWatchdog now ends the stream gracefully on a pure silence timeout (yield break, guarded by IsSilenceTimeout: watchdog fired but the request token was not cancelled) instead of surfacing OCE. WhenDurationAvailable then succeeds with the partial duration, so the normal Close/SaveAndCreateMedia path runs and the audio that reached the server is saved (a valid shorter WebM rebuilt from the frame list) and the entry finalizes like a short recording.

2. DispatchRefineTranscription + await transcribeTask now run in an outer finally, so finalization still happens on a genuine OCE (real request cancel / server shutdown).

Regression test StreamingEntryNetworkLossTest drives a stream that emits frames then hangs, asserting the entry finalizes with Audio.MediaId set and ProcessAudio completes without cancellation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>