### PR TITLE
fix(chat): show transcribing badge only for own streaming entries

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -27,7 +27,6 @@
     }
 
     _rendered = m;
-    _renderedIsChatLanguageSelected = IsChatLanguageSelected;
     var streamingCls = "";
     if (!oldIsStreaming && !m.IsStreaming) {
         streamingCls = "not-streaming";
@@ -87,11 +86,15 @@
         <ChatEntryKindView IsTranscribed="@entry.HasAudio"/>
     }
     @if (m.IsStreaming) {
-        @if (sm.RetainedText.IsNullOrEmpty()
+        @if (IsOwnMessage
+             && sm.RetainedText.IsNullOrEmpty()
              && sm.ChangedText.IsNullOrEmpty()
              && sm.AnimatedText.IsNullOrEmpty()
              && !HasNewerStreamingEntry()) {
-            <StreamingEntryBadge ChatId="@ChatContext.Chat.Id" IsLanguageKnown="@IsChatLanguageSelected" IsVoiceActive="@true"/>
+            <StreamingEntryBadge
+                ChatId="@ChatContext.Chat.Id"
+                IsVoiceActive="@true"
+                IsLanguageKnown="@m.IsChatLanguageSelected"/>
         }
         @if (!sm.RetainedText.IsNullOrEmpty()) {
             <span class="retained">@sm.RetainedText</span>
@@ -151,13 +154,13 @@
 
     private string? _temporaryText;
     private Model? _rendered;
-    private bool _renderedIsChatLanguageSelected;
     private TranscriptStreamReader _streamReader = null!;
     private ChatEntryId _textEntryId = null!;
     private ILogger Log => Hub.LogFor(GetType());
     private IMarkupParser MarkupParser => ChatContext.ChatMarkupHub.Parser;
     private ChatUI ChatUI => Hub.ChatUI;
     private TranslationUI TranslationUI => Hub.TranslationUI;
+    private LanguageUI LanguageUI => Hub.LanguageUI;
     private IChatMarkupHub ChatMarkupHub => ChatContext.ChatMarkupHub;
 
     private bool HasNewerStreamingEntry() {
@@ -180,8 +183,7 @@
     [Parameter, EditorRequired] public Markup Markup { get; set; } = null!;
     [Parameter] public bool IsUnreadByOthers { get; set; }
     [Parameter] public bool IsUnreadByOthersBlockStart { get; set; }
-    [Parameter] public bool IsFirstAuthorMessage { get; set; }
-    [Parameter] public bool IsChatLanguageSelected { get; set; }
+    [Parameter] public bool IsOwnMessage { get; set; }
 
     public override async ValueTask DisposeAsync() {
         await JSRef.DisposeSilentlyAsync("dispose");
@@ -232,10 +234,10 @@
     protected override bool ShouldRender() {
         var stateValue = State.Value;
         var shouldRender = _rendered is null
-            || _renderedIsChatLanguageSelected != IsChatLanguageSelected
             || !ReferenceEquals(_rendered, stateValue)
                 && (stateValue.IsStreaming
                     || _rendered.IsStreaming != stateValue.IsStreaming
+                    || _rendered.IsChatLanguageSelected != stateValue.IsChatLanguageSelected
                     || _rendered.Entry.ContentHash != stateValue.Entry.ContentHash
                     || _rendered.Entry.IsSending != stateValue.Entry.IsSending
                     || _rendered.Entry.HasAudio != stateValue.Entry.HasAudio
@@ -281,7 +283,10 @@
             var translationState = streamingState.IsTranslating
                 ? TranslationState.Translating
                 : TranslationState.None;
-            return new(markup, entry, translationState, streamingState, isUnreadByOthers, isUnreadByOthersBlockStart);
+            var isChatLanguageSelected = await LanguageUI.IsChatLanguageSelected(entry.ChatId, cancellationToken).ConfigureAwait(false);
+            return new(markup, entry, translationState, streamingState, isUnreadByOthers, isUnreadByOthersBlockStart) {
+                IsChatLanguageSelected = isChatLanguageSelected,
+            };
         }
 
         // If we're not streaming, handle possible translation
@@ -332,6 +337,7 @@
         bool IsUnread,
         bool IsUnreadBlockStart)
     {
+        public bool IsChatLanguageSelected { get; init; }
         public bool IsStreaming => Entry.IsContentStreaming || Streaming.IsStreaming;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
@@ -58,8 +58,6 @@
     case ChatMessageKind.SendingNewMessage:
         break;
     case ChatMessageKind.AudioRecordingMessage:
-        if (HasPriorStreamingEntry(message))
-            return;
         break;
     default:
         throw new ArgumentOutOfRangeException();
@@ -164,7 +162,7 @@
                     <ChatMessageQuote Entry="@m.RepliedEntry" IsOwn="@isReplyToOwnMessage"/>
                 }
                 @if (message.Kind is ChatMessageKind.AudioRecordingMessage) {
-                    <StreamingEntryBadge ChatId="@ChatId" IsLanguageKnown="@m.IsChatLanguageSelected" IsVoiceActive="@m.IsVoiceActive"/>
+                    <StreamingEntryBadge ChatId="@ChatId" IsVoiceActive="@false" IsLanguageKnown="@false"/>
                 } else {
                     <ChatEntryMessageInternalView
                         Markup="@markup"
@@ -172,8 +170,7 @@
                         ChatContext="@ChatContext"
                         IsUnreadByOthers="@m.IsUnreadByOthers"
                         IsUnreadByOthersBlockStart="@m.IsUnreadByOthersBlockStart"
-                        IsFirstAuthorMessage="@showAuthorBadge"
-                        IsChatLanguageSelected="@m.IsChatLanguageSelected"/>
+                        IsOwnMessage="@m.IsOwnMessage"/>
                 }
             </div>
             @if (entry.Attachments.Length > 0 || entry.HasUploadingAttachments) {
@@ -235,7 +232,6 @@
     private ChatUI ChatUI => Hub.ChatUI;
     private AuthorUI AuthorUI => Hub.AuthorUI;
     private SelectionUI SelectionUI => Hub.SelectionUI;
-    private LanguageUI LanguageUI => Hub.LanguageUI;
     private ChatEditorUI ChatEditorUI => Hub.ChatEditorUI;
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
     private OptimisticReactions OptimisticReactions => Hub.OptimisticReactions;
@@ -318,11 +314,7 @@
         if (repliedEntryId is not null)
             repliedEntry = ChatEntry.Loading(repliedEntryId);
         var isOwnMessage = Message.Flags.HasFlag(ChatMessageFlags.IsOwnMessage);
-        var selectedComputed = Computed.GetExisting(() => LanguageUI.IsChatLanguageSelected(Message.Entry.ChatId));
-        var isSelected = selectedComputed ?.IsConsistent() == true &&  selectedComputed is { HasValue: true, Value: true };
-        initialValue = new Model(null) {
-            IsChatLanguageSelected = isSelected,
-        };
+        initialValue = new Model(null);
         if (isOwnMessage || repliedEntry != null) {
             initialValue = initialValue with {
                 IsOwnMessage = isOwnMessage,
@@ -406,12 +398,6 @@
         var (isUnreadByOthers, isUnreadBlockStart) = (false, false);
         if (chat is not null && ownAuthorId is not null)
             (isUnreadByOthers, isUnreadBlockStart) = await IsUnreadByOthers(chat, entry, prevEntry, ownAuthorId, cancellationToken);
-        var isChatLanguageSelected = await LanguageUI.IsChatLanguageSelected(chatId, cancellationToken).ConfigureAwait(false);
-        var isVoiceActive = false;
-        if (chatMessage.Kind is ChatMessageKind.AudioRecordingMessage) {
-            var recorderState = await Hub.AudioRecorder.State.Use(cancellationToken).ConfigureAwait(false);
-            isVoiceActive = recorderState.ChatId == chatId && recorderState.IsVoiceActive;
-        }
         var result = new Model(chat) {
             RepliedEntry = repliedEntry,
             IsOwnMessage = isOwnMessage,
@@ -428,8 +414,6 @@
             IsUnreadByOthers = isUnreadByOthers,
             IsUnreadByOthersBlockStart = isUnreadBlockStart,
             MentionedAuthorIds = mentionedAuthorIds,
-            IsChatLanguageSelected = isChatLanguageSelected,
-            IsVoiceActive = isVoiceActive,
         };
         return result.Equals(_rendered) ? _rendered! : result;
 
@@ -502,18 +486,6 @@
 
     private void OnForwardedAuthorClick(Author forwardedAuthor)
         => _ = AuthorUI.Show(forwardedAuthor.Id);
-
-    private static bool HasPriorStreamingEntry(ChatEntryMessage message) {
-        var authorId = message.Entry.AuthorId;
-        var current = message.PreviousMessage;
-        for (var i = 0; i < 50 && current != null; i++, current = current.PreviousMessage) {
-            if (current is ChatEntryMessage em
-                && em.Entry.AuthorId == authorId
-                && em.Entry.IsContentStreaming)
-                return true;
-        }
-        return false;
-    }
 
     private bool HasAnyMentions(Markup markup)
         => MarkupValidator.ContainsAnyMention.IsValid(markup);
@@ -607,7 +579,5 @@
         public bool IsUnreadByOthers { get; init; }
         public bool IsUnreadByOthersBlockStart { get; init; }
         public IReadOnlyList<AuthorId>? MentionedAuthorIds { get; init; }
-        public bool IsChatLanguageSelected { get; init; }
-        public bool IsVoiceActive { get; init; }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -1,4 +1,3 @@
-using ActualChat.Kvas;
 using CommunityToolkit.HighPerformance;
 
 namespace ActualChat.UI.Blazor.App.Services;
@@ -511,17 +510,13 @@ public partial class ChatUI
             if (audioRecordingEntry is not null) {
                 // Hide "Transcribing..." when a real transcription entry already exists
                 // (i.e., the last entry from this author is streaming content).
-                var lastEntry = entries.Count > 0 ? entries[^1] : null;
-                var hasTranscription = lastEntry is { IsContentStreaming: true, AuthorId: var authorId }
-                    && authorId == currentAuthorId;
-                if (!hasTranscription)
+                var hasPriorStreamingEntry = HasPriorStreamingEntry(entries, currentAuthorId!);
+                if (!hasPriorStreamingEntry)
                     entries.Add(audioRecordingEntry);
             }
         }
         if (entries.Count == 0 && conversations.Length == 0)
             return new VirtualListTile<ChatMessage>(lidRange);
-
-        IReadOnlyDictionary<ChatEntryId, string> indexDocIds = ImmutableDictionary<ChatEntryId, string>.Empty;
 
         var prevEntry = (ChatEntry?)null;
         var prevDate = prevMessage?.Date ?? DateOnly.MinValue;
@@ -944,6 +939,24 @@ public partial class ChatUI
 
         int actualOffset = (int)(isForward ? travelled : -travelled);
         return (currentId, actualOffset);
+    }
+
+    private static bool HasPriorStreamingEntry(IList<ChatEntry> entries, AuthorId ownAuthorId)
+    {
+        var j = 0;
+        for (var i = entries.Count - 1; i >= 0; i--) {
+            if (j > 50) // scan depth is 50 entries
+                break;
+            j++;
+            var entry = entries[i];
+            if (entry.AuthorId != ownAuthorId)
+                continue;
+            if (entry.IsContentStreaming)
+                return true;
+            if (entry.HasAudio)
+                return false;
+        }
+        return false;
     }
 
     // Nested types


### PR DESCRIPTION
## Problem

The "Transcribing" / "Listening" badge (the status chip with the voice-settings gear) could appear on **other users'** messages, not just the current user's. In the chat view, when another author was speaking, their content-streaming entry showed the badge — including the settings gear, which opens the *current* user's `VoiceSettingsModal` and therefore makes no sense on someone else's entry.

Root cause: `ChatEntryMessageInternalView` rendered `StreamingEntryBadge` for **any** content-streaming entry with no text yet, without checking authorship. The badge's finer states ("Listening" / "Detecting language" / "Transcribing") are inherently a self-only concept — they derive from the local `AudioRecorder` state, which only exists for your own recording. For other users the client only knows `Entry.IsContentStreaming`.

## Changes

- **Gate the badge behind `IsOwnMessage`** in `ChatEntryMessageInternalView`. Other users' streaming entries now render nothing until their transcript text arrives (then stream normally). The badge stays a self-only indicator.
- **Move `IsChatLanguageSelected` computation into `ChatEntryMessageInternalView`** — it now self-computes via `LanguageUI` (only in the streaming branch) instead of being threaded down from `ChatEntryMessageView`. The parent no longer computes or passes it, and its now-unused `LanguageUI` accessor is removed. Initial value still primed from `Computed.GetExisting` to avoid a "Detecting language" flicker.
- **Drop the unused `IsFirstAuthorMessage` parameter** from `ChatEntryMessageInternalView` (declared and passed, never read).
- **Move audio-recording placeholder suppression into `ChatUI.Tiles`** (`HasPriorStreamingEntry`): the synthetic `AudioRecordingMessage` placeholder is no longer added to the tile when the author already has a real content-streaming entry nearby, replacing the previous last-entry-only check with a 50-entry backward scan.

## Verification

- `dotnet build src/dotnet/UI.Blazor.App/UI.Blazor.App.csproj` — succeeds, 0 errors.
