### PR TITLE
feat(maccatalyst): restore voice processing (AEC/NS/AGC) on Mac Catalyst #4060

### DIFF
--- a/docs/plans/maccatalyst-voice-processing.md
+++ b/docs/plans/maccatalyst-voice-processing.md
@@ -37,56 +37,104 @@ restore steady-state frame delivery: the input tap still went silent after the
 first buffer. So the missing clock is a necessary but not sufficient piece;
 something else in the Mac Catalyst VP graph is still wrong.
 
-Things not yet investigated (see "Open questions / next paths" below):
-explicit AUVoiceIO unit configuration, manual format/clock matching between
-input and the silent output, attaching the player to the input bus instead of
-MainMixer, or bypassing `AVAudioEngine`'s VP wrapper entirely in favor of a
-direct `AudioUnit` (`kAudioUnitSubType_VoiceProcessingIO`) graph.
+## The fix (2026-07, #4060)
 
-## Current behavior (shipped)
-`AppleAudioCapture.cs:34` skips `SetVoiceProcessingEnabled` when
-`OperatingSystem.IsMacCatalyst()`. Trade-offs:
+The missing piece was identified by studying LiveKit's `AudioEngineDevice`
+(`webrtc-sdk/webrtc`, `modules/audio_device/audio_engine_device.mm`) — a
+known-working AVAudioEngine + VP implementation on Mac Catalyst. Three
+requirements our graph violated:
 
-- ✅ Mic capture works end-to-end (frames flow → VAD → Opus → transcription).
-- ❌ No echo cancellation, noise suppression, or AGC on Mac.
-- Mitigation: desktops are typically used with headphones, so echo into the
-  mic is a minor regression versus iOS in practice. NS/AGC absence is more
-  noticeable in noisy rooms or on built-in laptop mics.
+1. **The input node must be part of a pulled render chain.** On iOS a bare
+   tap on the VP input works; on Mac nothing pulls the input node unless it
+   is connected downstream, so the tap fires once and goes silent. LiveKit
+   wires `inputNode → mixer → AVAudioSinkNode`; we wire
+   `inputNode → muted mixer → MainMixerNode` (which also gives the VP
+   downlink its output-side clock — the piece the silent-player experiment
+   got right).
+2. **The input connection must use ≤ 2 channels.** Mac input nodes can
+   expose multi-channel formats VPIO can't handle; LiveKit always connects
+   at mono. We connect at mono @ hardware sample rate.
+3. **VP must be enabled while the engine is stopped, and all format queries
+   must happen after enabling it** — enabling VP changes the input node's
+   format (VPIO brings up an aggregate device). Our resampler was built
+   from the pre-VP format.
 
-The disabled call is marked with `TODO(FC): restore AEC/NS/AGC on Mac
-Catalyst.` in `AppleAudioCapture.cs:26` so it surfaces in the existing
-`TODO(FC)` grep.
+Implemented in `AudioEngine.EnableVoiceProcessing()` (one-shot, engine-level)
+plus `ConnectVoiceProcessingPullChainUnsafe()` for the Mac-only pull chain;
+`AppleAudioCapture` now calls it on both platforms before querying formats.
 
-## Open questions / next paths
+**Round 2 (same day):** the first cut failed on-device — engine start hit
+`kAUInitialize` error **-10875** on the VPIO *output* element, because (a) the
+implicit `MainMixer → OutputNode` connection captured the output format while
+it was still `0ch/0Hz` (VPIO aggregate device not built yet; visible as
+`AudioConverter ... to 0 ch, 0 Hz, status -50` spam in the unified log), and
+(b) the engine start raced the VPIO uplink/downlink DSP bring-up. Fixes,
+all straight from LiveKit's implementation: validate input/output formats are
+non-zero before wiring (throw = the recorder's retry loop re-enters cleanly),
+connect `MainMixer → OutputNode` explicitly with a valid mono format, and on
+Mac start the VP engine via `Prepare()` + 100 ms + up to 3 start attempts
+(`StartWithVoiceProcessingUnsafe`).
 
-1. **Direct AudioUnit graph.** Build the recording side with a raw
-   `AUGraph` / `AVAudioUnitGenericIO` around
-   `kAudioUnitSubType_VoiceProcessingIO`, bypassing `AVAudioEngine`'s
-   wrapper. This is what most cross-platform conferencing SDKs (WebRTC,
-   LiveKit, Twilio) do on macOS, because the high-level Swift API has known
-   gaps. Highest cost but highest chance of working.
+**Why the split Playback/Recording engines still get AEC:** on macOS the
+VPIO reference signal is captured at the output-device level (that's how
+FaceTime/Safari cancel other apps' audio), so voice played by the separate
+Playback engine is still cancelled from the Recording engine's VP'd input.
 
-2. **Match formats between silent player and input bus.** The earlier
-   experiment used `MainMixerNode`'s default output format; the VP downlink
-   may require sample-rate/channel parity with the input format. Worth a
-   second attempt before reaching for raw AudioUnits.
+**Round 3 (same day):** with round 2 the recording engine started and VP ran
+(aggregate device built: mic + speaker ref, uplink/downlink DSP live), but two
+issues remained on-device:
 
-3. **`AUVoiceIO` properties.** Inspect/disable individual VP sub-features
-   (`kAUVoiceIOProperty_VoiceProcessingEnableAGC`,
-   `kAUVoiceIOProperty_BypassVoiceProcessing`, etc.) to see whether one
-   specific stage is the one timing out. If AEC is the culprit but NS/AGC
-   work standalone, we can land partial parity.
+1. `AUVPAggregate: incorrect pull size (err=-50)` on every render cycle
+   while recording — the session's 20 ms (960-frame) preferred IO buffer
+   fights the VP aggregate's 512/1024-frame quantum. Fix: skip
+   `SetPreferredIOBufferDuration` on Mac Catalyst (`AudioSession.ConfigureUnsafe`).
+2. After `StopRecording` → `AVAudioEngine.Stop`, the VPIO aggregate's IO
+   thread isn't torn down; the next engine start blocks ~15 s in AQME and
+   fails `kAUStartIO` with **-66681** before recovering. Fix: on Mac, stop
+   the IO units explicitly (`AudioOutputUnitStop` via `IONode.AudioUnit.Stop()`)
+   before `_engine.Stop()` when VP is enabled — LiveKit does exactly this
+   with the same rationale in a code comment.
 
-4. **macOS version dependence.** The bug was observed on macOS 15.x. Check
-   macOS 14 vs 16 — Apple has historically shipped CoreAudio VP fixes between
-   majors. If the bug is fixed in a recent macOS, we may be able to enable
-   VP behind a version guard.
+**Round 4 (same day):** two on-device findings.
 
-5. **Use macOS-native APIs directly.** Mac Catalyst can call AppKit /
-   CoreAudio HAL APIs via `[SupportedOSPlatform("maccatalyst")]`. A native
-   `AVCaptureSession`-based capture path (the same one Safari uses for
-   `getUserMedia`) gets AEC for free from the OS — at the cost of a second
-   capture pipeline to maintain.
+1. **Tap + render chain double-pull VPIO.** With both the input-node tap and
+   the muted pull chain attached, VP's uplink DSP glitched every cycle
+   (`incorrect pull size (err=-50)` storm) — full frame rate but chopped
+   content. Fix: no tap on Mac; capture through an `AVAudioSinkNode` as the
+   single puller (`inputNode → capture mixer → sink`,
+   `AudioEngine.AttachVoiceProcessedInputSink`), the exact LiveKit topology.
+   Result: steady 48k frames/s, zero pull-size errors, clean audio.
+2. **macOS AEC references only the VPIO unit's own output**, not the whole
+   device (unlike iOS). Audio played by the separate Playback engine (or
+   other apps) is NOT cancelled. Fix: `VoicePlayer` routes tracks that start
+   while `AudioEngines.Recording.IsRunning` through the Recording engine, so
+   in-app voice playback renders via VPIO's output and becomes the AEC
+   far-end reference. Limitations (accepted): a track already playing on the
+   Playback engine when recording starts isn't cancelled; a Recording-engine
+   track is cut off if recording stops mid-track (`StopRecording` stops the
+   shared engine); other apps' audio can't be cancelled at all on Mac.
+
+**Round 5 (same day):** enabling VP made macOS duck all other apps' audio
+(system music nearly muted while recording) — that's Apple's default
+"other audio ducking" (macOS 14+ / WWDC23). Wrong for a desktop app; disabled
+via `AVAudioInputNode.voiceProcessingOtherAudioDuckingConfiguration`
+(`EnableAdvancedDucking = false`, `DuckingLevel = Min`) in
+`InputNode.DisableOtherAudioDucking`, called right after VP enable on
+Catalyst 17+. Note `Min` is the minimum, not zero — if residual ducking is
+still noticeable, the next lever is adding
+`AVAudioSessionCategoryOptions.MixWithOthers` to the Recording category on
+Catalyst.
+
+## Fallback paths (if the fix regresses)
+
+1. **`AVAudioSinkNode` instead of tap + muted mixer** (exact LiveKit
+   topology) — needs a `SinkNode` wrapper and `AudioBufferList` → PCM buffer
+   adaptation for the resampler.
+2. **Direct `kAudioUnitSubType_VoiceProcessingIO` AudioUnit graph** —
+   bypasses `AVAudioEngine`'s wrapper entirely; highest cost.
+3. **`[engine prepare] + ~100ms delay` before start** — LiveKit's macOS
+   workaround for engine-start failures when another app already holds VP;
+   add to `EnsureRunning` if start errors show up.
 
 ## Reuse (mandatory section per CLAUDE.md)
 

--- a/docs/plans/maccatalyst-voice-processing.md
+++ b/docs/plans/maccatalyst-voice-processing.md
@@ -125,6 +125,18 @@ still noticeable, the next lever is adding
 `AVAudioSessionCategoryOptions.MixWithOthers` to the Recording category on
 Catalyst.
 
+**Round 6 (2026-07-29):** ducking persisted after recording stopped, until app
+exit. Cause: VP enable was one-shot sticky, and a Recording-bound `VoicePlayer`
+(the round-4 AEC-reference routing) restarts the stopped Recording engine on
+`Play`/`Resume` — with VP still armed, that revived the whole VPIO unit (mic
+live + ducking) with no capture consumer, and nothing ever stopped it again.
+Fix: `AudioEngine.DisableVoiceProcessing` (stop, unwire the capture mixer,
+`setVoiceProcessingEnabled(false)`), called from `StopRecording` on Mac, so VP
+now lives only while the mic does; each capture re-arms it via
+`EnableVoiceProcessing`. Side effect: a revived Recording engine now plays
+without VPIO, so Recording-bound tracks survive a mid-track recording stop
+instead of dying (softens a round-4 accepted limitation).
+
 ## Fallback paths (if the fix regresses)
 
 1. **`AVAudioSinkNode` instead of tap + muted mixer** (exact LiveKit

--- a/src/dotnet/App.Maui/App.Maui.csproj.DotSettings
+++ b/src/dotnet/App.Maui/App.Maui.csproj.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=libphonenumbers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=macios/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=macios_005Caudio_005Cenginewrapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=phonenumbers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=platforms/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=platforms_005Candroid/@EntryIndexedValue">True</s:Boolean>

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -55,7 +55,7 @@ public sealed class AppleAudioCapture(AppUIHub hub) : IAudioCapture
         yield break;
 
         [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
-        int HandleSinkSamples(AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData) {
+        int HandleSinkSamples(AudioTimeStamp timestamp, uint frameCount, AudioBuffers inputData) {
             try {
                 if (frameCount == 0 || frameCount > sinkBuffer!.FrameCapacity)
                     return 0;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -1,11 +1,12 @@
 using System.Buffers;
 using ActualChat.App.Maui.Services.Recording;
 using ActualChat.UI.Blazor.App.Services;
+using AudioToolbox;
 using AVFoundation;
 
 namespace ActualChat.App.Maui.Audio;
 
-public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
+public sealed class AppleAudioCapture(AppUIHub hub) : IAudioCapture
 {
     public ResamplerFactory ResamplerFactory => field ??= hub.Services.GetRequiredService<ResamplerFactory>();
 
@@ -16,24 +17,22 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
     public Task<IAsyncEnumerable<IMemoryOwner<float>>?> Capture(CancellationToken cancellationToken)
         => Task.FromResult<IAsyncEnumerable<IMemoryOwner<float>>?>(CaptureInternal(cancellationToken));
 
-    private async IAsyncEnumerable<IMemoryOwner<float>> CaptureInternal([EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<IMemoryOwner<float>> CaptureInternal(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Log.LogInformation("CaptureInternal: starting");
         var engine = AudioEngines.Recording;
         using var outBuffer = new BlockRingBuffer<float>(Constants.Audio.RecordingSampleRate * 10);
+        // Enabling VP changes the input node's format, so it must precede GetOutputFormat
+        engine.EnableVoiceProcessing();
         var hwFormat = engine.Input.GetOutputFormat();
         using var resampler = ResamplerFactory.Create(hwFormat, AudioEngine.VoiceRecordingFormat);
-        // TODO(FC): restore AEC/NS/AGC on Mac Catalyst.
-        // Voice processing breaks on Mac Catalyst: the engine's recording graph has no
-        // active output side, so the VoiceProcessor's downlink DSP can't get valid sample
-        // timestamps and either errors out continuously or delivers a single initial
-        // buffer then goes silent. Wiring a silent AVAudioPlayerNode to MainMixerNode
-        // suppressed the error spam but didn't restore steady-state frame delivery.
-        // Until we find a stable workaround, ship without VP on Mac Catalyst (desktops
-        // are typically used with headphones, so echo is a minor regression vs iOS).
-        if (!OperatingSystem.IsMacCatalyst())
-            engine.Input.SetVoiceProcessingEnabled(true);
-        using var _2 = engine.Input.Tap(HandleSamples);
+        using var sinkBuffer = OperatingSystem.IsMacCatalyst()
+            ? new AVAudioPcmBuffer(hwFormat, (uint)hwFormat.SampleRate)
+            : null;
+        using var _2 = OperatingSystem.IsMacCatalyst()
+            ? engine.AttachVoiceProcessedInputSink(HandleSinkSamples)
+            : engine.Input.Tap(HandleSamples);
         engine.EnsureRunning();
         // Voice processing activation can route audio to the earpiece — fix it
         await AudioSession.EnsureCorrectOutputRoute().ConfigureAwait(false);
@@ -56,10 +55,30 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
         yield break;
 
         [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
-        void HandleSamples(AVAudioPcmBuffer pcmBuffer, AVAudioTime when)
-        {
+        int HandleSinkSamples(AudioTimeStamp timestamp, uint frameCount, ref AudioBuffers inputData) {
             try {
-                var estimatedResampledLength = pcmBuffer.FrameLength / hwFormat.SampleRate * AudioEngine.VoiceRecordingFormat.SampleRate;
+                if (frameCount == 0 || frameCount > sinkBuffer!.FrameCapacity)
+                    return 0;
+
+                unsafe {
+                    var source = new ReadOnlySpan<float>((void*)inputData[0].Data, (int)frameCount);
+                    var target = new Span<float>((void*)((float**)sinkBuffer.FloatChannelData)[0], (int)frameCount);
+                    source.CopyTo(target);
+                }
+                sinkBuffer.FrameLength = frameCount;
+                HandleSamples(sinkBuffer, null!);
+            }
+            catch (Exception e) {
+                Log.LogError(e, "Failed to handle sink samples");
+            }
+            return 0;
+        }
+
+        [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+        void HandleSamples(AVAudioPcmBuffer pcmBuffer, AVAudioTime when) {
+            try {
+                var estimatedResampledLength =
+                    pcmBuffer.FrameLength / hwFormat.SampleRate * AudioEngine.VoiceRecordingFormat.SampleRate;
                 if (outBuffer.RemainingCapacity < estimatedResampledLength) {
                     Log.LogWarning("Buffer full, dropping samples");
                     return;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -23,12 +23,14 @@ public sealed class AppleAudioCapture(AppUIHub hub) : IAudioCapture
         Log.LogInformation("CaptureInternal: starting");
         var engine = AudioEngines.Recording;
         using var outBuffer = new BlockRingBuffer<float>(Constants.Audio.RecordingSampleRate * 10);
-        // Enabling VP changes the input node's format, so it must precede GetOutputFormat
+        // Enabling VP changes the input node's format, so it must precede the format query
         engine.EnableVoiceProcessing();
-        var hwFormat = engine.Input.GetOutputFormat();
-        using var resampler = ResamplerFactory.Create(hwFormat, AudioEngine.VoiceRecordingFormat);
+        // On Mac samples arrive through the VP graph's mono sink connection, which may have
+        // fewer channels than the input node's own output format
+        var captureFormat = engine.VoiceProcessedInputFormat ?? engine.Input.GetOutputFormat();
+        using var resampler = ResamplerFactory.Create(captureFormat, AudioEngine.VoiceRecordingFormat);
         using var sinkBuffer = OperatingSystem.IsMacCatalyst()
-            ? new AVAudioPcmBuffer(hwFormat, (uint)hwFormat.SampleRate)
+            ? new AVAudioPcmBuffer(captureFormat, (uint)captureFormat.SampleRate)
             : null;
         using var _2 = OperatingSystem.IsMacCatalyst()
             ? engine.AttachVoiceProcessedInputSink(HandleSinkSamples)
@@ -78,7 +80,7 @@ public sealed class AppleAudioCapture(AppUIHub hub) : IAudioCapture
         void HandleSamples(AVAudioPcmBuffer pcmBuffer, AVAudioTime when) {
             try {
                 var estimatedResampledLength =
-                    pcmBuffer.FrameLength / hwFormat.SampleRate * AudioEngine.VoiceRecordingFormat.SampleRate;
+                    pcmBuffer.FrameLength / captureFormat.SampleRate * AudioEngine.VoiceRecordingFormat.SampleRate;
                 if (outBuffer.RemainingCapacity < estimatedResampledLength) {
                     Log.LogWarning("Buffer full, dropping samples");
                     return;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -117,8 +117,14 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
                     | AVAudioSessionCategoryOptions.AllowBluetooth
                     | AVAudioSessionCategoryOptions.AllowBluetoothA2DP)
                 .Assert($"{mode}: failed to set category");
-            session.SetPreferredIOBufferDuration(Constants.Audio.OpusFrameDuration.TotalSeconds, out var error);
-            error.Assert("Failed to set preferred IO buffer duration");
+            // On Mac Catalyst a 20ms (960-frame) preference conflicts with the VPIO
+            // aggregate device's 512/1024-frame quantum and floods the log with
+            // "AUVPAggregate: incorrect pull size" every render cycle — keep the
+            // device default there.
+            if (!OperatingSystem.IsMacCatalyst()) {
+                session.SetPreferredIOBufferDuration(Constants.Audio.OpusFrameDuration.TotalSeconds, out var error);
+                error.Assert("Failed to set preferred IO buffer duration");
+            }
         }
         else if (mode is AudioFocusMode.Playback)
             session.SetCategory(AVAudioSessionCategory.Playback).Assert($"{mode}: failed to set category");

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -24,6 +24,20 @@ public class AudioEngine : IDisposable
     private ILogger Log => field ??= Hub.LogFor(GetType());
     public IState<bool> IsRunning => _isRunning;
 
+    public bool IsRunningNow {
+        get {
+            lock (_lock)
+                return _engine.Running;
+        }
+    }
+
+    public AVAudioFormat? VoiceProcessedInputFormat {
+        get {
+            lock (_lock)
+                return _vpCaptureFormat;
+        }
+    }
+
     public InputNode Input {
         get {
             lock (_lock)

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -128,10 +128,10 @@ public class AudioEngine : IDisposable
         _isRunning.Invalidate();
     }
 
-    public IDisposable AttachVoiceProcessedInputSink(AVAudioSinkNodeReceiverHandler handler)
+    public IDisposable AttachVoiceProcessedInputSink(AVAudioSinkNodeReceiverHandler2 handler)
     {
         lock (_lock) {
-            if (_vpCaptureMixer == null || _vpCaptureFormat == null)
+            if (_vpCaptureMixer is null || _vpCaptureFormat is null)
                 throw StandardError.Constraint("Voice processing graph is not initialized.");
 
             var sink = new AVAudioSinkNode(handler);

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -1,20 +1,26 @@
 using ActualChat.UI.Blazor.App.Services;
 using ActualChat.UI.Blazor.Services;
 using AVFoundation;
+using Foundation;
 
 namespace ActualChat.App.Maui.Audio;
 
 public class AudioEngine : IDisposable
 {
-    public static readonly AVAudioFormat VoicePlaybackFormat = new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.PlaybackSampleRate, 1, false);
-    public static readonly AVAudioFormat VoiceRecordingFormat = new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.RecordingSampleRate, 1, false);
+    public static readonly AVAudioFormat VoicePlaybackFormat =
+        new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.PlaybackSampleRate, 1, false);
+    public static readonly AVAudioFormat VoiceRecordingFormat =
+        new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.RecordingSampleRate, 1, false);
 
     private readonly Lock _lock = new ();
     private readonly AVAudioEngine _engine = new ();
     private bool _wasStarted;
+    private bool _isVoiceProcessingEnabled;
+    private AVAudioMixerNode? _vpCaptureMixer;
+    private AVAudioFormat? _vpCaptureFormat;
     private readonly ComputedState<bool> _isRunning;
     private AudioFocusMode Mode { get; }
-    private AppUIHub Hub { get;  }
+    private AppUIHub Hub { get; }
     private ILogger Log => field ??= Hub.LogFor(GetType());
     public IState<bool> IsRunning => _isRunning;
 
@@ -80,10 +86,55 @@ public class AudioEngine : IDisposable
     public void Stop()
     {
         lock (_lock) {
+            // On Mac Catalyst AVAudioEngine.Stop alone doesn't tear down the VPIO
+            // aggregate device's IO thread, which wedges the HAL transport and makes
+            // the next engine start block for ~15s (kAUStartIO error -66681) —
+            // stop the IO units explicitly first, as LiveKit does.
+            if (OperatingSystem.IsMacCatalyst() && _isVoiceProcessingEnabled) {
+                _engine.InputNode.AudioUnit?.Stop();
+                _engine.OutputNode.AudioUnit?.Stop();
+            }
             _engine.Stop();
             _wasStarted = false;
         }
         _isRunning.Invalidate();
+    }
+
+    public void EnableVoiceProcessing()
+    {
+        lock (_lock) {
+            if (_isVoiceProcessingEnabled)
+                return;
+
+            // Voice processing can be toggled only while the engine is stopped
+            _engine.Stop();
+            _wasStarted = false;
+            Input.SetVoiceProcessingEnabled(true);
+            if (OperatingSystem.IsMacCatalyst()) {
+                // VP ducks other apps' audio by default — unacceptable on desktop
+                if (OperatingSystem.IsMacCatalystVersionAtLeast(17))
+                    Input.DisableOtherAudioDucking();
+                ConnectVoiceProcessingGraphUnsafe();
+            }
+            _isVoiceProcessingEnabled = true;
+        }
+        _isRunning.Invalidate();
+    }
+
+    public IDisposable AttachVoiceProcessedInputSink(AVAudioSinkNodeReceiverHandler handler)
+    {
+        lock (_lock) {
+            if (_vpCaptureMixer == null || _vpCaptureFormat == null)
+                throw StandardError.Constraint("Voice processing graph is not initialized.");
+
+            var sink = new AVAudioSinkNode(handler);
+            _engine.AttachNode(sink);
+            _engine.Connect(_vpCaptureMixer, sink, _vpCaptureFormat);
+            return Disposable.New(() => {
+                lock (_lock)
+                    DisposeNodeUnsafe(sink);
+            });
+        }
     }
 
     public void AttachNode(AVAudioNode node)
@@ -132,6 +183,35 @@ public class AudioEngine : IDisposable
         return node;
     }
 
+    // Private methods
+
+    private void ConnectVoiceProcessingGraphUnsafe()
+    {
+        // Mac VPIO tolerates exactly one input puller: the sink attached via
+        // AttachVoiceProcessedInputSink (a tap glitches it), the
+        // MainMixer -> Output connection clocks the VP downlink and carries the
+        // playback that AEC uses as its far-end reference, and formats are
+        // explicit mono — see docs/plans/maccatalyst-voice-processing.md for why.
+        var input = _engine.InputNode;
+        var output = _engine.OutputNode;
+        var inputFormat = input.GetBusOutputFormat(AudioNode.Bus);
+        var outputFormat = output.GetBusOutputFormat(AudioNode.Bus);
+        if (inputFormat.SampleRate == 0 || inputFormat.ChannelCount == 0
+            || outputFormat.SampleRate == 0 || outputFormat.ChannelCount == 0)
+            throw StandardError.Internal(
+                $"Audio device formats aren't available yet (input: {inputFormat}, output: {outputFormat}).");
+
+        var inputMono = new AVAudioFormat(inputFormat.CommonFormat, inputFormat.SampleRate, 1, inputFormat.Interleaved);
+        var outputMono =
+            new AVAudioFormat(outputFormat.CommonFormat, outputFormat.SampleRate, 1, outputFormat.Interleaved);
+        var mixer = new AVAudioMixerNode();
+        _engine.AttachNode(mixer);
+        _engine.Connect(input, mixer, inputMono);
+        _engine.Connect(_engine.MainMixerNode, output, outputMono);
+        _vpCaptureMixer = mixer;
+        _vpCaptureFormat = inputMono;
+    }
+
     private void DisposeNode(AVAudioNode node)
     {
         lock (_lock)
@@ -150,10 +230,34 @@ public class AudioEngine : IDisposable
     {
         if (!_engine.Running) {
             Log.LogInformation("{Mode}.EnsureEngineRunningUnsafe: Engine not running, starting", Mode);
-            _engine.StartAndReturnError(out var nsError);
-            nsError.Assert();
+            if (OperatingSystem.IsMacCatalyst() && _isVoiceProcessingEnabled)
+                StartWithVoiceProcessingUnsafe();
+            else {
+                _engine.StartAndReturnError(out var nsError);
+                nsError.Assert();
+            }
         }
         _wasStarted = true;
+    }
+
+    private void StartWithVoiceProcessingUnsafe()
+    {
+        // On Mac the engine start races the VPIO aggregate device build and can
+        // fail with -10875 (also when another app holds VP); prepare, give it
+        // a moment, and retry — same workaround LiveKit uses on macOS.
+        _engine.Prepare();
+        Thread.Sleep(100);
+        NSError nsError = null!;
+        for (var i = 0; i < 3; i++) {
+            if (i > 0)
+                Thread.Sleep(100);
+            if (_engine.StartAndReturnError(out nsError))
+                return;
+
+            Log.LogWarning("{Mode}.StartWithVoiceProcessingUnsafe: attempt {Attempt} failed: {Error}",
+                Mode, i + 1, nsError.LocalizedDescription);
+        }
+        nsError.Assert();
     }
 
     private bool TryEnsureEngineRunningUnsafe()
@@ -163,7 +267,8 @@ public class AudioEngine : IDisposable
 
         Log.LogInformation("{Mode}.TryEnsureEngineRunningUnsafe: Engine not running, attempting to start", Mode);
         if (!_engine.StartAndReturnError(out var nsError)) {
-            Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}", Mode, nsError.LocalizedDescription);
+            Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}",
+                Mode, nsError.LocalizedDescription);
             return false;
         }
         _wasStarted = true;

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -85,18 +85,8 @@ public class AudioEngine : IDisposable
 
     public void Stop()
     {
-        lock (_lock) {
-            // On Mac Catalyst AVAudioEngine.Stop alone doesn't tear down the VPIO
-            // aggregate device's IO thread, which wedges the HAL transport and makes
-            // the next engine start block for ~15s (kAUStartIO error -66681) —
-            // stop the IO units explicitly first, as LiveKit does.
-            if (OperatingSystem.IsMacCatalyst() && _isVoiceProcessingEnabled) {
-                _engine.InputNode.AudioUnit?.Stop();
-                _engine.OutputNode.AudioUnit?.Stop();
-            }
-            _engine.Stop();
-            _wasStarted = false;
-        }
+        lock (_lock)
+            StopUnsafe();
         _isRunning.Invalidate();
     }
 
@@ -107,8 +97,7 @@ public class AudioEngine : IDisposable
                 return;
 
             // Voice processing can be toggled only while the engine is stopped
-            _engine.Stop();
-            _wasStarted = false;
+            StopUnsafe();
             Input.SetVoiceProcessingEnabled(true);
             if (OperatingSystem.IsMacCatalyst()) {
                 // VP ducks other apps' audio by default — unacceptable on desktop
@@ -117,6 +106,24 @@ public class AudioEngine : IDisposable
                 ConnectVoiceProcessingGraphUnsafe();
             }
             _isVoiceProcessingEnabled = true;
+        }
+        _isRunning.Invalidate();
+    }
+
+    public void DisableVoiceProcessing()
+    {
+        lock (_lock) {
+            if (!_isVoiceProcessingEnabled)
+                return;
+
+            StopUnsafe();
+            if (_vpCaptureMixer != null) {
+                DisposeNodeUnsafe(_vpCaptureMixer);
+                _vpCaptureMixer = null;
+                _vpCaptureFormat = null;
+            }
+            Input.SetVoiceProcessingEnabled(false);
+            _isVoiceProcessingEnabled = false;
         }
         _isRunning.Invalidate();
     }
@@ -184,6 +191,20 @@ public class AudioEngine : IDisposable
     }
 
     // Private methods
+
+    private void StopUnsafe()
+    {
+        // On Mac Catalyst AVAudioEngine.Stop alone doesn't tear down the VPIO
+        // aggregate device's IO thread, which wedges the HAL transport and makes
+        // the next engine start block for ~15s (kAUStartIO error -66681) —
+        // stop the IO units explicitly first, as LiveKit does.
+        if (OperatingSystem.IsMacCatalyst() && _isVoiceProcessingEnabled) {
+            _engine.InputNode.AudioUnit?.Stop();
+            _engine.OutputNode.AudioUnit?.Stop();
+        }
+        _engine.Stop();
+        _wasStarted = false;
+    }
 
     private void ConnectVoiceProcessingGraphUnsafe()
     {

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngineExt.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngineExt.cs
@@ -6,5 +6,10 @@ public static class AudioEngineExt
     {
         engine.Input.Reset();
         engine.Stop();
+        // On Mac VP must be disarmed between recordings: a lingering Recording-bound
+        // VoicePlayer restarts the engine on Play/Resume, and with VP still enabled
+        // that would revive the VPIO unit — mic goes live and ducking re-engages.
+        if (OperatingSystem.IsMacCatalyst())
+            engine.DisableVoiceProcessing();
     }
 }

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/InputNode.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/InputNode.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using ActualChat.UI.Blazor.App.Services;
 using AVFoundation;
 
@@ -27,6 +28,17 @@ public class InputNode(AVAudioNode node, AppUIHub hub) : AudioNode(node, _ => {}
             Node.SetVoiceProcessingEnabled(value, out var error);
             error.Assert();
         }
+    }
+
+    [SupportedOSPlatform("maccatalyst17.0")]
+    public void DisableOtherAudioDucking()
+    {
+        lock (Lock)
+            Node.VoiceProcessingOtherAudioDuckingConfiguration =
+                new AVAudioVoiceProcessingOtherAudioDuckingConfiguration {
+                    EnableAdvancedDucking = false,
+                    DuckingLevel = AVAudioVoiceProcessingOtherAudioDuckingLevel.Min,
+                };
     }
 
     public void Reset()

--- a/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
@@ -27,7 +27,7 @@ public class VoicePlayer : IDisposable
         // the mic is capturing, voice playback must go through the Recording engine
         // to become the AEC far-end reference (iOS references the whole device output,
         // so the separate Playback engine is fine there).
-        Engine = OperatingSystem.IsMacCatalyst() && engines.Recording.IsRunning.Value
+        Engine = OperatingSystem.IsMacCatalyst() && engines.Recording.IsRunningNow
             ? engines.Recording
             : engines.Playback;
         Node = Engine.NewPlayer(AudioEngine.VoicePlaybackFormat);

--- a/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
@@ -22,7 +22,14 @@ public class VoicePlayer : IDisposable
     {
         Id = id;
         Hub = hub;
-        Engine = Hub.Services.GetRequiredService<AudioEngines>().Playback;
+        var engines = Hub.Services.GetRequiredService<AudioEngines>();
+        // On Mac VPIO cancels only the audio rendered through its own unit, so while
+        // the mic is capturing, voice playback must go through the Recording engine
+        // to become the AEC far-end reference (iOS references the whole device output,
+        // so the separate Playback engine is fine there).
+        Engine = OperatingSystem.IsMacCatalyst() && engines.Recording.IsRunning.Value
+            ? engines.Recording
+            : engines.Playback;
         Node = Engine.NewPlayer(AudioEngine.VoicePlaybackFormat);
 
         _capacity = new AudioBufferCapacity(hub);


### PR DESCRIPTION

Re-enable AVAudioEngine voice processing for recording on Mac Catalyst, following the topology LiveKit's AudioEngineDevice uses on this platform:

- Enable VP once per engine, while stopped and before any format query (enabling changes the input node's format).
- Capture through inputNode -> capture mixer -> AVAudioSinkNode: VPIO on Mac tolerates exactly one input puller; the previous tap-based capture either went silent (no render chain) or delivered glitched audio ("incorrect pull size" every cycle when combined with a pull chain).
- Wire MainMixer -> Output with explicit mono formats validated non-zero (implicit connection could freeze a 0ch/0Hz output format and fail engine start with -10875) — this clocks the VP downlink.
- Start the VP engine via Prepare + delay + retries (start races the VPIO aggregate device build), and stop the IO units explicitly before engine stop (otherwise the HAL transport wedges for ~15s, -66681).
- Route voice playback through the Recording engine while the mic is capturing: macOS AEC only references audio rendered through the VPIO unit itself, unlike iOS where the reference is device-wide.
- Disable VP's default "other audio ducking" (macOS 14+) — it nearly muted other apps' audio while recording.
- Keep the 20ms preferred IO buffer duration iOS-only: it conflicts with the VP aggregate's 512-frame quantum on Mac.

See docs/plans/maccatalyst-voice-processing.md for the investigation log.


Claude-Session: https://claude.ai/code/session_019YzayxjSCyHb2eCrKPNpz2