### PR TITLE
fix(maccatalyst): authenticate JS RPC WebSocket so pasted/dropped upl…

### DIFF
--- a/src/dotnet/UI.Blazor/Services/Security/SessionTokens.cs
+++ b/src/dotnet/UI.Blazor/Services/Security/SessionTokens.cs
@@ -58,7 +58,7 @@ public sealed class SessionTokens(UIHub hub) : UIWorkerBase<UIHub>(hub), IComput
 
     private async Task AutoRefresh(CancellationToken cancellationToken)
     {
-        if (HostInfo.AppKind is not AppKind.Ios) {
+        if (HostInfo.AppKind is not (AppKind.Ios or AppKind.MacOS)) {
             var expiresAtMs = (long)(SystemNow.EpochOffset + InfLifespan).TotalMilliseconds;
             await SetJSToken("", expiresAtMs, cancellationToken).ConfigureAwait(false);
             return;


### PR DESCRIPTION
…oads work #4024

Mac Catalyst's WKWebView sets no Session cookie and relies on the SessionTokens JS-token workaround, but AutoRefresh pushed a real token only for AppKind.Ios. On AppKind.MacOS it pushed an empty token, so the JS RPC WebSocket opened unauthenticated and the '~' session couldn't resolve — GetOffset/AppendStream failed. Paste and drag-drop are the only uploads over the JS RPC connection, so they alone failed while native attach and audio (C#-authenticated RPC) worked.


Claude-Session: https://claude.ai/code/session_01Wc37hM7Ed48KSZwGgZ46X4