### PR TITLE
fix(tests): flaky CreateTextEntries + race-free contact blocking

### DIFF
--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -1072,7 +1072,7 @@ public partial class Chats(IServiceProvider services) : IChats
     {
         var contactId = ContactId.NewUser(ownerId, chatId.AnotherUserId(ownerId));
         var contact = await ContactsBackend.Get(ownerId, contactId, cancellationToken).ConfigureAwait(false);
-        if (contact.IsRegular)
+        if (contact.IsRegular || contact.IsBlocked)
             return;
 
         var command = new ContactsBackend_Change(

--- a/src/dotnet/Contacts.Service/ContactLinker.cs
+++ b/src/dotnet/Contacts.Service/ContactLinker.cs
@@ -87,6 +87,8 @@ public class ContactLinker(IServiceProvider services) : ActivatedWorkerBase(serv
         var contactId = ContactId.NewUser(ownerId, userId);
         // check existing contact since command always performs db request
         var contact = await ContactsBackend.Get(ownerId, contactId, cancellationToken).ConfigureAwait(false);
+        if (contact.IsBlocked)
+            return; // Never revive a blocked contact to Regular
         if (!contact.IsRegular) {
             contact = contact with { State = ContactState.Regular };
             // This command doesn't throw an exception in case contact already exists

--- a/src/dotnet/Contacts.Service/ContactsBackend.cs
+++ b/src/dotnet/Contacts.Service/ContactsBackend.cs
@@ -360,9 +360,12 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
         var existing = dbContact?.ToModel();
 
         if (change.IsCreate(out var contact)) {
+            if (contact.State == ContactState.Blocked)
+                throw StandardError.Constraint("Blocking is managed by the SetIsBlocked command.");
             if (dbContact != null) {
                 var existingContact = existing.Require();
-                if (contact.State != ContactState.Regular || existingContact.State == ContactState.Regular)
+                // The only state change Create can cause is reviving a Temporary contact to Regular
+                if (contact.State != ContactState.Regular || existingContact.State != ContactState.Temporary)
                     return existingContact; // Already exists, so we don't recreate one
 
                 contact = existingContact with {
@@ -467,7 +470,7 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
     public virtual async Task OnSetIsBlocked(ContactsBackend_SetIsBlocked command, CancellationToken cancellationToken)
     {
         if (Invalidation.IsActive)
-            return; // It just spawns other commands, so nothing to do here
+            return; // The child ContactsBackend_Change commands handle invalidation
 
         var (id, isBlocked) = command;
         id.Require();
@@ -475,24 +478,29 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
             throw StandardError.Constraint("Only peer contacts can be blocked.");
 
         var ownerId = id.OwnerId;
-        var existing = await Get(ownerId, id, cancellationToken).ConfigureAwait(false);
-        if (existing.Version != 0) {
-            if (existing.IsBlocked == isBlocked)
+        if (isBlocked) {
+            // Ensure a Regular contact exists (create it or promote a Temporary one), then block it.
+            // Both child commands share this command's transaction and the advisory lock OnChange takes,
+            // so a concurrent contact creation can't slip between the two steps.
+            var contact = await Commander
+                .Call(new ContactsBackend_Change(id, null, Change.Create(new Contact(id) { State = ContactState.Regular })),
+                    false, cancellationToken)
+                .ConfigureAwait(false);
+            if (contact!.IsBlocked)
                 return;
 
-            var newState = isBlocked ? ContactState.Blocked : ContactState.Regular;
-            var change = Change.Update(existing with { State = newState });
-            var cmd = new ContactsBackend_Change(id, existing.Version, change);
-            await Commander.Call(cmd, false, cancellationToken).ConfigureAwait(false);
+            var blockChange = Change.Update(contact with { State = ContactState.Blocked });
+            await Commander.Call(new ContactsBackend_Change(id, contact.Version, blockChange), false, cancellationToken)
+                .ConfigureAwait(false);
         }
         else {
-            // Contact doesn't exist yet (e.g. you've never opened the chat); create it as Blocked
-            if (!isBlocked)
+            var contact = await Get(ownerId, id, cancellationToken).ConfigureAwait(false);
+            if (!contact.IsBlocked)
                 return;
 
-            var change = Change.Create(new Contact(id) { State = ContactState.Blocked });
-            var cmd = new ContactsBackend_Change(id, null, change);
-            await Commander.Call(cmd, false, cancellationToken).ConfigureAwait(false);
+            var unblockChange = Change.Update(contact with { State = ContactState.Regular });
+            await Commander.Call(new ContactsBackend_Change(id, contact.Version, unblockChange), false, cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 

--- a/tests/Chat.IntegrationTests/ChatBlockTest.cs
+++ b/tests/Chat.IntegrationTests/ChatBlockTest.cs
@@ -156,6 +156,99 @@ public class ChatBlockTest(ChatCollection.AppHostFixture fixture, ITestOutputHel
         entry.Content.Should().Be("back to talking");
     }
 
+    [Fact]
+    public async Task BlockWorksOverExistingTemporaryContact()
+    {
+        // arrange
+        await using var aliceTester = AppHost.NewBlazorTester(Out);
+        await using var bobTester = AppHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        var bob = await bobTester.SignInAsUniqueBob();
+        var contactId = ContactId.NewUser(alice.Id, bob.Id);
+        var commander = aliceTester.AppServices.Commander();
+        var contactsBackend = aliceTester.AppServices.GetRequiredService<IContactsBackend>();
+        // Emulates the AuthorUpsertedEvent handler creating a Temporary contact first
+        await commander.Call(new ContactsBackend_Change(contactId, null,
+            new Change<Contact> { Create = new Contact(contactId) { State = ContactState.Temporary } }));
+
+        // act
+        await BlockUser(aliceTester, alice.Id, bob.Id);
+
+        // assert
+        var isBlocked = await contactsBackend.IsBlocked(alice.Id, bob.Id, CancellationToken.None);
+        isBlocked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BlockSurvivesLateTemporaryContactCreate()
+    {
+        // arrange
+        await using var aliceTester = AppHost.NewBlazorTester(Out);
+        await using var bobTester = AppHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        var bob = await bobTester.SignInAsUniqueBob();
+        var contactId = ContactId.NewUser(alice.Id, bob.Id);
+        var commander = aliceTester.AppServices.Commander();
+        var contactsBackend = aliceTester.AppServices.GetRequiredService<IContactsBackend>();
+        await BlockUser(aliceTester, alice.Id, bob.Id);
+
+        // act
+        // The AuthorUpsertedEvent handler lands its Temporary create after the block
+        await commander.Call(new ContactsBackend_Change(contactId, null,
+            new Change<Contact> { Create = new Contact(contactId) { State = ContactState.Temporary } }));
+
+        // assert
+        var isBlocked = await contactsBackend.IsBlocked(alice.Id, bob.Id, CancellationToken.None);
+        isBlocked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateBlockedContactIsRejected()
+    {
+        // arrange
+        await using var aliceTester = AppHost.NewBlazorTester(Out);
+        await using var bobTester = AppHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        var bob = await bobTester.SignInAsUniqueBob();
+        var contactId = ContactId.NewUser(alice.Id, bob.Id);
+        var commander = aliceTester.AppServices.Commander();
+
+        // act
+        var create = () => commander.Call(new ContactsBackend_Change(contactId, null,
+            new Change<Contact> { Create = new Contact(contactId) { State = ContactState.Blocked } }));
+
+        // assert
+        await create.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task CreateRegularDoesNotUnblockContact()
+    {
+        // arrange
+        await using var aliceTester = AppHost.NewBlazorTester(Out);
+        await using var bobTester = AppHost.NewBlazorTester(Out);
+        var alice = await aliceTester.SignInAsUniqueAlice();
+        var bob = await bobTester.SignInAsUniqueBob();
+        var chatId = PeerChatId.New(alice.Id, bob.Id);
+        await bobTester.CreateTextEntry(chatId, "hi");
+        await BlockUser(aliceTester, alice.Id, bob.Id);
+        var contactId = ContactId.NewUser(alice.Id, bob.Id);
+        var commander = aliceTester.AppServices.Commander();
+        var contactsBackend = aliceTester.AppServices.GetRequiredService<IContactsBackend>();
+        var blocked = await contactsBackend.Get(alice.Id, contactId, CancellationToken.None);
+
+        // act
+        await commander.Call(new ContactsBackend_Change(contactId, null,
+            new Change<Contact> { Create = new Contact(contactId) { State = ContactState.Regular } }));
+
+        // assert
+        var contact = await contactsBackend.Get(alice.Id, contactId, CancellationToken.None);
+        contact.State.Should().Be(ContactState.Blocked);
+        contact.Version.Should().Be(blocked.Version);
+        var isBlocked = await contactsBackend.IsBlocked(alice.Id, bob.Id, CancellationToken.None);
+        isBlocked.Should().BeTrue();
+    }
+
     private static Task BlockUser(IWebTester tester, UserId ownerId, UserId otherUserId, bool isBlocked = true)
     {
         var contactId = ContactId.NewUser(ownerId, otherUserId);

--- a/tests/Testing.Host/ChatEntryOperations.cs
+++ b/tests/Testing.Host/ChatEntryOperations.cs
@@ -35,9 +35,11 @@ public static class ChatEntryOperations
 
     public static async Task<ChatEntry[]> CreateTextEntries(this IWebTester tester, ChatId chatId, string textPrefix, int entryCount)
     {
-        var entries = await Enumerable.Range(1, entryCount)
-            .Select(async i => await tester.CreateTextEntry(chatId, $"{textPrefix} {i}").ConfigureAwait(false))
-            .Collect(1);
+        // Posts strictly one-by-one: Collect(1) keeps 2 tasks in flight, so entry LIDs
+        // could come out non-monotonic vs the array order, which tests rely on.
+        var entries = new ChatEntry[entryCount];
+        for (var i = 0; i < entryCount; i++)
+            entries[i] = await tester.CreateTextEntry(chatId, $"{textPrefix} {i + 1}").ConfigureAwait(false);
         return entries;
     }
 


### PR DESCRIPTION
## Summary

Fixes two flaky integration-test failures on CI, one of which turned out to be a real product bug (and a second latent one) in contact blocking.

### 1. `CreateTextEntries` was not strictly sequential (`fix/tests`)

`CreateTextEntries` posted messages via `Enumerable.Range(...).Select(async ...).Collect(1)`. ActualLab's `Collect(1)` acquires its semaphore permit only *after* the next hot task has already been started by enumeration, so it keeps **2 posts in flight**. Chat-entry `LocalId`s come from a Redis sequence, so two overlapping `Chats_UpsertEntry` commands could commit LIDs out of submission order (adjacent pairs swapped, e.g. `posted: 2,3,5,4,6,7`).

`McpMessageToolsTest` asserts assume `posted[]` is LID-ordered, which made `ListMessages_AfterId_SkipsPreviousEntries` (and `ListMessages_FromBeginning`, `GetIdRange_ReturnsInclusiveRange`) flaky. Reproduced locally at ~1/10; the product `list_messages` was always correct. Fixed by posting strictly one-by-one with a `for`/`await` loop.

### 2. Contact blocking could silently no-op under a race (`fix/contacts`)

Blocking a peer right after their first message could silently fail. `OnSetIsBlocked` did a non-atomic `Get`-then-`Change`, and the racing async Temporary-contact create (from `AuthorUpsertedEvent`, delivered via NATS) let `OnChange`'s create-over-existing branch return the existing contact without applying the block. Root cause of the flaky `ChatBlockTest.BlockedUserCannot*` failures, and a real hazard: blocking a new correspondent right after their first message could not stick.

**Blocking is now owned solely by `SetIsBlocked`:**

- `OnSetIsBlocked` is an orchestrator: for a block it calls two child `ContactsBackend_Change` commands (`isOutermost: false`) — `Create(Regular)` (creates the contact or promotes a Temporary one), then `Update(Blocked)`. Both share one DB transaction and the `pg_advisory_xact_lock` that `OnChange` takes (`DbOperationScope` reuses the outer operation's scope/transaction), so a concurrent contact create serializes on the lock — no race by construction.
- `OnChange` now rejects `Create(Blocked)`; a blocked contact cannot be created through a generic change.
- Unblock protection is caller-side: `ContactLinker.EnsureContactExists` (**a live latent bug** — its `Upsert(Regular)` silently unblocked phone-book contacts) and `Chats.EnsureOwnPeerContactStored` now skip Blocked contacts.

## Testing

- `ChatBlockTest` — 11/11, incl. new `BlockWorksOverExistingTemporaryContact`, `BlockSurvivesLateTemporaryContactCreate`, `CreateBlockedContactIsRejected`, `CreateRegularDoesNotUnblockContact`; 10 consecutive loops green.
- `McpMessageToolsTest` — 15 consecutive class runs green (was ~1/10 flaky before).
- `Contacts.IntegrationTests` — 17 passed / 6 skipped / 0 failed (OnChange semantics changed — no regressions).
- `NonContactPeerLimitTest` — 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
