### PR TITLE
feat(live): joined-mode conversation block, seamless close, early titles

### DIFF
--- a/docs/superpowers/plans/2026-07-14-live-conversation-block-ux-plan.md
+++ b/docs/superpowers/plans/2026-07-14-live-conversation-block-ux-plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Live Conversation Block UX — Joined Mode & Seamless Close
+
+**Spec:** `docs/superpowers/specs/2026-07-13-live-conversation-block-ux-design.md` (approved 2026-07-14)
+
+## Context
+
+Live session conversation blocks frustrate users in joined mode and around lifecycle transitions: the expand icon renders with nothing to expand; joined viewers see live transcript entries as disconnected plain messages below the card; titles never appear during short calls (first-summary gate of 1200 mature words is unreachable); close is non-seamless (no-title sessions vanish and reappear minutes later via the offline split flow); the 2-peer latch swallows pre-latch messages viewers already saw; and below-threshold close makes collapsed messages pop back.
+
+The approved spec introduces: a **no-hide rule** (entries rendered before the block appeared never fold while live; sanctioned exceptions: mid-call progressive folding of block-born entries, tier-3 collapse at close); **two start points** (`ContextStartLid` for summary context via split-flow pause heuristics; `VisibleStartLid` = chat end at latch, bounding all hiding/folding); **lowered first-summary gates** (150 mature words + 3 entries, 1-min maturity); **tiered explicit close** over `[ContextStartLid, end]` (<150w/3e → vanish; <1200w/10e → materialize expanded via new `Conversation.IsExpandedByDefault`; ≥1200w/10e → materialize collapsed); **joined rendering** as one group block (card + folded range + live tail); split-flow guard widened to `[ContextStartLid, ∞)`.
+
+## Core design resolution — three lids, three roles
+
+- **`StartEntryLid`** (existing): unchanged — raw session start, set at first stream.
+- **`VisibleStartLid`** (new): set once at latch to the chat-end lid. **The live block's `ConversationId` keys on it** (`ConversationId.New(ChatId, EffectiveVisibleStartLid)`, falling back to `StartEntryLid` for old Redis states). This makes the existing client machinery produce exactly the spec'd behavior: card placed after pre-latch entries, fold range `[V, EndEntryLid]`, not-joined hidden = `[V, ∞)` combined with the existing `hiddenLiveTailRange`. Id is stable for the block's whole visible lifetime — no mid-call re-keying.
+- **`ContextStartLid`** (new, server-only): computed once by `LiveConversationSummaryFlow` post-latch (backward pause scan); feeds the summarizer, the split-flow guard, and the **materialized** conversation id/range at close.
+
+Rejected: shifting the live id to `ContextStartLid` while live — it would move the card above visible pre-latch entries, fold them (violating no-hide), and re-key `@key`s mid-call.
+
+**Finalize sequencing** (Streaming.Service has no `FlowHub`): the flow owns the final pass, the backend owns the close. `CloseNow` for a latched transcription session marks `IsClosing` instead of closing instantly; the flow (throttle lowered 30s→15s) detects `IsClosing`, runs the final pass (`matureOnly: false`, full `[ContextStartLid, end]`), decides the tier, writes the summary + `IsExpandedByDefault`, then calls new `ILiveSessionsBackend.FinalizeSession` → `CloseWithFinal` (materialize-then-close, no gap). LLM failure → short flow retry; the existing 90s `SelfClose` backstop still closes with whatever summary exists.
+
+## Phase 1 — API models & settings
+
+- `src/dotnet/Api/Chat/Conversation.cs`: add `bool IsExpandedByDefault` — order **13** on `Conversation`, order **10** on `ConversationDiff` **plus** its copy-ctor line (triple-attribute pattern: `[DataMember] + [MemoryPackOrder(N)] + [Key(N)]`).
+- `src/dotnet/Api/Live/LiveSessionState.cs`: add orders **19** `long VisibleStartLid`, **20** `long ContextStartLid`, **21** `bool IsExpandedByDefault`. Add ignored helpers `EffectiveVisibleStartLid => VisibleStartLid > 0 ? VisibleStartLid : StartEntryLid` and `VisibleEntryLidRange`. Re-key `ConversationId` on `EffectiveVisibleStartLid`. `ToConversation()`: clamp `EndEntryLid = Math.Max(EndEntryLid, EffectiveVisibleStartLid)` (keeps the block passing `GetTile`'s non-empty-intersect filter pre-first-summary), forward the flag. New `ToMaterializedConversation()`: id = `ConversationId.New(ChatId, ContextStartLid > 0 ? ContextStartLid : EffectiveVisibleStartLid)`, unclamped `EndEntryLid`, flag forwarded.
+- `src/dotnet/Api/Live/LiveSessionSummary.cs`: add order 6 `bool IsExpandedByDefault`.
+- `src/dotnet/Chat.Service/Module/ChatSettings.cs` (Summarization): `MinLiveConversationWords = 150`, `MinLiveConversationEntries = 3`, `FirstLiveSummaryDelay = 1 min`.
+
+## Phase 2 — DB + migration
+
+- `src/dotnet/Chat.Service/Db/DbConversation.cs`: add `bool IsExpandedByDefault`; map in **both** `ToModel()` and `UpdateFrom()`.
+- Migration: `./ef-migrations.cmd Chat.Service add Add_Conversation_IsExpandedByDefault` → expect `AddColumn<bool>(name: "is_expanded_by_default", table: "conversations", type: "boolean", nullable: false, defaultValue: false)` (pattern: `20260630125740_Add_SharedLocation_Version.cs`).
+
+## Phase 3 — LiveSessionsBackend (Streaming.Service)
+
+`src/dotnet/Streaming.Contracts/ILiveSessionsBackend.cs` + `src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs`:
+
+- Latch block in `OnStreamRegistered` (~L256): set `VisibleStartLid = ChatsBackend.GetLidRange(...).End` in the same `with`. Same for the `StartCall` latch path.
+- `UpdateSummary`: copy `IsExpandedByDefault` from the summary.
+- New `SetContextStart(chatId, lid, ct)`: lock + isolation, idempotent (no-op if already set), write + `InvalidateState`.
+- New `FinalizeSession(chatId, ct)`: skip if state null or a participant rejoined (`!IsClosing && HasParticipant`); else `CloseWithFinal`.
+- `CloseNow` (~L709): for `{ TranscriptionOn: true, SessionStartedAt: not null, Kind: not Call }` → `StartClosingGrace` instead of instant `CloseWithFinal` (flow finalizes in ~15–25s; `SelfClose` at 90s stays the backstop). Other shapes unchanged.
+- `CloseWithFinal` (~L754): materialize `ToMaterializedConversation()` instead of `ToConversation()`; empty-title vanish and FINAL notification unchanged.
+
+## Phase 4 — ConversationsBackend overlay
+
+`src/dotnet/Chat.Service/ConversationsBackend.cs`:
+- `GetRangeMeta` (L86-99): use `lc.VisibleEntryLidRange` for the overlay/overlap math — pre-latch persisted conversations stay visible (server half of defect 5).
+- `GetTile` (L129-139): no change — already uses `ToConversation().EntryLidRange`, now visible-based.
+
+## Phase 5 — Flows
+
+**New `src/dotnet/Chat.ML/ContextStartScanner.cs`** — pure static `FindContextStartLid(precedingEntries, anchorEntry)`: backward walk applying the extractor boundary rules (`minPause = IsTranscript ? Constants.Audio.MaxStreamDuration : MinPauseBetweenTextEntries (5 min)`, 10× running average pause, 12h hard cap). Promote `EntryGroupExtractor.MinPauseBetweenTextEntries`/`MaxPauseBetweenEntries` to `public const`; pause math mirrors `EntryGroupBuilder.GetPauseBetween`.
+
+**`src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs`**:
+1. `Throttle` 30s → 15s; `[Flow(ResumeTimeout = 60, DelayQuanta = 15)]`.
+2. `Resume`: `live is null` → return; `live.IsClosing` → `Finalize(live, ct)` for latched transcription sessions (replaces the early return); otherwise the regular pass now reads from `EnsureContextStart(live, ct)` and, when `neverSummarized`, gates on `MinLiveConversationEntries`/`MinLiveConversationWords` with `FirstLiveSummaryDelay` maturity; re-summaries keep existing gates/cadence.
+3. `EnsureContextStart`: return `live.ContextStartLid` if set; else fetch preceding entries tile-by-tile backward from `StartEntryLid` (budget ~200 entries, bounded by `GetLidRange().Start`), run `ContextStartScanner`, **clamp to `PreviousConversationLidRange.End + 1`** (via `ConversationsBackend.GetRangeMeta`) so a persisted conversation's range is never re-claimed, then `LiveSessionsBackend.SetContextStart`.
+4. `Finalize`: full-transcript entries from context start (`matureOnly: false`); **tier 1** (below 150w/3e) → `FinalizeSession` (title empty → vanish); **tier 2/3** → `Summarize` (on failure `StageResumeIn(5s)` retry inside the backstop window); `IsExpandedByDefault = words < MinConversationWords || entries.Count < MinConversationEntries` (tier 2 true, tier 3 false); `UpdateSummary` then `FinalizeSession`.
+
+**`src/dotnet/Chat.Service/Flows/ConversationSplitFlow.cs`**: widen the live guard in both places (L73-78 `Process`, L235-236 `GetEntries`) to `lc.ContextStartLid > 0 ? lc.ContextStartLid : lc.StartEntryLid`. `IsAlreadyCovered` already prevents post-close re-summarization.
+
+## Phase 6 — Client tile builder
+
+**`src/dotnet/UI.Blazor.App/Services/ChatUI.cs`**:
+- `_expandedConversations` → `_conversationExpansionOverrides` (in-memory as today); membership = *opposite of* `IsExpandedByDefault`. `ToggleExpandConversation` keeps its signature (call sites unchanged).
+- Helper `IsConversationExpanded(conversation)` = `IsExpandedByDefault ^ overrides.Contains(Id)`.
+
+**`src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs`**:
+1. `ConversationViewState` += `ConversationId JoinedLiveConversationId` and `Range<long> LiveFoldRange` (value-equal — compute-cache friendly; no `Conversation` object).
+2. `GetChatItemsInternal`:
+   - Effective expansion set = `(defaultExpanded ∖ overrides) ∪ (overrides ∖ defaultExpanded)`, resolving `IsExpandedByDefault` from `Conversations.GetTile` results; navigation auto-expand (L88-101) becomes "ensure effective-expanded". When not joined, drop `liveConversation.Id` from the set (stale joined-era expand must not leak hidden entries).
+   - `LiveFoldRange` from raw live state (`LiveSessionUI.GetState`): `raw.EndEntryLid >= raw.EffectiveVisibleStartLid ? [V, raw.EndEntryLid] : empty` — **the joined skip range comes from here, not `EntryLidRange`**, so nothing folds before the first summary lands (pre-summary `ToConversation` clamps `EndEntryLid` to V, which must not hide entry V for joined viewers).
+   - `hiddenLiveTailRange` formula unchanged (not-joined combined hidden = `[V, ∞)`).
+3. `GetTile`:
+   - Live card always emitted, even when expanded: include the live conversation in the `entries.Merge(...)` right side regardless of expansion, and **handle the paired-tuple case** — `Merge` is a full outer join, so when a loaded entry shares the card's key lid (`V`), the tuple arrives as `(entry, conversation)` and the card must be emitted *before* processing the entry (today's code only emits cards from `(null, conversation)` tuples).
+   - For `joinedLiveId`: skip range = `LiveFoldRange` (not `EntryLidRange`); suppress the regular `ConversationHeader`/`ConversationFooter` (the card is the header); entries still get `Conversation` set for grouping; force `BlockStart` on the first entry at/after `V` so a pre-latch author group can't swallow tail entries.
+4. `GroupExpandedConversations(messages, joinedLive)`: a `ConversationMessage` with `Conversation.Id == joinedLive.Id` **starts** a block (today `ConversationMessage` never does, L807); `belongs` for the live block uses grouping range `[V, ∞)` (`item.Id >= V` for `Conversation == null` items — the un-summarized tail and the trailing `AudioRecordingMessage` land inside). Non-live blocks keep `EntryLidRange.Contains`. Invoke when `expandedConversations.Count > 0 || joinedLive != null`. Result: one `ExpandedConversationMessage` keyed `ConversationBlock:{V}`, stable all call.
+
+## Phase 7 — UI & CSS
+
+- `src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs`: add `[ComputeMethod] GetState(chatId)` passthrough (raw `LiveSessionState` for fold-range/icon computations).
+- `ConversationLiveState.cs`: += `bool HasFoldedEntries`, `bool IsExpanded`.
+- `ConversationMessageView.razor`: expand button `.c-lc-expand` gated on `HasFoldedEntries` (= `raw.EndEntryLid >= raw.EffectiveVisibleStartLid && !isVoiceOnly` — only `UpdateSummary` advances `EndEntryLid`) instead of `hasSummary = !IsVoiceOnly`; icon from `IsExpanded` (`ChatUI.IsConversationExpanded`), not `_isOpen`. Pre-first-summary card: no icon; title fallback, meta row, "You on the call"/"Tap to join" only.
+- `conversation.css`: `live joined` group variant scoped via `:has()` on the VirtualList group wrapper (pattern: `virtual-list.css` L141-145): continuous background/rounded border owning card + tail; card flush as first row.
+
+## Phase 8 — Tests
+
+- **`tests/Chat.UnitTests/ContextStartScannerTest.cs`** (new): text 5-min boundary, transcript `MaxStreamDuration` boundary, 10× average pause, 12h cap, empty-preceding → anchor, budget stop.
+- **`tests/Chat.UnitTests`**: extend `Conversation` serialization round-trip with `IsExpandedByDefault = true` (SerializationCodeGen/ChatModelSerialization tests).
+- **`tests/Chat.IntegrationTests/LiveSessionsTest.cs`** (existing pattern — drive `ILiveSessionsBackend`): `LatchSetsVisibleStartLidToChatEnd`; `RangeMetaKeepsPreLatchConversationsVisible`; `CloseNowKeepsLatchedTranscriptionSessionClosing` (adjust existing instant-close facts for this shape only); `FinalizeSessionMaterializesContextRange` (materialized at `ContextStartLid` with flag; live state dropped).
+- **`tests/Chat.IntegrationTests/LiveConversationFinalizeFlowTest.cs`** (new; summarizer stub per `ConversationSummarizationTest`): first-summary gate boundaries (150w/3e/1-min); re-summary cadence unchanged; context-start scan; close tiers 1/2/3 outcomes.
+- **`tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`** (new; pattern `SendingMessagesDisplayTest.cs`): `NotJoinedHidesOnlyFromVisibleStart`; `JoinedGroupsCardAndTailIntoOneBlock`; `JoinedFoldsSummarizedRangeAndTogglesMidCall`; `ExpandedByDefaultConversationRendersExpanded` + local overrides both directions; `RegularConversationsUnchanged`.
+
+## Phase 9 — Verification
+
+1. `dotnet build ActualChat.CI.slnf` after phases 1–5 and again after 6–7 (or trigger the `run-watch` rebuild if the watch loop is running — check `tmp/watch-dotnet.log`).
+2. Generate + inspect the migration; rebuild.
+3. `npm run build:Verify` (CSS touched).
+4. `dotnet test` on `Chat.UnitTests`, `Chat.IntegrationTests`, `Chat.UI.Blazor.IntegrationTests`.
+5. Manual two-device pass: solo talk ≥1 min → second device joins → a third not-joined viewer keeps solo messages in place at latch; title by ~2 min; tail inside the block for joined; expand/collapse mid-call flips icon and reveals/hides the folded range; both stop → tier outcomes (short vanishes to plain messages; mid-size swaps in expanded; long collapses for everyone) with no gap and no orphaned tail. Watch the viewport at every transition; use `/virtual-list-debug` if anything jumps.
+
+## Risks & mitigations
+
+- **VirtualList key stability**: latch inserts the card (nothing removed); mid-call id fixed at `V`; close materializes *before* dropping Redis state (single invalidation wave, no empty frame). Key changes only at close when `ContextStartLid != V` (tier 2/3 with pre-latch context) — a sanctioned visual transition, covered by the manual pass.
+- **Id shift at close**: local expansion overrides keyed on `V` stop matching — harmless (tier 3 wants collapsed default; tier 2 renders expanded via the persisted flag).
+- **Split-flow races**: guard widens once `ContextStartLid` lands; scanner clamps to `PreviousConversationLidRange.End + 1`; `OnChange` overlap-delete remains the last-resort self-heal.
+- **Pre-first-summary fold**: joined skip range comes from `LiveFoldRange` (empty until a summary passes `V`), never from the clamped `EntryLidRange`.
+- **Merge pairing**: card emission handles the `(entry, conversation)` equal-key tuple explicitly.
+- **Old Redis states** (`VisibleStartLid == 0`): `EffectiveVisibleStartLid` falls back to `StartEntryLid` — current behavior.
+- **`ApplyDiff` validation** (requires non-empty Title/Description/Summary, MessageCount > 0): tiers 2/3 always materialize after a successful summarize, so the invariant holds; tier 1 never materializes.

--- a/src/dotnet/Api/Chat/Conversation.cs
+++ b/src/dotnet/Api/Chat/Conversation.cs
@@ -30,6 +30,7 @@ public sealed partial record Conversation(
     [DataMember, MemoryPackOrder(10), Key(10)] public int AttachmentCount { get; init; }
     [DataMember, MemoryPackOrder(11), Key(11)] public Symbol[] AttachmentIds { get; init; } = [];
     [DataMember, MemoryPackOrder(12), Key(12)] public ChatEntryAttachment[] Attachments { get; init; } = []; // Populated only on reads by ConversationsBackend
+    [DataMember, MemoryPackOrder(13), Key(13)] public bool IsExpandedByDefault { get; init; }
 
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public Range<long> EntryLidRange => new(Id.StartEntryLid, EndEntryLid + 1);
@@ -57,6 +58,7 @@ public sealed partial record ConversationDiff() : RecordDiff
     [DataMember, MemoryPackOrder(7)] public IReadOnlyList<AuthorId>? AuthorIds { get; init; }
     [DataMember, MemoryPackOrder(8)] public int? AttachmentCount { get; init; }
     [DataMember, MemoryPackOrder(9)] public Symbol[]? AttachmentIds { get; init; } = [];
+    [DataMember, MemoryPackOrder(10)] public bool? IsExpandedByDefault { get; init; }
 
     public ConversationDiff(Conversation conversation) : this()
     {
@@ -70,5 +72,6 @@ public sealed partial record ConversationDiff() : RecordDiff
         AuthorIds = conversation.AuthorIds;
         AttachmentCount = conversation.AttachmentCount;
         AttachmentIds = conversation.AttachmentIds;
+        IsExpandedByDefault = conversation.IsExpandedByDefault;
     }
 }

--- a/src/dotnet/Api/Live/LiveSessionState.cs
+++ b/src/dotnet/Api/Live/LiveSessionState.cs
@@ -48,10 +48,36 @@ public sealed partial record LiveSessionState
     public Moment? SessionStartedAt { get; init; }
     [DataMember(Order = 18), MemoryPackOrder(18), Key(18)]
     public LiveSessionKind Kind { get; init; } = LiveSessionKind.Ambient;
+    [DataMember(Order = 19), MemoryPackOrder(19), Key(19)]
+    public long VisibleStartLid { get; init; }
+    [DataMember(Order = 20), MemoryPackOrder(20), Key(20)]
+    public long ContextStartLid { get; init; }
+    [DataMember(Order = 21), MemoryPackOrder(21), Key(21)]
+    public bool IsExpandedByDefault { get; init; }
+
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
-    public ConversationId ConversationId => ConversationId.New(ChatId, StartEntryLid);
+    public long EffectiveVisibleStartLid => VisibleStartLid > 0 ? VisibleStartLid : StartEntryLid;
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public Range<long> VisibleEntryLidRange
+        => new(EffectiveVisibleStartLid, Math.Max(EndEntryLid, EffectiveVisibleStartLid) + 1);
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public ConversationId ConversationId => ConversationId.New(ChatId, EffectiveVisibleStartLid);
+
     public Conversation ToConversation()
         => new(ConversationId, Version) {
+            Title = Title,
+            Description = Description,
+            Summary = Summary,
+            EndEntryLid = Math.Max(EndEntryLid, EffectiveVisibleStartLid),
+            StartsAt = StartedAt,
+            EndsAt = LastSummaryAt == default ? StartedAt : LastSummaryAt,
+            MessageCount = MessageCount,
+            AuthorIds = AuthorIds,
+            IsExpandedByDefault = IsExpandedByDefault,
+        };
+
+    public Conversation ToMaterializedConversation()
+        => new(ConversationId.New(ChatId, ContextStartLid > 0 ? ContextStartLid : EffectiveVisibleStartLid), Version) {
             Title = Title,
             Description = Description,
             Summary = Summary,
@@ -60,5 +86,6 @@ public sealed partial record LiveSessionState
             EndsAt = LastSummaryAt == default ? StartedAt : LastSummaryAt,
             MessageCount = MessageCount,
             AuthorIds = AuthorIds,
+            IsExpandedByDefault = IsExpandedByDefault,
         };
 }

--- a/src/dotnet/Api/Live/LiveSessionSummary.cs
+++ b/src/dotnet/Api/Live/LiveSessionSummary.cs
@@ -18,4 +18,6 @@ public sealed partial record LiveSessionSummary
     public int MessageCount { get; init; }
     [DataMember(Order = 5), MemoryPackOrder(5), Key(5)]
     public IReadOnlyList<AuthorId> AuthorIds { get; init; } = [];
+    [DataMember(Order = 6), MemoryPackOrder(6), Key(6)]
+    public bool IsExpandedByDefault { get; init; }
 }

--- a/src/dotnet/Chat.ML/ContextStartScanner.cs
+++ b/src/dotnet/Chat.ML/ContextStartScanner.cs
@@ -1,0 +1,52 @@
+namespace ActualChat.Chat.ML;
+
+/// <summary>
+/// Finds where a live conversation's summary context should begin by walking backward from the
+/// session's first entry, applying the same pause-boundary rules as <see cref="EntryGroupExtractor"/>.
+/// </summary>
+public static class ContextStartScanner
+{
+    public static long FindContextStartLid(IReadOnlyList<ChatEntrySlim> precedingEntries, ChatEntrySlim anchorEntry)
+    {
+        var contextStart = anchorEntry.LocalId;
+        var accepted = new List<ChatEntrySlim> { anchorEntry };
+        var newer = anchorEntry;
+        for (var i = precedingEntries.Count - 1; i >= 0; i--) {
+            var older = precedingEntries[i];
+            if (older.LocalId >= newer.LocalId)
+                continue;
+
+            var currentPause = GetPause(older, newer);
+            var minPause = newer.IsTranscript
+                ? (int)Constants.Audio.MaxStreamDuration.TotalSeconds
+                : EntryGroupExtractor.MinPauseBetweenTextEntries;
+            var significantlyLargerThanAverage = AveragePause(accepted) * 10;
+            var withinGroup = (currentPause < minPause || currentPause < significantlyLargerThanAverage)
+                && currentPause < EntryGroupExtractor.MaxPauseBetweenEntries;
+            if (!withinGroup)
+                break;
+
+            accepted.Add(older);
+            contextStart = older.LocalId;
+            newer = older;
+        }
+        return contextStart;
+    }
+
+    // Private methods
+
+    private static int GetPause(ChatEntrySlim earlier, ChatEntrySlim later)
+        => (int)Math.Max(0, (later.BeginsAt - (earlier.EndsAt ?? earlier.BeginsAt)).TotalSeconds);
+
+    private static int AveragePause(List<ChatEntrySlim> entries)
+    {
+        if (entries.Count <= 1)
+            return 0;
+
+        var ordered = entries.OrderBy(e => e.LocalId).ToList();
+        var total = 0;
+        for (var i = 1; i < ordered.Count; i++)
+            total += GetPause(ordered[i - 1], ordered[i]);
+        return total / (ordered.Count - 1);
+    }
+}

--- a/src/dotnet/Chat.ML/EntryGroupExtractor.cs
+++ b/src/dotnet/Chat.ML/EntryGroupExtractor.cs
@@ -69,8 +69,8 @@ public enum EntryGroupLimit
 public class EntryGroupExtractor(IEmbeddingsCalculator embeddingsCalculator, ILogger<EntryGroupExtractor> log, int? groupWordCount = null) : IEntryGroupExtractor
 {
     private const int ChunkWordCount = 100;
-    private const int MaxPauseBetweenEntries = 60 * 60 * 12; // 12 hours
-    private const int MinPauseBetweenTextEntries = 5 * 60; // 5 minutes
+    public const int MaxPauseBetweenEntries = 60 * 60 * 12; // 12 hours
+    public const int MinPauseBetweenTextEntries = 5 * 60; // 5 minutes
 
     private IEmbeddingsCalculator EmbeddingsCalculator { get; } = embeddingsCalculator;
     private ILogger Log { get; } = log;

--- a/src/dotnet/Chat.Service.Migration/Migrations/20260714141943_Add_Conversation_IsExpandedByDefault.Designer.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20260714141943_Add_Conversation_IsExpandedByDefault.Designer.cs
@@ -4,6 +4,7 @@ using ActualChat.Chat.Db;
 using ActualChat.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ActualChat.Chat.Migrations
 {
     [DbContext(typeof(ChatDbContext))]
-    partial class ChatDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714141943_Add_Conversation_IsExpandedByDefault")]
+    partial class Add_Conversation_IsExpandedByDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/dotnet/Chat.Service.Migration/Migrations/20260714141943_Add_Conversation_IsExpandedByDefault.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20260714141943_Add_Conversation_IsExpandedByDefault.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActualChat.Chat.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Conversation_IsExpandedByDefault : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_expanded_by_default",
+                table: "conversations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_expanded_by_default",
+                table: "conversations");
+        }
+    }
+}

--- a/src/dotnet/Chat.Service/ConversationsBackend.cs
+++ b/src/dotnet/Chat.Service/ConversationsBackend.cs
@@ -85,8 +85,8 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
         // the single live range (the UI swaps the regular block for the live one).
         var live = await LiveSessionsBackend.GetState(chatId, cancellationToken).ConfigureAwait(false);
         if (live is { SessionStartedAt: not null } lc
-            && lc.StartEntryLid < idTileRange.End && lc.EndEntryLid >= idTileRange.Start) {
-            var liveRange = new Range<long>(lc.StartEntryLid, lc.EndEntryLid + 1);
+            && !lc.VisibleEntryLidRange.IntersectWith(idTileRange).IsEmpty) {
+            var liveRange = lc.VisibleEntryLidRange;
             conversationRanges = conversationRanges
                 .Where(r => r.IntersectWith(liveRange).IsEmpty)
                 .Append(liveRange)

--- a/src/dotnet/Chat.Service/Db/DbConversation.cs
+++ b/src/dotnet/Chat.Service/Db/DbConversation.cs
@@ -34,6 +34,7 @@ public class DbConversation : IHasId<string>, IHasVersion<long>, IRequirementTar
     }
     public string AuthorIds { get; set; } = "[]";
     public string AttachmentIds { get; set; } = "[]";
+    public bool IsExpandedByDefault { get; set; }
 
     public Conversation ToModel()
     {
@@ -51,6 +52,7 @@ public class DbConversation : IHasId<string>, IHasVersion<long>, IRequirementTar
             AuthorIds = authorIds,
             AttachmentCount = AttachmentCount,
             AttachmentIds = attachmentIds,
+            IsExpandedByDefault = IsExpandedByDefault,
         };
     }
 
@@ -73,5 +75,6 @@ public class DbConversation : IHasId<string>, IHasVersion<long>, IRequirementTar
         AuthorIds = JsonSerializer.Serialize(model.AuthorIds);
         AttachmentCount = model.AttachmentCount;
         AttachmentIds = JsonSerializer.Serialize(model.AttachmentIds);
+        IsExpandedByDefault = model.IsExpandedByDefault;
     }
 }

--- a/src/dotnet/Chat.Service/Flows/ConversationSplitFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/ConversationSplitFlow.cs
@@ -72,7 +72,7 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
         // Never (re)summarize a range a latched live session owns — the live flow materializes it.
         var live = await LiveSessionsBackend.GetState(ChatId, cancellationToken).ConfigureAwait(false);
         var liveSessionRange = live is { SessionStartedAt: not null } lc
-            ? new Range<long>(lc.StartEntryLid, long.MaxValue)
+            ? new Range<long>(lc.ContextStartLid > 0 ? lc.ContextStartLid : lc.StartEntryLid, long.MaxValue)
             : (Range<long>?)null;
         bool OverlapsLiveSession(IReadOnlyList<Range<long>> ranges)
             => liveSessionRange is { } lsr && ranges.Any(r => !r.IntersectWith(lsr).IsEmpty);
@@ -233,7 +233,9 @@ public sealed partial class ConversationSplitFlow : Flow<Unit>, IHasLastRunAt
 
         // A latched live session owns its tail [StartEntryLid, ...); pre-latch (solo) the split flow summarizes normally.
         var live = await LiveSessionsBackend.GetState(chatId, cancellationToken).ConfigureAwait(false);
-        var liveStartLid = live is { SessionStartedAt: not null } ? live.StartEntryLid : long.MaxValue;
+        var liveStartLid = live is { SessionStartedAt: not null } lc
+            ? (lc.ContextStartLid > 0 ? lc.ContextStartLid : lc.StartEntryLid)
+            : long.MaxValue;
 
         // Fetch up to (BatchSize + 1) items
         var entries = await ChatsBackend.ListNewEntries(chatId, lastId, BatchSize + 1, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
@@ -21,8 +21,8 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
     private static readonly TileStack<long> IdTileStack = Constants.Chat.ServerIdTileStack;
     // Resume throttle: the flow re-checks this often so entries maturing during silence (and the close/finalize
     // once nobody is talking) get handled without a new audio entry to trigger it; resummary itself is
-    // additionally gated on Settings.Summarization.ResummarizationDelay. Keep DelayQuanta (see [Flow]) <= Throttle
-    // so overlapping self-resumes coalesce without the loop stalling.
+    // additionally gated on Settings.Summarization.LiveResummarizationDelay. Keep DelayQuanta (see [Flow])
+    // <= Throttle so overlapping self-resumes coalesce without the loop stalling.
     private static readonly TimeSpan Throttle = TimeSpan.FromSeconds(15);
 
     private ChatSettings Settings => field ??= Services.GetRequiredService<ChatSettings>();
@@ -58,22 +58,16 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
         var contextStartLid = await EnsureContextStart(live, cancellationToken).ConfigureAwait(false);
 
         var neverSummarized = LastSummaryEndLid == 0;
-        // The first summary lands early (low gates, short maturity) so short calls still get a title; re-summaries
-        // keep the higher split-flow gates and cadence.
+        // Live gates throughout: the materialized 1200-word one doesn't open until ~11 minutes of speech.
         var maturity = neverSummarized
             ? Settings.Summarization.FirstLiveSummaryDelay
-            : Settings.Summarization.ChatEntrySummarizationDelay;
-        var minEntries = neverSummarized
-            ? Settings.Summarization.MinLiveConversationEntries
-            : Settings.Summarization.MinConversationEntries;
-        var minWords = neverSummarized
-            ? Settings.Summarization.MinLiveConversationWords
-            : Settings.Summarization.MinConversationWords;
+            : Settings.Summarization.LiveSummaryMaturity;
 
         var entries = await GetEntries(contextStartLid, maturity, cancellationToken).ConfigureAwait(false);
-        var enoughData = entries.Count >= minEntries && entries.Sum(WordCount) >= minWords;
+        var enoughData = entries.Count >= Settings.Summarization.MinLiveConversationEntries
+            && entries.Sum(WordCount) >= Settings.Summarization.MinLiveConversationWords;
         var hasNew = entries.Count > 0 && entries[^1].LocalId > LastSummaryEndLid;
-        var dueForResummary = ResumedAt - live.LastSummaryAt >= Settings.Summarization.ResummarizationDelay;
+        var dueForResummary = ResumedAt - live.LastSummaryAt >= Settings.Summarization.LiveResummarizationDelay;
         if (enoughData && hasNew && (neverSummarized || dueForResummary)) {
             var result = await ConversationSummarizer.Summarize(entries, cancellationToken).ConfigureAwait(false);
             if (result.Summary is { } summary) {

--- a/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
@@ -7,23 +7,27 @@ using ActualChat.Streaming;
 namespace ActualChat.Chat.Flows;
 
 /// <summary>
-/// Throttled resummarization of an in-progress live conversation (at the split-flow cadence). Close-time
-/// finalization (materialize into a persisted <see cref="Conversation"/> or vanish) is owned by
-/// <c>LiveSessionsBackend</c>; this flow only summarizes while the call is live.
+/// Throttled resummarization of an in-progress live conversation, plus close-time finalization: once the
+/// backend marks a latched transcription session <c>IsClosing</c>, this flow runs the final summary pass,
+/// decides the tier, and materializes (or vanishes) the conversation before calling
+/// <c>ILiveSessionsBackend.FinalizeSession</c>.
 /// </summary>
-[Flow(ResumeTimeout = 60, DelayQuanta = 30)]
+[Flow(ResumeTimeout = 60, DelayQuanta = 15)]
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject(true)]
 public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
 {
     private const int MaxEntries = 1000;
-    // Resume throttle: the flow re-checks this often so entries maturing during silence (and the tail before
-    // the backend closes + materializes the session) get summarized without a new audio entry to trigger it;
-    // resummary itself is additionally gated on Settings.Summarization.ResummarizationDelay. Keep DelayQuanta
-    // (see [Flow]) <= Throttle so overlapping self-resumes coalesce without the loop stalling.
-    private static readonly TimeSpan Throttle = TimeSpan.FromSeconds(30);
+    private const int ContextScanBudget = 200;
+    private static readonly TileStack<long> IdTileStack = Constants.Chat.ServerIdTileStack;
+    // Resume throttle: the flow re-checks this often so entries maturing during silence (and the close/finalize
+    // once nobody is talking) get handled without a new audio entry to trigger it; resummary itself is
+    // additionally gated on Settings.Summarization.ResummarizationDelay. Keep DelayQuanta (see [Flow]) <= Throttle
+    // so overlapping self-resumes coalesce without the loop stalling.
+    private static readonly TimeSpan Throttle = TimeSpan.FromSeconds(15);
 
     private ChatSettings Settings => field ??= Services.GetRequiredService<ChatSettings>();
     private IChatsBackend ChatsBackend => field ??= Services.GetRequiredService<IChatsBackend>();
+    private IConversationsBackend ConversationsBackend => field ??= Services.GetRequiredService<IConversationsBackend>();
     private IConversationSummarizer ConversationSummarizer => field ??= Services.GetRequiredService<IConversationSummarizer>();
     private ILiveSessionsBackend LiveSessionsBackend => field ??= Services.GetRequiredService<ILiveSessionsBackend>();
 
@@ -35,8 +39,15 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
     protected override async ValueTask Resume(CancellationToken cancellationToken)
     {
         var live = await LiveSessionsBackend.GetState(ChatId, cancellationToken).ConfigureAwait(false);
-        if (live is null || live.IsClosing)
-            return; // closed, or closing - the backend owns finalize + materialization now
+        if (live is null)
+            return; // closed
+
+        if (live.IsClosing) {
+            // A latched transcription session hands its close to this flow; other shapes are the backend's.
+            if (live is { TranscriptionOn: true, SessionStartedAt: not null, Kind: not LiveSessionKind.Call })
+                await Finalize(live, cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         // Pre-latch (solo): the normal ConversationSplitFlow owns summarization, so don't double-summarize.
         if (live.SessionStartedAt is null) {
@@ -44,18 +55,25 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
             return;
         }
 
-        // Summarize only mature entries (older than ChatEntrySummarizationDelay) so the collapsed block
-        // lags behind the newest message — participants keep reading the recent tail uncollapsed.
-        var entries = await GetEntries(live.StartEntryLid, matureOnly: true, cancellationToken)
-            .ConfigureAwait(false);
-        // Like ConversationSplitFlow: wait for enough data before the first LLM call (so the block isn't
-        // titled off 2 messages), then throttle re-summaries by ResummarizationDelay.
-        var enoughData = entries.Count >= Settings.Summarization.MinConversationEntries
-            && entries.Sum(WordCount) >= Settings.Summarization.MinConversationWords;
-        var hasNew = entries.Count > 0 && entries[^1].LocalId > LastSummaryEndLid;
+        var contextStartLid = await EnsureContextStart(live, cancellationToken).ConfigureAwait(false);
+
         var neverSummarized = LastSummaryEndLid == 0;
-        var dueForResummary =
-            ResumedAt - live.LastSummaryAt >= Settings.Summarization.ResummarizationDelay;
+        // The first summary lands early (low gates, short maturity) so short calls still get a title; re-summaries
+        // keep the higher split-flow gates and cadence.
+        var maturity = neverSummarized
+            ? Settings.Summarization.FirstLiveSummaryDelay
+            : Settings.Summarization.ChatEntrySummarizationDelay;
+        var minEntries = neverSummarized
+            ? Settings.Summarization.MinLiveConversationEntries
+            : Settings.Summarization.MinConversationEntries;
+        var minWords = neverSummarized
+            ? Settings.Summarization.MinLiveConversationWords
+            : Settings.Summarization.MinConversationWords;
+
+        var entries = await GetEntries(contextStartLid, maturity, cancellationToken).ConfigureAwait(false);
+        var enoughData = entries.Count >= minEntries && entries.Sum(WordCount) >= minWords;
+        var hasNew = entries.Count > 0 && entries[^1].LocalId > LastSummaryEndLid;
+        var dueForResummary = ResumedAt - live.LastSummaryAt >= Settings.Summarization.ResummarizationDelay;
         if (enoughData && hasNew && (neverSummarized || dueForResummary)) {
             var result = await ConversationSummarizer.Summarize(entries, cancellationToken).ConfigureAwait(false);
             if (result.Summary is { } summary) {
@@ -71,21 +89,107 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
 
     // Private methods
 
+    private async Task Finalize(LiveSessionState live, CancellationToken cancellationToken)
+    {
+        var contextStartLid = await EnsureContextStart(live, cancellationToken).ConfigureAwait(false);
+        var entries = await GetEntries(contextStartLid, maturity: null, cancellationToken).ConfigureAwait(false);
+        var words = entries.Sum(WordCount);
+
+        // Tier 1: below the first-summary floor - nothing worth keeping; FinalizeSession vanishes it (empty title).
+        if (entries.Count < Settings.Summarization.MinLiveConversationEntries
+            || words < Settings.Summarization.MinLiveConversationWords) {
+            await LiveSessionsBackend.FinalizeSession(ChatId, cancellationToken).ConfigureAwait(false);
+            Runtime.StageResumeIn(Throttle);
+            return;
+        }
+
+        var result = await ConversationSummarizer.Summarize(entries, cancellationToken).ConfigureAwait(false);
+        if (result.Summary is not { } summary) {
+            Runtime.StageResumeIn(TimeSpan.FromSeconds(5)); // retry within the backend's 90s SelfClose backstop
+            return;
+        }
+
+        // Tier 2 (below the full-summary gate) materializes expanded; tier 3 (at/above it) materializes collapsed.
+        var isExpandedByDefault = words < Settings.Summarization.MinConversationWords
+            || entries.Count < Settings.Summarization.MinConversationEntries;
+        await LiveSessionsBackend
+            .UpdateSummary(ChatId, ToLiveSummary(summary, entries, isExpandedByDefault), cancellationToken)
+            .ConfigureAwait(false);
+        await LiveSessionsBackend.FinalizeSession(ChatId, cancellationToken).ConfigureAwait(false);
+        Runtime.StageResumeIn(Throttle);
+    }
+
+    private async Task<long> EnsureContextStart(LiveSessionState live, CancellationToken cancellationToken)
+    {
+        if (live.ContextStartLid > 0)
+            return live.ContextStartLid;
+        if (!live.TranscriptionOn)
+            return live.StartEntryLid;
+
+        var anchorLid = live.StartEntryLid;
+        var minLid = (await ChatsBackend.GetLidRange(ChatId, false, cancellationToken).ConfigureAwait(false)).Start;
+        var (anchor, preceding) = await GetContextScanEntries(anchorLid, minLid, cancellationToken).ConfigureAwait(false);
+        if (anchor is null)
+            return anchorLid;
+
+        var contextStart = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // Never re-claim a persisted conversation's range: clamp to just past the one preceding the scan start.
+        var idRange = IdTileStack.LastLayer.GetTile(contextStart).Range;
+        var rangeMeta = await ConversationsBackend.GetRangeMeta(ChatId, idRange.Start, cancellationToken).ConfigureAwait(false);
+        if (rangeMeta.PreviousConversationLidRange is { } prev && prev.End > contextStart)
+            contextStart = prev.End;
+
+        await LiveSessionsBackend.SetContextStart(ChatId, contextStart, cancellationToken).ConfigureAwait(false);
+        return contextStart;
+    }
+
+    private async Task<(ChatEntrySlim? Anchor, IReadOnlyList<ChatEntrySlim> Preceding)> GetContextScanEntries(
+        long anchorLid, long minLid, CancellationToken cancellationToken)
+    {
+        ChatEntrySlim? anchor = null;
+        var preceding = new List<ChatEntrySlim>();
+        var tile = IdTileStack.LastLayer.GetTile(anchorLid);
+        while (preceding.Count < ContextScanBudget) {
+            var chatTile = await ChatsBackend.GetTile(ChatId, tile.Range, false, cancellationToken).ConfigureAwait(false);
+            foreach (var entry in chatTile.Entries) {
+                if (entry.Content.IsNullOrEmpty())
+                    continue;
+
+                var slim = new ChatEntrySlim(entry);
+                if (slim.LocalId == anchorLid)
+                    anchor ??= slim;
+                else if (slim.LocalId < anchorLid)
+                    preceding.Add(slim);
+            }
+            if (tile.Range.Start <= minLid)
+                break;
+
+            tile = IdTileStack.LastLayer.GetTile(tile.Range.Start - 1);
+        }
+        preceding.Sort(ChatEntrySlim.LocalIdComparer);
+        if (preceding.Count > ContextScanBudget)
+            preceding = preceding.Skip(preceding.Count - ContextScanBudget).ToList();
+
+        return (anchor, preceding);
+    }
+
     private async Task<IReadOnlyList<ChatEntrySlim>> GetEntries(
-        long startEntryLid, bool matureOnly, CancellationToken cancellationToken)
+        long startEntryLid, TimeSpan? maturity, CancellationToken cancellationToken)
     {
         var entries = await ChatsBackend
             .ListNewEntries(ChatId, startEntryLid - 1, MaxEntries, cancellationToken)
             .ConfigureAwait(false);
-        var matureBefore = ResumedAt - Settings.Summarization.ChatEntrySummarizationDelay;
+        var matureBefore = maturity is { } m ? ResumedAt - m : (Moment?)null;
         return entries
             .Where(e => !e.Content.IsNullOrEmpty()
-                && (!matureOnly || (e.EndsAt ?? e.BeginsAt) <= matureBefore))
+                && (matureBefore is not { } mb || (e.EndsAt ?? e.BeginsAt) <= mb))
             .Select(e => new ChatEntrySlim(e))
             .ToList();
     }
 
-    private static LiveSessionSummary ToLiveSummary(ConversationSummary summary, IReadOnlyList<ChatEntrySlim> entries)
+    private static LiveSessionSummary ToLiveSummary(
+        ConversationSummary summary, IReadOnlyList<ChatEntrySlim> entries, bool isExpandedByDefault = false)
         => new() {
             Title = summary.Title,
             Description = summary.Description,
@@ -97,6 +201,7 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
                 .OrderByDescending(g => g.Count())
                 .Select(g => g.Key)
                 .ToArray(),
+            IsExpandedByDefault = isExpandedByDefault,
         };
 
     private static int WordCount(ChatEntrySlim entry)

--- a/src/dotnet/Chat.Service/Module/ChatSettings.cs
+++ b/src/dotnet/Chat.Service/Module/ChatSettings.cs
@@ -53,6 +53,9 @@ public class SummarizationSettings
     public int MinLiveConversationWords { get; set; } = 150;
     public int MinLiveConversationEntries { get; set; } = 3;
     public TimeSpan FirstLiveSummaryDelay { get; set; } = TimeSpan.FromMinutes(1);
+    // Live summaries are provisional - each pass rewrites the last - so they gate tighter than the one-shot pair below.
+    public TimeSpan LiveSummaryMaturity { get; set; } = TimeSpan.FromSeconds(45);
+    public TimeSpan LiveResummarizationDelay { get; set; } = TimeSpan.FromMinutes(2);
     public TimeSpan ChatEntrySummarizationDelay { get; set; } = TimeSpan.FromMinutes(3);
     public TimeSpan ResummarizationDelay { get; set; } = TimeSpan.FromMinutes(5);
     public TimeSpan ChatEntrySummarizationDelayQuanta { get; set; } = TimeSpan.FromMinutes(1);

--- a/src/dotnet/Chat.Service/Module/ChatSettings.cs
+++ b/src/dotnet/Chat.Service/Module/ChatSettings.cs
@@ -50,6 +50,9 @@ public class SummarizationSettings
     public string OpenAIModel { get; set; } = "gpt-4.1";
     public int MinConversationWords { get; set; } = 1200;
     public int MinConversationEntries { get; set; } = 10;
+    public int MinLiveConversationWords { get; set; } = 150;
+    public int MinLiveConversationEntries { get; set; } = 3;
+    public TimeSpan FirstLiveSummaryDelay { get; set; } = TimeSpan.FromMinutes(1);
     public TimeSpan ChatEntrySummarizationDelay { get; set; } = TimeSpan.FromMinutes(3);
     public TimeSpan ResummarizationDelay { get; set; } = TimeSpan.FromMinutes(5);
     public TimeSpan ChatEntrySummarizationDelayQuanta { get; set; } = TimeSpan.FromMinutes(1);

--- a/src/dotnet/Redis/RedisScope.cs
+++ b/src/dotnet/Redis/RedisScope.cs
@@ -31,6 +31,16 @@ public sealed class RedisScope<TValue>(RedisDb redisDb, string? keyPrefix = null
         return Serializer.Read<TValue>(raw);
     }
 
+    public async Task<bool> Refresh(string key, TimeSpan? ttl = null)
+    {
+        // A keepalive for a live but rarely-rewritten value; no-op if the key already expired.
+        if ((ttl ?? DefaultTtl) is not { } effectiveTtl)
+            return false;
+
+        var db = await RedisDb.Database.Get().ConfigureAwait(false);
+        return await db.KeyExpireAsync(key, effectiveTtl).ConfigureAwait(false);
+    }
+
     public async Task<bool> Remove(string key)
     {
         var db = await RedisDb.Database.Get().ConfigureAwait(false);

--- a/src/dotnet/Streaming.Contracts/ILiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Contracts/ILiveSessionsBackend.cs
@@ -37,6 +37,8 @@ public interface ILiveSessionsBackend : IComputeService, IBackendService
         ChatId chatId,
         LiveSessionSummary summary,
         CancellationToken cancellationToken);
+    Task SetContextStart(ChatId chatId, long contextStartLid, CancellationToken cancellationToken);
+    Task FinalizeSession(ChatId chatId, CancellationToken cancellationToken);
 
     // Voice-call ring lifecycle (StartCall invitees empty = every other chat member).
     // Caller methods

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -242,8 +242,11 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             var authorIds = state.AuthorIds.Contains(authorId)
                 ? state.AuthorIds
                 : [..state.AuthorIds, authorId];
-            if (ReferenceEquals(authorIds, state.AuthorIds) && !state.IsClosing)
+            if (ReferenceEquals(authorIds, state.AuthorIds) && !state.IsClosing) {
+                // Nothing to write, but a re-registering stream is proof of life: keep the key alive.
+                await _redisScope.Refresh(chatId.Value).ConfigureAwait(false);
                 return;
+            }
 
             state = state with {
                 AuthorIds = authorIds,
@@ -289,6 +292,10 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 var info = new ParticipationInfo(kind, Clocks.SystemClock.Now,
                     existing?.MicMuted ?? false);
                 await _participants.Set(chatId.Value, authorId.Value, info).ConfigureAwait(false);
+                // The participants hash refreshes its own TTL on write, but the session state key only
+                // does so on Set - which a steady-state session never reaches. Without this the state
+                // silently expires mid-call and the next stream rebuilds it as a brand-new session.
+                await _redisScope.Refresh(chatId.Value).ConfigureAwait(false);
             }
             else
                 await _participants.Remove(chatId.Value, authorId.Value).ConfigureAwait(false);

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -254,8 +254,10 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         }
 
         if (state.SessionStartedAt is null && state.AuthorIds.Count >= 2) {
+            var visibleStartLid = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
             state = state with {
                 SessionStartedAt = now,
+                VisibleStartLid = visibleStartLid,
                 Version = VersionGenerator.NextVersion(state.Version),
             };
             // START fires at the 2+ latch for both modes; transcription's later Titled updates the same banner.
@@ -365,6 +367,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             EndEntryLid = summary.EndEntryLid,
             MessageCount = summary.MessageCount,
             AuthorIds = summary.AuthorIds.Count > 0 ? summary.AuthorIds : state.AuthorIds,
+            IsExpandedByDefault = summary.IsExpandedByDefault,
             LastSummaryAt = Clocks.SystemClock.Now,
             Version = VersionGenerator.NextVersion(state.Version),
         };
@@ -374,6 +377,34 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 state, ConversationNotificationPhase.Titled, $"Voice chat: {summary.Title}", cancellationToken)
                 .ConfigureAwait(false);
         InvalidateState(chatId);
+    }
+
+    public virtual async Task SetContextStart(ChatId chatId, long contextStartLid, CancellationToken cancellationToken)
+    {
+        using var _ = Computed.BeginIsolation();
+        using var lockHolder = await _changeLocks.Lock(chatId, cancellationToken).ConfigureAwait(false);
+
+        var state = await SafeGet(chatId).ConfigureAwait(false);
+        if (state is null || state.ContextStartLid > 0)
+            return;
+
+        state = state with {
+            ContextStartLid = contextStartLid,
+            Version = VersionGenerator.NextVersion(state.Version),
+        };
+        await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
+        InvalidateState(chatId);
+    }
+
+    public virtual async Task FinalizeSession(ChatId chatId, CancellationToken cancellationToken)
+    {
+        var state = await SafeGet(chatId).ConfigureAwait(false);
+        if (state is null)
+            return;
+        if (!state.IsClosing && await HasParticipant(chatId).ConfigureAwait(false))
+            return; // a participant rejoined during the final pass - keep the session live
+
+        await CloseWithFinal(state, cancellationToken).ConfigureAwait(false);
     }
 
     // Voice-call ring lifecycle
@@ -392,8 +423,8 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         using (await _changeLocks.Lock(chatId, cancellationToken).ConfigureAwait(false)) {
             var now = Clocks.SystemClock.Now;
             var state = await SafeGet(chatId).ConfigureAwait(false);
-            var startEntryLid = state?.StartEntryLid
-                ?? (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
+            var lidRangeEnd = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
+            var startEntryLid = state?.StartEntryLid ?? lidRangeEnd;
             // A call latches immediately: it is "live" the moment it rings, with the caller alone.
             // Promote an already-live (ambient) session to a call too, so ring dismissal/close - gated
             // on Kind == Call - runs for it.
@@ -401,6 +432,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 EndEntryLid = state?.EndEntryLid ?? startEntryLid,
                 StartedAt = state?.StartedAt ?? now,
                 SessionStartedAt = state?.SessionStartedAt ?? now,
+                VisibleStartLid = state?.VisibleStartLid is { } vsl && vsl > 0 ? vsl : lidRangeEnd,
                 AuthorIds = state?.AuthorIds is { Count: > 0 } ids ? ids : [callerAuthorId],
                 Host = callerAuthorId,
                 Kind = LiveSessionKind.Call,
@@ -714,6 +746,13 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 return;
             if (await HasParticipant(chatId).ConfigureAwait(false))
                 return; // someone (re)joined before we got here
+            if (state is { TranscriptionOn: true, SessionStartedAt: not null, Kind: not LiveSessionKind.Call }) {
+                // Hand the close to LiveConversationSummaryFlow: it runs the final summary pass, decides the
+                // tier, materializes, then calls FinalizeSession. StartClosingGrace marks IsClosing; the 90s
+                // SelfClose stays the backstop if the flow never finalizes.
+                await StartClosingGrace(chatId).ConfigureAwait(false);
+                return;
+            }
             await CloseWithFinal(state, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException) {
@@ -772,7 +811,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             // threshold) has nothing to keep and just vanishes.
             if (!state.Title.IsNullOrEmpty())
                 await Commander
-                    .Call(new ConversationBackend_Materialize(state.ToConversation()), true, cancellationToken)
+                    .Call(new ConversationBackend_Materialize(state.ToMaterializedConversation()), true, cancellationToken)
                     .ConfigureAwait(false);
             var content = state.Title.IsNullOrEmpty() ? "Voice chat ended" : $"Voice chat ended: {state.Title}";
             await EnqueueLiveNotification(state, ConversationNotificationPhase.Final, content, cancellationToken)

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -401,8 +401,8 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         var state = await SafeGet(chatId).ConfigureAwait(false);
         if (state is null)
             return;
-        if (!state.IsClosing && await HasParticipant(chatId).ConfigureAwait(false))
-            return; // a participant rejoined during the final pass - keep the session live
+        if (await HasParticipant(chatId).ConfigureAwait(false))
+            return; // someone (re)joined during the final pass - keep the session live
 
         await CloseWithFinal(state, cancellationToken).ConfigureAwait(false);
     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
@@ -28,7 +28,7 @@
     var systemClass = isSystem ? "system-entry" : "";
     var forwardedClass = isForward ? "forwarded-message" : "";
     var forwardedBorderClass = isForward && !showAuthor ? "forwarded-border" : "";
-    var paddingClass = isBlockStart ? "pt-2" : "";
+    var paddingClass = isBlockStart && !message.Flags.HasFlag(ChatMessageFlags.FirstInConversation) ? "pt-2" : "";
     var unreadBlockClass = m.IsUnreadByOthersBlockStart ? "unread-block" : "";
     var ownMessageClass = m.IsOwnMessage ? "own-message" : "";
     var highlightClass = m.IsHighlighted ? "chat-message-highlighted" : "";

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageFlags.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageFlags.cs
@@ -9,4 +9,5 @@ public enum ChatMessageFlags
     HasEntryKindSign = 1 << 3,
     ForwardAuthorStart = 1 << 4,
     IsOwnMessage = 1 << 5,
+    FirstInConversation = 1 << 6,
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -11,4 +11,6 @@ public sealed record ConversationLiveState(
     bool IsLive,
     bool IsJoined,
     bool IsVoiceOnly,
-    string ParticipantsText = "");
+    string ParticipantsText = "",
+    bool HasFoldedEntries = false,
+    bool IsExpanded = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -14,4 +14,4 @@ public sealed record ConversationLiveState(
     string ParticipantsText = "",
     bool HasFoldedEntries = false,
     bool IsExpanded = false,
-    IReadOnlyList<(ChatEntry Entry, Markup Markup)>? TailPreview = null);
+    IReadOnlyList<PreviewEntry>? TailPreview = null);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -13,4 +13,5 @@ public sealed record ConversationLiveState(
     bool IsVoiceOnly,
     string ParticipantsText = "",
     bool HasFoldedEntries = false,
-    bool IsExpanded = false);
+    bool IsExpanded = false,
+    IReadOnlyList<(ChatEntry Entry, Markup Markup)>? TailPreview = null);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -15,9 +15,10 @@
     var attachments = conversation.Attachments;
     var canExpand = !state.IsLive || state.IsJoined;
     var hasLiveTitle = !m.Title.Text.IsNullOrEmpty();
+    var hasDescription = !m.Description.Markup.ToReadableText().IsNullOrEmpty();
     // Exactly what GetClipboardText concatenates - with none of it there, copying yields blank lines.
     var hasCopyText = hasLiveTitle
-        || !m.Description.Markup.ToReadableText().IsNullOrEmpty()
+        || hasDescription
         || !m.Summary.Markup.ToReadableText().IsNullOrEmpty();
 }
 <div class="@cls"
@@ -37,13 +38,14 @@
                         </HeaderButton>
                     }
                 </div>
-                @if (hasSummary) {
-                    <CascadingValue Value="@_fakeEntry" IsFixed="true">
-                        <div class="c-lc-summary">
-                            <MarkupView Markup="@m.Description.Markup"/>
-                        </div>
-                    </CascadingValue>
-                }
+            }
+            @* Gated on the text, not hasSummary: a fold can outlive an empty description. *@
+            @if (hasDescription) {
+                <CascadingValue Value="@_fakeEntry" IsFixed="true">
+                    <div class="c-lc-summary">
+                        <MarkupView Markup="@m.Description.Markup"/>
+                    </div>
+                </CascadingValue>
             }
             <div class="c-lc-meta-row">
                 @if (!hasLiveTitle) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -14,7 +14,7 @@
     var cls = $"conversation-message message-wrapper {openClass} {liveClass}";
     var attachments = conversation.Attachments;
     var canExpand = !state.IsLive || state.IsJoined;
-    var liveTitle = m.Title.Text.IsNullOrEmpty() ? state.ParticipantsText : m.Title.Text;
+    var hasLiveTitle = !m.Title.Text.IsNullOrEmpty();
 }
 <div class="@cls"
      data-menu="@(MenuRef.New<ConversationMenu>(conversation.Id.Value, false.ToString()))">
@@ -23,26 +23,28 @@
         var startedAt = $"Started at {startsAt:HH:mm}";
         var hasSummary = state.HasFoldedEntries;
         <div class="c-live-card">
-            <div class="c-lc-title">
-                <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
-                <span class="c-lc-name">@liveTitle</span>
+            @if (hasLiveTitle) {
+                <div class="c-lc-title">
+                    <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
+                    <span class="c-lc-name">@m.Title.Text</span>
+                    @if (hasSummary) {
+                        <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
+                            <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
+                        </HeaderButton>
+                    }
+                </div>
                 @if (hasSummary) {
-                    <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
-                        <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
-                    </HeaderButton>
+                    <CascadingValue Value="@_fakeEntry" IsFixed="true">
+                        <div class="c-lc-summary">
+                            <MarkupView Markup="@m.Description.Markup"/>
+                        </div>
+                    </CascadingValue>
                 }
-            </div>
-            @if (state.IsJoined) {
-                <div class="c-lc-oncall">You on the call</div>
-            }
-            @if (hasSummary) {
-                <CascadingValue Value="@_fakeEntry" IsFixed="true">
-                    <div class="c-lc-summary">
-                        <MarkupView Markup="@m.Description.Markup"/>
-                    </div>
-                </CascadingValue>
             }
             <div class="c-lc-meta-row">
+                @if (!hasLiveTitle) {
+                    <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
+                }
                 <AuthorCircleGroup
                     Class="c-lc-authors"
                     AuthorIds="@conversation.AuthorIds"
@@ -50,9 +52,16 @@
                     MaxCount="4"
                     ShowRing="false"/>
                 <div class="c-lc-meta">
-                    <div class="c-lc-started">@startedAt</div>
-                    <div class="c-lc-second">@secondLine</div>
+                    @if (!hasLiveTitle) {
+                        <div class="c-lc-roster">@state.ParticipantsText</div>
+                    }
+                    <div class="c-lc-started">@startedAt · @secondLine</div>
                 </div>
+                @if (!hasLiveTitle && hasSummary) {
+                    <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
+                        <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
+                    </HeaderButton>
+                }
                 <HeaderButton Class="c-lc-copy" Click="@OnCopyToClipboardRequested">
                     <i class="icon-copy"></i>
                 </HeaderButton>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -21,14 +21,14 @@
     @if (state.IsLive) {
         var secondLine = state.IsVoiceOnly ? "Voice only" : messageCount + " message".Pluralize(messageCount);
         var startedAt = $"Started at {startsAt:HH:mm}";
-        var hasSummary = !state.IsVoiceOnly;
+        var hasSummary = state.HasFoldedEntries;
         <div class="c-live-card">
             <div class="c-lc-title">
                 <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
                 <span class="c-lc-name">@liveTitle</span>
                 @if (hasSummary) {
                     <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
-                        <i class="@(_isOpen ? "icon-collapse" : "icon-expand")"></i>
+                        <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
                     </HeaderButton>
                 }
             </div>
@@ -172,7 +172,16 @@
         var participantsText = isLive
             ? await GetParticipantsText(chatId, conversation.AuthorIds, cancellationToken).ConfigureAwait(true)
             : "";
-        return new ConversationLiveState(translated, isLive, isJoined, isVoiceOnly, participantsText);
+        // EndEntryLid only advances past the visible start once a summary lands, so this both gates the
+        // expand affordance and marks that a summary/folded range exists.
+        var rawLive = await LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(true);
+        var hasFoldedEntries = isLive && !isVoiceOnly
+            && rawLive is { SessionStartedAt: not null }
+            && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid;
+        var overrides = await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
+        var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);
+        return new ConversationLiveState(
+            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded);
     }
 
     private async Task<string> GetParticipantsText(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -172,11 +172,10 @@
         var participantsText = isLive
             ? await GetParticipantsText(chatId, conversation.AuthorIds, cancellationToken).ConfigureAwait(true)
             : "";
-        // EndEntryLid only advances past the visible start once a summary lands, so this both gates the
-        // expand affordance and marks that a summary/folded range exists.
+        // Pre-summary EndEntryLid still holds its session-creation value, so only LastSummaryAt proves a fold.
         var rawLive = await LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(true);
         var hasFoldedEntries = isLive && !isVoiceOnly
-            && rawLive is { SessionStartedAt: not null }
+            && rawLive is { SessionStartedAt: not null, LastSummaryAt.EpochOffsetTicks: > 0 }
             && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid;
         var overrides = await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
         var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -143,6 +143,7 @@
     private IAuthors Authors => Hub.Authors;
     private ChatAudioUI ChatAudioUI => Hub.ChatAudioUI;
     private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
+    private TranscriptUI TranscriptUI => Hub.TranscriptUI;
     private IChatMarkupHub ChatMarkupHub => ChatContext.ChatMarkupHub;
     private ClipboardUI ClipboardUI => ChatContext.Hub.ClipboardUI;
     private ConversationUI ConversationUI => Hub.ConversationUI;
@@ -207,7 +208,7 @@
             translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded, tailPreview);
     }
 
-    private async Task<IReadOnlyList<(ChatEntry Entry, Markup Markup)>> GetTailPreview(
+    private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(
         ChatId chatId, CancellationToken cancellationToken) {
         var entries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken).ConfigureAwait(true);
         var markupHub = Hub.ChatMarkupHubFactory[chatId];
@@ -215,7 +216,13 @@
             .Select(e => markupHub.GetMarkup(e, MarkupConsumer.MessageView, cancellationToken).AsTask())
             .Collect(cancellationToken)
             .ConfigureAwait(true);
-        return entries.Zip(markups).ToList();
+        var streamingTexts = await entries
+            .Select(e => TranscriptUI.GetStreamingText(e.Id, cancellationToken))
+            .Collect(cancellationToken)
+            .ConfigureAwait(true);
+        return entries
+            .Select((e, i) => new PreviewEntry(e, markups[i], streamingTexts[i]))
+            .ToList();
     }
 
     private async Task<string> GetParticipantsText(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -15,6 +15,10 @@
     var attachments = conversation.Attachments;
     var canExpand = !state.IsLive || state.IsJoined;
     var hasLiveTitle = !m.Title.Text.IsNullOrEmpty();
+    // Exactly what GetClipboardText concatenates - with none of it there, copying yields blank lines.
+    var hasCopyText = hasLiveTitle
+        || !m.Description.Markup.ToReadableText().IsNullOrEmpty()
+        || !m.Summary.Markup.ToReadableText().IsNullOrEmpty();
 }
 <div class="@cls"
      data-menu="@(MenuRef.New<ConversationMenu>(conversation.Id.Value, false.ToString()))">
@@ -62,9 +66,11 @@
                         <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
                     </HeaderButton>
                 }
-                <HeaderButton Class="c-lc-copy" Click="@OnCopyToClipboardRequested">
-                    <i class="icon-copy"></i>
-                </HeaderButton>
+                @if (hasCopyText) {
+                    <HeaderButton Class="c-lc-copy" Click="@OnCopyToClipboardRequested">
+                        <i class="icon-copy"></i>
+                    </HeaderButton>
+                }
             </div>
             @if (state.TailPreview is { Count: > 0 } tailPreview) {
                 <Divider/>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -41,10 +41,6 @@
                     </CascadingValue>
                 }
             }
-            @if (state.TailPreview is { Count: > 0 } tailPreview) {
-                <Divider/>
-                <LastEntriesPreview Entries="@tailPreview"/>
-            }
             <div class="c-lc-meta-row">
                 @if (!hasLiveTitle) {
                     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
@@ -70,6 +66,10 @@
                     <i class="icon-copy"></i>
                 </HeaderButton>
             </div>
+            @if (state.TailPreview is { Count: > 0 } tailPreview) {
+                <Divider/>
+                <LastEntriesPreview Entries="@tailPreview"/>
+            }
             @if (!state.IsJoined) {
                 <button type="button" class="c-join-row" @onclick="@OnJoin">Tap to join</button>
             }
@@ -202,8 +202,7 @@
     }
 
     private async Task<IReadOnlyList<(ChatEntry Entry, Markup Markup)>> GetTailPreview(
-        ChatId chatId, CancellationToken cancellationToken)
-    {
+        ChatId chatId, CancellationToken cancellationToken) {
         var entries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken).ConfigureAwait(true);
         var markupHub = Hub.ChatMarkupHubFactory[chatId];
         var markups = await entries

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -41,6 +41,10 @@
                     </CascadingValue>
                 }
             }
+            @if (state.TailPreview is { Count: > 0 } tailPreview) {
+                <Divider/>
+                <LastEntriesPreview Entries="@tailPreview"/>
+            }
             <div class="c-lc-meta-row">
                 @if (!hasLiveTitle) {
                     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
@@ -188,8 +192,25 @@
             && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid;
         var overrides = await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
         var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);
+        // A joined viewer already reads the live tail below the card; an unjoined one has it hidden, so the
+        // card carries the last entries itself to show the conversation is moving.
+        var tailPreview = isLive && !isJoined && !isVoiceOnly
+            ? await GetTailPreview(chatId, cancellationToken).ConfigureAwait(true)
+            : null;
         return new ConversationLiveState(
-            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded);
+            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded, tailPreview);
+    }
+
+    private async Task<IReadOnlyList<(ChatEntry Entry, Markup Markup)>> GetTailPreview(
+        ChatId chatId, CancellationToken cancellationToken)
+    {
+        var entries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken).ConfigureAwait(true);
+        var markupHub = Hub.ChatMarkupHubFactory[chatId];
+        var markups = await entries
+            .Select(e => markupHub.GetMarkup(e, MarkupConsumer.MessageView, cancellationToken).AsTask())
+            .Collect(cancellationToken)
+            .ConfigureAwait(true);
+        return entries.Zip(markups).ToList();
     }
 
     private async Task<string> GetParticipantsText(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -104,10 +104,11 @@ body.hoverable .conversation-message .c-join-row:hover {
 }
 
 /* An expanded conversation leads with its header, not a .conversation-message, so the card's own top
-   margin can't space it; and the header is sticky, so margining it would move where it pins. Space the
-   whole block from the outside instead. */
+   margin can't space it, and the header is sticky, so margining it would move where it pins.
+   Padding, not margin: the list measures these li's with getBoundingClientRect, which counts padding
+   but not margin - a margin here silently shortens its geometry and the end drifts out of reach. */
 .virtual-list .c-virtual-container .group:has(> .item > .conversation-header) {
-    @apply mt-4;
+    @apply pt-4;
 }
 
 .conversation-header {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -16,7 +16,11 @@
 .conversation-message.live.joined {
     @apply border border-solid;
     border-color: var(--violet-60);
-    background: linear-gradient(249deg, rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%);
+    /* The bg-01 base is opaque so the tail tint can rise behind the card without bleeding through;
+       it composites identically, as the chat view's own ground is bg-01. */
+    background:
+        linear-gradient(249deg, rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%),
+        var(--background-01);
 }
 .c-live-card {
     @apply flex-y gap-y-2 w-full;
@@ -281,15 +285,33 @@ body.hoverable .conversation-attachments .image-attachment:hover {
     @apply bg-cr-badge-selected;
     @apply text-cr-badge-selected-text;
 }
-/* Joined live block: the group wrapper owns one continuous surface (card + folded range + tail),
-   and the live card sits flush as its first row instead of carrying its own border/rounding. */
+/* Joined live block: the card keeps its own border, and the live entries below it sit on a tint that
+   fades out - a live block runs to the chat's tail, so a closed box would wrap the whole viewport and
+   read as ended. The tint is anchored to the first entry, not the group, so it stays put as the card
+   grows and as entries arrive. */
 .virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) {
-    @apply rounded-2xl overflow-hidden mb-2;
-    @apply border border-solid;
-    border-color: var(--violet-60);
-    background: linear-gradient(249deg, rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%);
+    /* Without isolation the tint's z-index resolves against the root and paints under the chat bg. */
+    isolation: isolate;
+    /* The card's mb-2 (0.5rem) + its rounded-2xl radius (1rem): the tint rises by this much to meet
+       the border with no gap and to reach the wedges the rounded corners leave uncovered. */
+    --c-live-rise: 1.5rem;
+    --c-live-depth: 200px;
+    --c-live-tint: rgba(166, 53, 255, 0.1);
 }
-.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) > .item > .conversation-message.live.joined {
-    @apply rounded-none border-none mb-0;
-    background: transparent;
+/* Not `> .item:nth-child(2)`: an entry that author-grouped renders as .group, not .item, so the
+   first row below the card is either one - match whatever it is. */
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) > :nth-child(2) {
+    @apply relative;
+}
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) > :nth-child(2)::before {
+    @apply absolute inset-x-0;
+    @apply pointer-events-none;
+    content: '';
+    top: calc(-1 * var(--c-live-rise));
+    height: calc(var(--c-live-depth) + var(--c-live-rise));
+    background: linear-gradient(to bottom,
+        var(--c-live-tint) 0,
+        var(--c-live-tint) var(--c-live-rise),
+        rgba(166, 53, 255, 0) 100%);
+    z-index: -1;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -3,12 +3,16 @@
     @apply rounded-lg;
     @apply border-none;
     @apply overflow-hidden;
-    /* mt: a conversation block otherwise runs straight into the message above it. */
-    @apply mt-4 mb-2;
+    @apply mb-2;
     background: linear-gradient(5deg, var(--conversation-gradient-01) -96.64%, var(--conversation-gradient-02) 39.02%, var(--conversation-gradient-01) 182.11%)
 }
 .conversation-message.live {
     @apply rounded-2xl;
+}
+/* The gap goes on the data-key item, the only box the list measures, and as padding, which
+   getBoundingClientRect counts - a margin here escapes that box and drifts the list's geometry. */
+.virtual-list .c-virtual-container .item:has(> .conversation-message) {
+    @apply pt-4;
 }
 .conversation-message.live:not(.joined) {
     @apply border-none;
@@ -103,16 +107,11 @@ body.hoverable .conversation-message .c-join-row:hover {
     @apply flex-y;
 }
 
-/* An expanded conversation leads with its header, not a .conversation-message, so the card's own top
-   margin can't space it, and the header is sticky, so margining it would move where it pins.
-   Padding, not margin: the list measures these li's with getBoundingClientRect, which counts padding
-   but not margin - a margin here silently shortens its geometry and the end drifts out of reach. */
-.virtual-list .c-virtual-container .group:has(> .item > .conversation-header) {
-    @apply pt-4;
-}
-
 .conversation-header {
-    @apply mb-2;
+    /* Own padding, not spacing on any ancestor: only elements carrying data-key are measured, so a
+       group li's own box is invisible to the list and any gap there drifts its geometry. bg-01 is the
+       chat's own ground, so this reads as blank space. */
+    @apply pt-4;
     @apply rounded-t-lg;
     @apply bg-01;
     @apply min-h-15;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -14,13 +14,17 @@
     background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);
 }
 .conversation-message.live.joined {
-    @apply border border-solid;
-    border-color: var(--violet-60);
-    /* The bg-01 base is opaque so the tail tint can rise behind the card without bleeding through;
-       it composites identically, as the chat view's own ground is bg-01. */
+    @apply border border-solid border-transparent;
+    /* The outline is a border-box layer, not border-image, which would drop the rounded corners. It
+       decays into the tail's own tint, so the card merges downward instead of closing. The opaque
+       bg-01 base lets that tint rise behind the card, and must be an image - a bare color is only
+       legal in the final background layer, and would silently void the whole declaration here. */
     background:
-        linear-gradient(249deg, rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%),
-        var(--background-01);
+        linear-gradient(249deg,
+            rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%) padding-box,
+        linear-gradient(var(--background-01), var(--background-01)) padding-box,
+        linear-gradient(to bottom,
+            var(--violet-60) 0%, var(--violet-60) 50%, var(--c-live-tint, rgba(166, 53, 255, 0.1)) 100%) border-box;
 }
 .c-live-card {
     @apply flex-y gap-y-2 w-full;
@@ -43,9 +47,9 @@
 .c-live-card .c-lc-expand {
     @apply flex-none;
 }
-.c-live-card .c-lc-oncall {
-    @apply text-caption-1 font-medium;
-    color: var(--violet-60);
+.c-live-card .c-lc-roster {
+    @apply flex-1 min-w-0 truncate;
+    @apply text-01 text-base font-medium leading-5;
 }
 .c-live-card .c-lc-summary {
     @apply text-01 text-caption-4 leading-4;
@@ -64,12 +68,8 @@
     @apply flex-y flex-1 min-w-0 gap-y-0.5;
 }
 .c-live-card .c-lc-started {
+    @apply truncate;
     @apply text-03 font-semibold;
-    font-size: 10px;
-    line-height: 10px;
-}
-.c-live-card .c-lc-second {
-    @apply text-03 font-medium;
     font-size: 10px;
     line-height: 10px;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -281,3 +281,15 @@ body.hoverable .conversation-attachments .image-attachment:hover {
     @apply bg-cr-badge-selected;
     @apply text-cr-badge-selected-text;
 }
+/* Joined live block: the group wrapper owns one continuous surface (card + folded range + tail),
+   and the live card sits flush as its first row instead of carrying its own border/rounding. */
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) {
+    @apply rounded-2xl overflow-hidden mb-2;
+    @apply border border-solid;
+    border-color: var(--violet-60);
+    background: linear-gradient(249deg, rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%);
+}
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) > .item > .conversation-message.live.joined {
+    @apply rounded-none border-none mb-0;
+    background: transparent;
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -103,6 +103,13 @@ body.hoverable .conversation-message .c-join-row:hover {
     @apply flex-y;
 }
 
+/* An expanded conversation leads with its header, not a .conversation-message, so the card's own top
+   margin can't space it; and the header is sticky, so margining it would move where it pins. Space the
+   whole block from the outside instead. */
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-header) {
+    @apply mt-4;
+}
+
 .conversation-header {
     @apply mb-2;
     @apply rounded-t-lg;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -3,7 +3,8 @@
     @apply rounded-lg;
     @apply border-none;
     @apply overflow-hidden;
-    @apply mb-2;
+    /* mt: a conversation block otherwise runs straight into the message above it. */
+    @apply mt-4 mb-2;
     background: linear-gradient(5deg, var(--conversation-gradient-01) -96.64%, var(--conversation-gradient-02) 39.02%, var(--conversation-gradient-01) 182.11%)
 }
 .conversation-message.live {
@@ -292,6 +293,9 @@ body.hoverable .conversation-attachments .image-attachment:hover {
 .virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined) {
     /* Without isolation the tint's z-index resolves against the root and paints under the chat bg. */
     isolation: isolate;
+    /* The tint is a fixed-height box, so it would spill past the last entry into whatever follows;
+       clipping it to the block both stops that and gives it the block's rounded bottom. */
+    @apply overflow-hidden rounded-2xl;
     /* The card's mb-2 (0.5rem) + its rounded-2xl radius (1rem): the tint rises by this much to meet
        the border with no gap and to reach the wedges the rounded corners leave uncovered. */
     --c-live-rise: 1.5rem;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
@@ -4,7 +4,7 @@
     @if (IsLoading) {
         <chat-list-skeleton count="@SkeletonCount" messageCls="thread-skeleton"/>
     } else {
-        foreach (var (chatEntry, markup) in Entries) {
+        foreach (var (chatEntry, markup, streamingText) in Entries) {
             <div class="c-message-wrapper">
                 <AuthorCircle
                     AuthorId="@chatEntry.AuthorId"
@@ -15,9 +15,9 @@
                         <LiveTimeDeltaText Class="chat-message-timestamp min-w-fit" Moment="@chatEntry.BeginsAt"/>
                     </div>
                     <span class="c-message">
-                        @* An entry with no text and no attachments is one still being transcribed;
-                           without this guard the plug below reports "0 media attached". *@
-                        @if (markup.ToReadableText().IsNullOrEmpty() && chatEntry.Attachments.Length > 0) {
+                        @if (!streamingText.IsNullOrEmpty()) {
+                            @streamingText
+                        } else if (markup.ToReadableText().IsNullOrEmpty() && chatEntry.Attachments.Length > 0) {
                             var (mediaList, fileList) = SplitByKind(chatEntry.Attachments);
                             var mediaCount = mediaList.Length;
                             var fileCount = fileList.Length;
@@ -66,7 +66,7 @@
 </div>
 
 @code {
-    [Parameter] public IReadOnlyList<(ChatEntry Entry, Markup Markup)> Entries { get; set; } = [];
+    [Parameter] public IReadOnlyList<PreviewEntry> Entries { get; set; } = [];
     [Parameter] public bool IsLoading { get; set; }
     [Parameter] public int SkeletonCount { get; set; } = 2;
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
@@ -1,0 +1,76 @@
+@namespace ActualChat.UI.Blazor.App.Components
+
+<div class="last-entries-preview">
+    @if (IsLoading) {
+        <chat-list-skeleton count="@SkeletonCount" messageCls="thread-skeleton"/>
+    } else {
+        foreach (var (chatEntry, markup) in Entries) {
+            <div class="c-message-wrapper">
+                <AuthorCircle
+                    AuthorId="@chatEntry.AuthorId"
+                    Size="SquareSize.Size8"/>
+                <div class="c-content">
+                    <div class="c-info">
+                        <AuthorName AuthorId="@chatEntry.AuthorId" Class="chat-message-author-name"/>
+                        <LiveTimeDeltaText Class="chat-message-timestamp min-w-fit" Moment="@chatEntry.BeginsAt"/>
+                    </div>
+                    <span class="c-message">
+                        @* An entry with no text and no attachments is one still being transcribed;
+                           without this guard the plug below reports "0 media attached". *@
+                        @if (markup.ToReadableText().IsNullOrEmpty() && chatEntry.Attachments.Length > 0) {
+                            var (mediaList, fileList) = SplitByKind(chatEntry.Attachments);
+                            var mediaCount = mediaList.Length;
+                            var fileCount = fileList.Length;
+                            if (fileCount == 0) {
+                                if (mediaCount == 1) {
+                                    <span class="attachment-plug">
+                                        <i class="icon-image-2"></i>
+                                        <span>@mediaList[0].Media.FileName</span>
+                                    </span>
+                                } else {
+                                    <span class="attachment-plug">
+                                        <i class="icon-image-2"></i>
+                                        <span>@($"{mediaList.Length} media attached")</span>
+                                    </span>
+                                }
+                            } else {
+                                if (mediaCount == 0) {
+                                    if (fileCount == 1) {
+                                        <span class="attachment-plug">
+                                            <i class="icon-attach-2"></i>
+                                            <span>@fileList[0].Media.FileName</span>
+                                        </span>
+                                    } else {
+                                        <span class="attachment-plug">
+                                            <i class="icon-attach-2"></i>
+                                            <span>@($"{fileList.Length} files attached")</span>
+                                        </span>
+                                    }
+                                } else {
+                                    <span class="attachment-plug">
+                                        <i class="icon-attach-2"></i>
+                                        <span>@($"{fileList.Length + mediaList.Length} files and media attached")</span>
+                                    </span>
+                                }
+                            }
+                        } else {
+                            <CascadingValue Value="@chatEntry" IsFixed="true">
+                                <MarkupView Markup="@markup"></MarkupView>
+                            </CascadingValue>
+                        }
+                    </span>
+                </div>
+            </div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<(ChatEntry Entry, Markup Markup)> Entries { get; set; } = [];
+    [Parameter] public bool IsLoading { get; set; }
+    [Parameter] public int SkeletonCount { get; set; } = 2;
+
+    private static (ChatEntryAttachment[] Media, ChatEntryAttachment[] Files) SplitByKind(ChatEntryAttachment[] items)
+        => (items.Where(a => a.IsVisualMedia()).ToArray(),
+            items.Where(a => !a.IsVisualMedia()).ToArray());
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/PreviewEntry.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/PreviewEntry.cs
@@ -1,0 +1,7 @@
+namespace ActualChat.UI.Blazor.App.Components;
+
+/// <summary>
+/// One row of a <see cref="LastEntriesPreview"/>: an entry plus both places its text can live - its own
+/// markup once persisted, or the transcript stream while it is still being spoken.
+/// </summary>
+public sealed record PreviewEntry(ChatEntry Entry, Markup Markup, string StreamingText = "");

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
@@ -47,68 +47,7 @@
         @TranslationFragments.TranslationMark(description.State)
     </div>
     <Divider/>
-    <div class="c-last-messages">
-        @if (isLoading) {
-            <chat-list-skeleton count="2" messageCls="thread-skeleton"/>
-        } else {
-            foreach (var (chatEntry, markup) in m!.Entries) {
-                <div class="c-message-wrapper">
-                    <AuthorCircle
-                        AuthorId="@chatEntry.AuthorId"
-                        Size="SquareSize.Size8"/>
-                    <div class="c-content">
-                        <div class="c-info">
-                            <AuthorName AuthorId="@chatEntry.AuthorId" Class="chat-message-author-name"/>
-                            <LiveTimeDeltaText Class="chat-message-timestamp min-w-fit" Moment="@chatEntry.BeginsAt"/>
-                        </div>
-                        <span class="c-message">
-                            @if (markup.ToReadableText().IsNullOrEmpty()) {
-                                var (mediaList, fileList) = GetOrderedAttachmentList(chatEntry.Attachments);
-                                var mediaCount = mediaList.Length;
-                                var fileCount = fileList.Length;
-                                if (fileCount == 0) {
-                                    if (mediaCount == 1) {
-                                        <span class="attachment-plug">
-                                            <i class="icon-image-2"></i>
-                                            <span>@mediaList[0].Media.FileName</span>
-                                        </span>
-                                    } else {
-                                        <span class="attachment-plug">
-                                            <i class="icon-image-2"></i>
-                                            <span>@($"{mediaList.Length} media attached")</span>
-                                        </span>
-                                    }
-                                } else {
-                                    if (mediaCount == 0) {
-                                        if (fileCount == 1) {
-                                            <span class="attachment-plug">
-                                                <i class="icon-attach-2"></i>
-                                                <span>@fileList[0].Media.FileName</span>
-                                            </span>
-                                        } else {
-                                            <span class="attachment-plug">
-                                                <i class="icon-attach-2"></i>
-                                                <span>@($"{fileList.Length} files attached")</span>
-                                            </span>
-                                        }
-                                    } else {
-                                        <span class="attachment-plug">
-                                            <i class="icon-attach-2"></i>
-                                            <span>@($"{fileList.Length + mediaList.Length} files and media attached")</span>
-                                        </span>
-                                    }
-                                }
-                            } else {
-                                <CascadingValue Value="@chatEntry" IsFixed="true">
-                                    <MarkupView Markup="@markup"></MarkupView>
-                                </CascadingValue>
-                            }
-                        </span>
-                    </div>
-                </div>
-            }
-        }
-    </div>
+    <LastEntriesPreview Entries="@(m?.Entries ?? [])" IsLoading="@isLoading"/>
     @if (attachments.Length > 0) {
         var (mediaList, fileList) = GetOrderedAttachmentList(attachments);
         <div class="message-attachments">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
@@ -21,6 +21,7 @@
                         : createdAt.ToString("MMM dd"); // this year
     var attachments = m is null ? [] : m.Attachments;
     var messageCount = m?.MessageCount ?? 0;
+    var previewEntries = m?.Entries.Select(x => new PreviewEntry(x.Item1, x.Item2)).ToList() ?? [];
 }
 
 <div class="thread-message"
@@ -47,7 +48,7 @@
         @TranslationFragments.TranslationMark(description.State)
     </div>
     <Divider/>
-    <LastEntriesPreview Entries="@(m?.Entries ?? [])" IsLoading="@isLoading"/>
+    <LastEntriesPreview Entries="@previewEntries" IsLoading="@isLoading"/>
     @if (attachments.Length > 0) {
         var (mediaList, fileList) = GetOrderedAttachmentList(attachments);
         <div class="message-attachments">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/threads.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/threads.css
@@ -27,35 +27,6 @@
     @apply h-px w-full;
     @apply border-[var(--ash-90)];
 }
-.thread-message .c-last-messages {
-    @apply flex-y gap-y-2;
-}
-.thread-message .c-last-messages .c-message-wrapper {
-    @apply flex-x gap-x-4 items-start;
-    @apply h-10;
-}
-.thread-message .c-last-messages .c-message-wrapper .avatar-circle {
-    @apply self-start;
-}
-.thread-message .c-last-messages .c-message-wrapper .c-content {
-    @apply flex-y;
-    @apply w-full;
-    @apply overflow-hidden;
-}
-.thread-message .c-last-messages .c-message-wrapper .c-content .c-info {
-    @apply flex-x items-center gap-x-2;
-    @apply w-full;
-    @apply overflow-hidden;
-}
-.thread-message .c-last-messages .c-message-wrapper .c-content .c-message {
-    @apply text-caption-4 text-02;
-    @apply line-clamp-1;
-}
-.thread-message .attachment-plug {
-    @apply flex-x items-center gap-x-1;
-    @apply h-4.5;
-}
-
 .thread-message .c-footer {
     @apply flex-x items-center gap-x-4;
     @apply mt-4;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptUI.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptUI.cs
@@ -4,8 +4,34 @@ namespace ActualChat.UI.Blazor.App.Components;
 
 public class TranscriptUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeService
 {
+    private readonly IThreadSafeLruCache<ChatEntryId, TranscriptStreamReader> _previewReaders
+        = new ThreadSafeLruCache<ChatEntryId, TranscriptStreamReader>(32);
+
     private ChatUI ChatUI => Hub.ChatUI;
     private TranslationUI TranslationUI => Hub.TranslationUI;
+
+    [ComputeMethod]
+    public virtual async Task<string> GetStreamingText(ChatEntryId id, CancellationToken cancellationToken)
+    {
+        // A streaming entry's persisted Content is empty - its text exists only in the stream.
+        var entry = await ChatUI.GetEntry(id, cancellationToken).ConfigureAwait(false);
+        if (entry is not { IsContentStreaming: true }) {
+            // GetEntry invalidates when the entry finalizes, so this is where a finished reader is retired.
+            if (_previewReaders.TryGetValue(id, out var finished)) {
+                _previewReaders.Remove(id);
+                _ = finished.DisposeSilentlyAsync();
+            }
+            return "";
+        }
+
+        var reader = _previewReaders.GetOrAdd(id, entryId => {
+            var newReader = new TranscriptStreamReader(entryId, Hub);
+            newReader.Start();
+            return newReader;
+        });
+        var state = await reader.State.Use(cancellationToken).ConfigureAwait(false);
+        return state.RetainedText + state.ChangedText + state.AnimatedText;
+    }
 
     [ComputeMethod]
     public virtual async Task<StreamingState?> GetStreamingState(ChatEntryId id, CancellationToken cancellationToken)

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptUI.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranscriptUI.cs
@@ -4,8 +4,9 @@ namespace ActualChat.UI.Blazor.App.Components;
 
 public class TranscriptUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeService
 {
+    // This cache is the reader's only owner, so an eviction that doesn't dispose orphans a running worker.
     private readonly IThreadSafeLruCache<ChatEntryId, TranscriptStreamReader> _previewReaders
-        = new ThreadSafeLruCache<ChatEntryId, TranscriptStreamReader>(32);
+        = new ThreadSafeLruCache<ChatEntryId, TranscriptStreamReader>(32, evictionHandler: DisposeEvictedReader);
 
     private ChatUI ChatUI => Hub.ChatUI;
     private TranslationUI TranslationUI => Hub.TranslationUI;
@@ -63,6 +64,11 @@ public class TranscriptUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), ICompute
         var streamId = StreamId.New(sourceStreamId, translationLanguage);
         return new StreamingState(streamId, entry.Content, IsTranslation: true); // We can start ad-hoc translation stream.
     }
+
+    // Private methods
+
+    private static void DisposeEvictedReader(ChatEntryId id, TranscriptStreamReader reader)
+        => _ = reader.DisposeSilentlyAsync();
 
     // Nested types
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
@@ -1,0 +1,30 @@
+.last-entries-preview {
+    @apply flex-y gap-y-2;
+}
+/* Fixed row height + a one-line clamp: the host block can't change height as entries stream in or
+   replace each other, however much anyone says. */
+.last-entries-preview .c-message-wrapper {
+    @apply flex-x gap-x-4 items-start;
+    @apply h-10;
+}
+.last-entries-preview .c-message-wrapper .avatar-circle {
+    @apply self-start;
+}
+.last-entries-preview .c-message-wrapper .c-content {
+    @apply flex-y;
+    @apply w-full;
+    @apply overflow-hidden;
+}
+.last-entries-preview .c-message-wrapper .c-content .c-info {
+    @apply flex-x items-center gap-x-2;
+    @apply w-full;
+    @apply overflow-hidden;
+}
+.last-entries-preview .c-message-wrapper .c-content .c-message {
+    @apply text-caption-4 text-02;
+    @apply line-clamp-1;
+}
+.last-entries-preview .attachment-plug {
+    @apply flex-x items-center gap-x-1;
+    @apply h-4.5;
+}

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -179,14 +179,6 @@ public partial class ChatUI
                 chatRangeMetaList.Add(nextChatRangeMeta);
         }
 
-        // The live block is keyed by the chat end at latch - a lid with no entry yet. When that lid starts
-        // its own view tile, no entry ever pulls the tile in (a video-only session never writes one), so
-        // the block would never render. Only fires when the block sits past the last loaded tile, which
-        // also makes the added tile adjacent - never leaving a hole in idTiles.
-        if (liveConversation != null && !hasMoreAfter && idTiles.Count > 0
-            && liveConversation.Id.StartEntryLid >= idTiles[^1].End)
-            idTiles.Add(IdTileStack.FirstLayer.GetTile(liveConversation.Id.StartEntryLid).Range);
-
         // Prefetch tiles for the loaded id ranges
         {
             await Task.Run(async () => {

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -687,6 +687,9 @@ public partial class ChatUI
                             prevMessage.NextMessage = conversationHeaderMessage;
                         messages.Add(conversationHeaderMessage);
                         prevMessage = conversationHeaderMessage;
+                        // This entry opens the conversation - the header already spaces it off. A date line
+                        // can land in between, so the entry can't tell from its own PreviousMessage.
+                        flags |= ChatMessageFlags.FirstInConversation;
                     }
                     if (date != prevDate) {
                         var dateLineMessage = new ChatEntryMessage(entry) {

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -67,12 +67,14 @@ public partial class ChatUI
         var hiddenLiveTailRange = liveConversation is { } liveConv && !amInLiveConversation
             ? new Range<long>(liveConv.EndEntryLid + 1, long.MaxValue)
             : default;
-        // Joined viewers fold only the summarized range [V, EndEntryLid]; it is empty until the first
-        // summary advances EndEntryLid past V, so nothing folds (and entry V isn't hidden) pre-summary.
+        // Joined viewers fold only the summarized range [V, EndEntryLid]. Gate on LastSummaryAt: until the
+        // first summary lands, EndEntryLid still holds its session-creation value, which equals V whenever
+        // nothing was posted between creation and latch - folding entry V away as if it were summarized.
         var rawLive = await Hub.LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
-        var liveFoldRange = rawLive is { SessionStartedAt: not null } && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid
-            ? new Range<long>(rawLive.EffectiveVisibleStartLid, rawLive.EndEntryLid + 1)
-            : default;
+        var liveFoldRange = rawLive is { SessionStartedAt: not null, LastSummaryAt.EpochOffsetTicks: > 0 }
+            && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid
+                ? new Range<long>(rawLive.EffectiveVisibleStartLid, rawLive.EndEntryLid + 1)
+                : default;
 
         var metaIdTiles = ServerIdTileStack.LastLayer.GetCoveringTiles(dataQuery.ExistingLidRange.Expand(LoadLimit))
             .Where(t => t.Start >= 0)
@@ -176,6 +178,14 @@ public partial class ChatUI
             if (nextChatRangeMeta != null!)
                 chatRangeMetaList.Add(nextChatRangeMeta);
         }
+
+        // The live block is keyed by the chat end at latch - a lid with no entry yet. When that lid starts
+        // its own view tile, no entry ever pulls the tile in (a video-only session never writes one), so
+        // the block would never render. Only fires when the block sits past the last loaded tile, which
+        // also makes the added tile adjacent - never leaving a hole in idTiles.
+        if (liveConversation != null && !hasMoreAfter && idTiles.Count > 0
+            && liveConversation.Id.StartEntryLid >= idTiles[^1].End)
+            idTiles.Add(IdTileStack.FirstLayer.GetTile(liveConversation.Id.StartEntryLid).Range);
 
         // Prefetch tiles for the loaded id ranges
         {

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -206,6 +206,7 @@ public partial class ChatUI
         var hasVeryFirstItem = idTiles.Count > 0 && idTiles[0].Start <= chatLidRange.Start;
         var prevMessage = hasVeryFirstItem ? ChatMessage.Welcome(chatId) : null;
         var alreadyAddedConversationHeaders = new HashSet<ConversationId>();
+        var alreadyAddedConversationCards = new HashSet<ConversationId>();
         // The single tail tile merging optimistic "sending"/new/audio-recording messages - picked once so a
         // live session's beyond-end conversation tiles can't become a second tail (duplicate @key crash).
         var tailTileIndex = idTiles.FindIndex(t => t.Contains(chatLidRange.End - 1));
@@ -247,6 +248,16 @@ public partial class ChatUI
                 if (tile.Items[0] is ConversationHeader conversationHeader
                     && alreadyAddedConversationHeaders.Contains(conversationHeader.Conversation!.Id))
                     tile = tile with { Items = tile.Items.Skip(1).ToList() };
+            if (tile.Items.Count == 0)
+                continue;
+
+            // Every tile a conversation spans re-emits its card, and the duplicate @key kills the circuit.
+            var dedupedItems = tile.Items
+                .Where(chatMessage => chatMessage is not ConversationMessage conversationMessage
+                    || alreadyAddedConversationCards.Add(conversationMessage.Conversation!.Id))
+                .ToList();
+            if (dedupedItems.Count != tile.Items.Count)
+                tile = tile with { Items = dedupedItems };
             if (tile.Items.Count == 0)
                 continue;
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -11,7 +11,9 @@ public record ChatItems(IReadOnlyList<ChatMessage> Items, bool HasBefore, bool H
 public sealed record ConversationViewState(
     bool ShowConversations,
     IImmutableSet<ConversationId> ExpandedConversations,
-    Range<long> HiddenLiveTailRange);
+    Range<long> HiddenLiveTailRange,
+    ConversationId? JoinedLiveConversationId,
+    Range<long> LiveFoldRange);
 
 public partial class ChatUI
 {
@@ -23,7 +25,7 @@ public partial class ChatUI
 
     private volatile ChatEntry? _audioRecordingEntry;
 
-    private IImmutableSet<ConversationId> LastExpandedConversations { get; set; } =
+    private IImmutableSet<ConversationId> LastConversationExpansionOverrides { get; set; } =
         ImmutableHashSet<ConversationId>.Empty;
 
     public int HalfLoadLimit => BrowserInfo.IsMobile ? SecondTileSize : SecondTileSize * 2; // 20 for mobile
@@ -59,10 +61,17 @@ public partial class ChatUI
         var liveConversation = await Hub.LiveSessionUI.GetConversation(chatId, cancellationToken).ConfigureAwait(false);
         var amInLiveConversation = liveConversation != null
             && await Hub.LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
+        var joinedLiveConversation = amInLiveConversation ? liveConversation : null;
         // Non-joined users see the live block's summary only — no live entries. The synthetic
         // conversation already collapses [Start, EndEntryLid]; hide the un-summarized tail too.
         var hiddenLiveTailRange = liveConversation is { } liveConv && !amInLiveConversation
             ? new Range<long>(liveConv.EndEntryLid + 1, long.MaxValue)
+            : default;
+        // Joined viewers fold only the summarized range [V, EndEntryLid]; it is empty until the first
+        // summary advances EndEntryLid past V, so nothing folds (and entry V isn't hidden) pre-summary.
+        var rawLive = await Hub.LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
+        var liveFoldRange = rawLive is { SessionStartedAt: not null } && rawLive.EndEntryLid >= rawLive.EffectiveVisibleStartLid
+            ? new Range<long>(rawLive.EffectiveVisibleStartLid, rawLive.EndEntryLid + 1)
             : default;
 
         var metaIdTiles = ServerIdTileStack.LastLayer.GetCoveringTiles(dataQuery.ExistingLidRange.Expand(LoadLimit))
@@ -79,42 +88,63 @@ public partial class ChatUI
             .ToList();
 
         var showConversations = (chat.IsSummarized ?? false) || liveConversation != null;
-        if (showConversations && dataQuery.Navigation is { ShouldRestoreViewPosition: false, KeepConversationsCollapsed: false }) {
-            var conversationRanges = chatRangeMetaList
-                .SelectMany(rm => rm.ConversationLidRanges)
-                .EnsureMonotonic()
-                .ToList();
-            var navigateToId = dataQuery.Navigation.EntryLid;
-            var index = conversationRanges.AsSpan().BinarySearch(r => r.Contains(navigateToId) || r.Start > navigateToId);
-            if (index >= 0) {
-                var conversationRange = conversationRanges[index];
-                if (conversationRange.Contains(navigateToId)) {
-                    // Expand the conversation if its range contains the navigateToId
-                    var conversationId = ConversationId.New(chatId, conversationRange.Start);
-                    var currentExpandedConversations = ExpandedConversations.Value;
-                    var newExpandedConversations =  currentExpandedConversations.Add(conversationId);
-                    if (!ReferenceEquals(newExpandedConversations, currentExpandedConversations)) {
-                        _expandedConversations.Value = newExpandedConversations;
-                        // We don't need to navigate to the conversation start entry
-                        LastExpandedConversations = newExpandedConversations;
+
+        // Effective expansion = each conversation's IsExpandedByDefault flipped by a local override, so
+        // expandedConversations below is the resolved "render expanded" set, not the raw override set.
+        IImmutableSet<ConversationId> defaultExpanded = ImmutableHashSet<ConversationId>.Empty;
+        IImmutableSet<ConversationId> expandedConversations = ImmutableHashSet<ConversationId>.Empty;
+        if (showConversations) {
+            var conversationTiles = await metaIdTiles
+                .Select(t => Conversations.GetTile(Session, chatId, t.Range, cancellationToken))
+                .Collect(cancellationToken)
+                .ConfigureAwait(false);
+            defaultExpanded = conversationTiles
+                .SelectMany(t => t)
+                .Where(c => c.IsExpandedByDefault)
+                .Select(c => c.Id)
+                .ToImmutableHashSet();
+
+            if (dataQuery.Navigation is { ShouldRestoreViewPosition: false, KeepConversationsCollapsed: false }) {
+                var conversationRanges = chatRangeMetaList
+                    .SelectMany(rm => rm.ConversationLidRanges)
+                    .EnsureMonotonic()
+                    .ToList();
+                var navigateToId = dataQuery.Navigation.EntryLid;
+                var index = conversationRanges.AsSpan().BinarySearch(r => r.Contains(navigateToId) || r.Start > navigateToId);
+                if (index >= 0) {
+                    var conversationRange = conversationRanges[index];
+                    if (conversationRange.Contains(navigateToId)) {
+                        // Ensure the navigated-to conversation is effective-expanded (flip its override if not).
+                        var conversationId = ConversationId.New(chatId, conversationRange.Start);
+                        var overrides0 = ConversationExpansionOverrides.Value;
+                        var isExpanded = defaultExpanded.Contains(conversationId) ^ overrides0.Contains(conversationId);
+                        if (!isExpanded) {
+                            var newOverrides = overrides0.Contains(conversationId)
+                                ? overrides0.Remove(conversationId)
+                                : overrides0.Add(conversationId);
+                            _conversationExpansionOverrides.Value = newOverrides;
+                            LastConversationExpansionOverrides = newOverrides;
+                        }
                     }
                 }
             }
-        }
 
-        IImmutableSet<ConversationId> expandedConversations = [];
-        if (showConversations) {
-            expandedConversations = await ExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
-            var changedExpand = expandedConversations.SymmetricExcept(LastExpandedConversations)
+            var overrides = await ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
+            var changedOverrides = overrides.SymmetricExcept(LastConversationExpansionOverrides)
                 .OrderBy(c => c.StartEntryLid)
                 .ToList();
-            LastExpandedConversations = expandedConversations;
-            if (changedExpand.FirstOrDefault() is { } conversationId)
-                // Adjust data query to load tiles around expanded conversation entries
+            LastConversationExpansionOverrides = overrides;
+            if (changedOverrides.FirstOrDefault() is { } toggledId)
+                // Adjust data query to load tiles around the toggled conversation's entries
                 dataQuery = new ChatDataQuery(
-                    IdTileStack.LastLayer.GetTile(conversationId.StartEntryLid).Range,
+                    IdTileStack.LastLayer.GetTile(toggledId.StartEntryLid).Range,
                     -HalfLoadLimit,
                     HalfLoadLimit);
+
+            expandedConversations = defaultExpanded.SymmetricExcept(overrides);
+            // A stale joined-era expand must not leak the hidden tail once the viewer is no longer joined.
+            if (liveConversation != null && !amInLiveConversation)
+                expandedConversations = expandedConversations.Remove(liveConversation.Id);
         }
 
         Range<long> chatLidRange;
@@ -191,7 +221,7 @@ public partial class ChatUI
                     chatId,
                     chat.Rules.Author?.Id,
                     idTile,
-                    new ConversationViewState(showConversations, expandedConversations, hiddenLiveTailRange),
+                    new ConversationViewState(showConversations, expandedConversations, hiddenLiveTailRange, joinedLiveConversation?.Id, liveFoldRange),
                     prevMessage,
                     lastReadEntryLid,
                     isLastTile ? chatLidRange.End : null,
@@ -239,7 +269,7 @@ public partial class ChatUI
                     chatId,
                     chat.Rules.Author?.Id,
                     tailRange,
-                    new ConversationViewState(showConversations, expandedConversations, hiddenLiveTailRange),
+                    new ConversationViewState(showConversations, expandedConversations, hiddenLiveTailRange, joinedLiveConversation?.Id, liveFoldRange),
                     prevMessage,
                     shownReadyEntryLid,
                     chatLidRange.End,
@@ -299,10 +329,10 @@ public partial class ChatUI
 
         var groupedItems = GroupAuthorMessages(items);
 
-        if (expandedConversations.Count == 0)
+        if (expandedConversations.Count == 0 && joinedLiveConversation == null)
             return new ChatItems(groupedItems, hasMoreBefore, hasMoreAfter);
 
-        var groupedTiles = GroupExpandedConversations(groupedItems);
+        var groupedTiles = GroupExpandedConversations(groupedItems, joinedLiveConversation);
         return new ChatItems(groupedTiles, hasMoreBefore, hasMoreAfter);
 
         bool TryGetIdTilesToLoad(
@@ -454,7 +484,7 @@ public partial class ChatUI
         if (lidRange.IsEmptyOrNegative)
             throw new ArgumentOutOfRangeException(nameof(lidRange));
 
-        var (showConversations, expandedConversations, hiddenLiveTailRange) = conversationView;
+        var (showConversations, expandedConversations, hiddenLiveTailRange, joinedLiveId, liveFoldRange) = conversationView;
 
         var chatSendingMessages = chatSendingMessagesWrapper.Value;
         var requestedIdRange = prevMessage == null
@@ -474,7 +504,10 @@ public partial class ChatUI
                 .ToArray();
             idRangesToSkip = conversations
                 .Where(c => !expandedConversations.Contains(c.Id))
-                .Select(c => c.EntryLidRange)
+                // The joined live block folds only its summarized range (empty pre-summary), never the whole
+                // EntryLidRange - so entry V and the un-summarized tail stay visible.
+                .Select(c => c.Id == joinedLiveId ? liveFoldRange : c.EntryLidRange)
+                .Where(r => !r.IsEmpty)
                 .ToArray();
         }
         if (!hiddenLiveTailRange.IsEmpty)
@@ -536,12 +569,20 @@ public partial class ChatUI
         }
 
         var messages = new List<ChatMessage>(entries.Count);
-        var items = entries.Merge(conversations.Where(c => !expandedConversations.Contains(c.Id)),
+        // The joined live card is emitted even when expanded (it is the block header), so keep it on the
+        // merge's right side regardless of expansion.
+        var items = entries.Merge(
+            conversations.Where(c => !expandedConversations.Contains(c.Id) || c.Id == joinedLiveId),
             e => e.LocalId,
             c => c.Id.StartEntryLid);
         var isWelcomeBlockAdded = false;
         foreach (var (entry, conversation) in items) {
             var date = DateOnly.FromDateTime(DateTimeConverter.ToLocalTime(entry?.BeginsAt ?? conversation!.StartsAt));
+            var shouldEmitCard = conversation != null
+                && (!expandedConversations.Contains(conversation.Id) || conversation.Id == joinedLiveId);
+            // Paired tuple: a loaded entry shares the card's key lid (V) - emit the card before the entry.
+            if (shouldEmitCard && entry != null)
+                EmitConversationCard(conversation!, date);
             if (entry is { IsThreadStart: true }) {
                 var threadChatId = entry.ChatId.CreateThreadId(entry.LocalId);
                 var threadChat = await Chats.Get(Session, threadChatId, cancellationToken).ConfigureAwait(false);
@@ -560,6 +601,11 @@ public partial class ChatUI
                 var isClientMsg = entry.Version == 0;
                 var expandedConversation = conversations.FirstOrDefault(c => c.EntryLidRange.Contains(entry.LocalId));
                 var isBlockStart = IsBlockStart(prevEntry, entry);
+                // Force a block start on the first entry crossing into the joined live block, so a same-author
+                // pre-latch group can't swallow the block's tail entries.
+                if (joinedLiveId is { } jlId && entry.LocalId >= jlId.StartEntryLid
+                    && (prevEntry == null || prevEntry.LocalId < jlId.StartEntryLid))
+                    isBlockStart = true;
                 var isForward = entry.Forwarded is not null;
                 var isPrevForward = prevEntry is not null && prevEntry.Forwarded is not null;
                 var isForwardFromOtherChat = prevEntry?.Forwarded?.AuthorId.ChatId != entry.Forwarded?.AuthorId.ChatId;
@@ -611,8 +657,9 @@ public partial class ChatUI
                         prevMessage = newLineMessage;
                     }
 
-                    // Conversation header goes before the date line
-                    if (expandedConversation != null && alreadyAddedConversationHeaders.Add(expandedConversation.Id)
+                    // Conversation header goes before the date line (the joined live card is its own header).
+                    if (expandedConversation != null && expandedConversation.Id != joinedLiveId
+                        && alreadyAddedConversationHeaders.Add(expandedConversation.Id)
                         && (prevMessage == null
                             || prevMessage.Kind == ChatMessageKind.WelcomeBlock
                             || prevMessage.Id < expandedConversation.Id.StartEntryLid)) {
@@ -664,7 +711,7 @@ public partial class ChatUI
                     messages.Add(message);
                     prevMessage = message;
 
-                    if (expandedConversation != null)
+                    if (expandedConversation != null && expandedConversation.Id != joinedLiveId)
                         if (entry.Id.LocalId == expandedConversation.EndEntryLid) {
                             var conversationFooterMessage = new ConversationFooter(expandedConversation) {
                                 Kind = ChatMessageKind.ConversationEnd,
@@ -681,19 +728,8 @@ public partial class ChatUI
                 isPrevUnread = isEntryUnread;
                 isPrevAudio = isAudio;
             }
-            else if (conversation != null && !expandedConversations.Contains(conversation.Id)) {
-                var message = new ConversationMessage(conversation) {
-                    Kind = ChatMessageKind.ConversationStart,
-                    Date = date,
-                    PreviousMessage = prevMessage,
-                };
-                // Can't skip adding a conversation message even if it's the same as previous message
-                // Note: the same conversation can be returned by different id tiles as it spans across multiple tiles
-                if (prevMessage != null)
-                    prevMessage.NextMessage = message;
-                messages.Add(message);
-                prevMessage = message;
-            }
+            else if (shouldEmitCard)
+                EmitConversationCard(conversation!, date);
             prevDate = date;
         }
         if (messages.Count > 0 && !lidRange.Contains(messages[0].Id))
@@ -702,6 +738,21 @@ public partial class ChatUI
                 (m is ChatEntryMessage && !lidRange.Contains(m.Id))
                 || (m is ConversationMessage cm && lidRange.IntersectWith(cm.Conversation!.EntryLidRange).IsEmpty));
         return new VirtualListTile<ChatMessage>($"tile:{lidRange.Format()}", messages);
+
+        void EmitConversationCard(Conversation conversation, DateOnly date)
+        {
+            var message = new ConversationMessage(conversation) {
+                Kind = ChatMessageKind.ConversationStart,
+                Date = date,
+                PreviousMessage = prevMessage,
+            };
+            // Can't skip adding a conversation message even if it's the same as previous message
+            // Note: the same conversation can be returned by different id tiles as it spans across multiple tiles
+            if (prevMessage != null)
+                prevMessage.NextMessage = message;
+            messages.Add(message);
+            prevMessage = message;
+        }
     }
 
     [ComputeMethod]
@@ -779,7 +830,7 @@ public partial class ChatUI
         }
     }
 
-    private static List<ChatMessage> GroupExpandedConversations(IReadOnlyList<ChatMessage> messages)
+    private static List<ChatMessage> GroupExpandedConversations(IReadOnlyList<ChatMessage> messages, Conversation? joinedLive)
     {
         // Wrap every item of one expanded conversation into a single ExpandedConversationMessage in
         // source order - the block is the sticky containing element for the conversation header and
@@ -791,20 +842,29 @@ public partial class ChatUI
         var result = new List<ChatMessage>();
         Conversation? blockConversation = null;
         var blockItems = new List<ChatMessage>();
+        // The joined live block groups by lid range [V, ∞) so the un-summarized tail and the trailing
+        // AudioRecordingMessage (both Conversation == null) land inside it.
+        var liveStartLid = joinedLive?.Id.StartEntryLid ?? long.MaxValue;
 
         foreach (var item in messages) {
             var conversation = item.Conversation;
+            var isLiveBlock = joinedLive != null && blockConversation?.Id == joinedLive.Id;
             var belongs = blockConversation != null
                 && (conversation != null
                     ? conversation.Id == blockConversation.Id
-                    : blockConversation.EntryLidRange.Contains(item.Id));
+                    : isLiveBlock
+                        ? item.Id >= liveStartLid
+                        : blockConversation.EntryLidRange.Contains(item.Id));
             if (belongs) {
                 blockItems.Add(item);
                 continue;
             }
 
             FinalizeBlock();
-            if (conversation != null && item is not ConversationMessage) {
+            // A joined live card (a ConversationMessage) starts its block; other ConversationMessages don't.
+            var startsBlock = conversation != null
+                && (item is not ConversationMessage || conversation.Id == joinedLive?.Id);
+            if (startsBlock) {
                 blockConversation = conversation;
                 blockItems.Add(item);
             }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -23,7 +23,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private readonly StoredState<string> _selectedNavbarGroupId;
     private readonly StoredState<IImmutableDictionary<string, ChatId>> _selectedChatIds;
     private readonly MutableState<ChatEntryId?> _highlightedEntryId;
-    private readonly MutableState<IImmutableSet<ConversationId>> _expandedConversations;
+    private readonly MutableState<IImmutableSet<ConversationId>> _conversationExpansionOverrides;
     private ChatId? _searchEnabledChatId;
     private List<ChatId>? _pendingSelectedChatIds = new();
 
@@ -55,7 +55,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     public IState<PlaceId?> SelectedPlaceId => _selectedPlaceId;
     public IState<IImmutableDictionary<string, ChatId>> SelectedChatIds => _selectedChatIds;
     public IState<ChatEntryId?> HighlightedEntryId => _highlightedEntryId;
-    public IState<IImmutableSet<ConversationId>> ExpandedConversations => _expandedConversations;
+    public IState<IImmutableSet<ConversationId>> ConversationExpansionOverrides => _conversationExpansionOverrides;
     public Task WhenReady => _selectedChatId.WhenRead;
     public MutableState<ChatViewItemVisibility> ItemVisibility => _itemVisibility;
 
@@ -85,9 +85,9 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         _highlightedEntryId = StateFactory.NewMutable(
             (ChatEntryId?)null,
             StateCategories.Get(type, nameof(HighlightedEntryId)));
-        _expandedConversations = StateFactory.NewMutable(
+        _conversationExpansionOverrides = StateFactory.NewMutable(
             (IImmutableSet<ConversationId>)ImmutableHashSet<ConversationId>.Empty,
-            StateCategories.Get(type, nameof(ExpandedConversations)));
+            StateCategories.Get(type, nameof(ConversationExpansionOverrides)));
         _itemVisibility = StateFactory.NewMutable(
             ChatViewItemVisibility.Empty,
             StateCategories.Get(type, nameof(ItemVisibility)));
@@ -356,13 +356,18 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
 
     public void ToggleExpandConversation(ConversationId conversationId)
     {
-        var expandedConversations = _expandedConversations.Value;
-        var mustRemove = expandedConversations.Contains(conversationId);
-        expandedConversations = mustRemove
-            ? expandedConversations.Remove(conversationId)
-            : expandedConversations.Add(conversationId);
-        _expandedConversations.Value = expandedConversations;
+        // Membership here flips a conversation's expansion away from its IsExpandedByDefault, so the
+        // toggle works regardless of which default (expanded/collapsed) the conversation carries.
+        var overrides = _conversationExpansionOverrides.Value;
+        var mustRemove = overrides.Contains(conversationId);
+        overrides = mustRemove
+            ? overrides.Remove(conversationId)
+            : overrides.Add(conversationId);
+        _conversationExpansionOverrides.Value = overrides;
     }
+
+    public bool IsConversationExpanded(Conversation conversation)
+        => conversation.IsExpandedByDefault ^ _conversationExpansionOverrides.Value.Contains(conversation.Id);
 
     // Helpers
 

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -33,6 +33,10 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     }
 
     [ComputeMethod]
+    public virtual Task<LiveSessionState?> GetState(ChatId chatId, CancellationToken cancellationToken)
+        => LiveSessions.GetState(Session, chatId, cancellationToken);
+
+    [ComputeMethod]
     public virtual async Task<LiveSession?> Get(ChatId chatId, CancellationToken cancellationToken)
         => await LiveSessions.Get(Session, chatId, cancellationToken).ConfigureAwait(false);
 

--- a/src/dotnet/UI.Blazor.App/styles.css
+++ b/src/dotnet/UI.Blazor.App/styles.css
@@ -20,6 +20,7 @@
 @import './Components/ChatView/Items/Attachment/attachment.css';
 @import './Components/ChatView/Items/ChatMessageSendingStatus/chat-message-sending-status.css';
 @import './Components/ChatView/Items/Conversation/conversation.css';
+@import './Components/ChatView/Items/last-entries-preview.css';
 @import './Components/ChatView/Items/LinkPreview/link-preview.css';
 @import './Components/ChatView/Items/StreamingEntryBadge/streaming-entry-badge.css';
 @import './Components/ChatView/Items/Reactions/reaction-badge.css';

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -159,8 +159,11 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         // act — the last participant leaves too
         await backend.SetParticipation(chatId, bobAuthor!.Id, ParticipationKind.Record, false, default);
 
-        // assert — now the empty call closes
-        (await backend.GetState(chatId, default)).Should().BeNull();
+        // assert — a latched transcription session doesn't vanish on empty: it's marked closing and
+        // LiveConversationSummaryFlow owns the final pass, then calls FinalizeSession
+        live = await backend.GetState(chatId, default);
+        live.Should().NotBeNull();
+        live!.IsClosing.Should().BeTrue();
     }
 
     [Fact]
@@ -397,9 +400,11 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         // act — a second distinct peer latches the session
         await backend.OnStreamRegistered(chatId, AuthorId.New(chatId, 777_031), null, true, default);
 
-        // assert — the live block is now present
+        // assert — the live block is now present, re-keyed by the latch to the chat end (VisibleStartLid)
+        var latched = await backend.GetState(chatId, default);
+        latched.Should().NotBeNull();
         var tileAfter = await conversations.GetTile(chatId, tileRange, default);
-        tileAfter.Should().Contain(c => c.Id == live.ConversationId);
+        tileAfter.Should().Contain(c => c.Id == latched!.ConversationId);
     }
 
     [Fact]

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -678,4 +678,145 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         state!.Kind.Should().Be(LiveSessionKind.Call);
         state.Host.Should().Be(bobAuthor.Id);
     }
+
+    [Fact]
+    public async Task LatchSetsVisibleStartLidToChatEnd()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var (chatId, _) = await tester.CreateChat(true);
+        var author = await tester.AppServices.GetRequiredService<IAuthors>().GetOwn(session, chatId, default);
+        var backend = tester.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var chatsBackend = tester.AppServices.GetRequiredService<IChatsBackend>();
+
+        // act — a second peer latches the session
+        await backend.OnStreamRegistered(chatId, author!.Id, null, true, default);
+        await backend.OnStreamRegistered(chatId, AuthorId.New(chatId, 777_021), null, true, default);
+
+        // assert — VisibleStartLid is pinned to the chat end at latch time
+        var chatEnd = (await chatsBackend.GetLidRange(chatId, false, default)).End;
+        var live = await backend.GetState(chatId, default);
+        live.Should().NotBeNull();
+        live!.SessionStartedAt.Should().NotBeNull();
+        live.VisibleStartLid.Should().Be(chatEnd);
+        live.VisibleStartLid.Should().BeGreaterThan(0);
+        live.EffectiveVisibleStartLid.Should().Be(live.VisibleStartLid);
+    }
+
+    [Fact]
+    public async Task CloseNowKeepsLatchedTranscriptionSessionClosing()
+    {
+        // arrange — a latched transcription session (2 peers)
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var (chatId, _) = await tester.CreateChat(true);
+        var author = await tester.AppServices.GetRequiredService<IAuthors>().GetOwn(session, chatId, default);
+        var backend = tester.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var otherId = AuthorId.New(chatId, 777_022);
+        await backend.OnStreamRegistered(chatId, author!.Id, null, true, default);
+        await backend.OnStreamRegistered(chatId, otherId, null, true, default);
+        (await backend.GetState(chatId, default))!.SessionStartedAt.Should().NotBeNull();
+
+        // act — everyone leaves
+        await backend.SetParticipation(chatId, otherId, ParticipationKind.Record, false, default);
+        await backend.SetParticipation(chatId, author.Id, ParticipationKind.Record, false, default);
+
+        // assert — it doesn't vanish instantly; the flow finalizes it, so it stays live-but-closing
+        var live = await backend.GetState(chatId, default);
+        live.Should().NotBeNull();
+        live!.IsClosing.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FinalizeSessionMaterializesContextRange()
+    {
+        // arrange — a chat with a few entries, then a latched transcription session
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var (chatId, _) = await tester.CreateChat(true);
+        var author = await tester.AppServices.GetRequiredService<IAuthors>().GetOwn(session, chatId, default);
+        var backend = tester.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var conversationsBackend = tester.AppServices.GetRequiredService<IConversationsBackend>();
+
+        var entries = new List<ChatEntry>();
+        foreach (var text in new[] { "one", "two", "three" }) {
+            var entry = await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = text });
+            entries.Add(entry);
+        }
+        var contextStart = entries[0].LocalId;
+        var endEntryLid = entries[^1].LocalId;
+
+        var otherId = AuthorId.New(chatId, 777_024);
+        await backend.OnStreamRegistered(chatId, author!.Id, null, true, default);
+        await backend.OnStreamRegistered(chatId, otherId, null, true, default);
+
+        await backend.SetContextStart(chatId, contextStart, default);
+        await backend.UpdateSummary(chatId, new LiveSessionSummary {
+            Title = "Recap",
+            Description = "A description",
+            Summary = "A summary",
+            EndEntryLid = endEntryLid,
+            MessageCount = 8,
+            AuthorIds = [author.Id],
+            IsExpandedByDefault = true,
+        }, default);
+
+        // everyone leaves -> the session is marked closing
+        await backend.SetParticipation(chatId, otherId, ParticipationKind.Record, false, default);
+        await backend.SetParticipation(chatId, author.Id, ParticipationKind.Record, false, default);
+
+        // act — finalize materializes the conversation at the context start, then drops the live state
+        await backend.FinalizeSession(chatId, default);
+
+        // assert
+        (await backend.GetState(chatId, default)).Should().BeNull();
+        var materialized = await conversationsBackend.Get(ConversationId.New(chatId, contextStart), default);
+        materialized.Should().NotBeNull();
+        materialized!.Title.Should().Be("Recap");
+        materialized.IsExpandedByDefault.Should().BeTrue();
+        materialized.EndEntryLid.Should().Be(endEntryLid);
+    }
+
+    [Fact]
+    public async Task RangeMetaKeepsPreLatchConversationsVisible()
+    {
+        // arrange — transcription starts solo at e0, a conversation is persisted over [e0, e2] before the
+        // session latches (V = chat end after e3), so it sits in [StartEntryLid, VisibleStartLid).
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var (chatId, _) = await tester.CreateChat(true);
+        var author = await tester.AppServices.GetRequiredService<IAuthors>().GetOwn(session, chatId, default);
+        var backend = tester.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var conversationsBackend = tester.AppServices.GetRequiredService<IConversationsBackend>();
+
+        var e0 = await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "e0" });
+        await backend.OnStreamRegistered(chatId, author!.Id, e0.LocalId, true, default); // solo, StartEntryLid = e0
+        await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "e1" });
+        var e2 = await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "e2" });
+
+        var preLatch = new Conversation(ConversationId.New(chatId, e0.LocalId), 1) {
+            Title = "Earlier", Description = "d", Summary = "s", MessageCount = 3,
+            EndEntryLid = e2.LocalId,
+            StartsAt = e0.BeginsAt, EndsAt = e2.BeginsAt,
+        };
+        await commander.Call(new ConversationBackend_Materialize(preLatch));
+
+        await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "e3" });
+        await backend.OnStreamRegistered(chatId, AuthorId.New(chatId, 777_025), null, true, default); // latch
+        (await backend.GetState(chatId, default))!.SessionStartedAt.Should().NotBeNull();
+
+        // act
+        var idTileStart = Constants.Chat.ServerIdTileStack.LastLayer.GetTile(e0.LocalId).Range.Start;
+        var meta = await conversationsBackend.GetRangeMeta(chatId, idTileStart, default);
+
+        // assert — the pre-latch conversation's exact range survives; the live range no longer swallows it
+        meta.ConversationLidRanges.Should().Contain(new Range<long>(e0.LocalId, e2.LocalId + 1));
+    }
 }

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -56,6 +56,49 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
+    public async Task ShouldFlagFirstEntryOfAnExpandedConversation()
+    {
+        // The header already spaces the block off, so its first entry drops the block-start padding.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(true, "conv-first-entry-test");
+        var first = await Tester.CreateTextEntry(chat.Id, "opens the conversation");
+        ChatEntry last = first;
+        for (var i = 0; i < 4; i++)
+            last = await Tester.CreateTextEntry(chat.Id, $"body-{i}");
+        var conversationId = ConversationId.New(chat.Id, first.LocalId);
+        var conversation = new Conversation(conversationId) {
+            Title = "Recap",
+            Summary = "s",
+            Description = "d",
+            EndEntryLid = last.LocalId,
+            MessageCount = 5,
+            IsExpandedByDefault = true,
+        };
+        await Tester.Commander.Call(new ConversationBackend_Materialize(conversation), CancellationToken.None);
+
+        // act
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        var entries = items.Items.SelectMany(i => i.GetLeafMessages())
+            .OfType<ChatEntryMessage>()
+            .Where(m => m.Kind == ChatMessageKind.None)
+            .ToList();
+
+        // assert
+        items.Items.SelectMany(i => i.GetLeafMessages()).OfType<ConversationHeader>()
+            .Should().NotBeEmpty("the conversation must render expanded");
+        var opener = entries.Single(m => m.Id == first.LocalId);
+        opener.Flags.Should().HaveFlag(ChatMessageFlags.BlockStart, "it still shows its author");
+        opener.Flags.Should().HaveFlag(ChatMessageFlags.FirstInConversation);
+        entries.Where(m => m.Id != first.LocalId)
+            .Should().NotContain(m => m.Flags.HasFlag(ChatMessageFlags.FirstInConversation));
+    }
+
+    [Fact]
     public async Task ShouldNotDuplicateJoinedLiveCardAcrossTiles()
     {
         // A landed summary stretches the card's range across tiles, and each re-emits it under one @key.

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1,0 +1,55 @@
+using ActualChat.Streaming;
+using ActualChat.Testing.Host;
+using ActualChat.UI.Blazor.App.Components;
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
+
+[Collection(nameof(ChatUICollection))]
+public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<ChatAppHostFixture>(fixture, @out)
+{
+    private BlazorTester Tester => field ??= AppHost.NewBlazorTester(Out);
+
+    protected override async Task DisposeAsync()
+    {
+        await Tester.DisposeSilentlyAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ShouldSurfaceVideoOnlyLiveBlockStartingAViewTile()
+    {
+        // The block sits at a lid only transcription ever fills, so video-only leaves its tile unloaded.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "live-block-boundary-test");
+        var tileSize = ChatUI.IdTileStack.FirstLayer.TileSize;
+        ChatEntry entry;
+        do {
+            entry = await Tester.CreateTextEntry(chat.Id, "filler");
+        } while ((entry.LocalId + 1) % tileSize != 0);
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_070);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+
+        // act
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, false, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, false, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert
+        live.Should().NotBeNull();
+        live!.SessionStartedAt.Should().NotBeNull();
+        (live.VisibleStartLid % tileSize).Should()
+            .Be(0L, "the live block must start a fresh view tile or this test doesn't bite");
+        items.Items.OfType<ConversationMessage>()
+            .Select(m => m.Conversation!.Id)
+            .Should().Contain(live.ConversationId);
+    }
+}

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1,7 +1,9 @@
+using ActualChat.Live;
 using ActualChat.Streaming;
 using ActualChat.Testing.Host;
 using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.Components;
 
 namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
 
@@ -51,5 +53,54 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         items.Items.OfType<ConversationMessage>()
             .Select(m => m.Conversation!.Id)
             .Should().Contain(live.ConversationId);
+    }
+
+    [Fact]
+    public async Task ShouldNotDuplicateJoinedLiveCardAcrossTiles()
+    {
+        // A landed summary stretches the card's range across tiles, and each re-emits it under one @key.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "live-dup-key-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_080);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        live!.SessionStartedAt.Should().NotBeNull();
+
+        var tileSize = (int)ChatUI.IdTileStack.FirstLayer.TileSize;
+        ChatEntry lastEntry = null!;
+        for (var i = 0; i < tileSize * 3; i++)
+            lastEntry = await Tester.CreateTextEntry(chat.Id, $"live-{i}");
+        var summary = new LiveSessionSummary {
+            Title = "Recap",
+            Description = "d",
+            Summary = "s",
+            EndEntryLid = lastEntry.LocalId,
+            MessageCount = tileSize * 3,
+            IsExpandedByDefault = true,
+        };
+        await liveBackend.UpdateSummary(chat.Id, summary, CancellationToken.None);
+
+        // act
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        await chatAudioUI.SetListeningState(chat.Id, true);
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert
+        items.Items.OfType<ExpandedConversationMessage>().Should().NotBeEmpty("the viewer must be joined");
+        items.Items
+            .Select(i => ((IVirtualListItem)i).RenderKey)
+            .Should().OnlyHaveUniqueItems();
+        foreach (var block in items.Items.OfType<ExpandedConversationMessage>())
+            block.Items
+                .Select(i => ((IVirtualListItem)i).RenderKey)
+                .Should().OnlyHaveUniqueItems();
     }
 }

--- a/tests/Chat.UnitTests/ChatModelSerializationTest.cs
+++ b/tests/Chat.UnitTests/ChatModelSerializationTest.cs
@@ -313,6 +313,7 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
             StartsAt = new Moment(DateTime.UtcNow),
             EndsAt = new Moment(DateTime.UtcNow) + TimeSpan.FromHours(1),
             MessageCount = 42,
+            IsExpandedByDefault = true,
         };
 
         var s = conv.PassThroughAllSerializers(Out);
@@ -321,6 +322,7 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
         s.Description.Should().Be(conv.Description);
         s.Summary.Should().Be(conv.Summary);
         s.MessageCount.Should().Be(conv.MessageCount);
+        s.IsExpandedByDefault.Should().BeTrue();
     }
 
     [Fact]
@@ -329,11 +331,13 @@ public class ChatModelSerializationTest(ITestOutputHelper @out) : TestBase(@out)
         var diff = new ConversationDiff {
             Title = "Updated",
             MessageCount = 10,
+            IsExpandedByDefault = true,
         };
 
         var s = diff.PassThroughAllSerializers(Out);
         s.Title.Should().Be(diff.Title);
         s.MessageCount.Should().Be(diff.MessageCount);
+        s.IsExpandedByDefault.Should().Be(true);
     }
 
     [Fact]

--- a/tests/Chat.UnitTests/ContextStartScannerTest.cs
+++ b/tests/Chat.UnitTests/ContextStartScannerTest.cs
@@ -1,0 +1,158 @@
+using ActualChat.Chat.ML;
+
+namespace ActualChat.Chat.UnitTests;
+
+public class ContextStartScannerTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly DateTime BaseTime = new (2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private readonly AuthorId _authorId = AuthorId.New(GroupChatId.New(), 1);
+
+    private ChatEntrySlim Entry(long lid, double seconds, bool isTranscript = false)
+        => new (lid, "x", _authorId, BaseTime.AddSeconds(seconds), null, isTranscript, null, false);
+
+    [Fact]
+    public void EmptyPrecedingReturnsAnchor()
+    {
+        // arrange
+        var anchor = Entry(100, 500);
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid([], anchor);
+
+        // assert
+        result.Should().Be(100);
+    }
+
+    [Fact]
+    public void TextGapBelowFiveMinutesIsIncluded()
+    {
+        // arrange
+        var preceding = new List<ChatEntrySlim> { Entry(1, 0) };
+        var anchor = Entry(2, 200); // 200s < 300s (5 min) text boundary
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void TextGapAtFiveMinutesIsBoundary()
+    {
+        // arrange
+        var preceding = new List<ChatEntrySlim> { Entry(1, 0) };
+        var anchor = Entry(2, 300); // exactly 300s (5 min) - not < minPause, so a boundary
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(2);
+    }
+
+    [Fact]
+    public void TranscriptGapBelowMaxStreamDurationIsIncluded()
+    {
+        // arrange
+        var preceding = new List<ChatEntrySlim> { Entry(1, 0, isTranscript: true) };
+        var anchor = Entry(2, 170, isTranscript: true); // 170s < 180s (MaxStreamDuration)
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void TranscriptGapAtMaxStreamDurationIsBoundary()
+    {
+        // arrange
+        var preceding = new List<ChatEntrySlim> { Entry(1, 0, isTranscript: true) };
+        var anchor = Entry(2, 180, isTranscript: true); // exactly 180s - boundary
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(2);
+    }
+
+    [Fact]
+    public void LargeGapWithinTenTimesAverageIsIncluded()
+    {
+        // arrange - small established pauses raise the running average so an 800s gap (> 300s minPause)
+        // still falls under 10x the average and is pulled into the context.
+        var preceding = new List<ChatEntrySlim> {
+            Entry(1, 0),
+            Entry(2, 800),
+            Entry(3, 900),
+        };
+        var anchor = Entry(4, 1000);
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void GapAtTwelveHourCapIsBoundaryEvenUnderAverage()
+    {
+        // arrange - the running average grows large enough that 10x average would admit a 13h gap, but the
+        // 12h hard cap blocks it. Backward pauses from anchor: 250, 2000, 10000, 40000, then 46800 (13h).
+        var preceding = new List<ChatEntrySlim> {
+            Entry(0, 0),        // gap to e1 = 46800 (13h) - the cap boundary
+            Entry(1, 46800),
+            Entry(2, 86800),
+            Entry(3, 96800),
+            Entry(4, 98800),
+        };
+        var anchor = Entry(5, 99050);
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public void GapBelowTwelveHourCapUnderAverageIsIncluded()
+    {
+        // arrange - same shape as above but the final gap is 43000s (< 12h) and under 10x average, so it is
+        // pulled in, proving the previous case's boundary was the cap and not the average rule.
+        var preceding = new List<ChatEntrySlim> {
+            Entry(0, 55800),    // gap to e1 = 43000 (< 12h)
+            Entry(1, 98800),
+            Entry(2, 138800),
+            Entry(3, 148800),
+            Entry(4, 150800),
+        };
+        var anchor = Entry(5, 151050);
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void AllWithinGroupReturnsEarliest()
+    {
+        // arrange - a long run of sub-minPause text pauses is scanned end to end.
+        var preceding = Enumerable.Range(0, 50)
+            .Select(i => Entry(i, i * 100.0))
+            .ToList();
+        var anchor = Entry(50, 50 * 100.0);
+
+        // act
+        var result = ContextStartScanner.FindContextStartLid(preceding, anchor);
+
+        // assert
+        result.Should().Be(0);
+    }
+}


### PR DESCRIPTION
Implements `docs/superpowers/plans/2026-07-14-live-conversation-block-ux-plan.md` (approved 2026-07-14).

## What changed
Live-session conversation blocks were frustrating in joined mode and around lifecycle transitions. This reworks them:

- **Three lids, three roles.** New `VisibleStartLid` (chat-end at latch) keys the live block and bounds all hiding/folding; new server-only `ContextStartLid` (backward pause scan) feeds the summarizer, the split-flow guard, and the materialized range. `StartEntryLid` is unchanged.
- **Joined rendering** is now one group block — card + folded summarized range + live tail — instead of disconnected plain messages below the card. **Not-joined** viewers keep pre-latch entries in place and hide only from `VisibleStartLid`.
- **Seamless explicit close.** `CloseNow` marks a latched transcription session `IsClosing`; `LiveConversationSummaryFlow` (throttle 30s→15s) runs the final pass over `[ContextStartLid, end]`, picks a tier (**<150w/3e** → vanish; **<1200w/10e** → materialize expanded via `Conversation.IsExpandedByDefault`; else collapsed), then `FinalizeSession` materializes-then-closes (no gap). The 90s `SelfClose` backstop stays.
- **Lowered first-summary gates** (150 mature words + 3 entries, 1-min maturity) so short calls still get a title.
- **`Conversation.IsExpandedByDefault`** across API/DB/`ConversationDiff` (+ EF migration `Add_Conversation_IsExpandedByDefault`). Client expansion is now *default XOR local override*.

## Tests
- `ContextStartScannerTest` (9 cases: text/transcript boundaries, 10× average, 12h cap, empty→anchor, full scan).
- Conversation / `ConversationDiff` serialization round-trip with the flag.
- Backend integration (`LiveSessionsTest`): `LatchSetsVisibleStartLidToChatEnd`, `CloseNowKeepsLatchedTranscriptionSessionClosing`, `FinalizeSessionMaterializesContextRange`, `RangeMetaKeepsPreLatchConversationsVisible`.
- `npm run build:Verify` passes; 420 Chat.UnitTests pass.

## Deferred (follow-up)
- `LiveConversationFinalizeFlowTest` (flow-level, summarizer stub) and `LiveConversationDisplayTest` (UI Blazor) — the two larger new test files.
- **Manual two-device pass** (Phase 9 step 5) — the definitive UI validation; watch the viewport at each transition and use `/virtual-list-debug` if anything jumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)