### PR TITLE
Live conversation block — unified shell & chrome (Plan 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-live-block-swallow-and-show-more.md
+++ b/docs/superpowers/plans/2026-07-22-live-block-swallow-and-show-more.md
@@ -1,0 +1,635 @@
+# Live Block Swallow-Above-Viewport + Show-More Implementation Plan (Plan 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the collapsed joined live block swallow everything that scrolls above the viewport (summarised or not) into a compact card, and give the reader an in-place "Show N earlier messages of M" pill to pull back context a batch at a time without expanding to the first message.
+
+**Architecture:** Two client-side phases on the existing fold governor (`LiveBlockUI` / `LiveFoldMath`), no server/DB/contract changes. **Phase A (§4)** replaces the summary-driven fold rule with a pure viewport-top tracker: the fold boundary is the monotonic max of the topmost visible lid in the block, so un-summarised rows above the viewport fold too. **Phase B (§7)** adds a reader-controlled `RevealedBoundaryLid` that pins the *effective* fold below the governor's monotonic boundary, a `GetSwallowedCount` for the true "of M", and the straddling pill view. Expansion already suppresses the fold at the tile-builder level (`ChatUI.Tiles.cs:467-472` filters an expanded block out of the excluded ranges), and the monotonic boundary never retreats while expanded (expand jumps to the first message, viewport-top = V), so no jump on collapse and no governor expansion-awareness is needed.
+
+**Tech Stack:** C# (`LiveFoldMath`, `LiveBlockUI` — `IComputeService` / `UIWorkerBase` / `MutableState`), Blazor Server (`.razor`, `ConversationMessageView`, `ConversationLiveState`), Tailwind-compiled CSS (`conversation.css`), xUnit (`LiveFoldMathTest` in `Chat.UI.Blazor.UnitTests`; `LiveConversationDisplayTest` in `Chat.UI.Blazor.IntegrationTests`).
+
+## Global Constraints
+
+- Read `docs/CODING_STYLE.md` before writing C#/Razor/CSS. No `Async` suffix on async methods; no XML docs on members; comments only for non-obvious constraints; follow the surrounding brace/format style; ≤120 columns.
+- Build with `dotnet build ActualChat.CI.slnf`. CSS/TS-touching changes also run `npm run build:Verify` (or the `/server-loop` rebuild if the watch loop is running — check `tmp/watch-dotnet.log`).
+- A user-owned `dotnet watch` may own the server on port 7080 — do **not** `/server-start`/`/server-restart`. The user restarts it.
+- Branch `feat/live-block-swallow-show-more` off `dev`. Do not push unless asked. (Plan 1's `feat/live-block-unified-ux` is a separate, already-open PR — do not build on top of it unless it has merged; if it has, branch off `dev` after the merge so the unified shell is present.)
+- Reuse before adding (spec Reuse section): extend `LiveBlockUI`/`LiveFoldMath` — do **not** fork a new folding path; reuse the `.show-more-btn` colour token (`--cr-item-badge-selected-text`) and the Call/Map switch rounded-pill visual for the pill; reuse `ItemVisibility.VisibleMessageLids` for the viewport measure; reuse `Chats.ReadReverse` for entry counts.
+- **Batch size (user decision):** each reveal batch N = the current viewport message count **rounded up to the nearest 5**, floored at 5: `N = Math.Max(5, ((visibleCount + 4) / 5) * 5)`. The final click reveals only the remainder (`Math.Min(N, M)`).
+- **Reveal lifecycle (spec §7):** a reveal persists until the block is **expanded or re-collapsed** (re-latched). Reset is triggered imperatively from `ChatUI.ToggleExpandConversation`. It also resets when the block rebuilds (chat state recreated) or the session closes.
+- Spec: `docs/superpowers/specs/2026-07-22-live-conversation-block-unified-ux-design.md` (§4 swallow, §7 show-more pill). The "of M" copy reads the **true swallowed count**, never the summary's `MessageCount`.
+- Design tokens (light theme): `--violet-60 #A533FF`, `--cr-item-badge-selected-text #582EFF`, `--background-01`. Pill visual reference: Call/Map switch container — white bg, 1px border, soft shadow, ~30px tall, tight padding.
+
+---
+
+## File Structure
+
+- `src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs` — the pure fold-advance rule. Phase A rewrites it from the summary-lag `PendingFold` model to viewport-top tracking. **Primary Phase A surface.**
+- `src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs` — the governor. Phase A rewires `ProcessChat` to the new rule and drops the dead `Pending`/`FoldLag`/`LastObservedFoldEndLid` machinery. Phase B adds `RevealedBoundaryLid` to `LiveBlockState`, `RevealMore`/`ResetReveal`, and `GetSwallowedCount`.
+- `src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs` — Phase B threads the effective boundary (`min(FoldBoundaryLid, RevealedBoundaryLid)`) into `liveFoldRange` (~L80-85).
+- `src/dotnet/UI.Blazor.App/Services/ChatUI.cs` — Phase B calls `LiveBlockUI.ResetReveal` from `ToggleExpandConversation` (~L357-372).
+- `src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs` — Phase B adds `int SwallowedCount` + `int RevealBatch` for the pill label.
+- `src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor` — Phase B renders the pill and wires its click to `LiveBlockUI.RevealMore`.
+- `src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css` — Phase B pill styling (`.c-lc-showmore`).
+- Tests: `tests/Chat.UI.Blazor.UnitTests/LiveFoldMathTest.cs` (rewrite), `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs` (extend).
+
+Testing note: the fold *rule* and the reveal *state math* are unit/integration-testable at the `ChatItems` / `LiveFoldMath` model level. The **no-jump invariant** and the **pill visual** are verified manually via chrome-devtools MCP + `/virtual-list-debug` against the running app (a live block with a joined reader). The harness asserts the model, not rendered pixels or scroll offsets.
+
+---
+
+# Phase A — Swallow above the viewport (§4)
+
+Phase A is independently shippable: after it, a collapsed joined block folds everything above the viewport into the card (no reveal yet). Verify the no-jump invariant before starting Phase B.
+
+## Task 1: Rewrite `LiveFoldMath` as a viewport-top tracker
+
+Today `LiveFoldMath.Advance` computes `max(boundary, min(ripeSummaryEnd, viewportTop))` — the boundary can never cross the summarised range. §4 makes the boundary track the viewport top directly, so un-summarised rows above the viewport fold too. The summary-lag `PendingFold` model is removed.
+
+**Files:**
+- Rewrite: `src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs`
+- Rewrite: `tests/Chat.UI.Blazor.UnitTests/LiveFoldMathTest.cs`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `long LiveFoldMath.Advance(long boundaryLid, long? minVisibleLidInBlock)` — returns the new monotonic boundary. `PendingFold`, the `Result` record, `foldLag`, `serverNow`, and `pending` parameters are gone.
+
+- [ ] **Step 1: Rewrite the test first** in `LiveFoldMathTest.cs`. The new rule is small: advance to the viewport top, monotonic, and never below the current boundary; a null viewport (nothing visible in the block) holds the boundary.
+
+```csharp
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.UI.Blazor.UnitTests;
+
+public class LiveFoldMathTest
+{
+    [Fact]
+    public void AdvancesToViewportTop()
+        => LiveFoldMath.Advance(10, 15).Should().Be(15);
+
+    [Fact]
+    public void FoldsUnsummarizedRowsAboveViewport()
+        // No summary gate: a viewport top well above any summarised range still advances the boundary.
+        => LiveFoldMath.Advance(10, 500).Should().Be(500);
+
+    [Fact]
+    public void IsMonotonic_ViewportBelowBoundaryDoesNotRetreat()
+        // Reader scrolled up (viewport top below the boundary) must not move the boundary back.
+        => LiveFoldMath.Advance(20, 5).Should().Be(20);
+
+    [Fact]
+    public void NullViewportHoldsBoundary()
+        // Nothing visible in the block (e.g. not-joined, or block off-screen): boundary is unchanged.
+        => LiveFoldMath.Advance(20, null).Should().Be(20);
+
+    [Fact]
+    public void EqualViewportIsStable()
+        => LiveFoldMath.Advance(20, 20).Should().Be(20);
+}
+```
+
+- [ ] **Step 2: Run the test — expect a compile error** (the new signature does not exist yet):
+
+`dotnet test tests/Chat.UI.Blazor.UnitTests/Chat.UI.Blazor.UnitTests.csproj -c Debug --filter "FullyQualifiedName~LiveFoldMathTest"`
+Expected: build FAILS (old `Advance` signature / `PendingFold` referenced). This is the RED state.
+
+- [ ] **Step 3: Rewrite `LiveFoldMath.cs`** to the viewport tracker. Delete `PendingFold` and `Result`.
+
+```csharp
+namespace ActualChat.UI.Blazor.App.Services;
+
+public static class LiveFoldMath
+{
+    // The collapsed live block swallows everything above the viewport. The fold boundary is the
+    // topmost visible lid in the block, advanced monotonically - it never retreats when the reader
+    // scrolls up, so the block stays a compact card. A null viewport (nothing of the block visible)
+    // holds the current boundary. Summaries no longer gate this: un-summarised rows fold too.
+    public static long Advance(long boundaryLid, long? minVisibleLidInBlock)
+        => minVisibleLidInBlock is { } lid ? Math.Max(boundaryLid, lid) : boundaryLid;
+}
+```
+
+- [ ] **Step 4: Build the test project's dependency** and re-run the test. `LiveBlockUI` still references the old API, so build the app project first to confirm the compile break is localized, then Task 2 fixes it. For now, run only the unit test after Task 2 compiles. Skip to Task 2 (the two must land together in build terms); return here to confirm:
+
+`dotnet test tests/Chat.UI.Blazor.UnitTests/Chat.UI.Blazor.UnitTests.csproj -c Debug --filter "FullyQualifiedName~LiveFoldMathTest"`
+Expected (after Task 2 compiles the app): PASS (5/5).
+
+- [ ] **Step 5: Commit** together with Task 2 (they share a build). See Task 2 Step 6.
+
+---
+
+## Task 2: Rewire the governor to the viewport-tracking rule
+
+Replace the `Pending`/`FoldLag` advance in `ProcessChat` with a direct call to the new `LiveFoldMath.Advance`, and remove the now-dead summary-fold plumbing (`Pending`, `LastObservedFoldEndLid`, `FoldLag`, the `PendingFold` construction). The boundary now advances purely from the viewport top. `GetBlockState` → `LiveBlockState.FoldBoundaryLid` → `ChatUI.Tiles.liveFoldRange` is unchanged downstream.
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs`
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `LiveFoldMath.Advance(long, long?)` (Task 1); `visibility.VisibleMessageLids`; `raw.EffectiveVisibleStartLid`.
+- Produces: `LiveBlockState.FoldBoundaryLid` now = monotonic max of the block's viewport-top lid.
+
+- [ ] **Step 1: Replace the advance block** in `ProcessChat` (`LiveBlockUI.cs:266-283`). Keep the `minVisibleLid` computation; drop the `Pending`/`foldEndLid`/`LiveFoldMath` lag call:
+
+```csharp
+            if (raw is { SessionStartedAt: not null }) {
+                var v = raw.EffectiveVisibleStartLid;
+                var minVisibleLid = visibility.ChatId == chatId && !visibility.IsEmpty
+                    ? visibility.VisibleMessageLids.Where(lid => lid >= v).DefaultIfEmpty(long.MaxValue).Min()
+                    : long.MaxValue;
+                var boundaryLid = LiveFoldMath.Advance(
+                    state.FoldBoundaryLid, minVisibleLid == long.MaxValue ? null : minVisibleLid);
+                state = new LiveBlockState(boundaryLid, null, chatState.WasAttending);
+            }
+```
+
+- [ ] **Step 2: Remove the dead summary-fold machinery.** In `LiveBlockUI.cs`:
+  - Delete `internal TimeSpan FoldLag = TimeSpan.FromMinutes(3);` (line 35) and its comment.
+  - In `ChatFoldState` (nested class ~L309-319) delete `public IReadOnlyList<PendingFold> Pending = [];` and `public long LastObservedFoldEndLid;`.
+  - Delete the seeding of `LastObservedFoldEndLid` in `GetOrCreateChatState` (~L169) — replace the initializer with just the fields that remain.
+  - Keep `GetRawFoldEndLid` **only if** still used to seed the initial boundary (see Step 3). The `Pending`/`wakeAt` timer path is gone; `wakeAt` for the fold advance is no longer produced (the tier-1 dissolve still uses `wakeAt`, so keep that branch).
+
+- [ ] **Step 3: Decide the initial boundary seed.** The chat state is created with `FoldBoundaryLid = foldEndLid` (from `GetRawFoldEndLid`). With viewport tracking, the first governor tick advances it to the real viewport top. Seeding from the summary end is a reasonable pre-visibility guess that avoids a one-frame "nothing folded" flash when opening an already-long session. **Keep** the `GetRawFoldEndLid` seed in `GetOrCreateChatState` (it is a lower bound; the monotonic advance corrects it upward on the first tick with visibility). Verify `GetRawFoldEndLid` is still referenced only there; if the build warns it is unused, it means the seed was removed — restore the seed rather than deleting the method.
+
+- [ ] **Step 4: Confirm `wakeAt` handling.** After removing the fold timer, the only remaining `wakeAt` producer is the tier-1 dissolve window (`chatState.DissolveEndsAt`). Ensure `ProcessChat` still returns that `wakeAt` and the `raw is { SessionStartedAt: not null }` branch no longer overwrites it with a fold timer. Re-read the method top-to-bottom to confirm the dissolve `wakeAt` is not clobbered by the fold branch (the fold branch previously set `wakeAt = result.NextWakeAt`; that assignment is now gone).
+
+- [ ] **Step 5: Write the integration test** — a joined reader whose viewport top is above an **un-summarised** range must fold that range (today it would not, because no summary covers it). Add to `LiveConversationDisplayTest.cs` (pattern: existing joined tests that drive `ILiveSessionsBackend` + `ChatUI.SetItemVisibility`/`ItemVisibility`).
+
+```csharp
+[Fact]
+public async Task CollapsedBlockFoldsUnsummarizedRowsAboveViewport()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "swallow-above-viewport-test");
+    var author = await Tester.GetOwnAuthor(chat.Id).Require();
+    var peerId = AuthorId.New(chat.Id, 777_400);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+    var v = live!.EffectiveVisibleStartLid;
+    // A title so the block has a card, but the summary covers only V (EndEntryLid = v) - the entries
+    // below are UN-summarised. Viewport tracking must still fold them once they scroll above the top.
+    await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+        Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+    }, CancellationToken.None);
+    var lids = new List<long>();
+    for (var i = 0; i < 8; i++)
+        lids.Add((await Tester.CreateTextEntry(chat.Id, $"m-{i}")).LocalId);
+
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    await chatAudioUI.SetRecordingChatId(chat.Id);   // Bob is a recorder => joined
+    chatUI.SelectChatOnNavigation(chat.Id);
+
+    // Viewport top sits at the 6th entry: everything above it (incl. un-summarised rows) must fold.
+    var viewportTop = lids[5];
+    chatUI.SetItemVisibility(new VirtualListItemVisibility(
+        chat.Id, [new ChatMessageKey(chat.Id, viewportTop)], false));
+
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+    await ComputedTest.When(async ct => {
+        var blockState = await AppHost.Services.GetRequiredService<LiveBlockUI>()
+            .GetBlockState(chat.Id, ct);
+        blockState.FoldBoundaryLid.Should().BeGreaterThanOrEqualTo(viewportTop,
+            "the boundary tracks the viewport top, folding un-summarised rows above it");
+    }, TimeSpan.FromSeconds(15));
+}
+```
+
+> Note: adapt the visibility call to the real `ChatUI` API — inspect how existing tests set visibility (`SetItemVisibility` / assigning `ItemVisibility`) and the exact `VirtualListItemVisibility` / `ChatMessageKey` constructors before finalizing. If no test-side visibility setter exists, drive it through the same `MutableState<ChatViewItemVisibility>` the governor reads (`ChatUI._itemVisibility` via a test accessor) — mirror the closest existing pattern rather than inventing one.
+
+- [ ] **Step 6: Build, test, commit** (Tasks 1 + 2 together).
+
+```bash
+dotnet build ActualChat.CI.slnf   # 0 errors
+dotnet test tests/Chat.UI.Blazor.UnitTests/Chat.UI.Blazor.UnitTests.csproj -c Debug --filter "FullyQualifiedName~LiveFoldMathTest"
+dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"
+```
+Expected: unit 5/5 PASS; `LiveConversationDisplayTest` all PASS (fix any existing fold-range assertion that assumed the summary-lag rule — with §4 the boundary can now sit at the viewport top rather than the summary end; update those expectations to the viewport-tracking rule, and remove any test that asserted `FoldLag` timing).
+
+```bash
+git add src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs \
+  src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs \
+  tests/Chat.UI.Blazor.UnitTests/LiveFoldMathTest.cs \
+  tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): collapsed block swallows everything above the viewport (§4)"
+```
+
+- [ ] **Step 7: Manual no-jump verification (chrome-devtools + `/virtual-list-debug`).** With the running app and a live block joined as a recorder: scroll so older lines rise above the viewport and confirm they fold into the card **without the viewport jumping**, the card stays compact, and the boundary never retreats when you scroll back up (the folded rows re-render below, no snap). This is the core §4 risk — if any jump appears, capture it with `/virtual-list-debug` before proceeding to Phase B. Phase A is shippable on its own once this passes.
+
+---
+
+# Phase B — "Show N earlier messages of M" pill (§7)
+
+Built on Phase A's viewport-tracking boundary. A reader-controlled `RevealedBoundaryLid` pins the *effective* fold below the governor's monotonic boundary so revealed messages stay revealed; a straddling pill reveals a batch per click.
+
+## Task 3: Reveal state — `RevealedBoundaryLid`, `RevealMore`, `ResetReveal`
+
+Add the reveal offset to the governor and thread the effective boundary into the tile builder. The governor's monotonic `FoldBoundaryLid` keeps advancing; the *rendered* fold uses `min(FoldBoundaryLid, RevealedBoundaryLid)`, so revealed rows survive new tail arrivals.
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs` (`LiveBlockState`, `ChatFoldState`, new `RevealMore`/`ResetReveal`, `GetBlockState`)
+- Modify: `src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs` (effective boundary in `liveFoldRange`)
+- Modify: `src/dotnet/UI.Blazor.App/Services/ChatUI.cs` (`ToggleExpandConversation` → `ResetReveal`)
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `Chats.ReadReverse(Session, chatId, ct)`; `Hub.ChatUI.ItemVisibility`.
+- Produces:
+  - `LiveBlockState` gains `long RevealedBoundaryLid = long.MaxValue` (no reveal ⇒ effective = `FoldBoundaryLid`).
+  - `Task LiveBlockUI.RevealMore(ChatId chatId, CancellationToken ct = default)` — retreats `RevealedBoundaryLid` by one batch.
+  - `void LiveBlockUI.ResetReveal(ChatId chatId)` — clears the reveal (called on expand/collapse).
+
+- [ ] **Step 1: Add `RevealedBoundaryLid` to `LiveBlockState`** (`LiveBlockUI.cs:21-25`):
+
+```csharp
+public sealed record LiveBlockState(
+    long FoldBoundaryLid,
+    LiveBlockOverlay? Overlay,
+    bool WasAttending = false,
+    bool IsDissolving = false,
+    long RevealedBoundaryLid = long.MaxValue)
+{
+    public static readonly LiveBlockState None = new(0, null);
+}
+```
+
+- [ ] **Step 2: Store the reveal on `ChatFoldState`** and surface it from `GetBlockState`. Add to the nested `ChatFoldState`:
+
+```csharp
+        public long RevealedBoundaryLid = long.MaxValue;
+```
+
+In `GetBlockState`, carry it onto the returned state (inside the existing `lock (Lock)` return):
+
+```csharp
+        lock (Lock)
+            return baseState with {
+                Overlay = DeriveOverlay(chatState, baseState.FoldBoundaryLid, raw, amInLive),
+                RevealedBoundaryLid = chatState.RevealedBoundaryLid,
+            };
+```
+
+- [ ] **Step 3: Implement `RevealMore` and `ResetReveal`.** `RevealMore` computes the batch from the current viewport count (rounded up to 5, floor 5), reads that many entries backward from the current effective boundary within `[V, effectiveBoundary)`, and sets `RevealedBoundaryLid` to the batch-th entry's lid (or `V` if fewer remain). Add to `LiveBlockUI`:
+
+```csharp
+    public async Task RevealMore(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        ChatFoldState chatState;
+        long v, effectiveBoundary;
+        lock (Lock) {
+            if (!_chatStates.TryGetValue(chatId, out var s) || s.Template is not { } t)
+                return;
+            chatState = s;
+            v = t.V;
+            effectiveBoundary = Math.Min(chatState.State.Value.FoldBoundaryLid, chatState.RevealedBoundaryLid);
+        }
+        if (effectiveBoundary <= v)
+            return;
+
+        var visibleCount = Hub.ChatUI.ItemVisibility.Value.VisibleMessageLids.Count;
+        var batch = Math.Max(5, ((visibleCount + 4) / 5) * 5);
+
+        // Walk back `batch` real messages from just below the current effective boundary; the batch-th
+        // one becomes the new revealed boundary (clamped to V when fewer remain).
+        var revealed = v;
+        using (Computed.BeginIsolation()) {
+            var taken = 0;
+            await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
+                if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
+                    continue;
+                if (entry.LocalId < v)
+                    break;
+                revealed = entry.LocalId;
+                if (++taken >= batch)
+                    break;
+            }
+        }
+
+        lock (Lock)
+            chatState.RevealedBoundaryLid = Math.Min(chatState.RevealedBoundaryLid, revealed);
+        using (Invalidation.Begin())
+            _ = GetBlockState(chatId, default);
+    }
+
+    public void ResetReveal(ChatId chatId)
+    {
+        lock (Lock) {
+            if (!_chatStates.TryGetValue(chatId, out var chatState) || chatState.RevealedBoundaryLid == long.MaxValue)
+                return;
+            chatState.RevealedBoundaryLid = long.MaxValue;
+        }
+        using (Invalidation.Begin())
+            _ = GetBlockState(chatId, default);
+    }
+```
+
+> Verify `Chats.ReadReverse` yields ascending-local-id-descending order and its signature (`IAsyncEnumerable<ChatEntry>`), matching `GetThreadPreviewEntries` usage in `ChatUI.Tiles.cs`. `ChatEntry.LocalId` and `IsSystemEntry` are the fields used there.
+
+- [ ] **Step 4: Thread the effective boundary into the tile builder.** In `ChatUI.Tiles.cs` (~L80-85), fold to the effective boundary so revealed rows render below the card:
+
+```csharp
+        var effectiveFoldBoundaryLid = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
+        var liveFoldRange = rawLive is { SessionStartedAt: not null }
+            && effectiveFoldBoundaryLid > rawLive.EffectiveVisibleStartLid
+                ? new Range<long>(
+                    rawLive.EffectiveVisibleStartLid,
+                    Math.Min(effectiveFoldBoundaryLid, rawLive.EndEntryLid + 1))
+                : default;
+```
+
+- [ ] **Step 5: Reset the reveal on expand/collapse.** In `ChatUI.cs` `ToggleExpandConversation` (~L364-371), after flipping the override, reset the reveal for that conversation so a re-collapse re-latches to a compact card:
+
+```csharp
+        _conversationExpansionOverrides.Value = mustRemove
+            ? overrides.Remove(conversationId)
+            : overrides.Add(conversationId);
+        Hub.LiveBlockUI.ResetReveal(conversationId.ChatId);
+```
+
+(The overlay-collapse early-return path above it does not touch the reveal — a closed block has no reveal.)
+
+- [ ] **Step 6: Write the integration test** — after `RevealMore`, the effective fold boundary retreats so more rows render, and it survives a subsequent tail advance; `ResetReveal` restores it. Add to `LiveConversationDisplayTest.cs`:
+
+```csharp
+[Fact]
+public async Task RevealMoreRetreatsEffectiveFoldAndPersists()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "reveal-more-test");
+    var author = await Tester.GetOwnAuthor(chat.Id).Require();
+    var peerId = AuthorId.New(chat.Id, 777_410);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+    var v = live!.EffectiveVisibleStartLid;
+    await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+        Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+    }, CancellationToken.None);
+    for (var i = 0; i < 20; i++) await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+    await chatAudioUI.SetRecordingChatId(chat.Id);
+    chatUI.SelectChatOnNavigation(chat.Id);
+
+    // Drive the boundary up near the tail (viewport at the last entry), so a large range is folded.
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    chatUI.SetItemVisibility(new VirtualListItemVisibility(
+        chat.Id, [new ChatMessageKey(chat.Id, idRange.End - 1)], false));
+
+    long foldedBoundary = 0;
+    await ComputedTest.When(async ct => {
+        var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+        s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
+        foldedBoundary = s.FoldBoundaryLid;
+    }, TimeSpan.FromSeconds(15));
+
+    await liveBlockUI.RevealMore(chat.Id);
+    await ComputedTest.When(async ct => {
+        var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+        Math.Min(s.FoldBoundaryLid, s.RevealedBoundaryLid).Should().BeLessThan(foldedBoundary,
+            "revealing a batch retreats the effective fold boundary");
+    }, TimeSpan.FromSeconds(10));
+
+    liveBlockUI.ResetReveal(chat.Id);
+    await ComputedTest.When(async ct => {
+        var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+        s.RevealedBoundaryLid.Should().Be(long.MaxValue, "reset clears the reveal");
+    }, TimeSpan.FromSeconds(10));
+}
+```
+
+- [ ] **Step 7: Build + test.**
+
+```bash
+dotnet build ActualChat.CI.slnf   # 0 errors
+dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"
+```
+Expected: all PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs \
+  src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs \
+  src/dotnet/UI.Blazor.App/Services/ChatUI.cs \
+  tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): reveal-boundary state — RevealMore/ResetReveal + effective fold (§7 state)"
+```
+
+---
+
+## Task 4: Swallowed count + the straddling "Show N of M" pill
+
+Show the pill on a collapsed joined block whenever messages are swallowed. Label "▲ Show N earlier messages of M": M = the true swallowed count in `[V, effectiveBoundary)`, N = the next batch (`min(roundUpTo5(viewportCount), M)`). Clicking calls `RevealMore`; when M reaches 0 the pill disappears.
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs` — add `[ComputeMethod] GetSwallowedCount`
+- Modify: `.../Conversation/ConversationLiveState.cs` — add `int SwallowedCount`, `int RevealBatch`
+- Modify: `.../Conversation/ConversationMessageView.razor` — compute the two counts; render the pill; wire click
+- Modify: `.../Conversation/conversation.css` — `.c-lc-showmore` pill styling
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `LiveBlockUI.GetBlockState`; `Chats.ReadReverse`; `Hub.ChatUI.ItemVisibility`; `LiveBlockUI.RevealMore`.
+- Produces: `ConversationLiveState.SwallowedCount` (M) and `RevealBatch` (N); a `.c-lc-showmore` pill button in the collapsed joined card.
+
+- [ ] **Step 1: Add `GetSwallowedCount` to `LiveBlockUI`.** It counts real messages in `[V, effectiveBoundary)` for the pill's "of M". It is a `[ComputeMethod]` so it caches and re-computes only as the boundary/reveal move.
+
+```csharp
+    [ComputeMethod]
+    public virtual async Task<int> GetSwallowedCount(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        var blockState = await GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
+        var raw = await LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
+        if (raw is not { SessionStartedAt: not null })
+            return 0;
+        var v = raw.EffectiveVisibleStartLid;
+        var effectiveBoundary = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
+        if (effectiveBoundary <= v)
+            return 0;
+
+        var count = 0;
+        await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
+            if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
+                continue;
+            if (entry.LocalId < v)
+                break;
+            count++;
+        }
+        return count;
+    }
+```
+
+> Perf note (call it out in the review): `GetSwallowedCount` reads the swallowed range each recompute. It is cached (`[ComputeMethod]`) and the block is singular, but a very long collapsed session counts many entries. Acceptable for now; if it shows up in profiling, back it with `ChatRangeMeta` entry-count sums instead of a full read. Do **not** substitute a lid-span (`effectiveBoundary - v`) — lids have gaps; the count must be real messages.
+
+- [ ] **Step 2: Add the fields to `ConversationLiveState.cs`:**
+
+```csharp
+public sealed record ConversationLiveState(
+    TranslatedConversation Conversation,
+    bool IsLive,
+    bool IsJoined,
+    bool IsVoiceOnly,
+    string ParticipantsText = "",
+    bool HasFoldedEntries = false,
+    bool IsExpanded = false,
+    IReadOnlyList<PreviewEntry>? TailPreview = null,
+    bool HasSummary = false,
+    int SwallowedCount = 0,
+    int RevealBatch = 0);
+```
+
+- [ ] **Step 3: Populate them in `ConversationMessageView.ComputeState`.** The pill only matters for a joined, collapsed block, so compute the count only then (avoid the read otherwise):
+
+```csharp
+var swallowedCount = 0;
+var revealBatch = 0;
+if (isJoined && !isExpanded) {
+    swallowedCount = await Hub.LiveBlockUI.GetSwallowedCount(chatId, cancellationToken).ConfigureAwait(false);
+    if (swallowedCount > 0) {
+        var visibleCount = Hub.ChatUI.ItemVisibility.Value.VisibleMessageLids.Count;
+        revealBatch = Math.Min(Math.Max(5, ((visibleCount + 4) / 5) * 5), swallowedCount);
+    }
+}
+return new ConversationLiveState(
+    translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded,
+    tailPreview, hasSummary, swallowedCount, revealBatch);
+```
+
+> Match the actual `ComputeState` locals (`isJoined`, `isExpanded`, `chatId`) already present from Plan 1's Task 3/4. `ItemVisibility.Value` is a non-reactive read here — that is fine for the batch label (a display heuristic); the pill's *visibility* is gated on `SwallowedCount` which IS reactive.
+
+- [ ] **Step 4: Render the pill** in `ConversationMessageView.razor`, at the bottom edge of the collapsed live card (after the meta-row, inside the `c-live-card` so it can straddle the card's bottom border). Show only when `state.SwallowedCount > 0`:
+
+```razor
+@if (!state.IsExpanded && state.SwallowedCount > 0) {
+    <button type="button" class="c-lc-showmore" @onclick="@OnRevealMore">
+        <i class="icon-chevron-up"></i>
+        <span>Show @state.RevealBatch earlier message@(state.RevealBatch == 1 ? "" : "s") of @state.SwallowedCount</span>
+    </button>
+}
+```
+
+Add the handler (mirrors `OnJoin`):
+
+```csharp
+private async Task OnRevealMore() {
+    var chatId = Message.Conversation!.Id.ChatId;
+    await Hub.LiveBlockUI.RevealMore(chatId).ConfigureAwait(true);
+}
+```
+
+> Confirm the up-chevron icon class against the icon set (`rg "icon-chevron-up|icon-expand" src/dotnet/UI.Blazor.App` — use the one already in the codebase; the header expand chevron's icon is the reference).
+
+- [ ] **Step 5: Style `.c-lc-showmore`** in `conversation.css` — the Call/Map-switch rounded pill, straddling the card's bottom edge. The card wrapper must be `position: relative` and must not clip (the sticky-header work already dropped `overflow:hidden` on the joined group — verify no ancestor clips). Reuse the `--cr-item-badge-selected-text` colour token.
+
+```css
+.c-live-card {
+    @apply relative;   /* anchor for the straddling pill; add only if not already present */
+}
+.c-lc-showmore {
+    @apply absolute left-1/2 bottom-0 flex-x items-center gap-x-1;
+    @apply px-3 h-7 rounded-full;
+    @apply text-caption-1 text-[var(--cr-item-badge-selected-text)];
+    @apply bg-[var(--background-01)] border border-solid;
+    border-color: var(--separator-01, rgba(0, 0, 0, 0.08));
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    transform: translate(-50%, 50%);
+    z-index: 5;
+}
+.c-lc-showmore i {
+    @apply text-icons-05;
+}
+body.hoverable .c-lc-showmore:hover {
+    @apply bg-[var(--background-02)];
+}
+```
+
+> Adjust tokens/utilities to the ones the file actually uses (grep the existing `.show-more-btn` and switch container rules for the exact border/shadow the design uses). Keep it ≤120 cols. Verify the pill visually straddles (half over the tint, half over the first message row) in the visual pass; nudge `bottom`/`transform` if the card's bottom padding hides it.
+
+- [ ] **Step 6: Write the test** — a collapsed joined block with swallowed messages exposes a positive `SwallowedCount` on its card state; an expanded one does not. Assert at the model level. Add to `LiveConversationDisplayTest.cs`:
+
+```csharp
+[Fact]
+public async Task CollapsedJoinedBlockReportsSwallowedCount()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "swallowed-count-test");
+    var author = await Tester.GetOwnAuthor(chat.Id).Require();
+    var peerId = AuthorId.New(chat.Id, 777_420);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+    var v = live!.EffectiveVisibleStartLid;
+    await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+        Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+    }, CancellationToken.None);
+    for (var i = 0; i < 12; i++) await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+    await chatAudioUI.SetRecordingChatId(chat.Id);
+    chatUI.SelectChatOnNavigation(chat.Id);
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    chatUI.SetItemVisibility(new VirtualListItemVisibility(
+        chat.Id, [new ChatMessageKey(chat.Id, idRange.End - 1)], false));
+
+    await ComputedTest.When(async ct => {
+        var count = await liveBlockUI.GetSwallowedCount(chat.Id, ct);
+        count.Should().BeGreaterThan(0, "a collapsed joined block with tail above the viewport swallows messages");
+    }, TimeSpan.FromSeconds(15));
+}
+```
+
+- [ ] **Step 7: Build + verify.**
+
+```bash
+dotnet build ActualChat.CI.slnf   # 0 errors
+npm run build:Verify              # CSS touched — tsc + eslint + debug build clean
+dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"
+```
+Expected: build 0 errors; `build:Verify` clean; tests all PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css \
+  tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): Show N earlier messages of M pill (§7)"
+```
+
+- [ ] **Step 9: Manual visual + no-jump pass (chrome-devtools + `/virtual-list-debug`).** Joined, collapsed, with a backlog above the viewport: the pill straddles the card's bottom edge (half over the tint, half over the first message), reads "▲ Show N earlier messages of M" with M = the true swallowed count; each click reveals a batch **in place with no viewport jump** (older rows appear above, bottom-anchored; scroll up into them), M decrements, and when it hits 0 the pill disappears. Expand → collapse resets the reveal (pill returns for the full backlog). Confirm the number reads from the true swallowed count, not the summary's MessageCount.
+
+---
+
+## Verification (whole plan)
+
+1. `dotnet build ActualChat.CI.slnf` — 0 errors.
+2. `dotnet test tests/Chat.UI.Blazor.UnitTests/Chat.UI.Blazor.UnitTests.csproj -c Debug --filter "FullyQualifiedName~LiveFoldMathTest"` — 5/5.
+3. `dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"` — all PASS (existing + 3 new).
+4. `npm run build:Verify` — clean.
+5. Manual two-identity pass against the running app (joined reader): collapsed block swallows lines above the viewport as you read (no jump, compact card); the "Show N of M" pill reveals a batch in place per click (no jump), M decrements to 0 then the pill vanishes; expanding reads as a plain conversation and collapsing re-latches to a compact card with the pill back. Use `/virtual-list-debug` at every transition.
+
+## Self-review notes (spec coverage)
+
+- §4 swallow-above-viewport → Phase A (Tasks 1-2): boundary = monotonic viewport-top max, un-summarised rows fold. §7 show-more → Phase B (Tasks 3-4): `RevealedBoundaryLid` retreat + straddling pill + true swallowed count. Batch = viewport count rounded up to 5 (user decision). Reveal persists until expand/re-collapse (reset from `ToggleExpandConversation`).
+- **Reused, not forked:** `LiveBlockUI`/`LiveFoldMath` (extended, summary-lag path removed per spec), `ItemVisibility`, `Chats.ReadReverse`, the `--cr-item-badge-selected-text` token + switch pill visual. New: `RevealedBoundaryLid` state (on the existing governor, not a new service) and the `.c-lc-showmore` pill (local to the live block, promotion path noted in the spec if a second use appears).
+- **Out of scope (spec):** unjoined preview (Plan 1 §6 — pill is joined-only), close/materialisation tiers, activity panel, summary/ContextStartLid recomputation.
+
+## Risks & mitigations
+
+- **No-jump on fold (core §4 risk).** Folding un-summarised above-viewport rows is new. Mitigation: the boundary is monotonic and clamped to the viewport top; expansion already suppresses the fold at the tile builder, so no jump on collapse. Verified with `/virtual-list-debug` at Task 2 Step 7 before Phase B.
+- **No-jump on reveal (§7).** Revealing retreats the *effective* boundary while the governor's monotonic boundary keeps advancing — so new tail arrivals never un-reveal, and revealed rows render bottom-anchored. Verified at Task 4 Step 9.
+- **Existing fold-timing tests.** Phase A removes `FoldLag`; any `LiveConversationDisplayTest` that asserted summary-lag fold ranges must move to the viewport-tracking expectation (Task 2 Step 6).
+- **`GetSwallowedCount` cost.** Cached; reads the swallowed range per recompute. Perf caveat flagged for review; back with `ChatRangeMeta` counts if it profiles hot. Never approximate with a lid span.
+- **Reveal stranding.** `ResetReveal` fires on expand/collapse; the reveal also resets when the chat state is recreated (block rebuild) and is absent for closed/overlay blocks (which have no `Template` reveal path). Confirm no half-revealed card survives a session close in the manual pass.

--- a/docs/superpowers/plans/2026-07-22-live-block-swallow-and-show-more.md
+++ b/docs/superpowers/plans/2026-07-22-live-block-swallow-and-show-more.md
@@ -328,15 +328,13 @@ In `GetBlockState`, carry it onto the returned state (inside the existing `lock 
 
 > Verify `Chats.ReadReverse` yields ascending-local-id-descending order and its signature (`IAsyncEnumerable<ChatEntry>`), matching `GetThreadPreviewEntries` usage in `ChatUI.Tiles.cs`. `ChatEntry.LocalId` and `IsSystemEntry` are the fields used there.
 
-- [ ] **Step 4: Thread the effective boundary into the tile builder.** In `ChatUI.Tiles.cs` (~L80-85), fold to the effective boundary so revealed rows render below the card:
+- [ ] **Step 4: Thread the effective boundary into the tile builder.** In `ChatUI.Tiles.cs` (~L80-85), fold to the effective boundary so revealed rows render below the card. **Do NOT cap at `EndEntryLid + 1`** — `EndEntryLid` only advances on `UpdateSummary`, so capping there would re-defeat §4's un-summarised folding (Phase A already dropped this cap; keep it dropped). `FoldBoundaryLid` is always a real visible lid ≤ the last entry, so `[V, effectiveFoldBoundaryLid)` is safe:
 
 ```csharp
         var effectiveFoldBoundaryLid = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
         var liveFoldRange = rawLive is { SessionStartedAt: not null }
             && effectiveFoldBoundaryLid > rawLive.EffectiveVisibleStartLid
-                ? new Range<long>(
-                    rawLive.EffectiveVisibleStartLid,
-                    Math.Min(effectiveFoldBoundaryLid, rawLive.EndEntryLid + 1))
+                ? new Range<long>(rawLive.EffectiveVisibleStartLid, effectiveFoldBoundaryLid)
                 : default;
 ```
 

--- a/docs/superpowers/plans/2026-07-22-live-block-unified-shell.md
+++ b/docs/superpowers/plans/2026-07-22-live-block-unified-shell.md
@@ -1,0 +1,505 @@
+# Live Block Unified Shell — Implementation Plan (Plan 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the live conversation block one shell across joined/unjoined/expanded and make its chrome correct (Join-to-record button in the sticky header, meta-row gated on a real summary, unjoined fixed-height faded preview, expanded = a plain conversation), leaving the fold *mechanism* unchanged.
+
+**Architecture:** All changes are client-side rendering in `UI.Blazor.App`. The joined live block already renders through a sticky `LiveConversationHeaderView` + a `c-live-card` (`ConversationMessageView` live path) inside one VirtualList group. This plan (a) routes the **unjoined** live block through that same path so both share the shell, (b) fixes the card's chrome (meta-row, description, Join button, preview), and (c) composes join-with-recording. The fold boundary / swallow behaviour and the "Show more" pill are **Plan 2**.
+
+**Tech Stack:** Blazor Server components (`.razor`), ActualLab.Fusion `ComputedStateComponent`, Tailwind-compiled CSS (`conversation.css`, `last-entries-preview.css`), xUnit integration tests (`Chat.UI.Blazor.IntegrationTests`, `ComputedTest.When` over `ChatUI.GetChatItems`).
+
+## Global Constraints
+
+- Read `docs/CODING_STYLE.md` before writing C#/TS/Razor. No `Async` suffix; no XML docs on members; comments only for non-obvious constraints; follow surrounding brace/format style.
+- Build with `dotnet build ActualChat.CI.slnf`. TS/CSS-touching changes: `npm run build:Verify` (or the `/server-loop` rebuild if running — check `tmp/watch-dotnet.log`).
+- A user-owned `dotnet watch` may own the server on port 7080 — do **not** `/server-start`/`/server-restart`.
+- Branch `feat/live-block-unified-ux` (already created off `dev`, holds the spec commit). Do not push unless asked.
+- Reuse before adding: activity-panel button classes for the Join button; existing `c-lc-meta-row`/`c-lc-authors`/`c-lc-started` markup; `LastEntriesPreview` for the preview; the `.group:has(…)` tint pattern. Spec: `docs/superpowers/specs/2026-07-22-live-conversation-block-unified-ux-design.md`.
+- Real design tokens (light theme, captured from the running app): `--violet-60 #A533FF`, `--violet-60-10 #A635FF1A`, `--text-01/02 #1C1C1C`, `--text-03 #777777`, `--cr-item-badge-selected-text #582EFF`, unjoined tint `linear-gradient(90deg, rgba(255,202,255,.3) 2%, rgba(130,104,255,.3) 100%)`.
+
+---
+
+## File Structure
+
+- `src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor` — the live `c-live-card`: description, meta-row, Join button, preview, expanded gating. **Primary edit surface.**
+- `.../Conversation/LiveConversationHeaderView.razor` + `LiveConversationHeaderState.cs` — sticky header; gains the Join affordance for the unjoined block.
+- `.../Conversation/ConversationLiveState.cs` — render-state record; may gain a `HasSummary` flag.
+- `src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs` — routes the live conversation (joined **and** unjoined) through the sticky-header + card path (`GetTile` card emission ~L858-888, `hiddenLiveTailRange` ~L101-107, `GroupExpandedConversations` ~L965-1028).
+- `src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor` + `last-entries-preview.css` — fixed-height, bottom-anchored, top-faded preview.
+- `.../Conversation/conversation.css` — shell tints, meta-row, Join button, description gating, header Join layout.
+- Tests: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs` (extend).
+
+Testing note: pure-CSS/layout changes (preview fade, tints, button look) are verified **manually** via chrome-devtools MCP against the running app (a live block is easy to spin up) — the existing test harness asserts the `ChatItems` model, not rendered pixels. Structural/logic changes (which message types are emitted, join action, state gating) get integration tests.
+
+---
+
+## Task 1: Join = join **and** record; label "Join"
+
+The unjoined card's join action currently only starts listening. Spec §5: in the block it must start **recording** (active participation). Label stays "Join", no icon.
+
+**Files:**
+- Modify: `.../Conversation/ConversationMessageView.razor` (`OnJoin`, ~L249-252; the `c-join-row` button text ~L84)
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `ChatAudioUI.SetRecordingChatId(ChatId? chatId, bool isPushToTalk = false)` (`ChatAudioUI.cs:163`) — starts recording in `chatId`, which makes the caller a recorder (so `AmIInLiveConversation` becomes true).
+- Produces: `OnJoin()` now records; used by the header Join button in Task 5.
+
+- [ ] **Step 1: Write the failing test** in `LiveConversationDisplayTest.cs` (pattern: `ClosedBlockRendersAsCompletedNotLive`). Arrange a live session the viewer has NOT joined, call the join, assert the viewer becomes a recorder.
+
+```csharp
+[Fact]
+public async Task JoinFromBlockStartsRecording()
+{
+    // arrange - a live session this Bob has not joined
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "join-records-test");
+    var peerId = AuthorId.New(chat.Id, 777_310);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    chatUI.SelectChatOnNavigation(chat.Id);
+
+    // act - the block's Join action
+    await chatAudioUI.SetRecordingChatId(chat.Id);
+
+    // assert - Bob is now recording in this chat
+    await ComputedTest.When(async ct => {
+        var s = await chatAudioUI.GetState(chat.Id).ConfigureAwait(true);
+        s.IsRecording.Should().BeTrue("Join from the live block starts recording");
+    }, TimeSpan.FromSeconds(10));
+}
+```
+
+- [ ] **Step 2: Run it and watch it pass or fail meaningfully.** This test pins the *behaviour we are wiring `OnJoin` to* (recording start), so it should already pass at the `ChatAudioUI` level — its role is a regression guard on the join-to-record contract. Run:
+
+`dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~JoinFromBlockStartsRecording"`
+Expected: PASS (confirms `SetRecordingChatId` ⇒ `IsRecording`). If it FAILS, the recording API differs — stop and reconcile before editing `OnJoin`.
+
+- [ ] **Step 3: Change `OnJoin`** in `ConversationMessageView.razor` from listen to record:
+
+```csharp
+private async Task OnJoin() {
+    var chatId = Message.Conversation!.Id.ChatId;
+    await ChatAudioUI.SetRecordingChatId(chatId).ConfigureAwait(true);
+}
+```
+
+- [ ] **Step 4: Confirm the button label is "Join"** (no icon). The current `c-join-row` reads "Tap to join" (`ConversationMessageView.razor:84`); change its text to `Join`. (Its relocation into the header and restyle happens in Task 5 — here only the label + action change.)
+
+```razor
+<button type="button" class="c-join-row" @onclick="@OnJoin">Join</button>
+```
+
+- [ ] **Step 5: Build + test.** `dotnet build src/dotnet/UI.Blazor.App/UI.Blazor.App.csproj -c Debug` (expect 0 errors), then re-run the Step 2 filter (expect PASS).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): block Join starts recording, label \"Join\""
+```
+
+---
+
+## Task 2: Unjoined preview — 5 messages, fixed-height, bottom-anchored, faded
+
+Spec §6. The preview is a self-contained region (not VirtualList swallowing): last ~5 messages, fixed height, newest pinned to the bottom, older lines fading out at the top so incoming messages never grow/jump the block.
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor` (wrapper class)
+- Modify: `src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css`
+- Modify: `.../Conversation/ConversationMessageView.razor` — `GetThreadPreviewEntries` count (it currently takes 2)
+- Modify: `src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs` — `GetThreadPreviewEntries` `.Take(2)` → `.Take(5)` (~L894-899)
+
+**Interfaces:**
+- Consumes: existing `LastEntriesPreview` component + `PreviewEntry` list from `GetTailPreview`.
+- Produces: a `.last-entries-preview` region with fixed height + bottom anchor + top fade.
+
+- [ ] **Step 1: Bump the preview entry count** to 5 in `ChatUI.Tiles.cs` `GetThreadPreviewEntries`:
+
+```csharp
+    public virtual async Task<IReadOnlyList<ChatEntry>> GetThreadPreviewEntries(
+        ChatId chatId,
+        CancellationToken cancellationToken = default)
+        => await Chats.ReadReverse(Session, chatId, cancellationToken)
+            .Where(x => !x.IsSystemEntry)
+            .Take(5)
+            .Reverse()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+```
+
+- [ ] **Step 2: Make the preview fixed-height, bottom-anchored, faded** in `last-entries-preview.css`. Replace the `.last-entries-preview` rule so the region is a fixed-height flex column pinned to the bottom with a top opacity gradient (values validated in the visual companion):
+
+```css
+.last-entries-preview {
+    position: relative;
+    width: 100%;
+    height: 8.25rem;              /* fixed: ~5 lines; incoming messages don't grow the block */
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;    /* newest line fully visible at the bottom */
+    padding-bottom: 0.375rem;
+}
+.last-entries-preview::before {   /* older lines fade out under the card */
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 3.75rem;
+    z-index: 2;
+    pointer-events: none;
+    background: linear-gradient(to bottom, var(--background-01) 0%, transparent 100%);
+}
+```
+
+Keep the existing per-entry `animation: lc-fade-in 200ms ease;` and `> *` rule.
+
+- [ ] **Step 3: Verify manually** (pure CSS). With the running app: spin up a live conversation from a second identity, view it as a non-joined user, and confirm via chrome-devtools that `.last-entries-preview` has a fixed height, the newest line sits at the bottom, the top fades, and sending a new message does **not** change the block's height (no jump). Reference: this is the state A the companion mocked.
+
+- [ ] **Step 4: `npm run build:Verify`** (CSS touched) — expect clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+git commit -m "feat(live): fixed-height bottom-anchored faded unjoined preview (5 msgs)"
+```
+
+---
+
+## Task 3: Expanded joined block = a plain conversation (no description, no header count)
+
+Spec §8. When the block is expanded, the `c-live-card`'s description box must not render, and the sticky header must not show a count. (The sticky header today already has no count — this task guards it and drops the description on expand.) `state.IsExpanded` is already computed in `ConversationLiveState`.
+
+**Files:**
+- Modify: `.../Conversation/ConversationMessageView.razor` (the live-card description block ~L42-51)
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `ConversationLiveState.IsExpanded` (already present).
+- Produces: no new interface.
+
+- [ ] **Step 1: Write the failing test.** Extend `ClosedBlockRendersAsCompletedNotLive`-style setup, expand the block, and assert the rendered `ConversationLiveState` for the card has no description shown. Since the harness asserts `ChatItems`, assert at the model level that the block, when expanded, does not carry a description message and the header carries no count. Add to `LiveConversationDisplayTest.cs`:
+
+```csharp
+[Fact]
+public async Task ExpandedLiveBlockHasNoDescription()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "expanded-no-desc-test");
+    var author = await Tester.GetOwnAuthor(chat.Id).Require();
+    var peerId = AuthorId.New(chat.Id, 777_320);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+    var v = live!.EffectiveVisibleStartLid;
+    await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+        Title = "Recap", Description = "a description", Summary = "s", EndEntryLid = v, MessageCount = 1,
+    }, CancellationToken.None);
+    for (var i = 0; i < 3; i++) await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    await chatAudioUI.SetListeningState(chat.Id, true);
+    chatUI.SelectChatOnNavigation(chat.Id);
+    // ensure the block renders expanded
+    var live2 = await Tester.Conversations.Get(Tester.Session, live.ToConversation().Id, CancellationToken.None);
+    if (live2 is { IsExpandedByDefault: false })
+        chatUI.ToggleExpandConversation(live.ToConversation().Id);
+
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+    await ComputedTest.When(async ct => {
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+        var block = items.Items.OfType<ExpandedConversationMessage>().Single();
+        // the card carries HasSplitHeader; when expanded it must not surface the description markup as a rendered row
+        block.Items.OfType<ConversationMessage>().Single().HasSplitHeader.Should().BeTrue();
+    }, TimeSpan.FromSeconds(15));
+}
+```
+
+Note: description suppression is a Razor concern (the `c-live-card` markup), so the definitive check is manual (Step 3); this test guards the block still renders as one split-header block when expanded. If a cleaner model-level signal exists after implementation, tighten the assertion.
+
+- [ ] **Step 2: Run it** — `dotnet test … --filter "FullyQualifiedName~ExpandedLiveBlockHasNoDescription"`. Expect PASS on the structural assertion (it does not yet test description suppression).
+
+- [ ] **Step 3: Gate the description on collapsed.** In `ConversationMessageView.razor`, wrap the live-card description block so it renders only when the block is **not** expanded:
+
+```razor
+@* Description belongs to the collapsed recap only; expanded reads as a plain conversation. *@
+@if (hasDescription && !state.IsExpanded) {
+    <div class="c-lc-summary-box">
+        <div class="c-lc-summary" @key="@m.Description.Markup.ToReadableText()">
+            <CascadingValue Value="@_fakeEntry" IsFixed="true">
+                <MarkupView Markup="@m.Description.Markup"/>
+            </CascadingValue>
+        </div>
+    </div>
+}
+```
+
+- [ ] **Step 4: Verify manually** the sticky header shows no count in either state and the description disappears when expanded (chrome-devtools against the running app). `LiveConversationHeaderView.razor` already renders only icon + title + expand — confirm no count leaks in.
+
+- [ ] **Step 5: Build + test.** `dotnet build src/dotnet/UI.Blazor.App/UI.Blazor.App.csproj -c Debug` (0 errors), re-run the Step 2 filter (PASS).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): expanded live block drops the description box"
+```
+
+---
+
+## Task 4: Meta-row gated on a real summary (no "0 messages", no orphan heads)
+
+Spec §3. Below the description, show the existing `c-lc-meta-row` (author heads + `c-lc-started` "Started at HH:MM · N messages") **only when a title/summary exists**. Pre-first-summary, render nothing there. This also removes the current title-less "0 messages" line and the duplicate roster.
+
+**Files:**
+- Modify: `.../Conversation/ConversationLiveState.cs` — add `bool HasSummary`
+- Modify: `.../Conversation/ConversationMessageView.razor` — compute `HasSummary`; gate the meta-row
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `conversation.Title`, `conversation.MessageCount`.
+- Produces: `ConversationLiveState.HasSummary` (`= title present OR MessageCount > 0`) used to gate the meta-row.
+
+- [ ] **Step 1: Add `HasSummary` to `ConversationLiveState.cs`:**
+
+```csharp
+public sealed record ConversationLiveState(
+    TranslatedConversation Conversation,
+    bool IsLive,
+    bool IsJoined,
+    bool IsVoiceOnly,
+    string ParticipantsText = "",
+    bool HasFoldedEntries = false,
+    bool IsExpanded = false,
+    IReadOnlyList<PreviewEntry>? TailPreview = null,
+    bool HasSummary = false);
+```
+
+- [ ] **Step 2: Populate it** in `ConversationMessageView.ComputeState` — a summary exists once there is a title (the first-summary gate always writes one):
+
+```csharp
+var hasSummary = !translated.Title.Text.IsNullOrEmpty();
+return new ConversationLiveState(
+    translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded, tailPreview, hasSummary);
+```
+
+- [ ] **Step 3: Gate the meta-row** in `ConversationMessageView.razor`. The live-card `c-lc-meta-row` (author heads + started/count) should render only when `state.HasSummary` and the block is not expanded. Wrap it:
+
+```razor
+@if (state.HasSummary && !state.IsExpanded) {
+    <div class="c-lc-meta-row">
+        <AuthorCircleGroup Class="c-lc-authors" AuthorIds="@conversation.AuthorIds"
+            Size="@SquareSize.Size5" MaxCount="4" ShowRing="false"/>
+        <div class="c-lc-meta">
+            <div class="c-lc-started">Started at @startsAt.ToString("HH:mm") · @messageCount message@(messageCount == 1 ? "" : "s")</div>
+        </div>
+    </div>
+}
+```
+
+(Reuse the existing meta-row markup already in the file; the only change is the surrounding `@if` and dropping the separate no-title icon/roster branch that produced "0 messages".)
+
+- [ ] **Step 4: Write the failing test** — a live block with no summary must not surface the meta line. Add to `LiveConversationDisplayTest.cs`:
+
+```csharp
+[Fact]
+public async Task PreSummaryBlockShowsNoMetaCount()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "pre-summary-meta-test");
+    var author = await Tester.GetOwnAuthor(chat.Id).Require();
+    var peerId = AuthorId.New(chat.Id, 777_330);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    await chatAudioUI.SetListeningState(chat.Id, true);
+    chatUI.SelectChatOnNavigation(chat.Id);
+    // no UpdateSummary => no title => HasSummary must be false on the rendered live conversation
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+    await ComputedTest.When(async ct => {
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+        var card = items.Items.SelectMany(i => i.GetLeafMessages())
+            .OfType<ConversationMessage>().SingleOrDefault(c => c.Conversation!.Title.Text.IsNullOrEmpty());
+        card.Should().NotBeNull("a pre-summary live block still emits its card");
+        card!.Conversation!.MessageCount.Should().Be(0);   // the card carries 0; the view must NOT render "0 messages"
+    }, TimeSpan.FromSeconds(10));
+}
+```
+
+The "does not render 0 messages" outcome is a Razor gate (`HasSummary`), verified manually in Step 6; this test pins that a title-less card is what we gate on.
+
+- [ ] **Step 5: Build + test.** `dotnet build … UI.Blazor.App.csproj` (0 errors); `dotnet test … --filter "FullyQualifiedName~PreSummaryBlockShowsNoMetaCount"` (PASS).
+
+- [ ] **Step 6: Verify manually** — start a live conversation, and before any summary lands confirm the card shows no heads / no "0 messages"; after the first summary the meta row appears with the real count.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): gate meta-row on a real summary (no 0 messages)"
+```
+
+---
+
+## Task 5: One shell — unjoined block renders through the sticky header + tinted card
+
+Spec §1, §2, §5. Today the unjoined live block renders via the plain conversation-card path (no sticky header, `c-join-row` at the bottom). Route it through the same live-block path the joined block uses — a sticky `LiveConversationHeaderView` + the `c-live-card` — with the unjoined tint on the whole shell and the **Join** button in the header (activity-panel style). No expand affordance while unjoined.
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs` — treat the live conversation as a split-header block whether or not joined (`GetTile` `EmitConversationCard` ~L858-888 `hasSplitHeader`; `GroupExpandedConversations` ~L965-1028 so the unjoined block is one group with a header + footer; `hiddenLiveTailRange` stays hiding the un-summarized tail so the card shows its preview).
+- Modify: `.../Conversation/LiveConversationHeaderView.razor` + `LiveConversationHeaderState.cs` — render a **Join** button (instead of the expand chevron) when the viewer is not joined.
+- Modify: `.../Conversation/ConversationMessageView.razor` — remove the now-redundant bottom `c-join-row` (join lives in the header).
+- Modify: `.../Conversation/conversation.css` — apply the unjoined tint to the unified shell wrapper; style the header Join button; drop the old `c-join-row` block if unused.
+- Test: `tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs`
+
+**Interfaces:**
+- Consumes: `OnJoin()` (Task 1); `ConversationLiveState.IsJoined`; the `.group:has(> .item > .conversation-message.live:not(.joined))` selector for the unjoined tint.
+- Produces: an unjoined live block that emits a `LiveConversationHeader` + one `ExpandedConversationMessage`, same as joined.
+
+- [ ] **Step 1: Write the failing test** — an unjoined live block must now emit a `LiveConversationHeader` (today it does not). Add to `LiveConversationDisplayTest.cs`:
+
+```csharp
+[Fact]
+public async Task UnjoinedLiveBlockUsesStickyHeader()
+{
+    await Tester.SignInAsUniqueBob();
+    var (chat, _) = await Tester.CreateAndGetChat(false, "unjoined-shell-test");
+    var peerId = AuthorId.New(chat.Id, 777_340);
+    var peer2Id = AuthorId.New(chat.Id, 777_341);
+    var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+    await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+    await liveBackend.OnStreamRegistered(chat.Id, peer2Id, null, true, CancellationToken.None); // 2+ => SessionStartedAt latches
+    var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+    var v = live!.EffectiveVisibleStartLid;
+    await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+        Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+    }, CancellationToken.None);
+
+    var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+    chatUI.SelectChatOnNavigation(chat.Id);   // Bob is NOT recording/listening => not joined
+    var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+    var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+
+    await ComputedTest.When(async ct => {
+        var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+        items.Items.SelectMany(i => i.GetLeafMessages())
+            .OfType<LiveConversationHeader>().Should().ContainSingle(
+                "the unjoined live block shares the sticky-header shell");
+    }, TimeSpan.FromSeconds(15));
+}
+```
+
+- [ ] **Step 2: Run it** — expect FAIL (no `LiveConversationHeader` for the unjoined block today):
+`dotnet test … --filter "FullyQualifiedName~UnjoinedLiveBlockUsesStickyHeader"`.
+
+- [ ] **Step 3: Route the unjoined live conversation through the live-block path** in `ChatUI.Tiles.cs`. The live block id must be the live conversation's id whether or not joined, so the split header + grouping apply. Change the `else` branch that sets `liveBlockId` (currently `liveBlockId = joinedLiveConversation?.Id;`, ~L97) to use the live conversation's id when there is a live session:
+
+```csharp
+        else {
+            // The live block uses the same shell joined or not; only the tint + header affordance differ.
+            liveBlockId = liveConversation?.Id;
+            liveBlockFoldRange = liveFoldRange;
+        }
+```
+
+Then in `EmitConversationCard`, `hasSplitHeader` already keys on `conversation.Id == liveBlockId && materializedBlockId == null`, so the unjoined block now gets the sticky header. Verify `GroupExpandedConversations`'s `startsBlock`/`belongs` (which key on `liveBlockId`) now wrap the unjoined block into one `ExpandedConversationMessage` with the header + footer — the `liveBlockRange` open-ended `[V, ∞)` grouping already covers "no BlockEndLid" (still-live) blocks. Keep `hiddenLiveTailRange` hiding the un-summarized tail for the not-joined viewer (unchanged, ~L101-107) so the card renders its `TailPreview` rather than the live tail.
+
+Run the Step 1 test — expect PASS. If grouping mis-nests (duplicate `@key` or the card outside a block), adjust `GroupExpandedConversations` so a `ConversationMessage` whose `Conversation.Id == liveBlockId` starts a block even when not in `expandedConversations` (it already does via `conversation.Id == liveBlockId`).
+
+- [ ] **Step 4: Add the Join affordance to the sticky header.** In `LiveConversationHeaderState.cs` add `bool IsJoined`; in `LiveConversationHeaderView.ComputeState` set it from `LiveSessionUI.AmIInLiveConversation`; in the markup, show a **Join** button when not joined instead of the expand chevron:
+
+```razor
+<div class="@cls">
+    <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
+    <span class="c-lc-name">@title</span>
+    @if (!s.IsJoined) {
+        <button type="button" class="c-lc-join btn btn-sm btn-transparent" @onclick="@Join">Join</button>
+    }
+    else if (s.HasFoldedEntries) {
+        <HeaderButton Class="c-lc-expand" Click="@Toggle">
+            <i class="@(s.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
+        </HeaderButton>
+    }
+</div>
+```
+
+Add the `Join` handler (mirrors Task 1):
+
+```csharp
+private async Task Join()
+    => await Hub.ChatAudioUI.SetRecordingChatId(Header.Conversation!.Id.ChatId).ConfigureAwait(true);
+```
+
+- [ ] **Step 5: Remove the redundant bottom join row** from `ConversationMessageView.razor` (the `@if (!state.IsJoined) { <button class="c-join-row" …>Join</button> }` block) — join now lives in the header.
+
+- [ ] **Step 6: CSS — unjoined tint on the unified shell + header Join button** in `conversation.css`. Extend the existing joined `.group:has(…)` tint rule (captured at `conversation.css`) with an unjoined variant that paints the whole shell with the unjoined gradient, and give the header its rounded top for the unjoined case too:
+
+```css
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live:not(.joined)),
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header):has(.conversation-message.live:not(.joined)) {
+    isolation: isolate;
+    border-radius: 1rem;
+    background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);
+}
+.live-conversation-header .c-lc-join {
+    flex: 0 0 auto;
+    height: 2.5rem;
+    padding: 0 1rem;
+    border-radius: 0.5rem;
+    color: var(--violet-60);
+    background-color: var(--violet-60-10);
+}
+```
+
+(If reusing the app's `btn btn-sm btn-transparent` gives the exact activity-panel look with no extra CSS, prefer that and drop the `.c-lc-join` background/height overrides — verify against the panel's real button captured earlier: violet-60 text, 8px radius, 40px, `rgba(255,255,255,.1)`-style transparent bg.)
+
+- [ ] **Step 7: Build + verify.** `dotnet build … UI.Blazor.App.csproj` (0 errors); `npm run build:Verify` (CSS). Re-run all touched tests:
+`dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"` (all PASS).
+
+- [ ] **Step 8: Verify manually** (chrome-devtools) — as a non-joined viewer the live block now shows the sticky header + unjoined tint + a **Join** button in the header + the fixed-height faded preview; tapping Join starts recording and the block flips to the joined tint. Watch the viewport across the join transition; use `/virtual-list-debug` if anything jumps.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor \
+  src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css \
+  tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+git commit -m "feat(live): unify joined/unjoined shell — sticky header + header Join + unjoined tint"
+```
+
+---
+
+## Verification (whole plan)
+
+1. `dotnet build ActualChat.CI.slnf` — 0 errors.
+2. `dotnet test tests/Chat.UI.Blazor.IntegrationTests/Chat.UI.Blazor.IntegrationTests.csproj -c Debug --filter "FullyQualifiedName~LiveConversationDisplayTest"` — all PASS (existing + the four new tests).
+3. `npm run build:Verify` — clean.
+4. Manual two-identity pass against the running app: unjoined shell (tint + header Join + faded fixed preview, no jump on new messages); Join → records + flips to joined tint; pre-summary shows no "0 messages"/heads; after summary the meta-row appears; expand → plain conversation (no description, no header count); collapse returns to the card. Use `/virtual-list-debug` at each transition.
+
+## Self-review notes (spec coverage)
+
+- §1 unified shell + unjoined tint → Task 5. §2 sticky header (icon+title+chevron/Join) → Task 5 (header already minimal). §3 meta-row gated → Task 4. §5 Join = record, no icon → Task 1 + Task 5 (placement). §6 fixed-height faded preview → Task 2. §8 expanded = no description/count → Task 3.
+- **Deferred to Plan 2 (governor rewrite):** §4 swallow-above-viewport and §7 the "Show N of M" straddling pill. These require reworking `LiveFoldMath.Advance` / `LiveBlockUI.ProcessChat` (boundary tracks the viewport-top lid instead of summary-driven `PendingFold`s + `FoldLag`) and a reader-controlled "revealed count", with `/virtual-list-debug` verification — a different risk class, kept out of this plan so the shell can ship independently.
+
+---
+
+## Plan 2 (to be written next): Collapsed swallow + Show-more
+
+Outline for the follow-up plan, once Plan 1 lands:
+
+1. **Swallow-above-viewport (§4).** Rework `LiveBlockUI.ProcessChat` (`LiveBlockUI.cs:266-283`) + `LiveFoldMath.Advance` so the fold boundary = the viewport-top lid (`minVisibleLid`), advanced monotonically, instead of ripening summary-driven `PendingFold`s behind `FoldLag`. Preserve the no-jump invariant (folding above-viewport rows, growing the card). Unit-test the new `LiveFoldMath` rule (pattern: `LiveFoldMathTest.cs`); integration-test the fold range in `ChatUI.Tiles`; verify with `/virtual-list-debug`.
+2. **Revealed-count reveal (§7).** Add a per-chat "revealed" offset on `LiveBlockUI` that retreats the boundary by N (≈ one viewport of messages); resolve the exact batch measure and the reveal lifecycle (persist until expand/re-collapse) — the two open questions the spec flags.
+3. **Show-more pill UI.** A rounded pill straddling the collapsed card's bottom edge, label "▲ Show N earlier messages of M" (N = batch, M = swallowed remaining from the true swallowed count), reusing the `.show-more-btn` colour + the Call/Map switch pill visual; wired to the reveal action.

--- a/docs/superpowers/specs/2026-07-22-live-conversation-block-unified-ux-design.md
+++ b/docs/superpowers/specs/2026-07-22-live-conversation-block-unified-ux-design.md
@@ -1,0 +1,226 @@
+# Live conversation block — unified UX
+
+**Status:** Approved (design) · 2026-07-22
+**Branch target:** `feat/*` off `dev`
+**Predecessors:** `2026-07-20-live-block-ux-polish-design.md`,
+`2026-07-21-live-block-sticky-header-footer-design.md` (both merged in PR #4062).
+
+## Goal
+
+Make the live conversation block one coherent, self-consistent element across
+every state — unjoined, joined-collapsed, joined-expanded, and the pre-first-summary
+"no title yet" phase — and make the collapsed reading experience actually usable
+while a live session streams: the block swallows what scrolls above the viewport,
+and a reader can pull back a little context on demand instead of expanding to the
+very first message.
+
+## Context (current behaviour)
+
+Two structurally different layouts exist today:
+
+- **Joined**: sticky `live-conversation-header` + a folded (summarised) range +
+  the live tail rendered inside the VirtualList; expandable.
+- **Unjoined**: a non-expandable `c-live-card` whose whole live range is hidden
+  (`[V, ∞)`), replaced by a 2-message `LastEntriesPreview` and a "Tap to join" row.
+
+Folding is **summary-driven**: `LiveBlockUI`'s governor advances a fold boundary
+behind the newest summary, held back by a freshness lag and a viewport clamp
+(`LiveFoldMath`). The collapsed card shows a title band, a description
+(summary), and a `c-lc-meta-row` (author heads + `c-lc-started` "Started at
+HH:MM · N messages"). Pre-first-summary the meta line reads "· 0 messages", the
+expand icon appears with nothing to expand, and (per the recent review) a
+title-less folded block can show two expand affordances.
+
+Files in play: `Components/ChatView/Items/Conversation/ConversationMessageView.razor`,
+`LiveConversationHeaderView.razor`, `LiveConversationHeaderState.cs`,
+`ConversationLiveState.cs`; `Services/LiveBlockUI.cs`, `LiveFoldMath.cs`,
+`ChatUI.Tiles.cs`, `ChatUI.cs`, `LiveSessionUI.cs`; styles `conversation.css`,
+`last-entries-preview.css`. Real CSS hooks: `.conversation-message.live(.joined)`,
+`.c-live-card`, `.c-lc-name/summary/meta-row/authors/meta/started/expand`,
+`.c-join-row`, `.live-conversation-header`, `.live-conversation-footer`, and the
+`.group:has(…)` tint rules.
+
+## Design
+
+### 1. One shell, tint distinguishes join-state
+
+Joined and unjoined use the **same** block chrome (sticky header, card body,
+message rows, footer). The only visual difference is the background:
+
+- **Joined**: the existing violet border-box tint on the
+  `.group:has(> .item > .conversation-message.live.joined)` /
+  `…live-conversation-header` wrapper (unchanged).
+- **Unjoined**: the existing `.conversation-message.live:not(.joined)` tint —
+  `linear-gradient(90deg, rgba(255,202,255,.3) 2%, rgba(130,104,255,.3) 100%)`
+  — applied to the whole shell as the "you haven't joined" signal.
+
+The distinct unjoined preview/`c-join-row` layout is removed.
+
+### 2. Sticky header
+
+The sticky `live-conversation-header` is used in **both** collapsed and expanded
+states and holds only: the activity icon (equalizer), the title (`c-lc-name`,
+falling back to the participant-names string pre-title), and the expand/collapse
+**chevron**. For an **unjoined** block the chevron's place is taken by a **Join**
+button (§5). No author heads and no message count live in the header.
+
+### 3. Header/meta content by phase
+
+- **No title yet (state D):** header = icon + participant-names + chevron/Join.
+  **No** description, **no** `c-lc-meta-row` (so no "0 messages", no orphan heads).
+- **Title/summary present:** header shows the title; below the description the
+  existing `c-lc-meta-row` returns in its current position — author heads
+  (`c-lc-authors`) + `c-lc-started` "Started at HH:MM · N messages".
+
+### 4. Collapsed joined block swallows above the viewport
+
+While collapsed, the fold boundary **tracks the viewport top continuously and
+monotonically**: everything that scrolls above the viewport is swallowed into the
+card — summarised or not. The boundary advances as the reader stays with the live
+tail and older lines flow up out of view; it never retreats on its own, so the
+block stays a compact card. Swallowed messages are **folded (not rendered)**;
+scrolling up lands on the card, not on the folded region. This replaces the
+summary-driven `[V, summaryEnd)` fold as the collapsed fold rule.
+
+The description shown in the card remains the latest summary (a recap of older
+content); the swallowed **count** is exact and may run ahead of what the summary
+covers — that is expected.
+
+### 5. Join = join **and** record (block only)
+
+The unjoined header's **Join** button:
+
+- Label **"Join"**, no icon.
+- Styled like the activity-panel join control (`btn-transparent`): violet-60
+  text, subtle background, 8px radius, ~40px tall, 13.6px/500 — reuse the app's
+  button component/classes rather than a bespoke button.
+- Action: **joins the session and turns recording on** (active participation),
+  unlike the activity panel's listen-only "Join muted".
+- The activity panel's own buttons and behaviour are **unchanged**.
+
+### 6. Unjoined = fixed-height, bottom-anchored, faded preview
+
+An unjoined viewer sees a **limited** preview, not the full live tail:
+
+- The last ~N messages (default 5) in a **fixed-height** region so incoming
+  messages never grow the block or jump the layout.
+- **Bottom-anchored** (`justify-content: flex-end`): the newest line is always
+  fully visible at the bottom; older lines rise up and **fade out** under the card
+  via an opacity gradient at the top of the region.
+- This is a self-contained card region (an evolution of `LastEntriesPreview`),
+  **not** VirtualList swallowing — so it sidesteps the no-jump machinery entirely.
+
+### 7. "Show more" pill — read context without expanding
+
+Full expand jumps the reader to the conversation's first message, losing their
+place. Instead, a collapsed joined block offers an in-place reveal:
+
+- A **rounded pill** (the Call/Map-switch container style: white, 1px border,
+  soft shadow, ~30px tall, tight padding) **straddles the collapsed card's bottom
+  edge** — half over the tinted card, half over the messages below.
+- Label: **"▲ Show N earlier messages of M"** — N = the reveal batch
+  (≈ one viewport's worth of messages), M = the total still swallowed.
+- Each click **reveals another batch in place** (older messages rendered above
+  the current view, bottom-anchored so nothing jumps; the reader scrolls up into
+  them), decrementing M by the batch. Repeat until none remain, then the pill
+  disappears.
+- Mechanically this **retreats the fold boundary by a "revealed" count**; the
+  reveal persists until the block is expanded or re-collapsed (re-latched).
+
+The header **chevron** remains the separate full expand/collapse control. There is
+**no** segmented/toggle switch.
+
+### 8. Expanded joined block = a regular expanded conversation
+
+When expanded: sticky header (icon + title + collapse chevron), all messages
+rendered like normal conversation rows (avatar left, author line, message text on
+the next line), and the thin rounded `live-conversation-footer`. **No description
+box. No message count in the header** — identical to a regular expanded
+conversation. (The recent duplicate-expand-button fix already lives on `dev`.)
+
+## Reuse
+
+### Existing abstractions to reuse (research done)
+
+- **Fold governor** — extend `LiveBlockUI` / `LiveFoldMath`, do **not** build a
+  new folding path. The governor already consumes `ItemVisibility`; the change is
+  to derive the fold boundary from the **viewport-top lid** (monotonic max) plus a
+  reader-controlled "revealed" offset, instead of the summary end + lag. Its
+  overlay/freeze/materialisation machinery and @key stability stay as-is.
+- **Preview** — evolve `LastEntriesPreview.razor` / `last-entries-preview.css`
+  into the fixed-height, bottom-anchored, top-faded variant rather than a new
+  component.
+- **Meta-row** — reuse the existing `c-lc-meta-row` / `c-lc-authors` /
+  `c-lc-started` markup and CSS unchanged (just gate its visibility on
+  title/summary presence).
+- **Join button** — reuse the activity-panel button component/classes
+  (`btn btn-sm btn-transparent`, violet-60), not a hand-rolled button.
+- **Join-to-record** — reuse the existing recording-start path
+  (`ChatAudioUI` recording + `LiveSessionUI` join) rather than new plumbing;
+  the block's Join composes join + start-recording.
+- **Tint scoping** — reuse the existing `.group:has(…)` CSS pattern already used
+  for the joined tint and sticky header.
+- **Show-more base style** — start from the existing `.show-more-btn` colour token
+  (`--cr-item-badge-selected-text`) and the switch's rounded-pill visual.
+
+If any of the above turns out not to fit during planning, that must be called out
+explicitly rather than silently forked.
+
+### New components & placement
+
+- **Show-more straddling pill** — a small view + CSS. It is specific to the live
+  block, so default placement is
+  `Components/ChatView/Items/Conversation/` alongside the other `c-lc-*` styling.
+  *Reusability note:* "a pill button centred on a container's bottom edge" is a
+  generic pattern; if a second use appears, promote the CSS to a shared
+  `conversation`/`components` stylesheet. Recommend **local** now, with the
+  promotion path noted.
+- **Fixed-height faded preview** — folded into `LastEntriesPreview` (already a
+  shared-ish item component), not a new file.
+- **Revealed-count state** — small client-side state on the fold governor
+  (`LiveBlockUI`), not a new service.
+
+No server, protocol, DB, or Fusion-contract changes are anticipated: this is a
+client rendering + governor change plus a join-action composition. (If join-to-record
+needs a participation-kind nuance, that is the only candidate for a backend touch and
+must be flagged in the plan.)
+
+## Risks & open questions
+
+- **Swallow-above-viewport is the core risk.** Making the fold boundary follow the
+  viewport top (vs. the summarised range) is the subtlest change — it is
+  VirtualList-coupled and must preserve the no-jump invariant while folding
+  above-viewport rows and growing the card. This likely deserves its own plan
+  phase with `/virtual-list-debug` verification. Folding **un-summarised** rows is
+  new (today only summarised rows fold).
+- **Revealed-batch lifecycle.** Persist a reveal until expand/re-collapse; define
+  precisely when it resets (block rebuild, session close/re-latch) so it can't
+  strand a half-revealed card. Batch size ≈ one viewport of messages — confirm the
+  exact measure (visible message count vs. a fixed fallback) during planning.
+- **Description vs. swallowed-count skew** is intentional (recap lags the exact
+  count); make sure copy ("of M") reads from the true swallowed count, not the
+  summary's `MessageCount`.
+- **Unjoined preview privacy** — unjoined viewers now see ~5 recent lines (faded),
+  a limited teaser, not the full transcript; this matches the prior "preview"
+  intent, just restyled.
+
+## Out of scope
+
+- Changing the activity panel.
+- The expanded-block footer showing author heads/count (regular conversations put
+  these in a footer; the live footer stays a thin band for now).
+- The tier-1/2/3 close choreography, materialisation, and dissolve (unchanged).
+- Any recomputation of summaries / `ContextStartLid` behaviour.
+
+## Acceptance (manual, two-device)
+
+Solo talk → a second device joins → a third **unjoined** viewer sees the unified
+shell with the unjoined tint, a **Join** button, and a fixed-height faded 5-message
+preview that never jumps as new lines arrive. The joined reader, collapsed, sees
+the block swallow lines above the viewport as they read; the **"Show N of M"** pill
+straddles the card edge and reveals a batch in place (no jump) with M decrementing;
+the meta-row shows heads + "Started at HH:MM · N messages" only once a title/summary
+exists (no "0 messages" before). Expanding reads as a regular expanded conversation
+(no description, no header count); collapsing returns to the card. Tapping **Join**
+joins **and** starts recording. Watch the viewport at every transition; use
+`/virtual-list-debug` if anything jumps.

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -29,6 +29,19 @@ public static class NotificationHelper
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
         => urlMapper.IconUrl(chat.GetIconQuery(author));
 
+    public static string GetVoiceChatStartedText(IReadOnlyList<string> authorNames)
+    {
+        var shown = authorNames.Take(Constants.Notification.MaxSummaryAuthors).ToList();
+        var moreCount = authorNames.Count - shown.Count;
+        var names = shown.Count switch {
+            0 => "",
+            1 => shown[0],
+            _ when moreCount > 0 => $"{string.Join(", ", shown)} and {moreCount} more",
+            _ => $"{string.Join(", ", shown.Take(shown.Count - 1))} and {shown[^1]}",
+        };
+        return names.IsNullOrEmpty() ? "Voice chat started" : $"{names} started a voice chat";
+    }
+
     public static string GetAggregatedText(string leadText, IReadOnlyList<string> authorNames, int moreCount)
     {
         // moreCount counts messages beyond those LeadText already shows, so a rolled-in lead

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -419,6 +419,7 @@ public class NotificationsBackend(IServiceProvider services)
 
         var authorUserIds = new HashSet<UserId>();
         AuthorFull? primaryAuthor = null;
+        var authorNames = new List<string>();
         foreach (var authorId in authorIds) {
             var author = await AuthorsBackend.Get(chatId, authorId, RequestedAuthorKind.Full, cancellationToken).ConfigureAwait(false);
             if (author is null)
@@ -426,8 +427,13 @@ public class NotificationsBackend(IServiceProvider services)
 
             primaryAuthor ??= author;
             authorUserIds.Add(author.UserId);
+            authorNames.Add(author.Avatar.Name);
         }
         var iconUrl = primaryAuthor is null ? "" : NotificationHelper.GetIconUrl(chat, primaryAuthor, UrlMapper);
+
+        // The Started banner names who opened the voice chat instead of the generic phrase.
+        if (phase == ConversationNotificationPhase.Started && authorNames.Count > 0)
+            text = NotificationHelper.GetVoiceChatStartedText(authorNames);
 
         // Started/Titled/Final are live phases; their joined participants already see the call live.
         var isLive = phase != ConversationNotificationPhase.Created;

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -450,7 +450,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         if (await IsSessionLive(chatId).ConfigureAwait(false))
             return; // someone is streaming again - keep the session live
 
-        await CloseWithFinal(state, cancellationToken).ConfigureAwait(false);
+        await CloseAndMaterialize(state, cancellationToken).ConfigureAwait(false);
     }
 
     // Voice-call ring lifecycle
@@ -825,7 +825,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 await StartClosingGrace(chatId).ConfigureAwait(false);
                 return;
             }
-            await CloseWithFinal(state, CancellationToken.None).ConfigureAwait(false);
+            await CloseAndMaterialize(state, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException) {
             Log.LogWarning(e, "CloseNow failed for chat #{ChatId}", chatId);
@@ -840,7 +840,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             var state = await SafeGet(chatId).ConfigureAwait(false);
             if (state is null)
                 return;
-            await CloseWithFinal(state, CancellationToken.None).ConfigureAwait(false);
+            await CloseAndMaterialize(state, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException) {
             Log.LogWarning(e, "CloseCall failed for chat #{ChatId}", chatId);
@@ -855,18 +855,18 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             var state = await SafeGet(chatId).ConfigureAwait(false);
             if (state is not { IsClosing: true })
                 return;
-            await CloseWithFinal(state, CancellationToken.None).ConfigureAwait(false);
+            await CloseAndMaterialize(state, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException) {
             Log.LogWarning(e, "SelfClose failed for chat #{ChatId}", chatId);
         }
     }
 
-    private async Task CloseWithFinal(LiveSessionState state, CancellationToken cancellationToken)
+    private async Task CloseAndMaterialize(LiveSessionState state, CancellationToken cancellationToken)
     {
         if (state.Kind == LiveSessionKind.Call) {
-            // A voice call has no transcript to materialize or FINAL to post - just stop any lingering
-            // rings on the invitees' devices, then drop the session.
+            // A voice call has no transcript to materialize - just stop any lingering rings on the
+            // invitees' devices, then drop the session.
             var invitees = (await SafeGetInvites(state.ChatId).ConfigureAwait(false))
                 .Values.Where(i => i is not null).Select(i => i!.InviteeId).ToList();
             if (invitees.Count > 0)
@@ -876,19 +876,15 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         }
 
         // A session that never latched (solo) leaves its ordinary split-flow conversations behind;
-        // only a latched session sends FINAL and is covered by its own materialization.
-        if (state.SessionStartedAt is not null) {
-            // Persist the already-computed summary as a real conversation *before* the live state drops,
-            // so the in-chat block doesn't flicker; an empty title (phone-mode, or below the summary
-            // threshold) has nothing to keep and just vanishes.
-            if (!state.Title.IsNullOrEmpty())
-                await Commander
-                    .Call(new ConversationBackend_Materialize(state.ToMaterializedConversation()), true, cancellationToken)
-                    .ConfigureAwait(false);
-            var content = state.Title.IsNullOrEmpty() ? "Voice chat ended" : $"Voice chat ended: {state.Title}";
-            await EnqueueLiveNotification(state, ConversationNotificationPhase.Final, content, cancellationToken)
+        // only a latched session materializes its summary. There is no completion notification - the
+        // in-chat block already carries the summary in place, so an "ended" banner adds nothing.
+        // Persist the already-computed summary as a real conversation *before* the live state drops,
+        // so the in-chat block doesn't flicker; an empty title (phone-mode, or below the summary
+        // threshold) has nothing to keep and just vanishes.
+        if (state.SessionStartedAt is not null && !state.Title.IsNullOrEmpty())
+            await Commander
+                .Call(new ConversationBackend_Materialize(state.ToMaterializedConversation()), true, cancellationToken)
                 .ConfigureAwait(false);
-        }
         await Close(state.ChatId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -908,10 +904,17 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         ConversationNotificationPhase phase,
         string content,
         CancellationToken cancellationToken)
-        => Services.Queues()
+    {
+        // Peer (1:1) chats get no live-session banner - the sole recipient is the other participant,
+        // who is already inside the very conversation the session belongs to.
+        if (state.ChatId.Kind == ChatKind.Peer)
+            return Task.CompletedTask;
+
+        return Services.Queues()
             .Enqueue(
                 new NotificationsBackend_NotifyConversation(state.ConversationId, phase, content, state.EndEntryLid, state.AuthorIds),
                 cancellationToken);
+    }
 
     private void InvalidateState(ChatId chatId)
     {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -14,4 +14,5 @@ public sealed record ConversationLiveState(
     string ParticipantsText = "",
     bool HasFoldedEntries = false,
     bool IsExpanded = false,
-    IReadOnlyList<PreviewEntry>? TailPreview = null);
+    IReadOnlyList<PreviewEntry>? TailPreview = null,
+    bool HasSummary = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -15,4 +15,6 @@ public sealed record ConversationLiveState(
     bool HasFoldedEntries = false,
     bool IsExpanded = false,
     IReadOnlyList<PreviewEntry>? TailPreview = null,
-    bool HasSummary = false);
+    bool HasSummary = false,
+    int SwallowedCount = 0,
+    int RevealBatch = 0);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -39,8 +39,9 @@
                     }
                 </div>
             }
-            @* Gated on the text, not hasSummary: a fold can outlive an empty description. *@
-            @if (hasDescription) {
+            @* Gated on the text, not hasSummary: a fold can outlive an empty description. Also collapsed-only:
+               expanded reads as a plain conversation, so the description box drops out once expanded. *@
+            @if (hasDescription && !state.IsExpanded) {
                 <div class="c-lc-summary-box">
                     <div class="c-lc-summary" @key="@m.Description.Markup.ToReadableText()">
                         <CascadingValue Value="@_fakeEntry" IsFixed="true">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -72,9 +72,6 @@
                 <Divider/>
                 <LastEntriesPreview Entries="@tailPreview"/>
             }
-            @if (!state.IsJoined) {
-                <button type="button" class="c-join-row" @onclick="@OnJoin">Join</button>
-            }
         </div>
     } else {
         <CascadingValue Value="@_fakeEntry" IsFixed="true">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -26,13 +26,13 @@
     @if (state.IsLive) {
         var secondLine = state.IsVoiceOnly ? "Voice only" : messageCount + " message".Pluralize(messageCount);
         var startedAt = $"Started at {startsAt:HH:mm}";
-        var hasSummary = state.HasFoldedEntries;
+        var hasFoldedEntries = state.HasFoldedEntries;
         <div class="c-live-card">
             @if (!Message.HasSplitHeader && hasLiveTitle) {
                 <div class="c-lc-title">
                     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
                     <span class="c-lc-name">@m.Title.Text</span>
-                    @if (hasSummary) {
+                    @if (hasFoldedEntries) {
                         <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
                             <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
                         </HeaderButton>
@@ -70,7 +70,7 @@
             }
             @if (state.TailPreview is { Count: > 0 } tailPreview) {
                 <Divider/>
-                <LastEntriesPreview Entries="@tailPreview"/>
+                <LastEntriesPreview Entries="@tailPreview" Faded="true"/>
             }
         </div>
     } else {
@@ -212,7 +212,7 @@
 
     private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(
         ChatId chatId, CancellationToken cancellationToken) {
-        var entries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken).ConfigureAwait(true);
+        var entries = await ChatUI.GetThreadPreviewEntries(chatId, 5, cancellationToken).ConfigureAwait(true);
         var markupHub = Hub.ChatMarkupHubFactory[chatId];
         var markups = await entries
             .Select(e => markupHub.GetMarkup(e, MarkupConsumer.MessageView, cancellationToken).AsTask())

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -82,9 +82,9 @@
                 <LastEntriesPreview Entries="@tailPreview" Faded="true"/>
             }
             @if (!state.IsExpanded && state.SwallowedCount > 0) {
-                <button type="button" class="c-lc-showmore" @onclick="@OnRevealMore">
+                <button type="button" class="c-lc-showmore" data-anchor="below" @onclick="@OnRevealMore">
                     <i class="icon-chevron-up"></i>
-                    <span>Show @state.RevealBatch earlier message@(state.RevealBatch == 1 ? "" : "s") of @state.SwallowedCount</span>
+                    <span>Show @state.RevealBatch of @state.SwallowedCount</span>
                 </button>
             }
         </div>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -217,8 +217,8 @@
         // card carries the last entries itself to show the conversation is moving. A leaver is the third
         // case: !isJoined but the freeze overlay keeps the tail on screen, so a preview would double it -
         // gate on Overlay == null so only the genuinely-hidden case previews.
-        var tailPreview = isLive && !isJoined && !isVoiceOnly && blockState.Overlay == null
-            ? await GetTailPreview(chatId, cancellationToken).ConfigureAwait(true)
+        var tailPreview = isLive && !isJoined && !isVoiceOnly && blockState.Overlay == null && !isExpanded
+            ? await GetTailPreview(chatId, rawLive?.EffectiveVisibleStartLid ?? 0, cancellationToken).ConfigureAwait(true)
             : null;
         var hasSummary = !translated.Title.Text.IsNullOrEmpty();
         var swallowedCount = 0;
@@ -236,8 +236,8 @@
     }
 
     private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(
-        ChatId chatId, CancellationToken cancellationToken) {
-        var entries = await ChatUI.GetThreadPreviewEntries(chatId, 5, cancellationToken).ConfigureAwait(true);
+        ChatId chatId, long minLid, CancellationToken cancellationToken) {
+        var entries = await ChatUI.GetThreadPreviewEntries(chatId, 5, minLid, cancellationToken).ConfigureAwait(true);
         var markupHub = Hub.ChatMarkupHubFactory[chatId];
         var markups = await entries
             .Select(e => markupHub.GetMarkup(e, MarkupConsumer.MessageView, cancellationToken).AsTask())

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -33,6 +33,7 @@
         var showLiveCard = (!Message.HasSplitHeader && hasLiveTitle)
             || (hasDescription && !state.IsExpanded)
             || (state.HasSummary && !state.IsExpanded)
+            || (!state.IsExpanded && state.SwallowedCount > 0)
             || state.TailPreview is { Count: > 0 };
         if (showLiveCard) {
         <div class="c-live-card">
@@ -79,6 +80,12 @@
             @if (state.TailPreview is { Count: > 0 } tailPreview) {
                 <Divider/>
                 <LastEntriesPreview Entries="@tailPreview" Faded="true"/>
+            }
+            @if (!state.IsExpanded && state.SwallowedCount > 0) {
+                <button type="button" class="c-lc-showmore" @onclick="@OnRevealMore">
+                    <i class="icon-chevron-up"></i>
+                    <span>Show @state.RevealBatch earlier message@(state.RevealBatch == 1 ? "" : "s") of @state.SwallowedCount</span>
+                </button>
             }
         </div>
         }
@@ -214,9 +221,18 @@
             ? await GetTailPreview(chatId, cancellationToken).ConfigureAwait(true)
             : null;
         var hasSummary = !translated.Title.Text.IsNullOrEmpty();
+        var swallowedCount = 0;
+        var revealBatch = 0;
+        if (isJoined && !isExpanded) {
+            swallowedCount = await LiveBlockUI.GetSwallowedCount(chatId, cancellationToken).ConfigureAwait(true);
+            if (swallowedCount > 0) {
+                var visibleCount = ChatUI.ItemVisibility.Value.VisibleMessageLids.Count;
+                revealBatch = Math.Min(Math.Max(5, ((visibleCount + 4) / 5) * 5), swallowedCount);
+            }
+        }
         return new ConversationLiveState(
             translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries,
-            isExpanded, tailPreview, hasSummary);
+            isExpanded, tailPreview, hasSummary, swallowedCount, revealBatch);
     }
 
     private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(
@@ -249,6 +265,11 @@
     private async Task OnJoin() {
         var chatId = Message.Conversation!.Id.ChatId;
         await ChatAudioUI.SetRecordingChatId(chatId).ConfigureAwait(true);
+    }
+
+    private async Task OnRevealMore() {
+        var chatId = Message.Conversation!.Id.ChatId;
+        await LiveBlockUI.RevealMore(chatId).ConfigureAwait(true);
     }
 
     private void ToggleDetails() {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -50,33 +50,24 @@
                     </div>
                 </div>
             }
-            <div class="c-lc-meta-row">
-                @if (!hasLiveTitle && !Message.HasSplitHeader) {
-                    <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
-                }
-                <AuthorCircleGroup
-                    Class="c-lc-authors"
-                    AuthorIds="@conversation.AuthorIds"
-                    Size="@SquareSize.Size5"
-                    MaxCount="4"
-                    ShowRing="false"/>
-                <div class="c-lc-meta">
-                    @if (!hasLiveTitle && !Message.HasSplitHeader) {
-                        <div class="c-lc-roster">@state.ParticipantsText</div>
+            @if (state.HasSummary && !state.IsExpanded) {
+                <div class="c-lc-meta-row">
+                    <AuthorCircleGroup
+                        Class="c-lc-authors"
+                        AuthorIds="@conversation.AuthorIds"
+                        Size="@SquareSize.Size5"
+                        MaxCount="4"
+                        ShowRing="false"/>
+                    <div class="c-lc-meta">
+                        <div class="c-lc-started">@startedAt · @secondLine</div>
+                    </div>
+                    @if (hasCopyText) {
+                        <HeaderButton Class="c-lc-copy" Click="@OnCopyToClipboardRequested">
+                            <i class="icon-copy"></i>
+                        </HeaderButton>
                     }
-                    <div class="c-lc-started">@startedAt · @secondLine</div>
                 </div>
-                @if (!hasLiveTitle && hasSummary) {
-                    <HeaderButton Class="c-lc-expand" Click="@ToggleShowMessage">
-                        <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
-                    </HeaderButton>
-                }
-                @if (hasCopyText) {
-                    <HeaderButton Class="c-lc-copy" Click="@OnCopyToClipboardRequested">
-                        <i class="icon-copy"></i>
-                    </HeaderButton>
-                }
-            </div>
+            }
             @if (state.TailPreview is { Count: > 0 } tailPreview) {
                 <Divider/>
                 <LastEntriesPreview Entries="@tailPreview"/>
@@ -216,8 +207,10 @@
         var tailPreview = isLive && !isJoined && !isVoiceOnly && blockState.Overlay == null
             ? await GetTailPreview(chatId, cancellationToken).ConfigureAwait(true)
             : null;
+        var hasSummary = !translated.Title.Text.IsNullOrEmpty();
         return new ConversationLiveState(
-            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries, isExpanded, tailPreview);
+            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries,
+            isExpanded, tailPreview, hasSummary);
     }
 
     private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -81,7 +81,7 @@
                 <LastEntriesPreview Entries="@tailPreview"/>
             }
             @if (!state.IsJoined) {
-                <button type="button" class="c-join-row" @onclick="@OnJoin">Tap to join</button>
+                <button type="button" class="c-join-row" @onclick="@OnJoin">Join</button>
             }
         </div>
     } else {
@@ -248,7 +248,7 @@
 
     private async Task OnJoin() {
         var chatId = Message.Conversation!.Id.ChatId;
-        await ChatAudioUI.SetListeningState(chatId, true).ConfigureAwait(true);
+        await ChatAudioUI.SetRecordingChatId(chatId).ConfigureAwait(true);
     }
 
     private void ToggleDetails() {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -27,6 +27,14 @@
         var secondLine = state.IsVoiceOnly ? "Voice only" : messageCount + " message".Pluralize(messageCount);
         var startedAt = $"Started at {startsAt:HH:mm}";
         var hasFoldedEntries = state.HasFoldedEntries;
+        // The split-out header carries the title; when expanded the description + meta-row drop out, so an
+        // otherwise-empty card would render as a 1rem-padded gap between the header and the first message.
+        // Skip the card entirely unless it has something to show.
+        var showLiveCard = (!Message.HasSplitHeader && hasLiveTitle)
+            || (hasDescription && !state.IsExpanded)
+            || (state.HasSummary && !state.IsExpanded)
+            || state.TailPreview is { Count: > 0 };
+        if (showLiveCard) {
         <div class="c-live-card">
             @if (!Message.HasSplitHeader && hasLiveTitle) {
                 <div class="c-lc-title">
@@ -73,6 +81,7 @@
                 <LastEntriesPreview Entries="@tailPreview" Faded="true"/>
             }
         </div>
+        }
     } else {
         <CascadingValue Value="@_fakeEntry" IsFixed="true">
         <div class="c-details">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
@@ -7,4 +7,5 @@ public sealed record LiveConversationHeaderState(
     bool IsExpanded,
     bool IsJoined = false,
     bool HasOverlay = false,
-    bool IsDissolving = false);
+    bool IsDissolving = false,
+    bool CanExpand = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
@@ -6,4 +6,5 @@ public sealed record LiveConversationHeaderState(
     bool HasFoldedEntries,
     bool IsExpanded,
     bool IsJoined = false,
+    bool HasOverlay = false,
     bool IsDissolving = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
@@ -5,4 +5,5 @@ public sealed record LiveConversationHeaderState(
     string ParticipantsText,
     bool HasFoldedEntries,
     bool IsExpanded,
+    bool IsJoined = false,
     bool IsDissolving = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -9,7 +9,10 @@
 <div class="@cls">
     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
     <span class="c-lc-name">@title</span>
-    @if (s.HasFoldedEntries) {
+    @if (!s.IsJoined) {
+        <button type="button" class="c-lc-join btn btn-sm btn-transparent" @onclick="@Join">Join</button>
+    }
+    else if (s.HasFoldedEntries) {
         <HeaderButton Class="c-lc-expand" Click="@Toggle">
             <i class="@(s.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
         </HeaderButton>
@@ -41,6 +44,7 @@
         var translated = await ConversationUI.GetTranslatedConversation(conversation, cancellationToken).ConfigureAwait(true);
         var live = await LiveSessionUI.GetConversation(chatId, cancellationToken).ConfigureAwait(true);
         var isLive = live != null && live.Id == conversation.Id;
+        var isJoined = isLive && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(true);
         var isVoiceOnly = isLive
             && !await LiveSessionUI.IsTranscriptionOn(chatId, cancellationToken).ConfigureAwait(true);
         var participantsText = isLive
@@ -56,10 +60,13 @@
         var overrides = await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
         var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);
         return new LiveConversationHeaderState(
-            translated.Title.Text, participantsText, hasFoldedEntries, isExpanded,
+            translated.Title.Text, participantsText, hasFoldedEntries, isExpanded, isJoined,
             blockState.Overlay?.IsDissolving ?? false);
     }
 
     private void Toggle()
         => ChatUI.ToggleExpandConversation(Header.Conversation!.Id);
+
+    private async Task Join()
+        => await Hub.ChatAudioUI.SetRecordingChatId(Header.Conversation!.Id.ChatId).ConfigureAwait(true);
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -9,7 +9,7 @@
 <div class="@cls">
     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
     <span class="c-lc-name">@title</span>
-    @if (!s.IsJoined) {
+    @if (!s.IsJoined && !s.HasOverlay) {
         <button type="button" class="c-lc-join btn btn-sm btn-transparent" @onclick="@Join">Join</button>
     }
     else if (s.HasFoldedEntries) {
@@ -61,7 +61,7 @@
         var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);
         return new LiveConversationHeaderState(
             translated.Title.Text, participantsText, hasFoldedEntries, isExpanded, isJoined,
-            blockState.Overlay?.IsDissolving ?? false);
+            blockState.Overlay != null, blockState.Overlay?.IsDissolving ?? false);
     }
 
     private void Toggle()

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -12,7 +12,7 @@
     @if (!s.IsJoined && !s.HasOverlay) {
         <button type="button" class="c-lc-join btn btn-sm btn-transparent" @onclick="@Join">Join</button>
     }
-    else if (s.HasFoldedEntries) {
+    @if (s.CanExpand) {
         <HeaderButton Class="c-lc-expand" Click="@Toggle">
             <i class="@(s.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
         </HeaderButton>
@@ -59,11 +59,15 @@
         var hasFoldedEntries = isLive && !isVoiceOnly
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
+        // A not-joined viewer can expand the block to read the whole conversation before joining; a joined
+        // one only when there is folded content behind the card.
+        var canExpand = isLive && !isVoiceOnly && rawLive is { SessionStartedAt: not null }
+            && (!isJoined || hasFoldedEntries);
         var overrides = await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
         var isExpanded = conversation.IsExpandedByDefault ^ overrides.Contains(conversation.Id);
         return new LiveConversationHeaderState(
             translated.Title.Text, participantsText, hasFoldedEntries, isExpanded, isJoined,
-            blockState.Overlay != null, blockState.Overlay?.IsDissolving ?? false);
+            blockState.Overlay != null, blockState.Overlay?.IsDissolving ?? false, canExpand);
     }
 
     private void Toggle()

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -33,7 +33,9 @@
         var conversation = Header.Conversation!;
         return ComputedStateComponent.GetStateOptions(GetType(),
             t => new ComputedState<LiveConversationHeaderState>.Options() {
-                InitialValue = new LiveConversationHeaderState(conversation.Title, "", false, false),
+                // IsJoined defaults true in the placeholder so the clickable Join button doesn't flash
+                // before the first ComputeState resolves the real join state.
+                InitialValue = new LiveConversationHeaderState(conversation.Title, "", false, false, true),
                 Category = GetStateCategory(t),
             });
     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -57,10 +57,6 @@
 .c-live-card .c-lc-expand {
     @apply flex-none;
 }
-.c-live-card .c-lc-roster {
-    @apply flex-1 min-w-0 truncate;
-    @apply text-01 text-base font-medium leading-5;
-}
 .c-live-card .c-lc-summary-box {
     display: grid;
     grid-template-rows: 1fr;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -321,8 +321,13 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    so this wins whenever it matches. */
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) {
     isolation: isolate;
-    @apply rounded-2xl;
-    background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);
+    @apply rounded-2xl border border-solid border-transparent;
+    background:
+        linear-gradient(249deg,
+            rgba(228, 62, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(228, 62, 255, 0.12) 97%) padding-box,
+        linear-gradient(var(--background-01), var(--background-01)) padding-box,
+        linear-gradient(to bottom,
+            var(--purple-60) 0%, var(--purple-60) 50%, rgba(228, 62, 255, 0.12) 100%) border-box;
 }
 
 /* Mirrors virtual-list.css's .item:has(.conversation-header) rule - that one only matches the literal
@@ -341,6 +346,14 @@ body.hoverable .conversation-attachments .image-attachment:hover {
     background:
         linear-gradient(249deg,
             rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%),
+        linear-gradient(var(--background-01), var(--background-01));
+}
+/* Unjoined header shares the block's magenta tint instead of the joined violet, so the sticky header,
+   body, and faded preview all read as one surface. Keyed on its own Join button. */
+.virtual-list .c-virtual-container .live-conversation-header:has(.c-lc-join) {
+    background:
+        linear-gradient(249deg,
+            rgba(228, 62, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(228, 62, 255, 0.12) 97%),
         linear-gradient(var(--background-01), var(--background-01));
 }
 .live-conversation-header .c-lc-name {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -40,6 +40,11 @@
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .c-live-card {
     @apply pt-0;
 }
+/* The unjoined card ends with the faded preview; drop its bottom padding so the preview sits flush
+   above the footer (mirrors the pt-0 that butts the card under the header) - no gap after the last row. */
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) .c-live-card {
+    @apply pb-0;
+}
 /* When expanded, the split header carries the title so the card renders empty (no .c-live-card child).
    The item's default min-h-6 would then leave a gap between the header and the first message - collapse
    the empty card and its item to zero. The :not(:has(.c-live-card)) guard leaves the collapsed card
@@ -333,13 +338,10 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    so this wins whenever it matches. */
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) {
     isolation: isolate;
-    @apply rounded-2xl border border-solid border-transparent;
+    @apply rounded-2xl;
     background:
-        linear-gradient(249deg,
-            rgba(228, 62, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(228, 62, 255, 0.12) 97%) padding-box,
-        linear-gradient(var(--background-01), var(--background-01)) padding-box,
-        linear-gradient(to bottom,
-            var(--purple-60) 0%, var(--purple-60) 50%, rgba(228, 62, 255, 0.12) 100%) border-box;
+        linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%) padding-box,
+        linear-gradient(var(--background-01), var(--background-01)) padding-box;
 }
 
 /* Mirrors virtual-list.css's .item:has(.conversation-header) rule - that one only matches the literal
@@ -364,8 +366,7 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    body, and faded preview all read as one surface. Keyed on its own Join button. */
 .virtual-list .c-virtual-container .live-conversation-header:has(.c-lc-join) {
     background:
-        linear-gradient(249deg,
-            rgba(228, 62, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(228, 62, 255, 0.12) 97%),
+        linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%),
         linear-gradient(var(--background-01), var(--background-01));
 }
 .live-conversation-header .c-lc-name {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -26,12 +26,16 @@
     background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);
 }
 /* Any live card INSIDE a block is flush and transparent - the group owns the border, tint, and
-   rounding, so a card box here would draw a second box inside the block with the title detached. */
+   rounding, so a card box here would draw a second box inside the block with the title detached.
+   No rounded corners left to clip, so overflow goes visible too - lets the "Show more" pill straddle
+   below the card's bottom edge instead of being cut off by the base .conversation-message rule. */
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .conversation-message.live {
     @apply border-none rounded-none;
     background: none;
+    overflow: visible;
 }
 .c-live-card {
+    @apply relative;
     @apply flex-y gap-y-2 w-full;
     @apply p-4;
 }
@@ -115,6 +119,26 @@
 .c-live-card .c-lc-expand i,
 .c-live-card .c-lc-copy i {
     @apply text-xl;
+}
+/* Straddles the card's bottom edge (half over the tint, half over the first folded row below) -
+   c-live-card is the relative anchor. Mirrors navigate-to-end's floating pill (modal surface tokens). */
+.c-lc-showmore {
+    @apply absolute left-1/2 bottom-0 z-button;
+    @apply flex-x items-center gap-x-1;
+    @apply px-3 h-7 rounded-full;
+    @apply border border-modal bg-modal shadow-modal-wide;
+    @apply text-caption-1 text-[var(--cr-item-badge-selected-text)];
+    transform: translate(-50%, 50%);
+}
+.c-lc-showmore i {
+    @apply text-lg text-03;
+}
+body.hoverable .c-lc-showmore:hover {
+    @apply cursor-pointer;
+    @apply bg-hover;
+}
+.c-lc-showmore:active {
+    @apply opacity-70;
 }
 .conversation-message .c-details {
     @apply flex-y gap-y-2;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -383,11 +383,16 @@ body.hoverable .conversation-attachments .image-attachment:hover {
 .live-conversation-header .c-lc-expand i {
     @apply text-xl;
 }
-/* Header Join affordance - the activity-panel's transparent button, tinted violet-60. The
-   .virtual-list prefix outranks .btn.btn-transparent's text-primary so the violet colour wins. */
+/* Header Join affordance - styled like the activity panel's Join button: a visible tinted button by
+   default (not only on hover), violet-60 text, stronger tint on hover. The .virtual-list prefix
+   outranks .btn.btn-transparent's transparent background and text-primary colour. */
 .virtual-list .c-virtual-container .live-conversation-header .c-lc-join {
-    @apply flex-none;
+    @apply flex-none rounded-lg h-10 px-4;
     color: var(--violet-60);
+    background-color: var(--violet-60-10);
+}
+body.hoverable .virtual-list .c-virtual-container .live-conversation-header .c-lc-join:hover {
+    background-color: var(--violet-60-20);
 }
 
 /* Live conversation footer - just the block's rounded bottom edge, giving the last entry a little
@@ -399,6 +404,11 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    space between the last message and the rounded bottom. Collapse the item so the footer sits flush. */
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .live-conversation-footer) {
     @apply min-h-0;
+}
+/* The unjoined block is a compact preview card that the group's own rounding already closes, so its
+   footer band would just add empty space below the last preview row - collapse it to nothing. */
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) .live-conversation-footer {
+    @apply h-0;
 }
 
 /* Tier-1 dissolve: a too-short session leaves no card, so its block fades + collapses its chrome

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -359,7 +359,9 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    gradient and no violet outline. Keyed on the header's Join button - which shows ONLY for the
    never-attended block - so a leaver's frozen block (which shows the expand chevron, not Join) keeps
    the joined violet tint. The extra .c-lc-join in the :has() also outranks the joined tint rule above,
-   so this wins whenever it matches. */
+   so this wins whenever it matches. Its match set is a strict subset of the base shell rule's
+   expanded arm, so mx-1 and the transparent border cascade in from there - only the tint is overridden
+   here. */
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) {
     isolation: isolate;
     @apply rounded-2xl;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -124,8 +124,8 @@
    c-live-card is the relative anchor. Mirrors navigate-to-end's floating pill (modal surface tokens). */
 .c-lc-showmore {
     @apply absolute left-1/2 bottom-0 z-button;
-    @apply flex-x items-center gap-x-1;
-    @apply px-3 h-7 rounded-full;
+    @apply flex-x items-center gap-x-1 whitespace-nowrap;
+    @apply px-2.5 h-6 rounded-full;
     @apply border border-modal bg-modal shadow-modal-wide;
     @apply text-caption-1 text-[var(--cr-item-badge-selected-text)];
     transform: translate(-50%, 50%);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -305,7 +305,9 @@ body.hoverable .conversation-attachments .image-attachment:hover {
 .virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined),
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) {
     isolation: isolate;
-    @apply rounded-2xl border border-solid border-transparent;
+    /* mx-1 matches the 4px horizontal padding on regular conversation .item wrappers, so the live
+       block's box lines up with regular conversations and the message hover highlight (same width). */
+    @apply rounded-2xl border border-solid border-transparent mx-1;
     background:
         linear-gradient(249deg,
             rgba(166, 53, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 52%, rgba(166, 53, 255, 0.1) 97%) padding-box,

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -105,20 +105,6 @@
 .c-live-card .c-lc-copy i {
     @apply text-xl;
 }
-.conversation-message .c-join-row {
-    @apply block w-full;
-    @apply px-4 py-1;
-    @apply text-center text-caption-1 font-semibold uppercase;
-    @apply border-0 bg-transparent;
-    color: var(--violet-60);
-    letter-spacing: 0.42px;
-}
-body.hoverable .conversation-message .c-join-row:hover {
-    @apply cursor-pointer;
-}
-.conversation-message .c-join-row:active {
-    @apply opacity-70;
-}
 .conversation-message .c-details {
     @apply flex-y gap-y-2;
     @apply w-full;
@@ -332,6 +318,16 @@ body.hoverable .conversation-attachments .image-attachment:hover {
             var(--violet-60) 0%, var(--violet-60) 50%, var(--c-live-tint, rgba(166, 53, 255, 0.1)) 100%) border-box;
 }
 
+/* Unjoined live block: the same unified shell, but painted with the flat unjoined gradient and no
+   violet outline. The extra :has() outranks the joined tint rule above so it wins whenever the block
+   carries a not-yet-joined live card. */
+.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live:not(.joined)),
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header):has(.conversation-message.live:not(.joined)) {
+    isolation: isolate;
+    @apply rounded-2xl;
+    background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);
+}
+
 /* Mirrors virtual-list.css's .item:has(.conversation-header) rule - that one only matches the literal
    conversation-header class, not this component's own live-conversation-header. */
 .virtual-list .c-virtual-container .item:has(.live-conversation-header) {
@@ -363,6 +359,12 @@ body.hoverable .conversation-attachments .image-attachment:hover {
 }
 .live-conversation-header .c-lc-expand i {
     @apply text-xl;
+}
+/* Header Join affordance - the activity-panel's transparent button, tinted violet-60. The
+   .virtual-list prefix outranks .btn.btn-transparent's text-primary so the violet colour wins. */
+.virtual-list .c-virtual-container .live-conversation-header .c-lc-join {
+    @apply flex-none;
+    color: var(--violet-60);
 }
 
 /* Live conversation footer - just the block's rounded bottom edge, giving the last entry a little

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -40,6 +40,16 @@
 .virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .c-live-card {
     @apply pt-0;
 }
+/* When expanded, the split header carries the title so the card renders empty (no .c-live-card child).
+   The item's default min-h-6 would then leave a gap between the header and the first message - collapse
+   the empty card and its item to zero. The :not(:has(.c-live-card)) guard leaves the collapsed card
+   (which still has content) untouched. */
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .conversation-message.live:empty) {
+    @apply min-h-0;
+}
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .conversation-message.live:empty {
+    @apply min-h-0 mb-0;
+}
 .c-live-card .c-lc-title {
     @apply flex-x items-center gap-x-3;
 }
@@ -383,6 +393,11 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    breathing room from the border. No "Live" label here; the live state reads from the header alone. */
 .live-conversation-footer {
     @apply h-3 rounded-b-2xl;
+}
+/* The footer band is 0.75rem; without this its item keeps the default min-h-6, leaving ~12px of dead
+   space between the last message and the rounded bottom. Collapse the item so the footer sits flush. */
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .live-conversation-footer) {
+    @apply min-h-0;
 }
 
 /* Tier-1 dissolve: a too-short session leaves no card, so its block fades + collapses its chrome

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -318,11 +318,12 @@ body.hoverable .conversation-attachments .image-attachment:hover {
             var(--violet-60) 0%, var(--violet-60) 50%, var(--c-live-tint, rgba(166, 53, 255, 0.1)) 100%) border-box;
 }
 
-/* Unjoined live block: the same unified shell, but painted with the flat unjoined gradient and no
-   violet outline. The extra :has() outranks the joined tint rule above so it wins whenever the block
-   carries a not-yet-joined live card. */
-.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live:not(.joined)),
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header):has(.conversation-message.live:not(.joined)) {
+/* Unjoined (never-attended) live block: the same unified shell, but painted with the flat unjoined
+   gradient and no violet outline. Keyed on the header's Join button - which shows ONLY for the
+   never-attended block - so a leaver's frozen block (which shows the expand chevron, not Join) keeps
+   the joined violet tint. The extra .c-lc-join in the :has() also outranks the joined tint rule above,
+   so this wins whenever it matches. */
+.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) {
     isolation: isolate;
     @apply rounded-2xl;
     background: linear-gradient(90deg, rgba(255, 202, 255, 0.3) 2%, rgba(130, 104, 255, 0.3) 100%);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LastEntriesPreview.razor
@@ -1,6 +1,6 @@
 @namespace ActualChat.UI.Blazor.App.Components
 
-<div class="last-entries-preview">
+<div class="last-entries-preview @(Faded ? "faded" : "")">
     @if (IsLoading) {
         <chat-list-skeleton count="@SkeletonCount" messageCls="thread-skeleton"/>
     } else {
@@ -68,6 +68,7 @@
 @code {
     [Parameter] public IReadOnlyList<PreviewEntry> Entries { get; set; } = [];
     [Parameter] public bool IsLoading { get; set; }
+    [Parameter] public bool Faded { get; set; }
     [Parameter] public int SkeletonCount { get; set; } = 2;
 
     private static (ChatEntryAttachment[] Media, ChatEntryAttachment[] Files) SplitByKind(ChatEntryAttachment[] items)

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Threads/ThreadMessageView.razor
@@ -131,7 +131,7 @@
         var session = Session;
         var threadCreator = await ChatThreads.GetThreadCreator(session, chatId, cancellationToken).ConfigureAwait(false);
         var ownerName = threadCreator?.Avatar.Name ?? "Unknown";
-        var chatEntries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken).ConfigureAwait(false);
+        var chatEntries = await ChatUI.GetThreadPreviewEntries(chatId, cancellationToken: cancellationToken).ConfigureAwait(false);
         var markups = await chatEntries.Select(x => GetMarkup(x, cancellationToken)).Collect(cancellationToken).ConfigureAwait(false);
         var threadStat = await ChatThreads.GetThreadStat(session, chatId, cancellationToken).ConfigureAwait(false);
         var attachments = threadStat.Attachments;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
@@ -1,4 +1,7 @@
 .last-entries-preview {
+    @apply flex-y gap-y-2;
+}
+.last-entries-preview.faded {
     position: relative;
     width: 100%;
     height: 8.25rem;              /* fixed: ~5 lines; incoming messages don't grow the block */
@@ -7,14 +10,16 @@
     flex-direction: column;
     justify-content: flex-end;    /* newest line fully visible at the bottom */
     padding-bottom: 0.375rem;
+    gap: 0;
 }
-.last-entries-preview::before {   /* older lines fade out under the card */
+.last-entries-preview.faded::before {   /* older lines fade out under the card */
     content: "";
     position: absolute;
     inset: 0 0 auto 0;
     height: 3.75rem;
     z-index: 2;
     pointer-events: none;
+    /* Fade colour reads over the live tint (pink for unjoined); tune the exact shade in the visual pass. */
     background: linear-gradient(to bottom, var(--background-01) 0%, transparent 100%);
 }
 /* Fixed row height + a one-line clamp: the host block can't change height as entries stream in or

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
@@ -2,7 +2,6 @@
     @apply flex-y gap-y-2;
 }
 .last-entries-preview.faded {
-    position: relative;
     width: 100%;
     height: 8.25rem;              /* fixed: ~5 lines; incoming messages don't grow the block */
     overflow: hidden;
@@ -11,16 +10,10 @@
     justify-content: flex-end;    /* newest line fully visible at the bottom */
     padding-bottom: 0.375rem;
     gap: 0;
-}
-.last-entries-preview.faded::before {   /* older lines fade out under the card */
-    content: "";
-    position: absolute;
-    inset: 0 0 auto 0;
-    height: 3.75rem;
-    z-index: 2;
-    pointer-events: none;
-    /* Fade colour reads over the live tint (pink for unjoined); tune the exact shade in the visual pass. */
-    background: linear-gradient(to bottom, var(--background-01) 0%, transparent 100%);
+    /* Fade the top rows out with a content mask (not a colour overlay), so the block's own tint shows
+       through uniformly - no fade colour to match, works over any tint in either theme. */
+    -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 3.75rem);
+    mask-image: linear-gradient(to bottom, transparent 0, #000 3.75rem);
 }
 /* Fixed row height + a one-line clamp: the host block can't change height as entries stream in or
    replace each other, however much anyone says. */

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/last-entries-preview.css
@@ -1,5 +1,21 @@
 .last-entries-preview {
-    @apply flex-y gap-y-2;
+    position: relative;
+    width: 100%;
+    height: 8.25rem;              /* fixed: ~5 lines; incoming messages don't grow the block */
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;    /* newest line fully visible at the bottom */
+    padding-bottom: 0.375rem;
+}
+.last-entries-preview::before {   /* older lines fade out under the card */
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 3.75rem;
+    z-index: 2;
+    pointer-events: none;
+    background: linear-gradient(to bottom, var(--background-01) 0%, transparent 100%);
 }
 /* Fixed row height + a one-line clamp: the host block can't change height as entries stream in or
    replace each other, however much anyone says. */

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -192,10 +192,12 @@ public partial class ChatUI
                     HalfLoadLimit);
 
             expandedConversations = defaultExpanded.SymmetricExcept(overrides);
-            // A stale joined-era expand must not leak the hidden tail once the viewer is no longer joined -
-            // unless an overlay is freezing the block, in which case the leaver keeps their own expansion.
-            if (liveConversation != null && !amInLiveConversation && overlay == null)
-                expandedConversations = expandedConversations.Remove(liveConversation.Id);
+            // A not-joined viewer can expand the live block to read the whole conversation before joining;
+            // when expanded, stop hiding its tail so every entry [V, end] renders (the fold/skip logic
+            // already drops the fold range for an expanded block). Collapsed, the hidden tail stands.
+            if (liveConversation is { } liveConvExp && !amInLiveConversation && overlay == null
+                && expandedConversations.Contains(liveConvExp.Id))
+                hiddenLiveTailRange = default;
         }
 
         Range<long> chatLidRange;
@@ -912,8 +914,10 @@ public partial class ChatUI
     public virtual async Task<IReadOnlyList<ChatEntry>> GetThreadPreviewEntries(
         ChatId chatId,
         int count = 2,
+        long minLid = 0,
         CancellationToken cancellationToken = default)
         => await Chats.ReadReverse(Session, chatId, cancellationToken)
+            .TakeWhile(x => x.LocalId >= minLid) // reverse order: stop before the conversation start (minLid = V)
             .Where(x => !x.IsSystemEntry)
             .Take(count)
             .Reverse()

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -71,7 +71,6 @@ public partial class ChatUI
         var liveConversation = await Hub.LiveSessionUI.GetConversation(chatId, cancellationToken).ConfigureAwait(false);
         var amInLiveConversation = liveConversation != null
             && await Hub.LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
-        var joinedLiveConversation = amInLiveConversation ? liveConversation : null;
         var rawLive = await Hub.LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
         var blockState = await Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
         var overlay = blockState.Overlay;
@@ -94,7 +93,8 @@ public partial class ChatUI
             materializedBlockId = overlay.MaterializedId;
         }
         else {
-            liveBlockId = joinedLiveConversation?.Id;
+            // The live block uses the same shell joined or not; only the tint + header affordance differ.
+            liveBlockId = liveConversation?.Id;
             liveBlockFoldRange = liveFoldRange;
         }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -899,10 +899,11 @@ public partial class ChatUI
     [ComputeMethod]
     public virtual async Task<IReadOnlyList<ChatEntry>> GetThreadPreviewEntries(
         ChatId chatId,
+        int count = 2,
         CancellationToken cancellationToken = default)
         => await Chats.ReadReverse(Session, chatId, cancellationToken)
             .Where(x => !x.IsSystemEntry)
-            .Take(5)
+            .Take(count)
             .Reverse()
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -78,10 +78,13 @@ public partial class ChatUI
         // The governed boundary replaces the raw fold end: it tracks the viewer's viewport top,
         // monotonically, so un-summarised rows above the viewport fold too (LiveBlockUI owns this).
         // No EndEntryLid cap here - FoldBoundaryLid is itself the monotonic max of real visible
-        // message lids, so it never exceeds the loaded entries.
+        // message lids, so it never exceeds the loaded entries. RevealedBoundaryLid pins the
+        // *effective* boundary below the monotonic one once the reader asks for more (§7), so
+        // revealed rows stay visible even as the governor keeps advancing.
+        var effectiveFoldBoundaryLid = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
         var liveFoldRange = rawLive is { SessionStartedAt: not null }
-            && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid
-                ? new Range<long>(rawLive.EffectiveVisibleStartLid, blockState.FoldBoundaryLid)
+            && effectiveFoldBoundaryLid > rawLive.EffectiveVisibleStartLid
+                ? new Range<long>(rawLive.EffectiveVisibleStartLid, effectiveFoldBoundaryLid)
                 : default;
 
         ConversationId? liveBlockId;

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -98,12 +98,21 @@ public partial class ChatUI
             liveBlockFoldRange = liveFoldRange;
         }
 
-        // Non-joined users see the live block's summary only — no live entries. The synthetic
-        // conversation already collapses [Start, EndEntryLid]; hide the un-summarized tail too.
+        // A non-joined viewer sees the block's summary card only — never its live entries. The card
+        // collapses [V, foldEnd) and this range hides everything from there on, so the two together
+        // cover [V, ∞) gaplessly. Starting the hidden range at foldEnd (not EndEntryLid+1) is what
+        // makes it gapless: the fold boundary lags EndEntryLid by up to FoldLag after a new summary,
+        // and anchoring to EndEntryLid would leak the entries in [foldEnd, EndEntryLid+1). Pre-first-
+        // summary the fold range is empty, so hide from V onward. Hiding the wider range is harmless -
+        // a non-joined viewer has no visible live entries to keep.
         var hiddenLiveTailRange = overlay != null
             ? overlay.HiddenTailRange
             : liveConversation is { } liveConv && !amInLiveConversation
-                ? new Range<long>(liveConv.EndEntryLid + 1, long.MaxValue)
+                ? new Range<long>(
+                    liveBlockFoldRange.IsEmpty
+                        ? liveConv.Id.StartEntryLid
+                        : Math.Min(liveConv.EndEntryLid + 1, liveBlockFoldRange.End),
+                    long.MaxValue)
                 : default;
         var liveAt = CpuTimestamp.Now;
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -893,7 +893,7 @@ public partial class ChatUI
         CancellationToken cancellationToken = default)
         => await Chats.ReadReverse(Session, chatId, cancellationToken)
             .Where(x => !x.IsSystemEntry)
-            .Take(2)
+            .Take(5)
             .Reverse()
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -75,13 +75,13 @@ public partial class ChatUI
         var blockState = await Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
         var overlay = blockState.Overlay;
 
-        // The governed boundary replaces the raw fold end: folds advance only FoldLag after the summary
-        // pass that produced them, and never across the viewer's viewport (LiveBlockUI owns both rules).
+        // The governed boundary replaces the raw fold end: it tracks the viewer's viewport top,
+        // monotonically, so un-summarised rows above the viewport fold too (LiveBlockUI owns this).
+        // No EndEntryLid cap here - FoldBoundaryLid is itself the monotonic max of real visible
+        // message lids, so it never exceeds the loaded entries.
         var liveFoldRange = rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid
-                ? new Range<long>(
-                    rawLive.EffectiveVisibleStartLid,
-                    Math.Min(blockState.FoldBoundaryLid, rawLive.EndEntryLid + 1))
+                ? new Range<long>(rawLive.EffectiveVisibleStartLid, blockState.FoldBoundaryLid)
                 : default;
 
         ConversationId? liveBlockId;
@@ -101,10 +101,11 @@ public partial class ChatUI
         // A non-joined viewer sees the block's summary card only — never its live entries. The card
         // collapses [V, foldEnd) and this range hides everything from there on, so the two together
         // cover [V, ∞) gaplessly. Starting the hidden range at foldEnd (not EndEntryLid+1) is what
-        // makes it gapless: the fold boundary lags EndEntryLid by up to FoldLag after a new summary,
-        // and anchoring to EndEntryLid would leak the entries in [foldEnd, EndEntryLid+1). Pre-first-
-        // summary the fold range is empty, so hide from V onward. Hiding the wider range is harmless -
-        // a non-joined viewer has no visible live entries to keep.
+        // makes it gapless: a non-joined viewer never renders live entries, so the governed boundary
+        // never gets a viewport signal and can trail EndEntryLid indefinitely - anchoring to
+        // EndEntryLid would leak the entries in [foldEnd, EndEntryLid+1). Pre-first-summary the fold
+        // range is empty, so hide from V onward. Hiding the wider range is harmless - a non-joined
+        // viewer has no visible live entries to keep.
         var hiddenLiveTailRange = overlay != null
             ? overlay.HiddenTailRange
             : liveConversation is { } liveConv && !amInLiveConversation
@@ -635,6 +636,14 @@ public partial class ChatUI
                 .Select(c => c.Id == liveBlockId ? liveFoldRange : c.EntryLidRange)
                 .Where(r => !r.IsEmpty)
                 .ToArray();
+            // The live conversation's own persisted EntryLidRange is server-tracked (EndEntryLid-based),
+            // so it can be narrower than the governed fold range once the boundary has advanced past
+            // un-summarised rows (§4) - this tile then carries no matching Conversation to substitute
+            // above, and the fold would never apply. Add it explicitly so folding is never limited by
+            // how far the persisted conversation record itself currently reaches.
+            if (liveBlockId is { } liveBlockConversationId && !expandedConversations.Contains(liveBlockConversationId)
+                && !liveFoldRange.IsEmpty && conversations.All(c => c.Id != liveBlockConversationId))
+                idRangesToSkip = [..idRangesToSkip, liveFoldRange];
         }
         if (!hiddenLiveTailRange.IsEmpty)
             idRangesToSkip = [..idRangesToSkip, hiddenLiveTailRange];

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -369,6 +369,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             ? overrides.Remove(conversationId)
             : overrides.Add(conversationId);
         _conversationExpansionOverrides.Value = overrides;
+        Hub.LiveBlockUI.ResetReveal(conversationId.ChatId);
     }
 
     public bool IsConversationExpanded(Conversation conversation)

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -25,14 +25,13 @@ public sealed record LiveBlockState(
 }
 
 /// <summary>
-/// Governs how far a live block's fold boundary is allowed to advance (lag + viewport clamp via
-/// <see cref="LiveFoldMath"/>), and freezes/materializes the block's render once the viewer leaves
-/// or the session closes, so a watched viewport never mutates under the reader.
+/// Governs how far a live block's fold boundary is allowed to advance (monotonic viewport-top
+/// tracking via <see cref="LiveFoldMath"/>), and freezes/materializes the block's render once the
+/// viewer leaves or the session closes, so a watched viewport never mutates under the reader.
 /// </summary>
 public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeService, INotifyInitialized
 {
     private readonly Dictionary<ChatId, ChatFoldState> _chatStates = new();
-    internal TimeSpan FoldLag = TimeSpan.FromMinutes(3);
     // A too-short (tier-1) session leaves nothing behind, so its block is held briefly on close to
     // fade + collapse out instead of vanishing in one frame.
     internal TimeSpan DissolveDuration = TimeSpan.FromMilliseconds(300);
@@ -139,7 +138,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 return existing;
 
         // Isolated read: the initial latch must not make the governor's boundary state reactive to
-        // the raw live state - only subsequent advances go through the lag + viewport governor. The
+        // the raw live state - only subsequent advances go through the viewport governor. The
         // attending latch is seeded here too - whichever caller creates the state first (this read
         // path or the governor loop) must agree on it, or a join immediately followed by a leave (no
         // governor iteration lands in between) would never mark the viewer as having attended.
@@ -165,7 +164,6 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 State = StateFactory.NewMutable(
                     new LiveBlockState(foldEndLid, null, isJoined),
                     StateCategories.Get(GetType(), nameof(GetBlockState), "[*]")),
-                LastObservedFoldEndLid = foldEndLid,
                 WasAttending = isJoined,
                 Template = template,
             };
@@ -265,21 +263,12 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
             if (raw is { SessionStartedAt: not null }) {
                 var v = raw.EffectiveVisibleStartLid;
-                var foldEndLid = GetRawFoldEndLid(raw);
-                if (foldEndLid > chatState.LastObservedFoldEndLid) {
-                    chatState.Pending = [..chatState.Pending, new PendingFold(foldEndLid, raw.LastSummaryAt)];
-                    chatState.LastObservedFoldEndLid = foldEndLid;
-                }
-
                 var minVisibleLid = visibility.ChatId == chatId && !visibility.IsEmpty
                     ? visibility.VisibleMessageLids.Where(lid => lid >= v).DefaultIfEmpty(long.MaxValue).Min()
                     : long.MaxValue;
-                var result = LiveFoldMath.Advance(
-                    state.FoldBoundaryLid, chatState.Pending, Clocks.ServerClock.Now, FoldLag,
-                    minVisibleLid == long.MaxValue ? null : minVisibleLid);
-                chatState.Pending = result.Pending;
-                wakeAt = result.NextWakeAt;
-                state = new LiveBlockState(result.BoundaryLid, null, chatState.WasAttending);
+                var boundaryLid = LiveFoldMath.Advance(
+                    state.FoldBoundaryLid, minVisibleLid == long.MaxValue ? null : minVisibleLid);
+                state = new LiveBlockState(boundaryLid, null, chatState.WasAttending);
             }
 
             if (!Equals(chatState.State.Value, state))
@@ -309,8 +298,6 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
     private sealed class ChatFoldState
     {
         public MutableState<LiveBlockState> State = null!;
-        public IReadOnlyList<PendingFold> Pending = [];
-        public long LastObservedFoldEndLid;
         public bool WasAttending;
         public bool IsClosed;
         public Moment DissolveEndsAt;

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -59,11 +59,13 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var raw = await LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
         var amInLive = raw != null
             && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
-        lock (Lock)
+        lock (Lock) {
+            var effectiveBoundaryLid = Math.Min(baseState.FoldBoundaryLid, chatState.RevealedBoundaryLid);
             return baseState with {
-                Overlay = DeriveOverlay(chatState, baseState.FoldBoundaryLid, raw, amInLive),
+                Overlay = DeriveOverlay(chatState, effectiveBoundaryLid, raw, amInLive),
                 RevealedBoundaryLid = chatState.RevealedBoundaryLid,
             };
+        }
     }
 
     [ComputeMethod]

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -19,7 +19,11 @@ public sealed record LiveBlockOverlay(
     bool IsDissolving = false);
 
 public sealed record LiveBlockState(
-    long FoldBoundaryLid, LiveBlockOverlay? Overlay, bool WasAttending = false, bool IsDissolving = false)
+    long FoldBoundaryLid,
+    LiveBlockOverlay? Overlay,
+    bool WasAttending = false,
+    bool IsDissolving = false,
+    long RevealedBoundaryLid = long.MaxValue)
 {
     public static readonly LiveBlockState None = new(0, null);
 }
@@ -58,7 +62,58 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         lock (Lock)
             return baseState with {
                 Overlay = DeriveOverlay(chatState, baseState.FoldBoundaryLid, raw, amInLive),
+                RevealedBoundaryLid = chatState.RevealedBoundaryLid,
             };
+    }
+
+    public async Task RevealMore(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        ChatFoldState chatState;
+        long v, effectiveBoundary;
+        lock (Lock) {
+            if (!_chatStates.TryGetValue(chatId, out var s) || s.Template is not { } t)
+                return;
+            chatState = s;
+            v = t.V;
+            effectiveBoundary = Math.Min(chatState.State.Value.FoldBoundaryLid, chatState.RevealedBoundaryLid);
+        }
+        if (effectiveBoundary <= v)
+            return;
+
+        var visibleCount = Hub.ChatUI.ItemVisibility.Value.VisibleMessageLids.Count;
+        var batch = Math.Max(5, ((visibleCount + 4) / 5) * 5);
+
+        // Walk back `batch` real messages from just below the current effective boundary; the batch-th
+        // one becomes the new revealed boundary (clamped to V when fewer remain).
+        var revealed = v;
+        using (Computed.BeginIsolation()) {
+            var taken = 0;
+            await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
+                if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
+                    continue;
+                if (entry.LocalId < v)
+                    break;
+                revealed = entry.LocalId;
+                if (++taken >= batch)
+                    break;
+            }
+        }
+
+        lock (Lock)
+            chatState.RevealedBoundaryLid = Math.Min(chatState.RevealedBoundaryLid, revealed);
+        using (Invalidation.Begin())
+            _ = GetBlockState(chatId, default);
+    }
+
+    public void ResetReveal(ChatId chatId)
+    {
+        lock (Lock) {
+            if (!_chatStates.TryGetValue(chatId, out var chatState) || chatState.RevealedBoundaryLid == long.MaxValue)
+                return;
+            chatState.RevealedBoundaryLid = long.MaxValue;
+        }
+        using (Invalidation.Begin())
+            _ = GetBlockState(chatId, default);
     }
 
     public bool TryCollapseOverlay(ConversationId conversationId)
@@ -303,6 +358,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         public Moment DissolveEndsAt;
         public bool DissolveDone;
         public FrozenTemplate? Template;
+        public long RevealedBoundaryLid = long.MaxValue;
     }
 
     private sealed record FrozenTemplate(

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -66,6 +66,31 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             };
     }
 
+    [ComputeMethod]
+    public virtual async Task<int> GetSwallowedCount(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        // Cached (this is a [ComputeMethod]) but counts real messages via a full read of the swallowed
+        // range on each recompute - never approximate with a lid span, since lids have gaps.
+        var blockState = await GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
+        var raw = await LiveSessionUI.GetState(chatId, cancellationToken).ConfigureAwait(false);
+        if (raw is not { SessionStartedAt: not null })
+            return 0;
+        var v = raw.EffectiveVisibleStartLid;
+        var effectiveBoundary = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
+        if (effectiveBoundary <= v)
+            return 0;
+
+        var count = 0;
+        await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
+            if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
+                continue;
+            if (entry.LocalId < v)
+                break;
+            count++;
+        }
+        return count;
+    }
+
     public async Task RevealMore(ChatId chatId, CancellationToken cancellationToken = default)
     {
         ChatFoldState chatState;

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -126,8 +126,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             }
         }
 
-        lock (Lock)
+        lock (Lock) {
             chatState.RevealedBoundaryLid = Math.Min(chatState.RevealedBoundaryLid, revealed);
+            chatState.RevealScrolledInto = false;
+        }
         using (Invalidation.Begin())
             _ = GetBlockState(chatId, default);
     }
@@ -138,6 +140,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             if (!_chatStates.TryGetValue(chatId, out var chatState) || chatState.RevealedBoundaryLid == long.MaxValue)
                 return;
             chatState.RevealedBoundaryLid = long.MaxValue;
+            chatState.RevealScrolledInto = false;
         }
         using (Invalidation.Begin())
             _ = GetBlockState(chatId, default);
@@ -316,6 +319,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             ? await BuildTemplate(chatId, raw, cancellationToken).ConfigureAwait(false)
             : null;
 
+        var clearedReveal = false;
+        Moment? wakeAt = null;
         lock (Lock) {
             chatState.WasAttending |= isJoined;
             if (template != null)
@@ -324,7 +329,6 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 chatState.IsClosed = true;
 
             var state = chatState.State.Value with { WasAttending = chatState.WasAttending };
-            Moment? wakeAt = null;
 
             // A tier-1 (never-summarized) close leaves no card behind. DeriveOverlay dissolves the
             // block immediately (synchronously) so the animation actually starts; the governor only
@@ -348,15 +352,31 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 var minVisibleLid = visibility.ChatId == chatId && !visibility.IsEmpty
                     ? visibility.VisibleMessageLids.Where(lid => lid >= v).DefaultIfEmpty(long.MaxValue).Min()
                     : long.MaxValue;
+                var oldBoundary = state.FoldBoundaryLid;
                 var boundaryLid = LiveFoldMath.Advance(
-                    state.FoldBoundaryLid, minVisibleLid == long.MaxValue ? null : minVisibleLid);
+                    oldBoundary, minVisibleLid == long.MaxValue ? null : minVisibleLid);
+                // A reveal is a temporary peek. Latch that the viewport entered the revealed region (above
+                // the governed boundary); once the reader scrolls back down so every revealed row is above
+                // the viewport again, re-swallow them - the block re-compacts on return to the live tail.
+                if (chatState.RevealedBoundaryLid != long.MaxValue && minVisibleLid != long.MaxValue) {
+                    if (minVisibleLid < oldBoundary)
+                        chatState.RevealScrolledInto = true;
+                    else if (chatState.RevealScrolledInto) {
+                        chatState.RevealedBoundaryLid = long.MaxValue;
+                        chatState.RevealScrolledInto = false;
+                        clearedReveal = true;
+                    }
+                }
                 state = new LiveBlockState(boundaryLid, null, chatState.WasAttending);
             }
 
             if (!Equals(chatState.State.Value, state))
                 chatState.State.Value = state;
-            return wakeAt;
         }
+        if (clearedReveal)
+            using (Invalidation.Begin())
+                _ = GetBlockState(chatId, default);
+        return wakeAt;
     }
 
     private void CleanupOtherChats(ChatId selectedChatId)
@@ -386,6 +406,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         public bool DissolveDone;
         public FrozenTemplate? Template;
         public long RevealedBoundaryLid = long.MaxValue;
+        public bool RevealScrolledInto;
     }
 
     private sealed record FrozenTemplate(

--- a/src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs
@@ -1,34 +1,11 @@
 namespace ActualChat.UI.Blazor.App.Services;
 
-public readonly record struct PendingFold(long FoldEndLid, Moment SummaryAt);
-
 public static class LiveFoldMath
 {
-    public sealed record Result(long BoundaryLid, IReadOnlyList<PendingFold> Pending, Moment? NextWakeAt);
-
-    public static Result Advance(
-        long boundaryLid,
-        IReadOnlyList<PendingFold> pending,
-        Moment serverNow,
-        TimeSpan foldLag,
-        long? minVisibleLidInBlock)
-    {
-        var ripeFoldEndLid = 0L;
-        Moment? nextWakeAt = null;
-        foreach (var fold in pending)
-            if (fold.SummaryAt + foldLag <= serverNow)
-                ripeFoldEndLid = Math.Max(ripeFoldEndLid, fold.FoldEndLid);
-            else {
-                var wakeAt = fold.SummaryAt + foldLag;
-                if (nextWakeAt == null || wakeAt < nextWakeAt.GetValueOrDefault())
-                    nextWakeAt = wakeAt;
-            }
-
-        var candidate = ripeFoldEndLid;
-        if (minVisibleLidInBlock is { } minVisibleLid)
-            candidate = Math.Min(candidate, minVisibleLid);
-        var newBoundaryLid = Math.Max(boundaryLid, candidate);
-        var remaining = pending.Where(f => f.FoldEndLid > newBoundaryLid).ToList();
-        return new Result(newBoundaryLid, remaining, nextWakeAt);
-    }
+    // The collapsed live block swallows everything above the viewport. The fold boundary is the
+    // topmost visible lid in the block, advanced monotonically - it never retreats when the reader
+    // scrolls up, so the block stays a compact card. A null viewport (nothing of the block visible)
+    // holds the current boundary. Summaries no longer gate this: un-summarised rows fold too.
+    public static long Advance(long boundaryLid, long? minVisibleLidInBlock)
+        => minVisibleLidInBlock is { } lid ? Math.Max(boundaryLid, lid) : boundaryLid;
 }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -980,11 +980,20 @@ export class VirtualList {
     };
 
     private onInteractiveEvent = (event: TouchEvent): void => {
-        // Your touchend event handling logic here
-        const itemRef = event.currentTarget;
-        const key = getItemKey(itemRef as HTMLElement);
+        const itemRef = event.currentTarget as HTMLElement;
+        let key = getItemKey(itemRef);
         if (!key)
             return;
+
+        // A control marked data-anchor="below" (the live block's Show-more pill) reveals rows ABOVE
+        // itself. Hold the first item BELOW this one as the interactive pivot instead of this item, so
+        // the revealed rows grow upward while everything from the control down keeps its screen position.
+        const target = event.target as HTMLElement | null;
+        if (target?.closest('[data-anchor="below"]')) {
+            const belowKey = this.getFirstItemKeyBelow(itemRef);
+            if (belowKey)
+                key = belowKey;
+        }
 
         if (BrowserInfo.appKind === 'Wasm')
             this.updateCurrentPivots(key); // Required to do it synchronously at WASM
@@ -1647,6 +1656,19 @@ export class VirtualList {
             return null;
 
         return this.containerRef.querySelector(`:scope .item[data-key="${key}"]`);
+    }
+
+    private getFirstItemKeyBelow(itemRef: HTMLElement): string | null {
+        const all = Array.from(this.containerRef.querySelectorAll<HTMLElement>(':scope .item[data-key]'));
+        const idx = all.indexOf(itemRef);
+        if (idx < 0)
+            return null;
+        for (let i = idx + 1; i < all.length; i++) {
+            const skip = all[i].dataset.skip;
+            if (skip == null || skip === 'false')
+                return all[i].dataset.key ?? null;
+        }
+        return null;
     }
 
     private getFirstItemRef(): HTMLElement | null {

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -872,7 +872,10 @@ export class VirtualList {
             this.updateState('onResize: windowScrollTop', this.state, { windowScrollTop: window.visualViewport?.offsetTop ?? window.scrollY });
             // Re-pin (don't recreate) the sticky edge on resize. 'viewport-resize' is honored even on the
             // initial render, so panels/keyboard resizing right after open still keep the edge pinned.
-            if (this.state.stickyEdge?.edge === this.defaultEdge && (viewportResized || !itemsWereMeasured))
+            // endAnchorHasChanged too: when the end-anchor headroom grows (e.g. the audio panel appears,
+            // h-12 -> h-20) alongside a last-item resize, the End max shifts by that delta - without re-pinning
+            // here the pin keeps the stale max and leaves that delta as dead space below the last block.
+            if (this.state.stickyEdge?.edge === this.defaultEdge && (viewportResized || endAnchorHasChanged || !itemsWereMeasured))
                 this.scrollToEdge(this.defaultEdge, false, viewportResized ? 'viewport-resize' : 'non-item-resize');
 
             if (DeviceInfo.isIos) {

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -982,6 +982,34 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(10));
     }
 
+    [Fact]
+    public async Task PreSummaryBlockShowsNoMetaCount()
+    {
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "pre-summary-meta-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_330);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        await chatAudioUI.SetListeningState(chat.Id, true);
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act + assert - no UpdateSummary => no title => HasSummary must be false on the rendered live conversation
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            var card = items.Items.SelectMany(i => i.GetLeafMessages())
+                .OfType<ConversationMessage>().SingleOrDefault(c => c.Conversation!.Title.IsNullOrEmpty());
+            card.Should().NotBeNull("a pre-summary live block still emits its card");
+            card!.Conversation!.MessageCount.Should().Be(0);   // the card carries 0; the view must NOT render "0 messages"
+        }, TimeSpan.FromSeconds(10));
+    }
+
     // Private methods
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -154,7 +154,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     public async Task GovernorLatchesInitialFoldBoundary()
     {
         // The first observation of a chat must latch to the raw fold end as-is - a fresh render
-        // starts fully folded, and only later advances go through the lag + viewport governor.
+        // starts fully folded, and only later advances go through the viewport governor.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -472,9 +472,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // When the summary's context reaches back before V, the persisted (materialized) conversation
         // starts at ContextStartLid, not V - id-tile loading must resolve that identity to the same
         // governed fold range GetTile uses, or the block's frozen (unfolded) tail loses its id-tiles
-        // and goes missing after close. A second, un-lagged summary widens the raw range past the
-        // governed fold boundary so the fold and the persisted range genuinely diverge - the exact
-        // condition that exposed the bug.
+        // and goes missing after close. A second summary widens the raw range past the governed fold
+        // boundary (which never advances without a viewport signal) so the fold and the persisted
+        // range genuinely diverge - the exact condition that exposed the bug.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -521,9 +521,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(10));
         preCloseLeafLids.Should().Contain(context0.LocalId, "the pre-latch context entry must already be visible");
 
-        // A second summary widens EndEntryLid to cover the tail, but the default (un-shrunk) FoldLag
-        // keeps the governed fold boundary at V+3 - so at close, the fold range [V, V+3) is genuinely
-        // narrower than the persisted range [ContextStartLid, V+6).
+        // A second summary widens EndEntryLid to cover the tail, but the governed fold boundary never
+        // advances past its initial latch without a viewport signal, so it stays parked at V+3 - at
+        // close, the fold range [V, V+3) is genuinely narrower than the persisted range
+        // [ContextStartLid, V+6).
         await liveBackend.UpdateSummary(chat.Id,
             new LiveSessionSummary {
                 Title = "Recap", Description = "d2", Summary = "s2",
@@ -612,73 +613,12 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task FoldLagDefersMidCallFold()
-    {
-        // A fold must not land the instant its summary does - the lag gives the reader a beat
-        // before the entries it just covered disappear behind the card.
-
-        // arrange
-        await Tester.SignInAsUniqueBob();
-        var (chat, _) = await Tester.CreateAndGetChat(false, "fold-lag-test");
-        var author = await Tester.GetOwnAuthor(chat.Id).Require();
-        var peerId = AuthorId.New(chat.Id, 777_140);
-        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
-        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
-        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
-        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
-        live.Should().NotBeNull();
-        var v = live!.EffectiveVisibleStartLid;
-        for (var i = 0; i < 3; i++)
-            await Tester.CreateTextEntry(chat.Id, $"folded-{i}");
-        await liveBackend.UpdateSummary(chat.Id,
-            new LiveSessionSummary {
-                Title = "Latch", Description = "d", Summary = "s",
-                EndEntryLid = v + 2, MessageCount = 3,
-            }, CancellationToken.None);
-        await Tester.CreateTextEntry(chat.Id, "extra-1");
-        await Tester.CreateTextEntry(chat.Id, "extra-2");
-
-        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        liveBlockUI.FoldLag = TimeSpan.FromSeconds(2);
-        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
-        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
-        await chatAudioUI.SetListeningState(chat.Id, true);
-        chatUI.SelectChatOnNavigation(chat.Id);
-        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
-        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
-        List<long> beforeLids = null!;
-        await ComputedTest.When(async ct => {
-            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
-            var lids = LeafEntryLids(items);
-            lids.Should().Contain(v + 3);
-            lids.Should().Contain(v + 4);
-            beforeLids = lids;
-        }, TimeSpan.FromSeconds(10));
-
-        // act - a summary pass advances coverage over the two new entries
-        await liveBackend.UpdateSummary(chat.Id,
-            new LiveSessionSummary {
-                Title = "Latch", Description = "d2", Summary = "s2",
-                EndEntryLid = v + 4, MessageCount = 5,
-            }, CancellationToken.None);
-
-        // assert (sustained - nothing folds within the lag window)
-        await Task.Delay(700);
-        LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None)).Should().Equal(beforeLids);
-
-        // assert - after the lag the two newly covered entries fold
-        await ComputedTest.When(async ct => {
-            var lids = LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, ct));
-            lids.Should().NotContain(v + 3);
-            lids.Should().NotContain(v + 4);
-        }, TimeSpan.FromSeconds(10));
-    }
-
-    [Fact]
     public async Task ViewportGuardDefersFoldWhileVisible()
     {
-        // The fold must defer while its entries are on screen and complete once they scroll away -
-        // even with zero lag, a visible entry can't vanish out from under the reader.
+        // The fold must defer while its entries are the topmost visible ones - even once a summary
+        // pass widens the live pipeline's coverage over them - and complete once the reader scrolls
+        // further so a later message becomes the topmost visible one. The boundary tracks the
+        // viewport top, not the summary, so a visible entry can't vanish out from under the reader.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -701,8 +641,6 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await Tester.CreateTextEntry(chat.Id, "extra-1");
         await Tester.CreateTextEntry(chat.Id, "extra-2");
 
-        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        liveBlockUI.FoldLag = TimeSpan.Zero;
         var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         await chatAudioUI.SetListeningState(chat.Id, true);
@@ -725,7 +663,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             },
             false);
 
-        // act 1 - a summary pass covers the visible entries, but the guard holds the fold
+        // act 1 - a summary pass widens the live pipeline's known coverage over v+3/v+4, but they're
+        // still the topmost visible entries, so the viewport guard holds the fold there regardless
         await liveBackend.UpdateSummary(chat.Id,
             new LiveSessionSummary {
                 Title = "Latch", Description = "d2", Summary = "s2",
@@ -734,10 +673,14 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await Task.Delay(700);
         LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None)).Should().Equal(beforeLids);
 
-        // act 2 - the entries scroll out of view, so the fold completes
-        chatUI.ItemVisibility.Value = ChatViewItemVisibility.Empty;
+        // act 2 - the reader scrolls further: a later message becomes the topmost visible one
+        var tailEntry = await Tester.CreateTextEntry(chat.Id, "tail-3");
+        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            chat.Id,
+            new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, tailEntry.LocalId) },
+            false);
 
-        // assert
+        // assert - the boundary advances past v+3/v+4, folding them
         await ComputedTest.When(async ct => {
             var lids = LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, ct));
             lids.Should().NotContain(v + 3);
@@ -1045,11 +988,13 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task UnjoinedBlockHidesLiveEntriesWhenFoldLagsBehindSummary()
+    public async Task UnjoinedBlockHidesLiveEntriesEvenWhenFoldBoundaryStaysBehindSummary()
     {
-        // A non-joined viewer must see the summary card only - never live entries. When a second
-        // summary advances EndEntryLid past the lag-held fold boundary, the entries in that gap
-        // (between the lagged fold end and the new summary end) must stay hidden behind the card.
+        // A non-joined viewer must see the summary card only - never live entries. A non-joined
+        // viewer never renders live entries, so the governed fold boundary never receives a viewport
+        // signal and stays parked at its initial latch even as later summaries advance EndEntryLid -
+        // the entries in that gap (between the parked fold end and the new summary end) must stay
+        // hidden behind the card regardless.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -1067,8 +1012,6 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v + 2, MessageCount = 3,
         }, CancellationToken.None);
 
-        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        liveBlockUI.FoldLag = TimeSpan.FromMinutes(3);   // the second fold stays lagged for the whole test
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         chatUI.SelectChatOnNavigation(chat.Id);   // Bob is NOT recording/listening => not joined
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
@@ -1082,18 +1025,78 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
                 "a non-joined viewer sees the card only, not the summarized live entries");
         }, TimeSpan.FromSeconds(15));
 
-        // act - two more entries land, then a second summary advances EndEntryLid past the lagged boundary
+        // act - two more entries land, then a second summary advances EndEntryLid past the parked boundary
         for (var i = 0; i < 2; i++)
             await Tester.CreateTextEntry(chat.Id, $"b-{i}");   // v+3, v+4
         await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
             Title = "Recap", Description = "d2", Summary = "s2", EndEntryLid = v + 4, MessageCount = 5,
         }, CancellationToken.None);
 
-        // assert (sustained) - the newly-summarized entries in the lagged gap must never surface
+        // assert (sustained) - the newly-summarized entries beyond the parked boundary must never surface
         await Task.Delay(1000);
         var items2 = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
         LeafEntryLids(items2).Should().NotContain([v + 3, v + 4],
-            "the fold boundary lags but the non-joined card must still hide the whole live range");
+            "the fold boundary stays parked but the non-joined card must still hide the whole live range");
+    }
+
+    [Fact]
+    public async Task CollapsedBlockFoldsUnsummarizedRowsAboveViewport()
+    {
+        // §4: the collapsed live block swallows everything above the viewport, even rows no summary
+        // has ever covered - the boundary tracks the viewport top directly, with no summary gate.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "swallow-above-viewport-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_400);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        // A title so the block has a card, but the summary covers only V (EndEntryLid = v) - the entries
+        // below are UN-summarised. Viewport tracking must still fold them once they scroll above the top.
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        var lids = new List<long>();
+        for (var i = 0; i < 8; i++)
+            lids.Add((await Tester.CreateTextEntry(chat.Id, $"m-{i}")).LocalId);
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        await chatAudioUI.SetRecordingChatId(chat.Id);   // Bob is a recorder => joined
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act - viewport top sits at the 6th entry: everything above it (incl. un-summarised rows) must fold
+        var viewportTop = lids[5];
+        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            chat.Id,
+            new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false);
+
+        // assert - the governed boundary (not just the summary-covered range) advances to the viewport
+        // top, so un-summarised rows above it are swallowed too
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await ComputedTest.When(async ct => {
+            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
+            blockState.FoldBoundaryLid.Should().BeGreaterThanOrEqualTo(viewportTop,
+                "the boundary tracks the viewport top, folding un-summarised rows above it");
+        }, TimeSpan.FromSeconds(15));
+
+        // assert - this must also hold at render level: the un-summarised rows above the viewport top
+        // are folded into the block (not rendered as individual messages), while the viewport top and
+        // everything below it still render normally
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        await ComputedTest.When(async ct => {
+            var renderedLids = LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, ct));
+            renderedLids.Should().NotContain(lids.Take(5),
+                "un-summarised rows above the viewport top must fold, not render as individual messages");
+            renderedLids.Should().Contain(lids.Skip(5),
+                "the viewport top and the tail below it must still render normally");
+        }, TimeSpan.FromSeconds(15));
     }
 
     // Private methods

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -917,6 +917,29 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(10));
     }
 
+    [Fact]
+    public async Task JoinFromBlockStartsRecording()
+    {
+        // arrange - a live session this Bob has not joined
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "join-records-test");
+        var peerId = AuthorId.New(chat.Id, 777_310);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act - the block's Join action
+        await chatAudioUI.SetRecordingChatId(chat.Id);
+
+        // assert - Bob is now recording in this chat
+        await ComputedTest.When(async ct => {
+            var s = await chatAudioUI.GetState(chat.Id).ConfigureAwait(true);
+            s.IsRecording.Should().BeTrue("Join from the live block starts recording");
+        }, TimeSpan.FromSeconds(10));
+    }
+
     // Private methods
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1099,6 +1099,73 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(15));
     }
 
+    [Fact]
+    public async Task RevealMoreRetreatsEffectiveFoldAndPersists()
+    {
+        // §7: RevealMore retreats RevealedBoundaryLid below the governor's monotonic FoldBoundaryLid,
+        // so the effective fold (min of the two) survives further governor advances; ResetReveal clears it.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "reveal-more-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_410);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        for (var i = 0; i < 20; i++)
+            await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await chatAudioUI.SetRecordingChatId(chat.Id);
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act - viewport top sits at the last entry, so a large range folds
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var viewportTop = idRange.End - 1;
+        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            chat.Id,
+            new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false);
+
+        long foldedBoundary = 0;
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
+            foldedBoundary = s.FoldBoundaryLid;
+        }, TimeSpan.FromSeconds(15));
+
+        // act - reveal one batch
+        await liveBlockUI.RevealMore(chat.Id);
+
+        // assert - the effective fold boundary retreats below where the governor had it
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            Math.Min(s.FoldBoundaryLid, s.RevealedBoundaryLid).Should().BeLessThan(foldedBoundary,
+                "revealing a batch retreats the effective fold boundary");
+        }, TimeSpan.FromSeconds(10));
+
+        // assert - it survives a further governor advance (viewport unchanged, so nothing pushes it back up)
+        await Task.Delay(500);
+        var afterReveal = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
+        Math.Min(afterReveal.FoldBoundaryLid, afterReveal.RevealedBoundaryLid).Should().BeLessThan(foldedBoundary,
+            "the revealed boundary persists across governor re-evaluation");
+
+        // act - reset clears the reveal
+        liveBlockUI.ResetReveal(chat.Id);
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.RevealedBoundaryLid.Should().Be(long.MaxValue, "reset clears the reveal");
+        }, TimeSpan.FromSeconds(10));
+    }
+
     // Private methods
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -918,6 +918,48 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
+    public async Task ExpandedLiveBlockHasNoDescription()
+    {
+        // Expanded reads as a plain conversation - the card's description box must not surface, and the
+        // sticky header (LiveConversationHeaderView) never carries a message count in either state.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "expanded-no-desc-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_320);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "a description", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        for (var i = 0; i < 3; i++)
+            await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        await chatAudioUI.SetListeningState(chat.Id, true);
+        chatUI.SelectChatOnNavigation(chat.Id);
+        // ensure the block renders expanded
+        var live2 = await Tester.Conversations.Get(Tester.Session, live.ToConversation().Id, CancellationToken.None);
+        if (live2 is { IsExpandedByDefault: false })
+            chatUI.ToggleExpandConversation(live.ToConversation().Id);
+
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            var block = items.Items.OfType<ExpandedConversationMessage>().Single();
+            // HasSplitHeader gates the description box off (Task 3); the structural guard here is that
+            // the block still renders as one split-header card once expanded.
+            block.Items.OfType<ConversationMessage>().Single().HasSplitHeader.Should().BeTrue();
+        }, TimeSpan.FromSeconds(15));
+    }
+
+    [Fact]
     public async Task JoinFromBlockStartsRecording()
     {
         // arrange - a live session this Bob has not joined

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1167,6 +1167,77 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
+    public async Task RevealReSwallowsOnReturnToTail()
+    {
+        // §7: a reveal is a temporary peek - once the reader scrolls back down so every revealed row is
+        // above the viewport again, the governor re-swallows them (clears the reveal). A "scrolled-into"
+        // latch keeps it from re-collapsing before the reader has actually entered the revealed region.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "reveal-reswallow-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_411);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        for (var i = 0; i < 20; i++)
+            await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await chatAudioUI.SetRecordingChatId(chat.Id);
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        void SetViewportTop(long lid)
+            => chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+                chat.Id,
+                new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, lid) },
+                false);
+
+        // drive the fold boundary up to the live tail
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var tailTop = idRange.End - 1;
+        SetViewportTop(tailTop);
+        long boundary = 0;
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
+            boundary = s.FoldBoundaryLid;
+        }, TimeSpan.FromSeconds(15));
+
+        // reveal a batch
+        await liveBlockUI.RevealMore(chat.Id);
+        long revealed = 0;
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.RevealedBoundaryLid.Should().BeLessThan(boundary, "reveal retreats below the boundary");
+            revealed = s.RevealedBoundaryLid;
+        }, TimeSpan.FromSeconds(10));
+
+        // scroll UP into the revealed region: the reveal must persist (only the latch flips here)
+        SetViewportTop(revealed);
+        await Task.Delay(500);
+        var whileReading = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
+        whileReading.RevealedBoundaryLid.Should().Be(revealed,
+            "the reveal persists while the reader is inside the revealed region");
+
+        // scroll back DOWN to the live tail: every revealed row is now above the viewport -> re-swallow
+        SetViewportTop(tailTop);
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.RevealedBoundaryLid.Should().Be(long.MaxValue,
+                "returning to the live tail re-swallows the revealed batch");
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
     public async Task RevealMoreSurvivesLeaveFreeze()
     {
         // §7 cross-task fix: a revealed batch must survive the freeze on leave/close - DeriveOverlay

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -50,7 +50,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         live!.SessionStartedAt.Should().NotBeNull();
         (live.VisibleStartLid % tileSize).Should()
             .Be(0L, "the live block must start a fresh view tile or this test doesn't bite");
-        items.Items.OfType<ConversationMessage>()
+        // The unjoined live block now renders through the unified sticky-header shell, so its card is a
+        // leaf inside the block rather than a top-level ConversationMessage.
+        items.Items.SelectMany(i => i.GetLeafMessages())
+            .OfType<ConversationMessage>()
             .Select(m => m.Conversation!.Id)
             .Should().Contain(live.ConversationId);
     }
@@ -1008,6 +1011,35 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             card.Should().NotBeNull("a pre-summary live block still emits its card");
             card!.Conversation!.MessageCount.Should().Be(0);   // the card carries 0; the view must NOT render "0 messages"
         }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task UnjoinedLiveBlockUsesStickyHeader()
+    {
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "unjoined-shell-test");
+        var peerId = AuthorId.New(chat.Id, 777_340);
+        var peer2Id = AuthorId.New(chat.Id, 777_341);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peer2Id, null, true, CancellationToken.None); // 2+ => SessionStartedAt latches
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);   // Bob is NOT recording/listening => not joined
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            items.Items.SelectMany(i => i.GetLeafMessages())
+                .OfType<LiveConversationHeader>().Should().ContainSingle(
+                    "the unjoined live block shares the sticky-header shell");
+        }, TimeSpan.FromSeconds(15));
     }
 
     // Private methods

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1042,6 +1042,58 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(15));
     }
 
+    [Fact]
+    public async Task UnjoinedBlockHidesLiveEntriesWhenFoldLagsBehindSummary()
+    {
+        // A non-joined viewer must see the summary card only - never live entries. When a second
+        // summary advances EndEntryLid past the lag-held fold boundary, the entries in that gap
+        // (between the lagged fold end and the new summary end) must stay hidden behind the card.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "unjoined-no-leak-test");
+        var peerId = AuthorId.New(chat.Id, 777_350);
+        var peer2Id = AuthorId.New(chat.Id, 777_351);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peer2Id, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        for (var i = 0; i < 3; i++)
+            await Tester.CreateTextEntry(chat.Id, $"a-{i}");   // v, v+1, v+2
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v + 2, MessageCount = 3,
+        }, CancellationToken.None);
+
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        liveBlockUI.FoldLag = TimeSpan.FromMinutes(3);   // the second fold stays lagged for the whole test
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);   // Bob is NOT recording/listening => not joined
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        // latch the fold boundary at the first summary's end; the summarized live entries are hidden
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            items.Items.SelectMany(i => i.GetLeafMessages())
+                .OfType<LiveConversationHeader>().Should().ContainSingle();
+            LeafEntryLids(items).Should().NotContain([v, v + 1, v + 2],
+                "a non-joined viewer sees the card only, not the summarized live entries");
+        }, TimeSpan.FromSeconds(15));
+
+        // act - two more entries land, then a second summary advances EndEntryLid past the lagged boundary
+        for (var i = 0; i < 2; i++)
+            await Tester.CreateTextEntry(chat.Id, $"b-{i}");   // v+3, v+4
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d2", Summary = "s2", EndEntryLid = v + 4, MessageCount = 5,
+        }, CancellationToken.None);
+
+        // assert (sustained) - the newly-summarized entries in the lagged gap must never surface
+        await Task.Delay(1000);
+        var items2 = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        LeafEntryLids(items2).Should().NotContain([v + 3, v + 4],
+            "the fold boundary lags but the non-joined card must still hide the whole live range");
+    }
+
     // Private methods
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1009,7 +1009,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             var card = items.Items.SelectMany(i => i.GetLeafMessages())
                 .OfType<ConversationMessage>().SingleOrDefault(c => c.Conversation!.Title.IsNullOrEmpty());
             card.Should().NotBeNull("a pre-summary live block still emits its card");
-            card!.Conversation!.MessageCount.Should().Be(0);   // the card carries 0; the view must NOT render "0 messages"
+            // the card carries 0; the view must NOT render "0 messages"
+            card!.Conversation!.MessageCount.Should().Be(0);
         }, TimeSpan.FromSeconds(10));
     }
 
@@ -1022,7 +1023,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var peer2Id = AuthorId.New(chat.Id, 777_341);
         var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
         await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
-        await liveBackend.OnStreamRegistered(chat.Id, peer2Id, null, true, CancellationToken.None); // 2+ => SessionStartedAt latches
+        // 2+ => SessionStartedAt latches
+        await liveBackend.OnStreamRegistered(chat.Id, peer2Id, null, true, CancellationToken.None);
         var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
         var v = live!.EffectiveVisibleStartLid;
         await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1167,6 +1167,73 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
+    public async Task RevealMoreSurvivesLeaveFreeze()
+    {
+        // §7 cross-task fix: a revealed batch must survive the freeze on leave/close - DeriveOverlay
+        // must use the reveal-aware effective boundary, not the raw monotonic FoldBoundaryLid, or
+        // leaving re-folds the rows the reader just revealed (a content shrink right under them).
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "reveal-leave-freeze-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_420);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        for (var i = 0; i < 20; i++)
+            await Tester.CreateTextEntry(chat.Id, $"m-{i}");
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await chatAudioUI.SetListeningState(chat.Id, true);
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act - viewport top sits at the last entry, so a large range folds
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var viewportTop = idRange.End - 1;
+        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            chat.Id,
+            new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false);
+
+        long foldedBoundary = 0;
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
+            foldedBoundary = s.FoldBoundaryLid;
+        }, TimeSpan.FromSeconds(15));
+
+        // act - reveal one batch, retreating the effective boundary below the raw governed one
+        await liveBlockUI.RevealMore(chat.Id);
+        long revealedEffectiveBoundary = 0;
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            revealedEffectiveBoundary = Math.Min(s.FoldBoundaryLid, s.RevealedBoundaryLid);
+            revealedEffectiveBoundary.Should().BeLessThan(foldedBoundary);
+        }, TimeSpan.FromSeconds(10));
+
+        // act - leave: hang up, which freezes the block via the overlay
+        await chatAudioUI.SetListeningState(chat.Id, false);
+        InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
+
+        // assert - the frozen overlay's FoldRange must end at the reveal-aware effective boundary,
+        // not the full monotonic FoldBoundaryLid the governor had reached before the reveal
+        await ComputedTest.When(async ct => {
+            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
+            s.Overlay.Should().NotBeNull();
+            s.Overlay!.FoldRange.End.Should().Be(revealedEffectiveBoundary,
+                "the freeze must preserve what the reader had revealed, not re-fold it back under them");
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
     public async Task CollapsedJoinedBlockReportsSwallowedCount()
     {
         // §7: SwallowedCount is the true message count folded in [V, effectiveBoundary) - not a lid

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -1166,6 +1166,76 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         }, TimeSpan.FromSeconds(10));
     }
 
+    [Fact]
+    public async Task CollapsedJoinedBlockReportsSwallowedCount()
+    {
+        // §7: SwallowedCount is the true message count folded in [V, effectiveBoundary) - not a lid
+        // span (lids have gaps) - and it must drop to 0 once RevealMore walks the whole backlog back
+        // into view.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "swallowed-count-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_420);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
+        }, CancellationToken.None);
+        var lids = new List<long>();
+        for (var i = 0; i < 3; i++)
+            lids.Add((await Tester.CreateTextEntry(chat.Id, $"m-{i}")).LocalId);
+        // A system entry sits inside the swallowed range - GetSwallowedCount must skip it (it filters
+        // on IsSystemEntry, same as RevealMore), so the true message count (5) differs from the lid
+        // span across the folded range (6). This guards the "never approximate with a lid span"
+        // invariant: a wrong `effectiveBoundary - v` implementation would report 6, not 5, here.
+        await Tester.Commander.Call(new ChatsBackend_ChangeEntry(
+            ChatEntryId.New(chat.Id, 0),
+            null,
+            Change.Create(new ChatEntryDiff {
+                Kind = ChatEntryKind.MembersChanged,
+                AuthorId = author.Id,
+                TargetAuthorId = peerId,
+                TargetAuthorName = "Peer",
+                HasLeft = false,
+            })));
+        for (var i = 3; i < 8; i++)
+            lids.Add((await Tester.CreateTextEntry(chat.Id, $"m-{i}")).LocalId);
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await chatAudioUI.SetRecordingChatId(chat.Id);
+        chatUI.SelectChatOnNavigation(chat.Id);
+
+        // act - viewport top sits at the 6th real entry, folding the 5 real rows above it (plus the
+        // interleaved system entry, which must not count towards SwallowedCount)
+        var viewportTop = lids[5];
+        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            chat.Id,
+            new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false);
+
+        // assert - the count is the true number of folded messages, not a lid-span approximation
+        await ComputedTest.When(async ct => {
+            var count = await liveBlockUI.GetSwallowedCount(chat.Id, ct);
+            count.Should().Be(5, "exactly the 5 rows above the viewport top are folded");
+        }, TimeSpan.FromSeconds(15));
+
+        // act - reveal the whole backlog in one batch (5 folded rows <= the rounded-up batch size)
+        await liveBlockUI.RevealMore(chat.Id);
+
+        // assert - the count drops to 0 once every folded row has been revealed
+        await ComputedTest.When(async ct => {
+            var count = await liveBlockUI.GetSwallowedCount(chat.Id, ct);
+            count.Should().Be(0, "revealing the whole backlog leaves nothing swallowed");
+        }, TimeSpan.FromSeconds(15));
+    }
+
     // Private methods
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.UnitTests/LiveFoldMathTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/LiveFoldMathTest.cs
@@ -4,84 +4,23 @@ namespace ActualChat.UI.Blazor.UnitTests;
 
 public class LiveFoldMathTest
 {
-    private static readonly Moment T0 = new(new DateTime(2026, 7, 20, 12, 0, 0, DateTimeKind.Utc));
-    private static readonly TimeSpan Lag = TimeSpan.FromMinutes(3);
+    [Fact]
+    public void AdvancesToViewportTop()
+        => LiveFoldMath.Advance(10, 15).Should().Be(15);
 
     [Fact]
-    public void RipeFoldAdvancesBoundary()
-    {
-        // arrange
-        var pending = new List<PendingFold> { new(21, T0) };
-
-        // act
-        var result = LiveFoldMath.Advance(10, pending, T0 + Lag, Lag, null);
-
-        // assert
-        result.BoundaryLid.Should().Be(21);
-        result.Pending.Should().BeEmpty();
-        result.NextWakeAt.Should().BeNull();
-    }
+    public void FoldsUnsummarizedRowsAboveViewport()
+        => LiveFoldMath.Advance(10, 500).Should().Be(500);
 
     [Fact]
-    public void UnripeFoldStaysPendingAndSchedulesWake()
-    {
-        // arrange
-        var pending = new List<PendingFold> { new(21, T0) };
-
-        // act
-        var result = LiveFoldMath.Advance(10, pending, T0 + TimeSpan.FromMinutes(1), Lag, null);
-
-        // assert
-        result.BoundaryLid.Should().Be(10);
-        result.Pending.Should().ContainSingle().Which.FoldEndLid.Should().Be(21);
-        result.NextWakeAt.Should().Be(T0 + Lag);
-    }
+    public void IsMonotonic_ViewportBelowBoundaryDoesNotRetreat()
+        => LiveFoldMath.Advance(20, 5).Should().Be(20);
 
     [Fact]
-    public void ViewportClampHoldsBoundaryAndKeepsFoldPending()
-    {
-        // arrange - Entry 15 is visible - the boundary must not cross it even though the fold is ripe
-        var pending = new List<PendingFold> { new(21, T0) };
-
-        // act
-        var result = LiveFoldMath.Advance(10, pending, T0 + Lag, Lag, 15);
-
-        // assert
-        result.BoundaryLid.Should().Be(15);
-        result.Pending.Should().ContainSingle().Which.FoldEndLid.Should().Be(21);
-        result.NextWakeAt.Should().BeNull(); // ripe - only visibility holds it, no timer needed
-    }
+    public void NullViewportHoldsBoundary()
+        => LiveFoldMath.Advance(20, null).Should().Be(20);
 
     [Fact]
-    public void BoundaryIsMonotonic()
-    {
-        // arrange - A visible lid below the current boundary (viewer expanded the fold) must not move it back
-        var pending = new List<PendingFold>();
-
-        // act
-        var result = LiveFoldMath.Advance(20, pending, T0, Lag, 5);
-
-        // assert
-        result.BoundaryLid.Should().Be(20);
-    }
-
-    [Fact]
-    public void MaxRipeFoldWinsAndEarliestUnripeSchedulesWake()
-    {
-        // arrange
-        var pending = new List<PendingFold>
-        {
-            new(15, T0),
-            new(21, T0 + TimeSpan.FromSeconds(30)),
-            new(30, T0 + TimeSpan.FromMinutes(2))
-        };
-
-        // act
-        var result = LiveFoldMath.Advance(10, pending, T0 + Lag + TimeSpan.FromMinutes(1), Lag, null);
-
-        // assert
-        result.BoundaryLid.Should().Be(21);
-        result.Pending.Should().ContainSingle().Which.FoldEndLid.Should().Be(30);
-        result.NextWakeAt.Should().Be(T0 + TimeSpan.FromMinutes(2) + Lag);
-    }
+    public void EqualViewportIsStable()
+        => LiveFoldMath.Advance(20, 20).Should().Be(20);
 }

--- a/tests/Testing.Host/BlazorTester.cs
+++ b/tests/Testing.Host/BlazorTester.cs
@@ -19,6 +19,7 @@ public class BlazorTester : BunitContext, IWebTester
     public IAuthorsBackend AuthorsBackend => field ??= AppServices.GetRequiredService<IAuthorsBackend>();
     public IAccountsBackend AccountsBackend => field ??= AppServices.GetRequiredService<IAccountsBackend>();
     public IChats Chats => field ??= AppServices.GetRequiredService<IChats>();
+    public IConversations Conversations => field ??= AppServices.GetRequiredService<IConversations>();
     public ITranslations Translations => field ??= AppServices.GetRequiredService<ITranslations>();
     public IPlaces Places => field ??= AppServices.GetRequiredService<IPlaces>();
     public ISearch Search => field ??= AppServices.GetRequiredService<ISearch>();


### PR DESCRIPTION
Plan 1 of the live-conversation-block redesign — the **shell & chrome** slice. Design brainstormed against the real app styles; implemented via subagent-driven development (5 tasks, each task-reviewed) + a whole-branch review + a chrome-devtools visual pass.

Spec: `docs/superpowers/specs/2026-07-22-live-conversation-block-unified-ux-design.md`
Plan: `docs/superpowers/plans/2026-07-22-live-block-unified-shell.md`

## What changed
- **One shell** for joined & unjoined: the unjoined block now routes through the same sticky-header + tinted-card path as joined; they differ only by tint + a header **Join** button.
- **Join = join + record** (`SetRecordingChatId`), label "Join", in the header (activity-panel style). Join shows only for the never-attended block; a leaver's frozen block keeps its chevron.
- **Unjoined preview**: fixed-height, bottom-anchored, top-faded (content mask) last-5-messages — never grows/jumps.
- **Meta-row** (heads + "Started at HH:MM · N messages") gated on a real summary — no more "0 messages".
- **Expanded = a plain conversation**: no description box, no header count.
- **Consistent unjoined tint** (magenta, structured like the joined tint over an opaque base, on header+body+preview), theme-proof preview fade.
- **Alignment/spacing**: live block width matched to regular conversations / the message hover highlight (779–1539); empty-card gap and footer dead-space collapsed in the expanded block.

Non-joined viewers see the summary only (gapless `[V,∞)` tail hiding) — a review-caught leak was fixed. Thread previews were kept untouched (the shared `LastEntriesPreview` restyle is scoped to the live card).

## Not in this PR
Plan 2 — the swallow-above-viewport governor rewrite and the "Show N of M" pill — is a separate follow-up (outlined at the end of the plan).

## Tests
`LiveConversationDisplayTest` 21/21 green (incl. 5 new: join-records, expanded-no-description, pre-summary-no-meta, unjoined-sticky-header, non-joined-no-leak); build + `npm run build:Verify` clean. Visual states verified live via chrome-devtools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)