### PR TITLE
fix(sharding): shard ownership and routing hardening

### DIFF
--- a/src/dotnet/Chat.Service/ShardRoutingMonitor.cs
+++ b/src/dotnet/Chat.Service/ShardRoutingMonitor.cs
@@ -51,13 +51,13 @@ public sealed class ShardRoutingMonitor(IServiceProvider services) : WorkerBase
         if (expected == null)
             return null; // The shard has no owner yet - the mesh is in transition
 
-        var direct = await Backend.GetShardHostIdNonComputed(shardIndex, cancellationToken)
+        var direct = await Backend.GetShardHostIdNonComputed(ShardKey.New(shardIndex), cancellationToken)
             .WaitAsync(CallTimeout, cancellationToken).ConfigureAwait(false);
 
         var probeComputed = _probeComputeds[shardIndex];
         if (probeComputed == null)
             probeComputed = await Computed
-                .Capture(() => Backend.GetShardHostId(shardIndex, cancellationToken), cancellationToken)
+                .Capture(() => Backend.GetShardHostId(ShardKey.New(shardIndex), cancellationToken), cancellationToken)
                 .AsTask().WaitAsync(CallTimeout, cancellationToken).ConfigureAwait(false);
         else {
             // A consistent computed is reused as-is: that's exactly what makes a frozen one detectable

--- a/src/dotnet/Core.Server/Mesh/MeshWatcher.cs
+++ b/src/dotnet/Core.Server/Mesh/MeshWatcher.cs
@@ -6,6 +6,7 @@ public sealed class MeshWatcher : WorkerBase, IHasServices
     private readonly MutableState<ImmutableArray<MeshNode>> _onlineNodes;
     private readonly ComputedState<MeshState> _state;
     private ImmutableArray<MeshNode> _lastNodes;
+    private int _listNodesFailureCount;
 
     private IMeshLocks EndpointLocks { get; }
     private IMeshLocks NodeLocks { get; }
@@ -186,9 +187,15 @@ public sealed class MeshWatcher : WorkerBase, IHasServices
                     return false;
                 }).Order());
             _lastNodes = nodes; // This method isn't called concurrently, so it's safe to update
+            _listNodesFailureCount = 0;
             return nodes;
         }
         catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
+            // Serving the last known list keeps the mesh going, but a persistent failure
+            // means the topology is frozen - it must be visible in logs
+            _listNodesFailureCount++;
+            Log.LogError(e, "ListNodes failed ({FailureCount} in a row) @ {MeshNode} - using the last known node list",
+                _listNodesFailureCount, ThisNode.Ref.Value);
             return _lastNodes;
         }
     }

--- a/src/dotnet/Core.Server/Module/CoreServerModule.cs
+++ b/src/dotnet/Core.Server/Module/CoreServerModule.cs
@@ -1,5 +1,4 @@
 ﻿using ActualChat.Blobs.Internal;
-using ActualChat.Geo;
 using ActualChat.Hosting;
 using ActualChat.AspNetCore;
 using ActualChat.Diagnostics;
@@ -31,6 +30,7 @@ public sealed class CoreServerModule(IServiceProvider moduleServices)
         services.AddRpcHost(HostInfo, Log);
 
         // ShardOwners
+        ShardKeyResolvers.MustThrowOnNotFound |= HostInfo.BaseUrlKind != BaseUrlKind.Production;
         services.AddSingleton(c => new ShardOwners(c));
 
         // Queues

--- a/src/dotnet/Core.Server/Rpc/MeshRpcPeerRef.cs
+++ b/src/dotnet/Core.Server/Rpc/MeshRpcPeerRef.cs
@@ -44,7 +44,9 @@ public sealed class MeshRpcPeerRef : RpcPeerRef
             // Gating this on a MustOwn snapshot is racy: ShardOwner may lag behind the mesh map,
             // and local calls made via an awaiter-less ref get no shard ownership dependency,
             // so their computeds are never invalidated once the shard migrates away.
-            var isLocal = Resolved.Node == Owner.ThisNode;
+            // ConnectionKind (vs Node == ThisNode) also covers the endpoint-equality branch:
+            // whenever calls execute locally, they must gate on local shard ownership.
+            var isLocal = Resolved.ConnectionKind == RpcPeerConnectionKind.Local;
             if (isLocal) {
                 RouteState.LocalExecutionAwaiter = GetLocalExecutionAwaiter(RouteState);
                 _ = MarkChangedWhenShardOwnershipEnds();

--- a/src/dotnet/Core.Server/Sharding/ShardKeyResolvers.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardKeyResolvers.cs
@@ -19,15 +19,24 @@ public static class ShardKeyResolvers
 
     private static readonly ConcurrentDictionary<Type, Delegate> Registered = new();
 
+    // Set at host startup, before the first resolution (resolvers are cached per type).
+    // Production keeps the warning + hash-based fallback; everywhere else it's better to fail fast:
+    // for reference types without a stable hash the fallback routes the same entity
+    // to different shards on different nodes.
+    public static bool MustThrowOnNotFound { get; set; }
+
     public static ShardKeyResolver<T> NewHashBased<T>() => static x => x?.GetHashCode() ?? 0;
     public static ShardKeyResolver<T?> NewNullable<T>(ShardKeyResolver<T> nonNullableResolver)
         where T : struct
         => source => source is { } v
             ? nonNullableResolver.Invoke(v)
             : 0;
-    //public static ShardKeyResolver<T> NewNotFound<T>() => static x => throw StandardError.Internal($"ShardKeyResolver not found for type {typeof(T).GetName()}.");
     public static ShardKeyResolver<T> NewNotFound<T>()
     {
+        if (MustThrowOnNotFound)
+            return static _ => throw StandardError.Internal(
+                $"ShardKeyResolver not found for type {typeof(T).GetName()}.");
+
         var hashBased = NewHashBased<T>();
         return x => {
             Log.LogWarning("ShardKeyResolver not found for type {TypeName}", typeof(T).GetName());

--- a/src/dotnet/Core.Server/Sharding/ShardOwner.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardOwner.cs
@@ -89,10 +89,11 @@ public sealed class ShardOwner : WorkerBase, IHasServices
         var cCurrent = addDependency ? Computed.Current : null;
         var ownershipStatus = shardState.OwnershipStatus;
         switch (ownershipStatus) {
-        case ShardOwnershipStatus.OwnedByThisNode:
+        case ShardOwnershipStatus.OwnedByThisNode when shardState.HasLiveOwnership:
             if (cCurrent is not null)
                 ComputedImpl.AddDependency(cCurrent, cShardState);
             return new(shardState.Ownership!);
+        case ShardOwnershipStatus.OwnedByThisNode: // The lock is lost, wait for it to be re-acquired
         case ShardOwnershipStatus.MappedToThisNode:
             return CompleteAsync();
         case ShardOwnershipStatus.MappedToOtherNode:
@@ -105,7 +106,7 @@ public sealed class ShardOwner : WorkerBase, IHasServices
 
         async ValueTask<ShardOwnership> CompleteAsync() {
             cShardState = await cShardState
-                .When(x => x.Ownership is not null || !x.MustOwn, FixedDelayer.YieldUnsafe, cancellationToken)
+                .When(x => x.HasLiveOwnership || !x.MustOwn, FixedDelayer.YieldUnsafe, cancellationToken)
                 .ConfigureAwait(false);
             if (cCurrent is not null)
                 ComputedImpl.AddDependency(cCurrent, cShardState);
@@ -228,7 +229,7 @@ public sealed class ShardOwner : WorkerBase, IHasServices
         DebugLog?.LogDebug("Shard #{ShardIndex}: ++ {ThisNodeId}", shardIndex, ThisNode.Ref);
 
         bool isAdded = false;
-        ShardOwnership ownership = null!;
+        ShardOwnership? ownership = null;
         var linkedCts = lockToken.LinkWith(cancellationToken);
         var linkedToken = linkedCts.Token;
         try {
@@ -251,8 +252,13 @@ public sealed class ShardOwner : WorkerBase, IHasServices
             linkedCts.CancelAndDisposeSilently();
         }
 
+        // The lock is lost or the shard is reassigned: stop claiming ownership right away,
+        // otherwise RequireShardOwnership keeps handing out an Ownership with a dead lock
+        if (ownership != null && ReferenceEquals(mutableState.Value.Ownership, ownership))
+            mutableState.Value = new ShardState(mutableState.Value, mustOwn: true);
+
         if (isAdded)
-            await Dispatcher.Remove(ownership).SilentAwait(false);
+            await Dispatcher.Remove(ownership!).SilentAwait(false);
         if (lockToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             Log.LogWarning("Shard #{ShardIndex}: -- {ThisNodeId} - lost the lock", shardIndex, ThisNode.Ref);
         else
@@ -269,6 +275,7 @@ public sealed class ShardOwner : WorkerBase, IHasServices
         public bool IsFinal { get; }
         public bool MustOwn { get; }
         public ShardOwnership? Ownership { get; }
+        public bool HasLiveOwnership => Ownership is { } ownership && !ownership.LockToken.IsCancellationRequested;
         public ShardOwnershipStatus OwnershipStatus { get; }
         public int Version { get; }
 

--- a/src/dotnet/Core.Server/Sharding/ShardOwner.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardOwner.cs
@@ -72,6 +72,9 @@ public sealed class ShardOwner : WorkerBase, IHasServices
         => Dispatcher.Use(shardRunnable);
 
     public Computed<ShardState> GetShardStateComputed<T>(T shardKey, bool addDependency)
+        => GetShardStateComputed(ShardScheme.GetShardIndex(shardKey), addDependency);
+
+    public Computed<ShardState> GetShardStateComputed(int shardKey, bool addDependency)
     {
         var shardIndex = ShardScheme.GetShardIndex(shardKey);
         var cShardState = States[shardIndex].Computed;
@@ -82,6 +85,9 @@ public sealed class ShardOwner : WorkerBase, IHasServices
     }
 
     public ValueTask<ShardOwnership> RequireShardOwnership<T>(T shardKey, bool addDependency, CancellationToken cancellationToken)
+        => RequireShardOwnership(ShardScheme.GetShardIndex(shardKey), addDependency, cancellationToken);
+
+    public ValueTask<ShardOwnership> RequireShardOwnership(int shardKey, bool addDependency, CancellationToken cancellationToken)
     {
         var shardIndex = ShardScheme.GetShardIndex(shardKey);
         var cShardState = States[shardIndex].Computed;

--- a/src/dotnet/Core.Server/Sharding/ShardRunnable.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardRunnable.cs
@@ -6,7 +6,7 @@ public sealed record ShardRunnable : IRunnable
 {
     public static readonly IRetryPolicy DefaultRetryPolicy = new RetryPolicy(RetryDelaySeq.Exp(0.1, 1));
     public static readonly IRetryPolicy NoRetryPolicy = new RetryPolicy(1, RetryDelaySeq.Exp(0.1, 1));
-    public static readonly RandomTimeSpan DefaultRepeatDelay = TimeSpan.FromMicroseconds(50).ToRandom(0.5);
+    public static readonly RandomTimeSpan DefaultRepeatDelay = TimeSpan.FromMilliseconds(50).ToRandom(0.5);
 
     public string Name { get; }
     public Delegate Func { get; }

--- a/src/dotnet/Core.Server/Sharding/ShardStateStateExt.cs
+++ b/src/dotnet/Core.Server/Sharding/ShardStateStateExt.cs
@@ -11,8 +11,9 @@ public static class ShardStateStateExt
         var computed = shardStateState.Computed;
         var shardState = computed.Value;
         switch (shardState.OwnershipStatus) {
-        case ShardOwnershipStatus.OwnedByThisNode:
+        case ShardOwnershipStatus.OwnedByThisNode when shardState.HasLiveOwnership:
             return new(computed);
+        case ShardOwnershipStatus.OwnedByThisNode: // The lock is lost, wait for it to be re-acquired
         case ShardOwnershipStatus.MappedToThisNode:
             return CompleteAsync();
         case ShardOwnershipStatus.MappedToOtherNode:
@@ -22,11 +23,11 @@ public static class ShardStateStateExt
         }
 
         async ValueTask<Computed<ShardOwner.ShardState>> CompleteAsync() {
-            static bool HasOwnershipOrMustNotOwn(ShardOwner.ShardState x)
-                => x.Ownership is not null || !x.MustOwn;
+            static bool HasLiveOwnershipOrMustNotOwn(ShardOwner.ShardState x)
+                => x.HasLiveOwnership || !x.MustOwn;
 
             computed = await shardStateState
-                .WhenUnsafe(HasOwnershipOrMustNotOwn, cancellationToken)
+                .WhenUnsafe(HasLiveOwnershipOrMustNotOwn, cancellationToken)
                 .ConfigureAwait(false);
             if (computed.Value.Ownership is not null)
                 return computed;

--- a/src/dotnet/Core/Identifiers/ShardKey.cs
+++ b/src/dotnet/Core/Identifiers/ShardKey.cs
@@ -12,10 +12,11 @@ namespace ActualChat;
 public readonly partial record struct ShardKey(
     [property: DataMember(Order = 0), MemoryPackOrder(0), Key(0)] int Value)
 {
+    public static ShardKey New(int value) => new(value);
+
     public override string ToString() => Value.Format();
 
     // Conversion
 
-    public static implicit operator ShardKey(int value) => new(value);
     public static implicit operator int(ShardKey shardKey) => shardKey.Value;
 }

--- a/tests/Core.Server.IntegrationTests/Commands/CommandsAndEvents.cs
+++ b/tests/Core.Server.IntegrationTests/Commands/CommandsAndEvents.cs
@@ -26,10 +26,10 @@ public partial record AddTestEvent1Command(
 public partial record AddBothTestEventsCommand : ICommand<Unit>;
 
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject(true)]
-public partial record AddBothTestEventsCommandWithShardKey : ICommand<Unit>, IHasShardKey<int>, IHasQueueRef
+public partial record AddBothTestEventsCommandWithShardKey : ICommand<Unit>, IHasShardKey<ShardKey>, IHasQueueRef
 {
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
-    public int ShardKey { get; init; }
+    public ShardKey ShardKey { get; init; }
 
     QueueRef IHasQueueRef.QueueRef => ShardScheme.SlowQueue;
 }

--- a/tests/Core.Server.IntegrationTests/Commands/NatsQueueTest.cs
+++ b/tests/Core.Server.IntegrationTests/Commands/NatsQueueTest.cs
@@ -94,7 +94,7 @@ public class NatsQueueTest(ITestOutputHelper @out)
         var testService = (ScheduledCommandTestService)services.GetRequiredService<IScheduledCommandTestService>();
         testService.ProcessedEvents.Count.Should().Be(0);
 
-        var command = new AddBothTestEventsCommandWithShardKey { ShardKey = 7 };
+        var command = new AddBothTestEventsCommandWithShardKey { ShardKey = ShardKey.New(7) };
         var queueRef = QueueRef.For(command, services);
         queueRef.ShardScheme.Should().Be(ShardScheme.SlowQueue);
 

--- a/tests/Core.Server.IntegrationTests/Routing/RoutingStressTest.cs
+++ b/tests/Core.Server.IntegrationTests/Routing/RoutingStressTest.cs
@@ -59,8 +59,8 @@ public class RoutingStressTest(ITestOutputHelper @out)
         // Set a value on host1
         var key = "test-key";
         var value1 = "value-from-h1";
-        await s1.SetValue(0, key, value1);
-        var result = await s1.GetValue(0, key);
+        await s1.SetValue(ShardKey.New(0), key, value1);
+        var result = await s1.GetValue(ShardKey.New(0), key);
         result.Value.Should().Be(value1);
         result.HostNodeRef.Should().Be(w1.ThisNode.Ref.Value);
         WriteLine($"Set and got value on h1: {result.Value} from {result.HostNodeRef}");
@@ -91,15 +91,15 @@ public class RoutingStressTest(ITestOutputHelper @out)
         }, TimeSpan.FromSeconds(15));
 
         // Value should still be accessible (may route to h1 or h2 depending on shard ownership)
-        var result2 = await s2.GetValue(0, key);
+        var result2 = await s2.GetValue(ShardKey.New(0), key);
         // Note: The value might be empty if shard 0 moved to h2 (which has empty storage)
         WriteLine($"Got value from h2's perspective: {result2.Value} from {result2.HostNodeRef}");
 
         // Test value on different shard key
         var key2 = "key2";
         var value2 = "value2";
-        await s2.SetValue(1, key2, value2);
-        var result3 = await s1.GetValue(1, key2);
+        await s2.SetValue(ShardKey.New(1), key2, value2);
+        var result3 = await s1.GetValue(ShardKey.New(1), key2);
         result3.Value.Should().Be(value2);
         WriteLine($"Cross-host routing works: got '{result3.Value}' from {result3.HostNodeRef}");
     }
@@ -149,8 +149,8 @@ public class RoutingStressTest(ITestOutputHelper @out)
 
         // Capture a computed value
         var key = "invalidation-test";
-        await s1.SetValue(0, key, "initial");
-        var computed = await Computed.Capture(() => s1.GetValue(0, key));
+        await s1.SetValue(ShardKey.New(0), key, "initial");
+        var computed = await Computed.Capture(() => s1.GetValue(ShardKey.New(0), key));
         computed.Value.Value.Should().Be("initial");
         var initialHostRef = computed.Value.HostNodeRef;
         WriteLine($"Initial computed from {initialHostRef}: {computed.Value.Value}");
@@ -166,7 +166,7 @@ public class RoutingStressTest(ITestOutputHelper @out)
         WriteLine($"Host2 joined: {w2.ThisNode.Ref}");
 
         // Update value on h2 for the same key (different shard)
-        await s2.SetValue(1, key, "updated");
+        await s2.SetValue(ShardKey.New(1), key, "updated");
 
         // The computed should eventually update (either same value or rerouted)
         // Note: If shard 0 moves to h2, the value will be empty because h2's storage is empty.
@@ -189,7 +189,7 @@ public class RoutingStressTest(ITestOutputHelper @out)
         WriteLine("H2 detected h1 is gone");
 
         // Now calling s2 should work and return values from h2
-        var result = await s2.GetValue(0, key);
+        var result = await s2.GetValue(ShardKey.New(0), key);
         result.HostNodeRef.Should().Be(w2.ThisNode.Ref.Value);
         WriteLine($"After h1 disposal, got value from {result.HostNodeRef}: {result.Value}");
     }
@@ -222,7 +222,7 @@ public class RoutingStressTest(ITestOutputHelper @out)
             var rnd = new Random();
             for (var i = 0; i < callCount && !cancellationToken.IsCancellationRequested; i++) {
                 try {
-                    var shardKey = rnd.Next(0, 10);
+                    var shardKey = ShardKey.New(rnd.Next(0, 10));
                     var key = $"call-{i}";
                     var value = $"value-{i}";
 
@@ -306,7 +306,7 @@ public class RoutingStressTest(ITestOutputHelper @out)
 
         for (var i = 0; i < callCount && !cancellationToken.IsCancellationRequested; i++) {
             try {
-                var shardKey = rnd.Next(0, ShardScheme.TestBackend.ShardCount);
+                var shardKey = ShardKey.New(rnd.Next(0, ShardScheme.TestBackend.ShardCount));
                 var key = $"{workerName}-key-{i}";
                 var value = $"{workerName}-value-{i}";
 

--- a/tests/Core.Server.IntegrationTests/Sharding/ShardLockLossTest.cs
+++ b/tests/Core.Server.IntegrationTests/Sharding/ShardLockLossTest.cs
@@ -1,0 +1,78 @@
+using ActualChat.Testing.Host;
+
+namespace ActualChat.Core.Server.IntegrationTests.Sharding;
+
+[Trait("Category", "Slow")]
+public class ShardLockLossTest(ITestOutputHelper @out)
+    : AppHostTestBase($"x-{nameof(ShardLockLossTest)}",
+        TestAppHostOptions.None with { MustStart = true }, @out)
+{
+    [Fact]
+    public async Task LockLossMustDowngradeShardState()
+    {
+        // Reproduces the stale-ownership hole: when the shard's lock is lost while the mesh
+        // map is unchanged, ShardState keeps claiming OwnedByThisNode with a dead lock,
+        // so RequireShardOwnership hands out an Ownership another node may already hold.
+
+        // arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        var cancellationToken = cts.Token;
+        var shardScheme = ShardScheme.TestBackend;
+        const int shard = 0;
+
+        await using var h1 = await NewAppHost();
+        var owner = h1.Services.ShardOwner(shardScheme);
+        var shardState = owner.States[shard];
+        await ComputedTest.When(async ct => {
+            var state = await shardState.Use(ct).ConfigureAwait(false);
+            state.OwnershipStatus.Should().Be(ShardOwnershipStatus.OwnedByThisNode);
+        }, TimeSpan.FromSeconds(30));
+
+        var ownership = shardState.Computed.Value.Ownership!;
+        // The same locks ShardOwners builds for this scheme, see ShardOwners.OwnershipLocks
+        var locks = h1.Services.MeshLocks()
+            .WithKeyPrefix(nameof(ShardOwners))
+            .WithKeyPrefix(shardScheme.Name);
+        var lockKey = shard.Format();
+        locks.GetFullKey(lockKey).Should().Be(ownership.LockHolder.FullKey);
+
+        // act: kill the lock behind ShardOwner's back and grab it ourselves,
+        // so h1 can't re-acquire it - like another node would during a rebalance
+        (await locks.Backend.ForceRelease(lockKey, mustNotify: true, cancellationToken)).Should().BeTrue();
+        var blocker = await locks.Lock(lockKey, cancellationToken);
+        try {
+            // The holder discovers the loss on its next renewal (~5s with MeshLockOptions.Test)
+            await TaskExt.NeverEnding(ownership.LockToken).SuppressExceptions()
+                .WaitAsync(TimeSpan.FromSeconds(60), cancellationToken);
+            WriteLine("The lock loss is detected by the holder");
+
+            // assert
+            await ComputedTest.When(async ct => {
+                var state = await shardState.Use(ct).ConfigureAwait(false);
+                WriteLine($"ShardState: {state.OwnershipStatus}, lock cancelled: "
+                    + $"{state.Ownership?.LockToken.IsCancellationRequested.ToString() ?? "no ownership"}");
+                var isStaleOwned = state.Ownership is { } o && o.LockToken.IsCancellationRequested;
+                isStaleOwned.Should().BeFalse(
+                    "the shard state must not claim ownership backed by a lost lock");
+            }, TimeSpan.FromSeconds(10));
+
+            // And RequireShardOwnership must not hand out a dead ownership either
+            var ownershipTask = owner
+                .RequireShardOwnership((ShardKey)shard, addDependency: false, cancellationToken)
+                .AsTask();
+            await Task.WhenAny(ownershipTask, Task.Delay(TimeSpan.FromSeconds(2), cancellationToken));
+            if (ownershipTask is { IsCompletedSuccessfully: true, Result.LockToken.IsCancellationRequested: true })
+                Assert.Fail("RequireShardOwnership returned an ownership whose lock is already lost");
+        }
+        finally {
+            await blocker.DisposeAsync();
+        }
+
+        // Recovery: once the lock is available again, h1 must re-acquire it
+        await ComputedTest.When(async ct => {
+            var state = await shardState.Use(ct).ConfigureAwait(false);
+            state.OwnershipStatus.Should().Be(ShardOwnershipStatus.OwnedByThisNode);
+            state.Ownership!.LockToken.IsCancellationRequested.Should().BeFalse();
+        }, TimeSpan.FromSeconds(30));
+    }
+}

--- a/tests/Core.Server.IntegrationTests/Sharding/ShardLockLossTest.cs
+++ b/tests/Core.Server.IntegrationTests/Sharding/ShardLockLossTest.cs
@@ -58,7 +58,7 @@ public class ShardLockLossTest(ITestOutputHelper @out)
 
             // And RequireShardOwnership must not hand out a dead ownership either
             var ownershipTask = owner
-                .RequireShardOwnership((ShardKey)shard, addDependency: false, cancellationToken)
+                .RequireShardOwnership(ShardKey.New(shard), addDependency: false, cancellationToken)
                 .AsTask();
             await Task.WhenAny(ownershipTask, Task.Delay(TimeSpan.FromSeconds(2), cancellationToken));
             if (ownershipTask is { IsCompletedSuccessfully: true, Result.LockToken.IsCancellationRequested: true })

--- a/tests/Core.Server.UnitTests/Sharding/MeshRefResolversTest.cs
+++ b/tests/Core.Server.UnitTests/Sharding/MeshRefResolversTest.cs
@@ -14,22 +14,22 @@ public class MeshRefResolversTest(ITestOutputHelper @out) : TestBase(@out)
         var r0u = MeshRefResolvers.GetUntyped(typeof(MeshRefResolversTest));
         r0u.Invoke(this).Should().Be(MeshRef.Shard(GetHashCode()));
 
-        var r1 = MeshRefResolvers.Get<int>();
-        r1.Invoke(0).Should().Be(MeshRef.Shard(0));
-        r1.Invoke(10).Should().Be(MeshRef.Shard(10));
+        var r1 = MeshRefResolvers.Get<ShardKey>();
+        r1.Invoke(ShardKey.New(0)).Should().Be(MeshRef.Shard(0));
+        r1.Invoke(ShardKey.New(10)).Should().Be(MeshRef.Shard(10));
 
-        var r1u = MeshRefResolvers.GetUntyped(typeof(int));
-        r1u.Invoke(0).Should().Be(MeshRef.Shard(0));
-        r1u.Invoke(10).Should().Be(MeshRef.Shard(10));
+        var r1u = MeshRefResolvers.GetUntyped(typeof(ShardKey));
+        r1u.Invoke(ShardKey.New(0)).Should().Be(MeshRef.Shard(0));
+        r1u.Invoke(ShardKey.New(10)).Should().Be(MeshRef.Shard(10));
 
-        var r2 = MeshRefResolvers.Get<int?>();
-        r2.Invoke(0).Should().Be(MeshRef.Shard(0));
-        r2.Invoke(10).Should().Be(MeshRef.Shard(10));
+        var r2 = MeshRefResolvers.Get<ShardKey?>();
+        r2.Invoke(ShardKey.New(0)).Should().Be(MeshRef.Shard(0));
+        r2.Invoke(ShardKey.New(10)).Should().Be(MeshRef.Shard(10));
         r2.Invoke(null).Should().Be(MeshRef.Shard(0));
 
-        var r2u = MeshRefResolvers.GetUntyped(typeof(int?));
-        r2u.Invoke(0).Should().Be(MeshRef.Shard(0));
-        r2u.Invoke(10).Should().Be(MeshRef.Shard(10));
+        var r2u = MeshRefResolvers.GetUntyped(typeof(ShardKey?));
+        r2u.Invoke(ShardKey.New(0)).Should().Be(MeshRef.Shard(0));
+        r2u.Invoke(ShardKey.New(10)).Should().Be(MeshRef.Shard(10));
         r2u.Invoke(null).Should().Be(MeshRef.Shard(0));
 
         var r3 = MeshRefResolvers.Get<NodeRef>();
@@ -54,8 +54,8 @@ public class MeshRefResolversTest(ITestOutputHelper @out) : TestBase(@out)
 
     public sealed record TestNodeCommand(NodeRef NodeRef) : IHasNodeRef;
 
-    public sealed record TestShardCommand(int Value) : IHasShardKey<int>
+    public sealed record TestShardCommand(int Value) : IHasShardKey<ShardKey>
     {
-        int IHasShardKey<int>.ShardKey => Value;
+        ShardKey IHasShardKey<ShardKey>.ShardKey => ShardKey.New(Value);
     }
 }


### PR DESCRIPTION
## What's done

A batch of fixes from the shard-switching code review (follow-up to the frozen-presence investigation).

### 1. A lost distributed lock left the node claiming shard ownership
On lock loss (Redis hiccup, expiry during a GC pause) `ShardOwner.LockAndUse` never downgraded `ShardState`: until re-acquisition, `RequireShardOwnership` kept handing out an `Ownership` backed by a dead lock — a dual-ownership window when mesh maps diverge. Now the state is downgraded to `MappedToThisNode` right away (which also invalidates dependent computeds), and both `RequireShardOwnership` fast paths accept only a live lock (`ShardState.HasLiveOwnership`).

Repro test: `ShardLockLossTest` — deterministically kills the lock via `ForceRelease` and blocks re-acquisition; failed 2/2 before the fix, green after, including the recovery phase.

### 2. Fail fast on unregistered shard key types outside production
The silent hash-based fallback in `ShardKeyResolvers` routes the same entity to different shards on different nodes for reference types without a stable hash. Outside production (`BaseUrlKind != Production`) it now throws immediately; production keeps the warning + fallback. Along the way: `int` is no longer a registered shard key (`IHasShardKey<int>` declarations migrated to `IHasShardKey<ShardKey>`, `ShardOwner` got int overloads, `ShardKey` dropped the implicit int cast in favor of `ShardKey.New`). The fail-fast paid off on its first run by catching an `IHasShardKey<int>` command on the fallback path.

### 3. `LocalExecutionAwaiter` gated by the RPC layer's own criterion
`MeshRpcPeerRef` set the ownership gate only when `Node == ThisNode`, while `ConnectionKind.Local` also covers endpoint equality with a stale dead node — local execution with no gate, the same frozen-computed class of bugs. `isLocal` now mirrors the RPC layer's criterion.

### 4. `ShardRunnable.DefaultRepeatDelay`: 50 us → 50 ms
A units typo: a runnable whose func returns was re-run ~20k times/sec. Latent so far (current workers loop forever), but the mine is defused.

### 5. Frozen-topology observability
On failure `MeshWatcher.ListNodes` silently served the last known node list — a persistently failing `ListKeys` froze the topology with zero log output. Now it logs an error with an in-a-row failure counter (the fallback behavior is preserved).

## Tests
- New: `ShardLockLossTest` (repro + recovery).
- Ran: Sharding + Routing Slow set — 15/15 (including `TwoWaveRebalance`, `MultiWaveRebalance`, `ShardRoutingMonitorTest`); non-Slow `Core.Server.IntegrationTests` — 67/67 (+5 manual skips); `Core.Server.UnitTests` — 225/225.

## Known, deliberately not included
Dead-node resources are never released: a node-only peer ref stays in `MeshRpcPeerRefs._peerRefs`, and its `RpcPeer` (no `RouteState`, no reconnect limit) retries the connection forever. The proper fix touches node-ref semantics (`RouteState` + `MarkChanged` on node death) — split off into a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)