### PR TITLE
fix(video): break sender recovery deadlock on WS peer-change

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/Video/streaming/push-to-pull-buffer.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/streaming/push-to-pull-buffer.ts
@@ -280,6 +280,13 @@ export function createWireSender(opts: CreateWireSenderOptions): DisposableStrea
             lastError = `stream error: ${msg}`;
         } finally {
             isDisposed = true;
+            // The gate only reopens from the generator above, which is now dead.
+            // On a peer-change/eviction it may be closed (uplink backlog) — leave
+            // it closed and capture stays gated forever, so no bundle reaches
+            // wireSend to trigger a sender rebuild. Reopen here to break that
+            // deadlock; clear the stale backlog we'll never drain.
+            floodGate.open();
+            bundles.clear();
             if (lastError)
                 pumpReject(new Error(lastError));
             else


### PR DESCRIPTION
## Problem

The publisher's video pipeline has a recovery **deadlock**: when the video WebSocket reconnects to a *different* peer while the uplink is backed up, the capture flood gate is closed — and a closed gate blocks the only mechanism that can detect the dead stream and rebuild it. The publisher then sits at **0 kbps forever** (encoder healthy, `connected=yes`) until recording is stopped manually. Trigger in the wild: dev pod churn force-reconnecting every client with `peerChanged=true`.

## Deadlock chain

1. During the WS outage acks stop → the RpcStream ring fills → the Denque hits `closeGateAt` → `FloodGate.close()` (`push-to-pull-buffer.ts:316`).
2. A closed gate drops every captured frame right after the source (`flood-gate.ts:52-61`), so nothing reaches the encoder or `wireSend`.
3. The reconnect lands with `peerChanged=true` → the RpcStream is disposed → the pump completes. But `wire-send.ts:246-251` only checks `pumpResolved`/`pumpFailure` when the **next** bundle arrives — and the closed gate guarantees none ever does.
4. The gate can only reopen from inside the dead pump's generator as it drains (`push-to-pull-buffer.ts:230`) — which never runs again. Deadlock.

Audio recovers because it re-issues `PushStream` per utterance; video's single long-lived stream has no re-publish path.

## Fix

Reopen the shared `FloodGate` (and clear the undrainable backlog) in `createWireSender`'s pump `finally` block. The `finally` runs on any pump termination (peer-change reject, eviction, `ensureRpcPush` throw, graceful stop). Once the gate reopens:

- capture resumes → the next bundle reaches `wireSend`
- the existing `pumpResolved`/`pumpFailure` check fires `resetSender`
- a fresh `createWireSender` re-issues `PushStream` → recovery completes

Minimal, targeted — the `FloodGate` is the singleton shared between the `floodGate(gate)` operator (`recorder.ts:149`) and every `createSender(gate)` (`recorder.ts:196`), so reopening it in the dead pump reopens the exact instance the operator reads. Graceful-stop path is unaffected (recorder is tearing down anyway).

## Verification

- `tsc --noEmit` → 0
- `eslint push-to-pull-buffer.ts` → 0
- 26 operator unit tests pass (incl. wire-send's "recreates the sender when the pump completes" — the reset mechanism this fix feeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)