### PR TITLE
fix(translation): translate voice entries recorded in language-detect mode

### DIFF
--- a/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
+++ b/src/dotnet/Streaming.Service/Backend/AudioStreamingBackend.ProcessAudio.cs
@@ -615,9 +615,8 @@ public partial class AudioStreamingBackend
 
         Task FinalizeLanguages()
         {
-            if (entryLanguage is null)
-                return Task.CompletedTask;
-
+            // In detect language mode entryLanguage is created only here, on finalization
+            entryLanguage ??= new ChatEntryLanguage(textEntry.Id);
             entryLanguage = entryLanguage with {
                 Languages = lastTranscript.Languages,
                 EntryContentHash = textEntry.ContentHash,

--- a/src/dotnet/UI.Blazor.App/Services/TranslationUI/TranslationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/TranslationUI/TranslationUI.cs
@@ -66,7 +66,7 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
             // always for typed text entries
             return true;
 
-        return await IsForeignEntry(entry.Id, true, cancellationToken).ConfigureAwait(false) == true;
+        return await MayNeedTranslation(entry.Id, cancellationToken).ConfigureAwait(false) == true;
     }
 
     [ComputeMethod]
@@ -158,7 +158,7 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
 
         var foreignCount = 0;
         foreach (var entryId in visibleEntryIds) {
-            if (await IsForeignEntry(entryId, false, cancellationToken).ConfigureAwait(false) == true)
+            if (await MaySuggestTranslation(entryId, cancellationToken).ConfigureAwait(false) == true)
                 foreignCount++;
         }
 
@@ -175,21 +175,15 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
         => Task.FromResult(_mustSuggestTranslationCache.TryGetValue(chatId, out _));
 
     [ComputeMethod]
-    protected virtual async Task<bool?> IsForeignEntry(
-        ChatEntryId entryId,
-        bool expectTranslationLanguageOnly,
-        CancellationToken cancellationToken = default)
+    protected virtual async Task<bool?> MayNeedTranslation(
+        ChatEntryId entryId, CancellationToken cancellationToken = default)
     {
         var entry = await ChatUI.GetEntry(entryId, cancellationToken).ConfigureAwait(false);
         if (entry is null)
             return null;
 
-        var mustTranslateOwnMessages = await MustTranslateOwnMessages(entry.ChatId, cancellationToken).ConfigureAwait(false);
-        if (!mustTranslateOwnMessages) {
-            var ownAuthor = await AuthorUI.GetOwn(entry.ChatId, cancellationToken).ConfigureAwait(false);
-            if (ownAuthor.Id == entry.AuthorId)
-                return false;
-        }
+        if (await IsOwnEntryWithDisabledTranslation(entry, cancellationToken).ConfigureAwait(false))
+            return false;
 
         var entryLanguage = await Translations.GetLanguage(entryId, cancellationToken).ConfigureAwait(false);
         if (entryLanguage == null)
@@ -197,22 +191,51 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
 
         if (entryLanguage.Languages.Length == 0) {
             // Nothing detectable (e.g. numbers-only); a voice entry with unsaved languages counts as foreign
-            return expectTranslationLanguageOnly && entry.HasAudio;
+            return entry.HasAudio;
         }
 
         var translationLanguage = await GetTranslationLanguage(entryId.ChatId, cancellationToken).ConfigureAwait(false);
-        var isOnTranslationLanguage = entryLanguage.Languages.All(x => x != translationLanguage);
-        if (expectTranslationLanguageOnly)
-            return isOnTranslationLanguage;
+        return entryLanguage.Languages.All(x => x != translationLanguage);
+    }
 
-        if (!isOnTranslationLanguage)
+    [ComputeMethod]
+    protected virtual async Task<bool?> MaySuggestTranslation(
+        ChatEntryId entryId, CancellationToken cancellationToken = default)
+    {
+        var entry = await ChatUI.GetEntry(entryId, cancellationToken).ConfigureAwait(false);
+        if (entry is null)
+            return null;
+
+        if (await IsOwnEntryWithDisabledTranslation(entry, cancellationToken).ConfigureAwait(false))
+            return false;
+
+        var entryLanguage = await Translations.GetLanguage(entryId, cancellationToken).ConfigureAwait(false);
+        if (entryLanguage == null)
+            return null;
+
+        if (entryLanguage.Languages.Length == 0)
+            return false; // Unknown language must not trigger the translation suggestion
+
+        var translationLanguage = await GetTranslationLanguage(entryId.ChatId, cancellationToken).ConfigureAwait(false);
+        if (entryLanguage.Languages.Any(x => x == translationLanguage))
             return false;
 
         var spokenLanguages = await LanguageUI.ListSpoken(cancellationToken).ConfigureAwait(false);
-        return !entryLanguage.Languages.Any(x => x == translationLanguage || spokenLanguages.Contains(x));
+        return !entryLanguage.Languages.Any(x => spokenLanguages.Contains(x));
     }
 
     // Private methods
+
+    private async Task<bool> IsOwnEntryWithDisabledTranslation(ChatEntry entry, CancellationToken cancellationToken)
+    {
+        var mustTranslateOwnMessages = await MustTranslateOwnMessages(entry.ChatId, cancellationToken)
+            .ConfigureAwait(false);
+        if (mustTranslateOwnMessages)
+            return false;
+
+        var ownAuthor = await AuthorUI.GetOwn(entry.ChatId, cancellationToken).ConfigureAwait(false);
+        return ownAuthor.Id == entry.AuthorId;
+    }
 
     private Task<bool?> GetSubHeaderVisibility(ChatId chatId, CancellationToken cancellationToken)
         => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))

--- a/src/dotnet/UI.Blazor.App/Services/TranslationUI/TranslationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/TranslationUI/TranslationUI.cs
@@ -13,7 +13,8 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
     private AuthorUI AuthorUI => Hub.AuthorUI;
 
     [ComputeMethod]
-    public virtual async Task<bool> IsSubHeaderVisible(ChatId chatId, CancellationToken cancellationToken = default) {
+    public virtual async Task<bool> IsSubHeaderVisible(ChatId chatId, CancellationToken cancellationToken = default)
+    {
         var isVisible = await GetSubHeaderVisibility(chatId, cancellationToken).ConfigureAwait(false);
         if (isVisible != null)
             return isVisible.Value;
@@ -105,7 +106,8 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
     }
 
     [ComputeMethod]
-    public virtual async Task<Translation?> Get(TranslationSourceId translationSourceId, CancellationToken cancellationToken = default){
+    public virtual async Task<Translation?> Get(TranslationSourceId translationSourceId, CancellationToken cancellationToken = default)
+    {
         var translationId = await ToTranslationId(translationSourceId, cancellationToken).ConfigureAwait(false);
         return await Translations
             .Get(translationId, cancellationToken)
@@ -121,118 +123,122 @@ public class TranslationUI : UIServiceBase<AppUIHub>, IComputeService
             .ConfigureAwait(false);
     }
 
+    public Task SetIsSubHeaderVisible(ChatId chatId, bool isVisible, CancellationToken cancellationToken = default)
+        => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
+            .Update(x => x with { IsTranslationSubHeaderVisible = isVisible }, cancellationToken);
+
+    public Task SetIsOn(ChatId chatId, bool? value, CancellationToken cancellationToken = default)
+        => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
+            .Update(x => x with { MustTranslate = value }, cancellationToken);
+
+    public Task SetMustTranslateOwnMessages(ChatId chatId, bool? value, CancellationToken cancellationToken = default)
+        => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
+            .Update(x => x with { MustTranslateOwnMessages = value }, cancellationToken);
+
+    public Task SetTargetLanguage(ChatId chatId, Language? language, CancellationToken cancellationToken = default)
+        => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
+            .Update(x => x with { TranslationTargetLanguage = language }, cancellationToken);
+
+    // Protected/internal methods
+
     [ComputeMethod]
-   protected virtual async Task<bool> MustSuggestTranslation(ChatId chatId, CancellationToken cancellationToken)
-   {
-       const int minForeignCount = 3;
-       const double minForeignRatio = 0.3;
+    protected virtual async Task<bool> MustSuggestTranslation(ChatId chatId, CancellationToken cancellationToken)
+    {
+        const int minForeignCount = 3;
+        const double minForeignRatio = 0.3;
 
-       var itemVisibility = await ChatUI.ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
-       if (itemVisibility.IsEmpty || itemVisibility.ChatId != chatId)
-           return false;
+        var itemVisibility = await ChatUI.ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
+        if (itemVisibility.IsEmpty || itemVisibility.ChatId != chatId)
+            return false;
 
-       var visibleEntryIds = itemVisibility.VisibleTextEntryIds;
-       var totalCount = visibleEntryIds.Count;
-       if (totalCount == 0)
-           return false;
+        var visibleEntryIds = itemVisibility.VisibleTextEntryIds;
+        var totalCount = visibleEntryIds.Count;
+        if (totalCount == 0)
+            return false;
 
-       var foreignCount = 0;
-       foreach (var entryId in visibleEntryIds) {
-           if (await IsForeignEntry(entryId, false, cancellationToken).ConfigureAwait(false) == true)
-               foreignCount++;
-       }
+        var foreignCount = 0;
+        foreach (var entryId in visibleEntryIds) {
+            if (await IsForeignEntry(entryId, false, cancellationToken).ConfigureAwait(false) == true)
+                foreignCount++;
+        }
 
-       if (foreignCount < minForeignCount && (double)foreignCount / totalCount < minForeignRatio)
-           return false;
+        if (foreignCount < minForeignCount && (double)foreignCount / totalCount < minForeignRatio)
+            return false;
 
-       using (Computed.BeginIsolation())
-           StoreMustSuggest(chatId);
-       return true;
-   }
+        using (Computed.BeginIsolation())
+            StoreMustSuggest(chatId);
+        return true;
+    }
 
-   [ComputeMethod]
-   protected virtual Task<bool> GetStoredMustSuggestTranslation(ChatId chatId, CancellationToken cancellationToken)
-       => Task.FromResult(_mustSuggestTranslationCache.TryGetValue(chatId, out _));
+    [ComputeMethod]
+    protected virtual Task<bool> GetStoredMustSuggestTranslation(ChatId chatId, CancellationToken cancellationToken)
+        => Task.FromResult(_mustSuggestTranslationCache.TryGetValue(chatId, out _));
 
-   [ComputeMethod]
-   protected virtual async Task<bool?> IsForeignEntry(
-       ChatEntryId entryId,
-       bool expectTranslationLanguageOnly,
-       CancellationToken cancellationToken = default)
-   {
-       var entry = await ChatUI.GetEntry(entryId, cancellationToken).ConfigureAwait(false);
-       if (entry is null)
-           return null;
+    [ComputeMethod]
+    protected virtual async Task<bool?> IsForeignEntry(
+        ChatEntryId entryId,
+        bool expectTranslationLanguageOnly,
+        CancellationToken cancellationToken = default)
+    {
+        var entry = await ChatUI.GetEntry(entryId, cancellationToken).ConfigureAwait(false);
+        if (entry is null)
+            return null;
 
-       var mustTranslateOwnMessages = await MustTranslateOwnMessages(entry.ChatId, cancellationToken).ConfigureAwait(false);
-       if (!mustTranslateOwnMessages) {
-           var ownAuthor = await AuthorUI.GetOwn(entry.ChatId, cancellationToken).ConfigureAwait(false);
-           if (ownAuthor.Id == entry.AuthorId)
-               return false;
-       }
+        var mustTranslateOwnMessages = await MustTranslateOwnMessages(entry.ChatId, cancellationToken).ConfigureAwait(false);
+        if (!mustTranslateOwnMessages) {
+            var ownAuthor = await AuthorUI.GetOwn(entry.ChatId, cancellationToken).ConfigureAwait(false);
+            if (ownAuthor.Id == entry.AuthorId)
+                return false;
+        }
 
-       var entryLanguage = await Translations.GetLanguage(entryId, cancellationToken).ConfigureAwait(false);
-       if (entryLanguage == null)
-           return null;
+        var entryLanguage = await Translations.GetLanguage(entryId, cancellationToken).ConfigureAwait(false);
+        if (entryLanguage == null)
+            return null;
 
-       if (entryLanguage.Languages.Length == 0)
-           return false; // No languages can be detected - e.g., empty message or just numbers
+        if (entryLanguage.Languages.Length == 0) {
+            // Nothing detectable (e.g. numbers-only); a voice entry with unsaved languages counts as foreign
+            return expectTranslationLanguageOnly && entry.HasAudio;
+        }
 
-       var translationLanguage = await GetTranslationLanguage(entryId.ChatId, cancellationToken).ConfigureAwait(false);
-       var isOnTranslationLanguage = entryLanguage.Languages.All(x => x != translationLanguage);
-       if (expectTranslationLanguageOnly)
-           return isOnTranslationLanguage;
+        var translationLanguage = await GetTranslationLanguage(entryId.ChatId, cancellationToken).ConfigureAwait(false);
+        var isOnTranslationLanguage = entryLanguage.Languages.All(x => x != translationLanguage);
+        if (expectTranslationLanguageOnly)
+            return isOnTranslationLanguage;
 
-       if (!isOnTranslationLanguage)
-           return false;
+        if (!isOnTranslationLanguage)
+            return false;
 
-       var spokenLanguages = await LanguageUI.ListSpoken(cancellationToken).ConfigureAwait(false);
-       return !entryLanguage.Languages.Any(x => x == translationLanguage || spokenLanguages.Contains(x));
-   }
+        var spokenLanguages = await LanguageUI.ListSpoken(cancellationToken).ConfigureAwait(false);
+        return !entryLanguage.Languages.Any(x => x == translationLanguage || spokenLanguages.Contains(x));
+    }
 
-   public Task SetIsSubHeaderVisible(ChatId chatId, bool isVisible, CancellationToken cancellationToken = default)
-       => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
-           .Update(x => x with { IsTranslationSubHeaderVisible = isVisible }, cancellationToken);
+    // Private methods
 
-   public Task SetIsOn(ChatId chatId, bool? value, CancellationToken cancellationToken = default)
-       => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
-           .Update(x => x with { MustTranslate = value }, cancellationToken);
+    private Task<bool?> GetSubHeaderVisibility(ChatId chatId, CancellationToken cancellationToken)
+        => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
+            .Get(x => x.IsTranslationSubHeaderVisible, cancellationToken);
 
-   public Task SetMustTranslateOwnMessages(ChatId chatId, bool? value, CancellationToken cancellationToken = default)
-       => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
-           .Update(x => x with { MustTranslateOwnMessages = value }, cancellationToken);
+    private async Task<TranslationId> ToTranslationId(
+        TranslationSourceId translationSourceId, CancellationToken cancellationToken)
+    {
+        var translationLanguage = await GetTranslationLanguage(translationSourceId.ChatId, cancellationToken).ConfigureAwait(false);
+        return TranslationId.New(translationSourceId, translationLanguage);
+    }
 
-   public Task SetTargetLanguage(ChatId chatId, Language? language, CancellationToken cancellationToken = default)
-       => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
-           .Update(x => x with { TranslationTargetLanguage = language }, cancellationToken);
+    private static ChatId GetTranslationSettingsTargetChatId(ChatId chatId)
+        => chatId.IsThread(out var threadChatId) ? threadChatId.GetOutermostParent() : chatId;
 
-   // Private methods
+    private void StoreMustSuggest(ChatId chatId)
+    {
+        if (!_mustSuggestTranslationCache.TryAdd(chatId, Unit.Default))
+            return;
 
-   private Task<bool?> GetSubHeaderVisibility(ChatId chatId, CancellationToken cancellationToken)
-       => UserSettingsUI.ChatUserSettings(GetTranslationSettingsTargetChatId(chatId))
-           .Get(x => x.IsTranslationSubHeaderVisible, cancellationToken);
+        InvalidateMustSuggestCache(chatId);
+    }
 
-   private async Task<TranslationId> ToTranslationId(
-       TranslationSourceId translationSourceId, CancellationToken cancellationToken)
-   {
-       var translationLanguage = await GetTranslationLanguage(translationSourceId.ChatId, cancellationToken).ConfigureAwait(false);
-       return TranslationId.New(translationSourceId, translationLanguage);
-   }
-
-   private static ChatId GetTranslationSettingsTargetChatId(ChatId chatId)
-       => chatId.IsThread(out var threadChatId) ? threadChatId.GetOutermostParent() : chatId;
-
-   private void StoreMustSuggest(ChatId chatId)
-   {
-       if (!_mustSuggestTranslationCache.TryAdd(chatId, Unit.Default))
-           return;
-
-       InvalidateMustSuggestCache(chatId);
-   }
-
-   private void InvalidateMustSuggestCache(ChatId chatId, Unit _1 = default)
-   {
-       using (Invalidation.Begin())
-           _ = GetStoredMustSuggestTranslation(chatId, default);
-   }
+    private void InvalidateMustSuggestCache(ChatId chatId, Unit _1 = default)
+    {
+        using (Invalidation.Begin())
+            _ = GetStoredMustSuggestTranslation(chatId, default);
+    }
 }

--- a/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
@@ -69,7 +69,7 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         var chatId = await CreateChat(cancellationToken);
 
         // act
-        await CreateVisibleEntries(chatId,"Does not need translation");
+        await CreateVisibleEntries(chatId, "Does not need translation");
 
         // assert
         await AssertIsSubHeaderVisible(chatId, false);
@@ -154,8 +154,10 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
 
         // act
         await TranslationUI.SetIsOn(chatId, true, cancellationToken);
-        var englishEntry = await AliceTester.CreateStreamingEntry(chatId, Languages.English, cancellationToken: cancellationToken);
-        var frenchEntry = await AliceTester.CreateStreamingEntry(chatId, Languages.French, cancellationToken: cancellationToken);
+        var englishEntry = await AliceTester
+            .CreateStreamingEntry(chatId, Languages.English, cancellationToken: cancellationToken);
+        var frenchEntry = await AliceTester
+            .CreateStreamingEntry(chatId, Languages.French, cancellationToken: cancellationToken);
 
         // assert
         await AssertMustTranslate(frenchEntry.ChatEntrySlim, true);
@@ -181,12 +183,31 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
 
         // act
         await TranslationUI.SetIsOn(chatId, true, cancellationToken);
-        var streamingEntry = await AliceTester.CreateStreamingEntry(chatId, Languages.French, cancellationToken: cancellationToken);
+        var streamingEntry = await AliceTester
+            .CreateStreamingEntry(chatId, Languages.French, cancellationToken: cancellationToken);
         streamingEntry = await AliceTester.FinalizeStreamingEntry(streamingEntry, "Bonjour!", cancellationToken);
 
         // assert
         await AssertMustTranslate(streamingEntry.ChatEntrySlim, true);
         await AssertTranslation(streamingEntry.ChatEntrySlim, "Hello!");
+    }
+
+    [Fact]
+    public async Task ShouldTranslateVoiceEntryWithNoSavedLanguages()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15).Debuggable());
+        var cancellationToken = cts.Token;
+        var chatId = await CreateChat(cancellationToken);
+        await TranslationUI.SetTargetLanguage(chatId, Languages.English, cancellationToken);
+        await TranslationUI.SetIsOn(chatId, true, cancellationToken);
+
+        // act
+        var entry = await CreateVoiceEntryWithNoLanguages(chatId, "¡Hola! ¿Cómo estás?", cancellationToken);
+
+        // assert
+        await AssertMustTranslate(entry, true);
+        await AssertTranslation(entry, "Hello! How are you?");
     }
 
     [Fact(Skip = "Flaky")] // TODO: fix
@@ -258,7 +279,8 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         var streamingState = await AssertIsStreaming(entry, true).Require();
 
         // act
-        var rpcStream = await LiveAudioStreams.GetTranscriptStream(Hub.Session, streamingState.StreamId.Value, cancellationToken);
+        var rpcStream = await LiveAudioStreams
+            .GetTranscriptStream(Hub.Session, streamingState.StreamId.Value, cancellationToken);
         var diffs = rpcStream is null
             ? new List<TranscriptDiff>()
             : await ((IAsyncEnumerable<TranscriptDiff>)rpcStream).ToListAsync(cancellationToken);
@@ -280,7 +302,8 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         var cancellationToken = cts.Token;
         var chatId = await CreateChat(cancellationToken);
         await TranslationUI.SetTargetLanguage(chatId, Languages.German, cancellationToken);
-        var entries = await CreateEntries(chatId, Enumerable.Range(0, ThrottledTranslations.ConcurrencyLevel + 10).Select(i => $"Hello {i}"));
+        var entries = await CreateEntries(chatId,
+            Enumerable.Range(0, ThrottledTranslations.ConcurrencyLevel + 10).Select(i => $"Hello {i}"));
 
         // act
         var translations = await GetTranslations(entries, cancellationToken);
@@ -326,7 +349,8 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         var cancellationToken = cts.Token;
         var chatId = await CreateChat(cancellationToken);
         await TranslationUI.SetTargetLanguage(chatId, Languages.German, cancellationToken);
-        var entries = await CreateVisibleEntries(chatId, Enumerable.Range(0, ThrottledTranslations.ConcurrencyLevel + 10).Select(i => $"Hello {i}"));
+        var entries = await CreateVisibleEntries(chatId,
+            Enumerable.Range(0, ThrottledTranslations.ConcurrencyLevel + 10).Select(i => $"Hello {i}"));
 
         // act
         var translations = await GetTranslations(entries, cancellationToken);
@@ -365,6 +389,23 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         return entries;
     }
 
+    private async Task<ChatEntry> CreateVoiceEntryWithNoLanguages(
+        ChatId chatId, string text, CancellationToken cancellationToken)
+    {
+        var now = AliceTester.AppServices.Clocks().SystemClock.Now;
+        var author = await AliceTester.GetOwnAuthor(chatId, cancellationToken).Require();
+        var command = new ChatsBackend_ChangeEntry(ChatEntryId.New(chatId, 0),
+            null,
+            Change.Create(new ChatEntryDiff {
+                AuthorId = author.Id,
+                Content = text,
+                Audio = new ChatEntryAudio { MediaId = MediaId.Parse("fake:mediaid") },
+                BeginsAt = now,
+                EndsAt = now,
+            }));
+        return await AliceTester.Commander.Call(command, cancellationToken: cancellationToken);
+    }
+
     private async Task<List<ChatEntry>> CreateEntries(ChatId chatId, params IEnumerable<string> texts)
     {
         var entries = new List<ChatEntry>();
@@ -379,7 +420,9 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
     {
         var chatId = entries.Select(x => x.ChatId).Distinct().Single();
         var lids = entries.Select(x => x.LocalId).ToHashSet();
-        ChatUI.ItemVisibility.Value = new ChatViewItemVisibility(chatId, lids.Select(lid => ChatMessageKey.New(ChatMessageKind.None, lid)).ToHashSet(), true);
+        ChatUI.ItemVisibility.Value = new ChatViewItemVisibility(chatId,
+            lids.Select(lid => ChatMessageKey.New(ChatMessageKind.None, lid)).ToHashSet(),
+            true);
     }
 
     private void ClearVisibleItems(ChatId chatId)
@@ -416,7 +459,8 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
             return translation;
         }, TimeSpan.FromSeconds(10).Debuggable());
 
-    private async Task<List<Translation?>> GetTranslations(IEnumerable<ChatEntry> entries, CancellationToken cancellationToken)
+    private async Task<List<Translation?>> GetTranslations(
+        IEnumerable<ChatEntry> entries, CancellationToken cancellationToken)
     {
         var translations = new List<Translation?>();
         foreach (var entry in entries) {


### PR DESCRIPTION
## Problem

Some voice messages are never translated: no translation indicator appears and enabling translation has no effect — yet forwarding the same message to another chat translates it fine (reported for Spanish voice messages in production).

## Root cause

Since 9d0b53124d (Mar 10, 2026), voice messages transcribed in **auto language detection mode** (no fixed transcription language selected for the chat) never persist their `ChatEntryLanguage`:

- `TranscribeAudio` skips `CreateLanguages` in detect mode, deferring persistence to finalization — but `FinalizeLanguages()` early-returned when `entryLanguage is null`, which is always the case in detect mode. So nothing was ever saved.
- Language detection is skipped for audio-backed entries (`SupportsLanguageDetection` assumes "languages are already saved for transcribed messages"), so nothing ever backfills the record.
- `TranslationUI` treats an entry with no saved languages as non-foreign → `MustTranslate` is false → no icon, no translation, and no live transcript translation either.

Forwarding works because the copy is a plain text entry (no audio), which is always translated.

## Fix

1. **Root cause** (`AudioStreamingBackend.ProcessAudio.cs`): `FinalizeLanguages` now creates the language record when it doesn't exist, so detect-mode entries persist their detected languages on finalization.
2. **Existing entries** (`TranslationUI.cs`): a voice entry with no saved languages is now assumed foreign when deciding whether to translate, so the ~4 months of already-produced affected entries translate without a backfill. The translation-suggestion heuristic intentionally keeps treating them as non-foreign to avoid spurious suggestions (the original intent of 9d0b53124d).
3. **Refactoring**: `IsForeignEntry(entryId, expectTranslationLanguageOnly)` is split into two compute methods — `MayNeedTranslation` (drives the per-entry translation decision) and `MaySuggestTranslation` (drives the enable-translation suggestion) — with the shared own-message check extracted into a helper.

Also fixes pre-existing style violations in the touched files (indentation, brace style, member ordering, line lengths).

## Testing

- Added `ShouldTranslateVoiceEntryWithNoSavedLanguages` (Nightly integration test): a finalized audio-backed entry with no language record must translate.
- Ran the full `TranslationUITest` suite: 13 passed, 1 pre-existing skip.
- Ran `TranslationTest` + `RetranscribeTranslationFlowTest` (Chat.IntegrationTests): 11 passed, 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AtykkcswDBKjHn34zyRR7
