### PR TITLE
ci(android): upload debug symbols to Sentry for crash/ANR symbolication

### DIFF
--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: false
         description: Build the iOS app with Native AOT (experimental, hits upstream linker bug — dotnet/runtime#119380)
+      uploadDevSymbols:
+        type: boolean
+        required: false
+        default: false
+        description: Upload Android debug symbols to Sentry for DEV builds too (PROD always uploads)
   create:
   push:
     branches:
@@ -80,6 +85,7 @@ jobs:
       MUST_BUILD_PACKAGE: ${{ steps.calc.outputs.MUST_BUILD_PACKAGE }}
       ENVIRONMENT: ${{ steps.calc.outputs.ENVIRONMENT }}
       IS_PROD_BRANCH: ${{ steps.calc.outputs.IS_PROD_BRANCH }}
+      UPLOAD_SENTRY_SYMBOLS: ${{ steps.calc.outputs.UPLOAD_SENTRY_SYMBOLS }}
     steps:
       - id: calc
         name: Calculate params for package jobs
@@ -109,11 +115,19 @@ jobs:
             environment=""
           fi
 
+          # Sentry symbol upload: always for PROD builds; for DEV only when explicitly requested
+          # (dev branch churns many builds/day — no point flooding Sentry's debug-file storage).
+          uploadSentrySymbols=false
+          if [[ $isDevMaui == false || "${{ github.event.inputs.uploadDevSymbols }}" == "true" ]]; then
+            uploadSentrySymbols=true
+          fi
+
           echo "IS_DEV_MAUI=$isDevMaui" | tee -a $GITHUB_OUTPUT
           echo "APP_ID=$appId" | tee -a $GITHUB_OUTPUT
           echo "MUST_BUILD_PACKAGE=$mustBuildPkg" | tee -a $GITHUB_OUTPUT
           echo "ENVIRONMENT=$environment" | tee -a $GITHUB_OUTPUT
           echo "IS_PROD_BRANCH=$isProdBranch" | tee -a $GITHUB_OUTPUT
+          echo "UPLOAD_SENTRY_SYMBOLS=$uploadSentrySymbols" | tee -a $GITHUB_OUTPUT
 
   build:
     name: Build image for ${{ github.ref_name }}
@@ -943,6 +957,17 @@ jobs:
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
       ActualChat_AndroidSigningKeyPass: ${{ secrets.ANDROIDSIGNINGKEYPASS }}
       ActualChat_AndroidSigningStorePass: ${{ secrets.ANDROIDSIGNINGSTOREPASS }}
+      # Sentry debug-symbol + ProGuard mapping upload for Android crash/ANR symbolication.
+      # SentryUploadSymbols / SentryUploadAndroidProguardMapping are MSBuild properties that
+      # Sentry.targets reads to enable its bundled sentry-cli upload; MSBuild picks them up
+      # from these env vars. Kept CI-only (no csproj changes) so local builds never touch Sentry.
+      # Gated by UPLOAD_SENTRY_SYMBOLS: always on for PROD, opt-in for DEV (uploadDevSymbols input).
+      # SENTRY_AUTH_TOKEN is consumed by sentry-cli from the environment (kept off command lines).
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SentryOrg: actual-chat
+      SentryProject: actual-chat-ui
+      SentryUploadSymbols: ${{ needs.calc-pkg-params.outputs.UPLOAD_SENTRY_SYMBOLS }}
+      SentryUploadAndroidProguardMapping: ${{ needs.calc-pkg-params.outputs.UPLOAD_SENTRY_SYMBOLS }}
       IS_DEV_MAUI: ${{ needs.calc-pkg-params.outputs.IS_DEV_MAUI }}
       APP_ID: ${{ needs.calc-pkg-params.outputs.APP_ID }}
       AAB_FILE_NAME: ${{ needs.calc-pkg-params.outputs.APP_ID }}-Signed.aab


### PR DESCRIPTION
## Why

Android fatals in Sentry (`actual-chat` / `actual-chat-ui`) are hard to act on. The highest-user-impact crash — a native `SIGSEGV` — arrives **fully unsymbolicated** (every frame `None`) because the build uploads no debug symbols. ANRs and the Java-side `RemoteServiceException` family are also harder to triage than they need to be.

The `Sentry` NuGet (5.14.1) already ships `sentry-cli` and the upload MSBuild targets — they're just never enabled. This turns them on for the Android build.

## What

- Enables `SentryUploadSymbols` + `SentryUploadAndroidProguardMapping` in the `build-android-pkg` job. For Android this uploads native `.so` ELF debug files (`-t elf`) + managed `pdb`s, matched by build-id, so new crashes symbolicate.
- **No csproj/props changes.** MSBuild reads env vars as properties, so the whole thing is driven from the workflow `env:` block → **local builds never touch Sentry** (`SentryUploadSymbols` defaults to `false`).
- **PROD always uploads; DEV is opt-in.** A computed `UPLOAD_SENTRY_SYMBOLS` output gates it: `true` for prod builds, or for dev only when the new `uploadDevSymbols` `workflow_dispatch` input is set. Debug symbols consume a finite storage pool and don't auto-expire, so we don't flood it with ephemeral dev builds.
- **Non-fatal.** Every upload step is `IgnoreExitCode`/`ContinueOnError` — a missing/invalid token warns but never breaks the build.

## Required secret

Add repo secret **`SENTRY_AUTH_TOKEN`** — an Organization Auth Token with scope **`org:ci`** (covers debug-file/source-map upload + release creation). Until it's added, the steps run and no-op harmlessly.

## Notes / caveats

- **Native symbol quality** may need one follow-up: if symbolicated AOT frames still show gaps, pass `NativeDebugSymbols: true` the same env-var way (CI-only, still no local wiring). Deliberately not added speculatively.
- **ProGuard mapping is low value here** — the mangled `crc64…` frames are .NET Android callable-wrapper names, not R8-renamed classes, so the mapping won't de-obfuscate them. Cheap and harmless to leave on; the native symbols are the real win.
- Old (pre-merge) crash events only symbolicate after **Reprocess** in the Sentry UI; new events are automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)