### PR TITLE
fix(tests): migrate LocationUITest to GetCountdown API #4057

### DIFF
--- a/tests/Chat.UI.Blazor.IntegrationTests/LocationUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LocationUITest.cs
@@ -27,7 +27,6 @@ public class LocationUITest(ChatAppHostFixture fixture, ITestOutputHelper @out)
         var cancellationToken = cts.Token;
 
         var (chatId, _) = await Tester.CreateChat(true, cancellationToken: cancellationToken);
-        var author = await Tester.GetOwnAuthor(chatId, cancellationToken: cancellationToken).Require();
         var entry = await Tester.CreateLocationEntry(
             chatId,
             new GeoPoint(51.5074, -0.1278, 12f, 90f),
@@ -36,9 +35,10 @@ public class LocationUITest(ChatAppHostFixture fixture, ITestOutputHelper @out)
         var locationId = entry.LocationId.Require();
 
         var computed = await Computed.Capture(
-            () => LocationUI.GetTimeLeftText(author.Id, cancellationToken),
+            () => LocationUI.GetCountdown(chatId, locationId, cancellationToken),
             cancellationToken);
-        computed.Value.Should().NotBeEmpty();
+        computed.Value.Should().NotBeNull();
+        computed.Value!.Text.Should().NotBeEmpty();
         computed.IsConsistent().Should().BeTrue();
 
         // act
@@ -47,7 +47,7 @@ public class LocationUITest(ChatAppHostFixture fixture, ITestOutputHelper @out)
         // assert
         computed.IsConsistent().Should().BeFalse();
         computed = await computed.Update(cancellationToken);
-        computed.Value.Should().Be("");
+        computed.Value.Should().BeNull();
         computed.IsConsistent().Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Problem

CI on `dev` was red across **every** job — all integration shards (chat/users/mlsearch/core), unit tests, and slow tests. Not infrastructure: the test assembly **failed to compile**, so no test ran.

```
tests/Chat.UI.Blazor.IntegrationTests/LocationUITest.cs(39,30): error CS1061:
'LocationUI' does not contain a definition for 'GetTimeLeftText'
```

### Root cause — silent merge conflict

- **#4016** added `LocationUI.GetTimeLeftText` + a test that calls it.
- **#4057** (`b26ad0181`) removed `GetTimeLeftText` in favor of `GetCountdown` / `LocationCountdown.Text`.

The removal lives in the source file, the stale call in the test file — different files, so git merged both onto `dev` with no textual conflict. Neither PR's CI saw the other's merged state, so it passed on each side and broke only after both landed. One compile error = build exit 1 = the whole test matrix goes red.

## Fix

Rewrite `LocationUITest` to the new API:
- `GetTimeLeftText(author.Id, ct)` → `GetCountdown(chatId, locationId, ct)` returning `LocationCountdown?`
- read `.Text` for the countdown string
- expect `null` (not `""`) once sharing stops — the new method returns `null` when the share is no longer live
- dropped the now-unused `author` local

## Verification

`dotnet build tests/Chat.UI.Blazor.IntegrationTests` → **0 errors** (remaining warnings are pre-existing, none in the test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)