### PR TITLE
fix(android-audio): fix ForegroundServiceDidNotStartInTimeException crash in the audio widget

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
@@ -195,7 +195,7 @@ public class AndroidAudioFocusHelper : IDisposable
             _log = log;
 
             // Register listener for device changes
-            _listener = new CommunicationDeviceListener(audioManager, log);
+            _listener = new CommunicationDeviceListener(log);
             _audioManager.AddOnCommunicationDeviceChangedListener(
                 Platform.AppContext.MainExecutor!,
                 _listener);

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidget.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidget.cs
@@ -53,6 +53,7 @@ public class AndroidAudioWidget : AudioWidget
         intent.PutExtra(IntentExtras.ExtraChatCount, state.Chat.ExtraChatCount);
         intent.PutExtra(IntentExtras.IsPaused, state.IsPaused);
         context.StartForegroundService(intent);
+        AndroidAudioWidgetForegroundService.OnStartRequested();
         _isShown = true;
     }
 
@@ -62,8 +63,6 @@ public class AndroidAudioWidget : AudioWidget
             return;
 
         _isShown = false;
-        var context = Context;
-        var intent = new Intent(context, typeof(AndroidAudioWidgetForegroundService));
-        context.StopService(intent);
+        AndroidAudioWidgetForegroundService.Stop(Context);
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioWidgetForegroundService.cs
@@ -27,9 +27,32 @@ public class AndroidAudioWidgetForegroundService : Service
     public const string ActionShow = "ACTION_SHOW";
     private const string ChannelId = "audio_widget";
     private const int NotificationId = 3001;
+    private static int _pendingStartCount;
+    private static volatile bool _isStopPending;
     private string _requestId = "";
     private MediaSessionCompat? _mediaSession;
     private ILogger Log { get; } = StaticLog.For<AndroidAudioWidgetForegroundService>();
+
+    public static void OnStartRequested()
+    {
+        // A new Show cancels a stop that's still waiting for the service to reach foreground.
+        _isStopPending = false;
+        Interlocked.Increment(ref _pendingStartCount);
+    }
+
+    public static void Stop(Context context)
+    {
+        // StopService() while a StartForegroundService() request hasn't reached OnStartCommand yet makes
+        // Android kill the process with ForegroundServiceDidNotStartInTimeException, even though
+        // OnStartCommand does call StartForeground(). Let the service stop itself in that case.
+        if (Volatile.Read(ref _pendingStartCount) > 0) {
+            _isStopPending = true;
+            return;
+        }
+
+        var intent = new Intent(context, typeof(AndroidAudioWidgetForegroundService));
+        context.StopService(intent);
+    }
 
     public override void OnCreate()
     {
@@ -42,6 +65,8 @@ public class AndroidAudioWidgetForegroundService : Service
     {
         Log.LogDebug("OnDestroy");
         _requestId = Guid.NewGuid().ToString();
+        Interlocked.Exchange(ref _pendingStartCount, 0);
+        _isStopPending = false;
         if (_mediaSession is not null) {
             _mediaSession.Active = false;
             _mediaSession.Release();
@@ -66,6 +91,15 @@ public class AndroidAudioWidgetForegroundService : Service
         // with a placeholder so a throw while building the rich notification (unexpected mode,
         // ChatId.Parse) can't leave the service without one -> ForegroundServiceDidNotStartInTimeException.
         StartForeground1(BuildStartingNotification());
+        if (Volatile.Read(ref _pendingStartCount) > 0)
+            Interlocked.Decrement(ref _pendingStartCount);
+        if (_isStopPending && Volatile.Read(ref _pendingStartCount) == 0) {
+            // Stop() deferred to us: StartForeground() above satisfied Android, so we can go away now.
+            _isStopPending = false;
+            StopForeground(StopForegroundFlags.Remove);
+            StopSelf();
+            return StartCommandResult.NotSticky;
+        }
 
         var chatTitle = intent.Extras!.GetString(IntentExtras.ChatTitle) ?? "Unknown chat";
         var chatSid = intent.Extras!.GetString(IntentExtras.ChatId);

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/CommunicationDeviceListener.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/CommunicationDeviceListener.cs
@@ -6,11 +6,11 @@ namespace ActualChat.App.Maui.Audio;
 // Java wrapper for this listener when it was a nested class inside AndroidAudioFocusHelper
 // (both doubly- and singly-nested variants were tried), causing ClassNotFoundException
 // at runtime when the instance was passed to AudioManager.AddOnCommunicationDeviceChangedListener.
-internal sealed class CommunicationDeviceListener(AudioManager audioManager, ILogger log) : Java.Lang.Object,
+internal sealed class CommunicationDeviceListener(ILogger log) : Java.Lang.Object,
     AudioManager.IOnCommunicationDeviceChangedListener
 {
     public void OnCommunicationDeviceChanged(AudioDeviceInfo? device)
-        => log.LogInformation(
-            "Communication device changed callback: {Type}, current: {Current}",
-            device?.Type, audioManager.CommunicationDevice?.Type);
+        // Never read AudioManager.CommunicationDevice here: it's a blocking binder call back into
+        // AudioService from its own main-thread callback, and it stalled there for 3s.
+        => log.LogInformation("Communication device changed callback: {Type}", device?.Type);
 }


### PR DESCRIPTION
## Summary

Fixes a crash of the Android app (`chat.actual.dev.app`) observed in a device log:

```
android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException:
Context.startForegroundService() did not then call Service.startForeground():
ServiceRecord{... AndroidAudioWidgetForegroundService}
```

The process was killed and `MainActivity` force-finished. Two independent defects lined up to produce it.

## 1. The main thread was blocked for 3 seconds

`CommunicationDeviceListener.OnCommunicationDeviceChanged` logged `audioManager.CommunicationDevice?.Type`. That property is a **synchronous binder call back into `AudioService`**, made from `AudioService`'s own callback, which is dispatched on the main thread (`MainExecutor`). The device log shows it stalling for 3005 ms:

```
W MIUIScout App: Enter APP_SCOUT_WARNING State (Current message: duration=2503ms ...)
W MIUIScout App:   at android.media.AudioManager.getCommunicationDevice(AudioManager.java:9861)
W MIUIScout App:   at crc64...CommunicationDeviceListener.onCommunicationDeviceChanged(...)
W BpBinder: PerfMonitor binderTransact: time=3005ms interface=android.media.IAudioService code=218
```

It reproduced again on the very next app launch, so it is not a one-off. The changed device already arrives as the callback argument, so the extra query added nothing. Removed.

## 2. `Hide` could race `Show` and kill the process

While the main thread was frozen, the `AudioWidgetState` transition to `null` queued up behind the transition to non-null. Once unblocked, both ran back to back:

```
11:08:35.445  Background started FGS: ... AndroidAudioWidgetForegroundService (ACTION_SHOW)
11:08:35.454  Bringing down service while still waiting for start foreground: ServiceRecord{...}
11:08:35.539  FATAL EXCEPTION: main
```

9 ms apart. `ShowImpl` calls `StartForegroundService()`, `HideImpl` called `StopService()`. When `StopService()` reaches AMS before the pending start turns into an `OnStartCommand` call, [`ActiveServices.bringDownServiceLocked`](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/services/core/java/com/android/server/am/ActiveServices.java) sees `fgRequired` still set, logs the line above and posts `SERVICE_FOREGROUND_CRASH_MSG`. **This kills the process deterministically** — it is not a timeout.

Note that the service already called `StartForeground()` as the first statement of `OnStartCommand`, and that did not help: AMS had dropped the service record 44 ms earlier, so the call landed on nothing. The fix has to be on the caller's side.

### Fix

A foreground service must stop itself — the same rule [`androidx.media3.session.MediaSessionService`](https://github.com/androidx/media/blob/release/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java) follows (`Util.stopForeground(...)` + `stopSelf()`, never an external `stopService()`).

- `OnStartRequested()` is called right after `StartForegroundService()` and increments a count of in-flight starts.
- `Stop(context)` calls `StopService()` only when no start is in flight; otherwise it raises `_isStopPending` and returns.
- `OnStartCommand`, immediately after `StartForeground(...)`, decrements the count and — if a stop is pending — performs `StopForeground(Remove)` + `StopSelf()` itself. By then `fgRequired` is satisfied.

A counter rather than a bool: a repeated `Show` on an already-foreground service (e.g. `Listening` -> `Recording`) re-arms `fgRequired`, so an `IsForeground` flag would still let `Hide` call `StopService()` into the same crash.

## Testing

`dotnet build src/dotnet/App.Maui/App.Maui.csproj -f net10.0-android` passes (0 errors; the 44 warnings are pre-existing `MediaSessionCompat`/`PlaybackStateCompat` obsolescence).

Not yet exercised on a device. Repro requires starting and stopping listening within the same frame while the main thread is busy — and fix #1 removes the main source of that busyness.

## Follow-up (not in this PR)

The same log has an unrelated ANR 10 minutes earlier: the main thread sat 5+ s in `ContentResolver.openInputStream`, called from .NET via `mono.java.lang.RunnableImplementor`. Same class of bug, different site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)