### PR TITLE
fix(android): eliminate main-thread ANRs and WebView onCreateWindow c…

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/AndroidWebChromeClient.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidWebChromeClient.cs
@@ -158,7 +158,18 @@ public class AndroidWebChromeClient : WebChromeClient
     }
 
     public override bool OnCreateWindow(WebView? view, bool isDialog, bool isUserGesture, Message? resultMsg)
-        => _client.OnCreateWindow(view, isDialog, isUserGesture, resultMsg);
+    {
+        try {
+            return _client.OnCreateWindow(view, isDialog, isUserGesture, resultMsg);
+        }
+        catch (Exception e) {
+            // A target=_blank / window.open() whose URL has no handling activity makes the default
+            // client throw (e.g. ActivityNotFoundException) on the UI thread, crashing the app.
+            // Decline the new window instead.
+            Log.LogWarning(e, "OnCreateWindow failed");
+            return false;
+        }
+    }
     public override void OnCloseWindow(WebView? window)
         => _client.OnCloseWindow(window);
     public override void OnGeolocationPermissionsHidePrompt()

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
@@ -60,6 +60,8 @@ public class AndroidAudioWidgetForegroundService : Service
             return StartCommandResult.Sticky;
 
         var mode = (AudioWidgetMode)(intent!.Extras?.GetInt(IntentExtras.Mode) ?? 0);
+        if (!Enum.IsDefined(mode))
+            mode = AudioWidgetMode.Listening;
         // Android requires StartForeground() within ~5s of StartForegroundService(). Call it up-front
         // with a placeholder so a throw while building the rich notification (unexpected mode,
         // ChatId.Parse) can't leave the service without one -> ForegroundServiceDidNotStartInTimeException.

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
@@ -59,7 +59,12 @@ public class AndroidAudioWidgetForegroundService : Service
         if ((intent?.Action ?? "") != ActionShow)
             return StartCommandResult.Sticky;
 
-        var mode = (AudioWidgetMode)intent!.Extras!.GetInt(IntentExtras.Mode);
+        var mode = (AudioWidgetMode)(intent!.Extras?.GetInt(IntentExtras.Mode) ?? 0);
+        // Android requires StartForeground() within ~5s of StartForegroundService(). Call it up-front
+        // with a placeholder so a throw while building the rich notification (unexpected mode,
+        // ChatId.Parse) can't leave the service without one -> ForegroundServiceDidNotStartInTimeException.
+        StartForeground1(BuildStartingNotification());
+
         var chatTitle = intent.Extras!.GetString(IntentExtras.ChatTitle) ?? "Unknown chat";
         var chatSid = intent.Extras!.GetString(IntentExtras.ChatId);
         var chatPicUrl = intent.Extras!.GetString(IntentExtras.ChatPicUri) ?? "";
@@ -173,6 +178,12 @@ public class AndroidAudioWidgetForegroundService : Service
             });
         }, TaskScheduler.Default);
     }
+
+    private Android.App.Notification BuildStartingNotification()
+        => new NotificationCompat.Builder(this, ChannelId)
+            .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
+            .SetOngoing(true)!
+            .Build()!;
 
     private Android.App.Notification BuildNotification(MediaSessionCompat mediaSession, string link)
     {

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -168,33 +168,36 @@ public partial class MainActivity : MauiAppCompatActivity
 
     private void DumpMemoryInfo()
     {
-        var activityManager = (ActivityManager)GetSystemService(ActivityService)!;
-        var memoryClass = activityManager.MemoryClass;
-        Log.LogInformation("MemoryClass: {MemoryClass}", memoryClass);
-        var memoryInfo = new ActivityManager.MemoryInfo();
-        activityManager.GetMemoryInfo(memoryInfo);
-        Log.LogInformation("MemoryInfo: AvailMem={AvailMem}, TotalMem={TotalMem}, LowMemory={LowMemory}, Threshold={Threshold}",
-            memoryInfo.AvailMem,
-            memoryInfo.TotalMem,
-            memoryInfo.LowMemory,
-            memoryInfo.Threshold);
-        var processInfo = new ActivityManager.RunningAppProcessInfo();
-        ActivityManager.GetMyMemoryState(processInfo);
-        Log.LogInformation(
-            "MyMemoryState: Pid={Pid}, LastTrimLevel={LastTrimLevel}, Lru={Lru}, Importance={Importance}, ImportanceReasonCode={ImportanceReasonCode}",
-            processInfo.Pid,
-            processInfo.LastTrimLevel,
-            processInfo.Lru,
-            processInfo.Importance,
-            processInfo.ImportanceReasonCode);
+        try {
+            var activityManager = (ActivityManager)GetSystemService(ActivityService)!;
+            var memoryClass = activityManager.MemoryClass;
+            Log.LogInformation("MemoryClass: {MemoryClass}", memoryClass);
+            var memoryInfo = new ActivityManager.MemoryInfo();
+            activityManager.GetMemoryInfo(memoryInfo);
+            Log.LogInformation("MemoryInfo: AvailMem={AvailMem}, TotalMem={TotalMem}, LowMemory={LowMemory}, Threshold={Threshold}",
+                memoryInfo.AvailMem,
+                memoryInfo.TotalMem,
+                memoryInfo.LowMemory,
+                memoryInfo.Threshold);
+            var processInfo = new ActivityManager.RunningAppProcessInfo();
+            ActivityManager.GetMyMemoryState(processInfo);
+            Log.LogInformation(
+                "MyMemoryState: Pid={Pid}, LastTrimLevel={LastTrimLevel}, Lru={Lru}, Importance={Importance}, ImportanceReasonCode={ImportanceReasonCode}",
+                processInfo.Pid,
+                processInfo.LastTrimLevel,
+                processInfo.Lru,
+                processInfo.Importance,
+                processInfo.ImportanceReasonCode);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "DumpMemoryInfo failed");
+        }
     }
 
     private class SplashDelayer(AView contentView) : JObject, ViewTreeObserver.IOnPreDrawListener
     {
-        // Failsafe cap on the pre-draw hold. Suspending the first frame until the WebView/Blazor
-        // startup callback fires is fine only if that callback is guaranteed to arrive - but on a
-        // stalled/warm-start boot it may not, and holding forever starves input dispatch, which
-        // Android reports as a "no focused window" ANR. Release the frame after this regardless.
+        // Cap the pre-draw hold: if the WebView callback never arrives, holding forever starves
+        // input dispatch and Android reports a "no focused window" ANR.
         private static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(4);
         private static readonly Task WhenRemoved = MauiLoadingUI.WhenFirstWebViewCreated;
         private readonly CpuTimestamp _startedAt = CpuTimestamp.Now;

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -133,8 +133,11 @@ public partial class MainActivity : MauiAppCompatActivity
     public override void OnTrimMemory(TrimMemory level)
     {
         Log.LogInformation("OnTrimMemory, Level: {Level}", level);
-        DumpMemoryInfo();
         base.OnTrimMemory(level);
+        // Diagnostics only, so run off the UI thread: OnTrimMemory fires under memory pressure -
+        // exactly when the managed runtime is busy collecting - and the JNI-heavy dump below blocks
+        // the UI thread long enough to be reported as an ANR.
+        _ = Task.Run(DumpMemoryInfo);
     }
 
     public void RequestPermission(string permission, Action<bool> onReceiveResult, bool throwIfHavePendingRequest = false)
@@ -188,11 +191,17 @@ public partial class MainActivity : MauiAppCompatActivity
 
     private class SplashDelayer(AView contentView) : JObject, ViewTreeObserver.IOnPreDrawListener
     {
+        // Failsafe cap on the pre-draw hold. Suspending the first frame until the WebView/Blazor
+        // startup callback fires is fine only if that callback is guaranteed to arrive - but on a
+        // stalled/warm-start boot it may not, and holding forever starves input dispatch, which
+        // Android reports as a "no focused window" ANR. Release the frame after this regardless.
+        private static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(4);
         private static readonly Task WhenRemoved = MauiLoadingUI.WhenFirstWebViewCreated;
+        private readonly CpuTimestamp _startedAt = CpuTimestamp.Now;
 
         public bool OnPreDraw()
         {
-            if (!WhenRemoved.IsCompleted)
+            if (!WhenRemoved.IsCompleted && CpuTimestamp.Now - _startedAt < MaxDelay)
                 return false;
 
             contentView.ViewTreeObserver!.RemoveOnPreDrawListener(this);

--- a/src/dotnet/Maui/Services/MauiBackgroundState.cs
+++ b/src/dotnet/Maui/Services/MauiBackgroundState.cs
@@ -3,12 +3,12 @@ namespace ActualChat.Maui.Services;
 /// <summary>
 /// Static background state shared across the Maui layer.
 /// Set by platform-specific code (AppDelegate on iOS, lifecycle events on Android/Windows).
-/// Consumed by <see cref="SQLiteBatchingKvasBackend"/> to auto-suspend when backgrounded.
+/// Consumed by <see cref="SQLiteBatchingKvasBackend"/> to suspend/resume when backgrounded.
 /// </summary>
 public static class MauiBackgroundState
 {
     private static readonly Lock Lock = new();
-    private static readonly List<Action> SuspendHandlers = [];
+    private static readonly List<Action<bool>> StateHandlers = [];
     private static readonly MutableState<bool> IsBackgroundMutable
         = StateFactory.Default.NewMutable(
             initialValue: false,
@@ -17,23 +17,24 @@ public static class MauiBackgroundState
     // ReSharper disable once InconsistentlySynchronizedField
     public static IState<bool> IsBackground => IsBackgroundMutable;
 
-    // Handlers run synchronously inside Set(true) so platform callbacks can wait.
-    public static void RegisterSuspendHandler(Action handler)
+    // Handlers run synchronously inside Set so the platform callback (e.g. iOS DidEnterBackground,
+    // still holding its background-task assertion) can wait for suspend work to finish.
+    public static void RegisterStateHandler(Action<bool> handler)
     {
         lock (Lock)
-            SuspendHandlers.Add(handler);
+            StateHandlers.Add(handler);
     }
 
     public static void Set(bool isBackground)
     {
-        Action[] handlersToRun;
+        Action<bool>[] handlersToRun;
         lock (Lock) {
             IsBackgroundMutable.Value = isBackground;
-            handlersToRun = isBackground ? SuspendHandlers.ToArray() : [];
+            handlersToRun = StateHandlers.ToArray();
         }
         foreach (var handler in handlersToRun)
             try {
-                handler();
+                handler(isBackground);
             }
             catch {
                 // ignored

--- a/src/dotnet/Maui/Services/SQLiteBatchingKvasBackend.cs
+++ b/src/dotnet/Maui/Services/SQLiteBatchingKvasBackend.cs
@@ -35,7 +35,12 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
 
         var hostInfo = services.HostInfo();
         if (hostInfo.AppKind is AppKind.Ios or AppKind.MacOS)
-            MauiBackgroundState.RegisterSuspendHandler(Suspend);
+            MauiBackgroundState.RegisterStateHandler(isBackground => {
+                if (isBackground)
+                    Suspend();
+                else
+                    Resume();
+            });
     }
 
     public ValueTask<byte[]?[]> GetMany(string[] keys, CancellationToken cancellationToken = default)
@@ -47,25 +52,23 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
         if (_connectionPool == null)
             return ValueTask.FromResult(result);
 
-        Resume();
-        using var lease = _connectionPool.Rent();
-        var connection = lease.Resource;
-        if (keys.Length == 1)
-            result[0] = DbHelpers.Find(connection, keys[0])?.Value;
-        else if (keys.Length < 16) {
-            // Small number of keys, use a simple loop
-            foreach (var dbItem in DbHelpers.FindMany(connection, keys))
-                result[FindIndex(keys, dbItem.Key)] = dbItem.Value;
-        }
-        else {
-            // Large number of keys, use a dictionary
-            var keyIndexes = new Dictionary<string, int>();
-            for (var i = 0; i < keys.Length; i++)
-                keyIndexes[keys[i]] = i;
-            foreach (var dbItem in DbHelpers.FindMany(connection, keys))
-                result[keyIndexes[dbItem.Key]] = dbItem.Value;
-        }
-        // Log.LogDebug("GetMany({KeyCount} keys) -> {Count} items", keys.Length, result.Count(x => x != null));
+        Run(connection => {
+            if (keys.Length == 1)
+                result[0] = DbHelpers.Find(connection, keys[0])?.Value;
+            else if (keys.Length < 16) {
+                // Small number of keys, use a simple loop
+                foreach (var dbItem in DbHelpers.FindMany(connection, keys))
+                    result[FindIndex(keys, dbItem.Key)] = dbItem.Value;
+            }
+            else {
+                // Large number of keys, use a dictionary
+                var keyIndexes = new Dictionary<string, int>();
+                for (var i = 0; i < keys.Length; i++)
+                    keyIndexes[keys[i]] = i;
+                foreach (var dbItem in DbHelpers.FindMany(connection, keys))
+                    result[keyIndexes[dbItem.Key]] = dbItem.Value;
+            }
+        });
         return ValueTask.FromResult(result);
 
         static int FindIndex(string[] keys, string key) {
@@ -81,11 +84,9 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
         if (_connectionPool == null)
             return ValueTask.FromResult(Array.Empty<(string Key, byte[] Value)>());
 
-        Resume();
-        using var lease = _connectionPool.Rent();
-        var connection = lease.Resource;
-        var dbItems = DbHelpers.SelectAll(connection);
-        var result = dbItems.Select(dbItem => (dbItem.Key, dbItem.Value)).ToArray();
+        var result = Run(connection => DbHelpers.SelectAll(connection)
+            .Select(dbItem => (dbItem.Key, dbItem.Value))
+            .ToArray());
         return ValueTask.FromResult(result);
     }
 
@@ -94,23 +95,22 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
         if (_connectionPool == null || updates.Count == 0)
             return Task.CompletedTask;
 
-        Resume();
-        using var lease = _connectionPool.Rent();
-        var connection = lease.Resource;
-        if (updates.Count == 1)
-            DbHelpers.Set(connection, updates[0]);
-        else {
-            var savepoint = connection.SaveTransactionPoint();
-            try {
-                foreach (var update in updates)
-                    DbHelpers.Set(connection, update);
-                connection.Release(savepoint);
+        Run(connection => {
+            if (updates.Count == 1)
+                DbHelpers.Set(connection, updates[0]);
+            else {
+                var savepoint = connection.SaveTransactionPoint();
+                try {
+                    foreach (var update in updates)
+                        DbHelpers.Set(connection, update);
+                    connection.Release(savepoint);
+                }
+                catch {
+                    connection.Rollback();
+                    throw;
+                }
             }
-            catch {
-                connection.Rollback();
-                throw;
-            }
-        }
+        });
         return Task.CompletedTask;
     }
 
@@ -119,10 +119,7 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
         if (_connectionPool == null)
             return Task.CompletedTask;
 
-        Resume();
-        using var lease = _connectionPool.Rent();
-        var connection = lease.Resource;
-        connection.DeleteAll<DbItem>();
+        Run(connection => connection.DeleteAll<DbItem>());
         return Task.CompletedTask;
     }
 
@@ -220,37 +217,78 @@ public sealed class SQLiteBatchingKvasBackend : IBatchingKvasBackend
         }
     }
 
+    // Runs an operation on a pooled connection. While suspended (backgrounded) the connection is
+    // checkpointed and closed afterwards instead of being returned open to the pool — an open
+    // connection left holding a WAL/-shm file lock across suspension is what iOS kills with 0xdead10cc.
+    private void Run(Action<SQLiteConnection> action)
+        => Run(connection => {
+            action(connection);
+            return true;
+        });
+
+    private T Run<T>(Func<SQLiteConnection, T> func)
+    {
+        var lease = _connectionPool!.Rent();
+        var connection = lease.Resource;
+        T result;
+        try {
+            result = func(connection);
+        }
+        catch {
+            // Don't return a possibly-broken connection to the pool.
+            CloseQuietly(connection);
+            throw;
+        }
+        // The suspend check and the re-pool/close decision must be atomic w.r.t. Suspend's drain,
+        // otherwise a connection could be re-pooled open right after Suspend has drained the pool.
+        lock (_suspendLock) {
+            if (_isSuspended) {
+                TryCheckpoint(connection);
+                CloseQuietly(connection);
+            }
+            else
+                lease.Dispose();
+        }
+        return result;
+    }
+
     private void Suspend()
     {
         if (_connectionPool == null || _isSuspended)
             return;
 
         lock (_suspendLock) {
-            if (_isSuspended) return; // Double-check locking
+            if (_isSuspended)
+                return;
 
             _isSuspended = true;
-            try {
-                // Checkpoint WAL to flush all pending writes to the main db file,
-                // then close all idle pooled connections to release file locks.
-                using var lease = _connectionPool.Rent();
-                var connection = lease.Resource;
-                connection.ExecuteScalar<string>("PRAGMA wal_checkpoint(TRUNCATE)");
-                connection.Close();
-            }
-            catch (Exception e) {
-                Log.LogWarning(e, "Failed to checkpoint WAL during suspend");
-            }
-            _connectionPool.Drain(static c => {
-                try { c.Close(); } catch { /* Intended */ }
-            });
+            // Checkpoint via a rented connection, then close it (dropped, not re-pooled), and close
+            // every idle connection so no WAL/-shm file lock survives into suspension.
+            var lease = _connectionPool.Rent();
+            TryCheckpoint(lease.Resource);
+            CloseQuietly(lease.Resource);
+            _connectionPool.Drain(CloseQuietly);
         }
     }
 
     private void Resume()
+        // Going foreground: pooling open connections is fine again. Lock-free so the main-thread
+        // OnActivated -> Set(false) callback never stalls behind a background op's checkpoint.
+        => _isSuspended = false;
+
+    private void TryCheckpoint(SQLiteConnection connection)
     {
-        if (!_isSuspended) return;
-        lock (_suspendLock)
-            _isSuspended = false;
+        try {
+            connection.ExecuteScalar<string>("PRAGMA wal_checkpoint(TRUNCATE)");
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to checkpoint WAL");
+        }
+    }
+
+    private static void CloseQuietly(SQLiteConnection connection)
+    {
+        try { connection.Close(); } catch { /* Intended */ }
     }
 
     // Nested types


### PR DESCRIPTION
…rash

On Android the UI thread is also the Mono main thread, so anything that blocks it inside a synchronous JNI upcall surfaces as an ANR. Four issues seen in the recent crash/ANR reports, addressed here:

- Startup ANR ("Input dispatching timed out (No focused window)"): SplashDelayer.OnPreDraw suspended the first frame indefinitely until the Blazor WebView invoked MarkFirstWebViewCreated. On a stalled or warm-start boot that callback may never arrive, so the frame is never drawn, no window gains focus, and the system kills the app. Cap the pre-draw hold at 4s.

- ForegroundServiceDidNotStartInTimeException: AndroidAudioWidgetForegroundService only called StartForeground() after building the media notification, so an earlier throw (unexpected mode, ChatId.Parse) left the service without a foreground notification within the ~5s deadline. Call StartForeground() up front with a placeholder, then update it; also parse the mode defensively.

- onTrimMemory ANR: OnTrimMemory ran the JNI-heavy DumpMemoryInfo() on the UI thread, exactly under memory pressure when the runtime is busy collecting. Run the diagnostic dump off the UI thread.

- SIGABRT in AndroidWebChromeClient.onCreateWindow: a target=_blank / window.open URL with no handling activity made the default client throw ActivityNotFoundException on the UI thread, crashing the app. Guard the call and decline the new window on failure.

Note: Android SDK is unavailable in this environment, so the Android head could not be compiled here; changes were reviewed statically.