### PR TITLE
refactor(location): reuse AuthorCircleGroup in live-location banner #…

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/Banners/LiveLocationBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/LiveLocationBanner.razor
@@ -19,11 +19,12 @@
     </Icon>
     <Body>
         <div class="c-body" @onclick="@OnClick">
-            <div class="c-avatars">
-                @foreach (var author in m.Authors.Take(MaxAvatars)) {
-                    <AvatarCircle Avatar="@author.Avatar" Size="@SquareSize.Size7"/>
-                }
-            </div>
+            <AuthorCircleGroup
+                Class="c-avatars"
+                MaxCount="@MaxAvatars"
+                Size="@SquareSize.Size7"
+                ShowRing="false"
+                AuthorIds="@m.AuthorIds"/>
             <div class="c-text">
                 <span class="c-description">@m.GetDescription()</span>
                 @if (!m.RemainingText.IsNullOrEmpty()) {
@@ -43,7 +44,6 @@
     private const int MaxAvatars = Constants.Location.MaxSharingAuthorsPerChat;
 
     private Chat Chat => ChatContext.Chat;
-    private ISharedLocations SharedLocations => Hub.SharedLocations;
     private LocationUI LocationUI => field ??= Hub.LocationUI;
 
     [CascadingParameter] public ChatContext ChatContext { get; set; } = null!;
@@ -58,21 +58,14 @@
 
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
         var chatId = Chat.Id;
-        var locations = await SharedLocations.ListLive(Session, chatId, cancellationToken).ConfigureAwait(false);
-        if (locations.Count == 0)
+        var participants = await LocationUI.ListParticipants(chatId, cancellationToken).ConfigureAwait(false);
+        if (participants.Count == 0)
             return Model.None;
 
-        var ownLive = await LocationUI.GetOwnLive(chatId, cancellationToken).ConfigureAwait(false);
-        var authors = await LocationUI.ListAuthors(chatId, cancellationToken).ConfigureAwait(false);
         var remaining = await LocationUI.GetOwnTimeLeftText(chatId, cancellationToken).ConfigureAwait(false);
         var trackingError = await LocationUI.GetTrackingError(chatId, cancellationToken).ConfigureAwait(false);
 
-        return new Model(
-            authors,
-            locations.Count,
-            ownLive is not null,
-            remaining,
-            trackingError);
+        return new Model(participants, remaining, trackingError);
     }
 
     private Task OnClick() {
@@ -88,14 +81,15 @@
     // Nested types
 
     public sealed record Model(
-        IReadOnlyList<Author> Authors,
-        int Count,
-        bool IsOwnSharing,
+        IReadOnlyList<LocationParticipant> Participants,
         string RemainingText = "",
         GeoTrackingError? TrackingError = null) {
-        public static readonly Model None = new([], 0, false);
+        public static readonly Model None = new([]);
 
         public bool IsTrackingBroken => TrackingError is not null;
+        public int Count => Participants.Count;
+        public bool IsOwnSharing => Participants.Any(x => x.IsOwn);
+        public IReadOnlyList<AuthorId> AuthorIds => [..Participants.Select(x => x.Author.Id)];
 
         public string GetErrorText()
             => TrackingError switch {

--- a/src/dotnet/UI.Blazor.App/Components/Banners/banners.css
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/banners.css
@@ -127,10 +127,7 @@ body.narrow .banner.reconnect-banner .banner-body > .c-main-text.desktop {
     @apply cursor-pointer;
 }
 .live-location-banner .c-avatars {
-    @apply flex-x items-center;
-}
-.live-location-banner .c-avatars .avatar-circle:not(:first-child) {
-    @apply -ml-2;
+    @apply flex-none;
 }
 .live-location-banner .c-text {
     @apply text-text-1;

--- a/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
@@ -44,11 +44,16 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
             .ToList();
 
         async Task<IReadOnlyList<SharedLocation>> GetLocations() {
-            if (locationId is null)
-                return await SharedLocations.ListLive(Session, chatId, cancellationToken).ConfigureAwait(false);
+            if (locationId is not null) {
+                var location = await SharedLocations.Get(Session, chatId, locationId, cancellationToken).ConfigureAwait(false);
+                if (location is null)
+                    return [];
 
-            var location = await SharedLocations.Get(Session, chatId, locationId, cancellationToken).ConfigureAwait(false);
-            return location is null ? [] : [location];
+                if (location.Duration == TimeSpan.Zero)
+                    return [location];
+            }
+
+            return await SharedLocations.ListLive(Session, chatId, cancellationToken).ConfigureAwait(false);
         }
 
         async Task<LocationParticipant?> GetParticipant(SharedLocation sharedLocation) {


### PR DESCRIPTION
…4048

Replace the banner's hand-rolled AvatarCircle row with AuthorCircleGroup, the same overlapping "talking heads" component the audio header renders. This adds the +N overflow chip and shared overlap for free, and drops the duplicated .c-avatars overlap CSS.


Claude-Session: https://claude.ai/code/session_01FHWz8yqqo8mkAy2nfsrP3S