### PR TITLE
fix(transcription): finalize voice entries reliably — deadline, stream retry, longer stream retention

### DIFF
--- a/src/dotnet/Api/Audio/AudioSettings.cs
+++ b/src/dotnet/Api/Audio/AudioSettings.cs
@@ -12,5 +12,8 @@ public sealed class AudioSettings
     public TimeSpan IdleListeningNewMessageTrigger { get; init; } = TimeSpan.FromMinutes(5);
     public TimeSpan RecordingBeepInterval { get; init; } = TimeSpan.FromMinutes(1);
     public TimeSpan RecordingAggressiveBeepInterval { get; init; } = TimeSpan.FromSeconds(10);
-    public TimeSpan StreamExpirationDelay { get; init; } = TimeSpan.FromSeconds(10);
+    // Streams must outlive entry finalization, which runs after the stream ends:
+    // audio blob save + refine retranscription (Constants.Transcription.RetranscriptionTimeout)
+    // + invalidation propagation to clients.
+    public TimeSpan StreamExpirationDelay { get; init; } = TimeSpan.FromSeconds(60);
 }

--- a/src/dotnet/Api/Audio/AudioSettings.cs
+++ b/src/dotnet/Api/Audio/AudioSettings.cs
@@ -8,12 +8,12 @@ public sealed class AudioSettings
     public TimeSpan IdleRecordingCheckPeriod { get; init; } = TimeSpan.FromSeconds(1);
     public TimeSpan IdleRecordingPreCountdownTimeout { get; init; }
         = Constants.Audio.RecordingDuration - TimeSpan.FromSeconds(10); // 10s to count
-    public TimeSpan IdleListeningCheckPeriod { get; init; } = TimeSpan.FromSeconds(3); // Not critical to stop it at the exact time
+    // Not critical to stop it at the exact time
+    public TimeSpan IdleListeningCheckPeriod { get; init; } = TimeSpan.FromSeconds(3);
     public TimeSpan IdleListeningNewMessageTrigger { get; init; } = TimeSpan.FromMinutes(5);
     public TimeSpan RecordingBeepInterval { get; init; } = TimeSpan.FromMinutes(1);
     public TimeSpan RecordingAggressiveBeepInterval { get; init; } = TimeSpan.FromSeconds(10);
-    // Streams must outlive entry finalization, which runs after the stream ends:
-    // audio blob save + refine retranscription (Constants.Transcription.RetranscriptionTimeout)
-    // + invalidation propagation to clients.
+    // Must outlive entry finalization, which runs after the stream ends:
+    // blob save + refine retranscription (RetranscriptionTimeout) + invalidation propagation
     public TimeSpan StreamExpirationDelay { get; init; } = TimeSpan.FromSeconds(60);
 }

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -208,6 +208,8 @@ public static partial class Constants
         public static readonly TimeSpan ThrottlePeriod = TimeSpan.FromSeconds(0.2);
         public static readonly TimeSpan CancellationDelay = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan RetranscriptionTimeout = TimeSpan.FromSeconds(20);
+        // Max time the realtime transcriber gets to complete after its audio source ends
+        public static readonly TimeSpan CompletionTimeout = TimeSpan.FromSeconds(5);
         public static readonly bool StartWithEllipsis = false;
 
         public static class Google

--- a/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
+++ b/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
@@ -430,12 +430,10 @@ public partial class AudioStreamingBackend
         else
             transcriptionEngine = await GetTranscriptionEngine(audioSegment.Record, cancellationToken).ConfigureAwait(false);
         var transcriber = TranscriberFactory.Get(transcriptionEngine);
-        // The deadline guarantees the realtime transcript stream ends even when the provider
-        // never completes it (e.g. a lost Deepgram finalize ack keeps the socket open forever),
-        // which would otherwise strand the entry in the streaming state until ChatEntryFixupFlow
-        // removes it. Whatever transcript exists when it fires is the final one. Anchored at the
-        // audio source end; the audio push lags it by at most a couple of seconds (2x pacing,
-        // arrival burstiness is capped by the frame-silence watchdog).
+        // Providers can fail to complete the transcript stream (e.g. a lost Deepgram finalize ack),
+        // which would strand the entry in the streaming state - so transcription gets a deadline,
+        // anchored at the audio source end. The paced (2x) audio push lags that end by at most
+        // a couple of seconds: arrival burstiness is capped by the frame-silence watchdog.
         using var deadlineCts = cancellationToken.CreateLinkedTokenSource();
         _ = audioSegment.Source.WhenDurationAvailable.ContinueWith(
             _ => {
@@ -528,7 +526,7 @@ public partial class AudioStreamingBackend
                     await Task.WhenAll(FinalizeTextEntry(), FinalizeLanguages()).ConfigureAwait(false);
                 }
             }
-            // No finalization -> no refine either; unblock its language wait so it can't hang
+            // No-op when finalization set the language above; otherwise refine must not stay blocked on it
             refineTranscriptLanguageTcs.TrySetResult(null);
             await transcriptDiffStream.DisposeSilentlyAsync().ConfigureAwait(false);
         }

--- a/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
+++ b/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
@@ -430,11 +430,26 @@ public partial class AudioStreamingBackend
         else
             transcriptionEngine = await GetTranscriptionEngine(audioSegment.Record, cancellationToken).ConfigureAwait(false);
         var transcriber = TranscriberFactory.Get(transcriptionEngine);
+        // The deadline guarantees the realtime transcript stream ends even when the provider
+        // never completes it (e.g. a lost Deepgram finalize ack keeps the socket open forever),
+        // which would otherwise strand the entry in the streaming state until ChatEntryFixupFlow
+        // removes it. Whatever transcript exists when it fires is the final one. Anchored at the
+        // audio source end; the audio push lags it by at most a couple of seconds (2x pacing,
+        // arrival burstiness is capped by the frame-silence watchdog).
+        using var deadlineCts = cancellationToken.CreateLinkedTokenSource();
+        _ = audioSegment.Source.WhenDurationAvailable.ContinueWith(
+            _ => {
+                try {
+                    deadlineCts.CancelAfter(Constants.Transcription.CompletionTimeout);
+                }
+                catch (ObjectDisposedException) { }
+            },
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         using var transcripts = transcriber
-            .Transcribe(audioSegment.StreamId.Value, audioSegment.Source, transcriptionOptions, cancellationToken)
+            .Transcribe(audioSegment.StreamId.Value, audioSegment.Source, transcriptionOptions, deadlineCts.Token)
             .ThrottleTranscript(Constants.Transcription.ThrottlePeriod, Clocks.CpuClock, cancellationToken)
             .Memoize(CancellationToken.None);
-        cancellationToken = CancellationToken.None; // We already accounted for it in TrimOnCancellation
+        cancellationToken = CancellationToken.None; // Past this point only deadlineCts cancels the transcriber
 
         var transcriptStreamId = audioSegment.StreamId;
         var chatId = audioSegment.Record.ChatId;
@@ -489,6 +504,11 @@ public partial class AudioStreamingBackend
                 await publishTranscriptStreamTask.ConfigureAwait(false);
             }
         }
+        catch (Exception e) when (deadlineCts.IsCancellationRequested) {
+            Log.LogWarning(e,
+                "TranscribeAudio: realtime transcription of #{StreamId} hit the completion deadline, finalizing with what we have",
+                audioSegment.StreamId);
+        }
         finally {
             if (lastTranscript != null && textEntry != null) {
                 // The entry may have been removed by the user or already finalized by
@@ -508,6 +528,8 @@ public partial class AudioStreamingBackend
                     await Task.WhenAll(FinalizeTextEntry(), FinalizeLanguages()).ConfigureAwait(false);
                 }
             }
+            // No finalization -> no refine either; unblock its language wait so it can't hang
+            refineTranscriptLanguageTcs.TrySetResult(null);
             await transcriptDiffStream.DisposeSilentlyAsync().ConfigureAwait(false);
         }
         return textEntry?.Id;

--- a/src/dotnet/Streaming.Service/Services/Transcribers/DeepgramTranscriber.cs
+++ b/src/dotnet/Streaming.Service/Services/Transcribers/DeepgramTranscriber.cs
@@ -126,7 +126,9 @@ public partial class DeepgramTranscriber : ITranscriber
 
             await PushAudio(transcriptState, deepgramClient, tokenSource.Token).ConfigureAwait(false);
 
-            await whenCompleted.ConfigureAwait(false);
+            // Completes on the finalize ack, connection close, or error; with keepAlive on,
+            // a lost ack would otherwise hang this await forever - so it must observe the token.
+            await whenCompleted.WaitAsync(tokenSource.Token).ConfigureAwait(false);
 
             try {
                 // Ignore errors on stopping

--- a/src/dotnet/Streaming.Service/Services/Transcribers/GoogleTranscriber.cs
+++ b/src/dotnet/Streaming.Service/Services/Transcribers/GoogleTranscriber.cs
@@ -145,8 +145,14 @@ public partial class GoogleTranscriber : ITranscriber
         ChannelWriter<Transcript> output,
         CancellationToken cancellationToken)
     {
+        // We want to stop both tasks here on any failure, so...
+#pragma warning disable CA2000
+        var cts = cancellationToken.CreateLinkedTokenSource();
+#pragma warning restore CA2000
+        // The call itself must be bound to cts as well: PullResponses reads its response stream
+        // with no token of its own, so cancelling the call is the only way to unblock it.
         var recognizeStream = SpeechClient.StreamingRecognize(
-            CallSettings.FromCancellationToken(cancellationToken),
+            CallSettings.FromCancellationToken(cts.Token),
             new BidirectionalStreamingSettings(1));
         await recognizeStream.WriteAsync(new StreamingRecognizeRequest {
             StreamingConfig = GetStreamingRecognitionConfig(options),
@@ -154,18 +160,17 @@ public partial class GoogleTranscriber : ITranscriber
         }).ConfigureAwait(false);
 
         var state = new GoogleTranscribeState(audioSource, options, recognizeStream, output);
-        // We want to stop both tasks here on any failure, so...
-#pragma warning disable CA2000
-        var cts = cancellationToken.CreateLinkedTokenSource();
-#pragma warning restore CA2000
+        Task? pullResponsesTask = null;
         try {
             var pushAudioTask = PushAudio(state, cts.Token);
-            var pullResponsesTask = PullResponses(state, options, cts.Token);
+            pullResponsesTask = PullResponses(state, options, cts.Token);
             await pushAudioTask.ConfigureAwait(false);
             await pullResponsesTask.ConfigureAwait(false);
         }
         finally {
             cts.CancelAndDisposeSilently();
+            if (pullResponsesTask is { IsCompleted: false })
+                await pullResponsesTask.SilentAwait(false);
         }
     }
 
@@ -219,7 +224,9 @@ public partial class GoogleTranscriber : ITranscriber
             throw;
         }
         finally {
-            _ = recognizeStream.TryWriteCompleteAsync();
+            // Must complete before PushAudio returns: Google closes the response stream
+            // (ending PullResponses) only after the write side is completed.
+            await recognizeStream.TryWriteCompleteAsync().SilentAwait(false);
         }
     }
 

--- a/src/dotnet/Streaming.Service/Services/Transcribers/GoogleTranscriber.cs
+++ b/src/dotnet/Streaming.Service/Services/Transcribers/GoogleTranscriber.cs
@@ -224,8 +224,7 @@ public partial class GoogleTranscriber : ITranscriber
             throw;
         }
         finally {
-            // Must complete before PushAudio returns: Google closes the response stream
-            // (ending PullResponses) only after the write side is completed.
+            // Google ends the response stream (unblocking PullResponses) only after the write side completes
             await recognizeStream.TryWriteCompleteAsync().SilentAwait(false);
         }
     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptStreamReader.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptStreamReader.cs
@@ -1,13 +1,12 @@
 using ActualChat.Streaming;
 using ActualChat.Transcription;
 using ActualChat.UI.Blazor.App.Services;
-using ActualLab.Rpc;
 
 namespace ActualChat.UI.Blazor.App.Components;
 
 public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
 {
-    private static readonly RetryDelaySeq RetryDelays = RetryDelaySeq.Exp(0.25, 2);
+    private static readonly RetryDelaySeq RetryDelays = RetryDelaySeq.Exp(0.25, 5);
 
     private TranscriptUI TranscriptUI => hub.TranscriptUI;
     private ILiveAudioStreams LiveAudioStreams => hub.LiveAudioStreams;
@@ -71,13 +70,21 @@ public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
         }
     }
 
-    private async Task ProcessTranscriptWithRetry(TranscriptUI.StreamingState streamingState, CancellationToken cancellationToken)
+    private async Task ProcessTranscriptWithRetry(
+        TranscriptUI.StreamingState streamingState,
+        CancellationToken cancellationToken)
     {
         var retryIndex = 0;
         while (!cancellationToken.IsCancellationRequested)
             try {
-                await ProcessTranscript(streamingState, cancellationToken).ConfigureAwait(false);
-                return; // Completed normally
+                var isCompleted = await ProcessTranscript(streamingState, cancellationToken).ConfigureAwait(false);
+                if (isCompleted)
+                    return;
+
+                // The stream isn't published yet (entry-creation race) or has already expired
+                // while the entry is still streaming. Retry: ProcessStreamingState cancels us
+                // once the entry leaves the streaming state.
+                await Clocks.SystemClock.Delay(RetryDelays[retryIndex++], cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
                 var delay = RetryDelays[retryIndex++];
@@ -86,16 +93,19 @@ public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
             }
     }
 
-    private async Task ProcessTranscript(TranscriptUI.StreamingState streamingState, CancellationToken cancellationToken) {
+    private async Task<bool> ProcessTranscript(
+        TranscriptUI.StreamingState streamingState,
+        CancellationToken cancellationToken)
+    {
         var (streamId, content, isTranslation) = streamingState;
+        var rpcStream = await LiveAudioStreams.GetTranscriptStream(hub.Session, streamId.Value, cancellationToken)
+            .ConfigureAwait(false);
+        if (rpcStream is null)
+            return false;
+
         var lastText = "";
         try {
-            var rpcStream = await LiveAudioStreams.GetTranscriptStream(hub.Session, streamId.Value, cancellationToken)
-                .ConfigureAwait(false);
-            var diffs = rpcStream is null
-                ? AsyncEnumerable.Empty<TranscriptDiff>()
-                : rpcStream.SuppressExceptions(e => e is RpcReconnectFailedException, cancellationToken);
-            var transcripts = diffs.ToTranscripts();
+            var transcripts = rpcStream.ToTranscripts();
 
             // Optimization state:
             // - stablePrefixLength: length of text that is known to be immutable (based on IsStable snapshots)
@@ -142,7 +152,8 @@ public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
         catch (Exception e) when (e.IsCancellationOf(cancellationToken)) {
             // Intended: suppress cancellation
         }
-        // Reached on normal completion or suppressed exception — mark streaming as done
+        // Reached on normal completion or cancellation — mark streaming as done.
+        // Any other error propagates to the retry loop with the state intact.
         _state.Value = new (
             RetainedText: lastText,
             ChangedText: "",
@@ -150,6 +161,7 @@ public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
             Tail: "",
             false,
             isTranslation);
+        return true;
     }
 
     // Uses knowledge of an immutable prefix (stablePrefixLength) to avoid re-comparing it.

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptStreamReader.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptStreamReader.cs
@@ -81,9 +81,8 @@ public class TranscriptStreamReader(ChatEntryId id, AppUIHub hub) : WorkerBase
                 if (isCompleted)
                     return;
 
-                // The stream isn't published yet (entry-creation race) or has already expired
-                // while the entry is still streaming. Retry: ProcessStreamingState cancels us
-                // once the entry leaves the streaming state.
+                // Not published yet (entry-creation race) or already expired; retry -
+                // ProcessStreamingState cancels us once the entry leaves the streaming state
                 await Clocks.SystemClock.Delay(RetryDelays[retryIndex++], cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {


### PR DESCRIPTION
## Problem

Voice messages sometimes never finish transcribing — they stay on screen with the "Transcribing…" badge (most often the first message of a session), and after ~4 minutes `ChatEntryFixupFlow` silently removes them, destroying the spoken message.

Root causes found:

1. **Unbounded transcriber completion.** `DeepgramTranscriber` awaits its finalize ack with no timeout (and `keepAlive: true` holds the socket open forever); `GoogleTranscriber` completed its gRPC write side fire-and-forget while `PullResponses` reads the response stream with no token of its own. Either hang leaves the entry in the streaming state forever — `FinalizeTextEntry` never runs. The whole transcribe task runs under `CancellationToken.None`, so nothing else stops it.
2. **No client retry on a missing transcript stream.** `TranscriptStreamReader.ProcessTranscript` treated a null `GetTranscriptStream` result as normal completion — no retry, contrary to what the server-side comment in `ProcessAudio` assumes. One missed fetch (publish race, expired stream, failed reconnect) = "Transcribing…" badge with no text until finalization.
3. **Streams expired before finalization.** Transcript/audio streams expired 10s after they end, but finalization (blob save + refine retranscription, up to `RetranscriptionTimeout` = 20s) keeps the entry streaming for up to ~30s — clients subscribing in that window got null. Cold starts stretch this window most, which is why the first message was hit most often.

## Changes

- **Completion deadline (provider-agnostic):** `TranscribeAudio` arms a deadline 5s after the audio source ends (`Constants.Transcription.CompletionTimeout`) and passes its token to the realtime transcriber. When it fires, the transcript stream ends and the entry is finalized with whatever transcript we have. Deadline-induced errors are logged as a warning, not rethrown.
- **Provider token plumbing (needed for the deadline to actually work):** Deepgram now awaits the finalize ack via `WaitAsync(token)`; Google binds the gRPC call itself to the linked cts and awaits its write-complete instead of fire-and-forget.
- **Refine can't hang or run pointlessly:** the refine-language TCS is always completed in `TranscribeAudio`'s `finally` (null when nothing was finalized), so `DispatchRefineTranscription` never waits forever and skips retranscription for dead entries. Refine stays inside the single finalize — no finalize-then-edit.
- **Client retry:** `TranscriptStreamReader` retries with backoff (0.25s → 5s) while the stream is missing and the entry is still streaming; the state watcher cancels the loop once the entry leaves the streaming state. Mid-stream reconnect failures now retry too instead of silently ending.
- **Stream retention:** `AudioSettings.StreamExpirationDelay` 10s → 60s, sized to blob save + `RetranscriptionTimeout` (20s) + invalidation propagation, with margin. Applies to both audio and transcript stores (the entry's `Audio.StreamId` also points at the live stream until finalization).

## Not changed (by design)

- `ChatEntryFixupFlow` still removes empty streaming entries — correct last-resort behavior for a completely failed transcription; with the deadline in place, entries that had any text should no longer reach it.
- No finalize-then-edit: bots and other consumers see the final text exactly once.
- Verified by inspection that a removed entry unmounts its message view (client `GetTile` passes `includeRemoved: false`, so the row leaves the virtual list) — the stale `_rendered` fallback in `ChatEntryMessageInternalView.ComputeState` is transient; no fix needed.
- Follow-up (separate PR): revisit `ShouldUseOriginalTranscript` thresholds to prefer the offline/refined transcript.

## Testing

- `Streaming.UnitTests` (106 passed) and `Transcription.UnitTests` (30 passed).
- `Streaming.IntegrationTests` transcription tests are all `Skip`-marked (flaky / need Google API). `RetranscribeNotifyFlowTest` (exercises the refine flow with fake transcribers) could not run in this session — PostgreSQL/Redis/NATS are down on this host; fixture setup fails before any test logic. Worth a run once infra is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AtykkcswDBKjHn34zyRR7