### PR TITLE
fix(location): full-screen Location modal with safe areas on iOS/Andr…

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/LocationMapModal/LocationMapModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationMapModal/LocationMapModal.razor
@@ -8,7 +8,8 @@
 <DialogFrame
     Class="location-map-modal"
     Title="Location"
-    HasCloseButton="true">
+    HasCloseButton="true"
+    NarrowViewSettings="DialogFrameNarrowViewSettings.Default">
     <Body>
         <div class="c-map-host">
             @if (m.Markers.Count == 0) {

--- a/src/dotnet/UI.Blazor.App/Components/LocationMapModal/location-map-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/LocationMapModal/location-map-modal.css
@@ -6,6 +6,10 @@
     @apply w-full h-128 max-h-[70vh];
     @apply overflow-hidden;
 }
+body.narrow .location-map-modal .c-map-host {
+    @apply flex-1;
+    @apply h-auto max-h-none;
+}
 .location-map-modal .c-map {
     @apply w-full h-full;
 }


### PR DESCRIPTION
…oid #4003

The Location modal used the default Bottom sheet, which on iOS/Android is forced to full viewport height by `body.device-* .modal-frame` (has-viewport-height). A bottom sheet has no safe-area-top padding, so the header landed under the notch and the fixed-height map left dead space below.

Switch it to the stretch (Default) narrow view — like other full-screen modals — which pads safe-area-top/bottom, and make the map fill the frame on narrow screens (keeping the fixed size on wide).