### PR TITLE
feat(calls): add admin-only start-call button to peer chat header

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
@@ -55,6 +55,9 @@
     </div>
     @if (chat is not null) {
         <div class="chat-header-control-panel hideable">
+            @if (chat.Kind == ChatKind.Peer) {
+                <ChatHeaderCallButton/>
+            }
             <TranslationButton/>
             @if (chat.Id.IsThread(out var threadChatId)) {
                 <ChatHeaderFollowThreadToggle ThreadChatId="@threadChatId"/>

--- a/src/dotnet/UI.Blazor.App/Components/ChatHeaderCallButton.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatHeaderCallButton.razor
@@ -1,0 +1,41 @@
+@inherits ComputedStateComponent<AppUIHub, ChatHeaderCallButton.Model>
+@{
+    if (State.IsInitial(out var m))
+        return;
+    // Admin-only; hidden while a live conversation is active — the ChatActivityPanel owns that state.
+    if (!m.IsAdmin || m.IsActive)
+        return;
+}
+
+<HeaderButton
+    Class="btn-start-call"
+    Tooltip="Start call"
+    TooltipPosition="FloatingPosition.Bottom"
+    Click="OnClick">
+    <i class="icon-phone-call text-2xl"></i>
+</HeaderButton>
+
+@code {
+    private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
+    private ChatActivityUI ChatActivityUI => Hub.ChatActivityUI;
+
+    private Chat Chat => ChatContext.Chat;
+
+    [CascadingParameter] public ChatContext ChatContext { get; set; } = null!;
+
+    protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
+        var account = await AccountUI.OwnAccount.Use(cancellationToken).ConfigureAwait(false);
+        if (!account.IsAdmin)
+            return new Model(false, false);
+
+        var activity = await ChatActivityUI.Get(Chat.Id, cancellationToken).ConfigureAwait(false);
+        return new Model(true, activity.IsActive);
+    }
+
+    private Task OnClick()
+        => LiveSessionUI.StartCall(Chat.Id, default, false, CancellationToken.None);
+
+    // Nested types
+
+    public sealed record Model(bool IsAdmin, bool IsActive);
+}

--- a/src/dotnet/UI.Blazor.App/Components/components.css
+++ b/src/dotnet/UI.Blazor.App/Components/components.css
@@ -178,6 +178,10 @@ body.narrow .layout-header.collapsed:has(.chat-activity-panel:not(.listening)) .
 .chat-header-control-panel .translation-btn.on .c-hill {
     @apply bg-primary;
 }
+.chat-header-control-panel .btn-start-call,
+body.hoverable .chat-header-control-panel .btn-start-call:hover {
+    @apply text-[var(--green-40)];
+}
 
 .message-counter-with-time {
     @apply flex-y items-center gap-y-0.5;


### PR DESCRIPTION
Shown in the peer chat header left of the translation button, for admins only, and hidden while a live conversation is active (the ChatActivityPanel owns that state). Clicking rings the peer via LiveSessionUI.StartCall.