### PR TITLE
feat(live): Dialing state — calls ring without surfacing a live conversation block

### DIFF
--- a/docs/superpowers/plans/2026-07-23-live-session-dialing-state.md
+++ b/docs/superpowers/plans/2026-07-23-live-session-dialing-state.md
@@ -1,0 +1,476 @@
+# Live-Session Dialing State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A call creates its live session while ringing (so the Call tab works) but shows **no** live conversation block until the first invitee answers.
+
+**Architecture:** Add an explicit `LiveSessionKind.Dialing` phase. A fresh call enters Dialing with `SessionStartedAt == null`; the first `AcceptCall` latches it to `Kind == Call` with `SessionStartedAt` set. Because `SessionStartedAt != null` is already the codebase-wide "there is a live conversation" signal (~20 gates), keeping it null while dialing suppresses the block everywhere for free. `Get` (the call projection) is relaxed to still surface a dialing call for the Call tab.
+
+**Tech Stack:** C# / .NET, ActualLab.Fusion, Redis-backed `LiveSessionState`, xUnit + FluentAssertions integration tests (`SharedAppHostTestBase`).
+
+**Spec:** `docs/superpowers/specs/2026-07-23-live-session-dialing-state-design.md`
+
+## Global Constraints
+
+- **Read `docs/CODING_STYLE.md` before writing C#.** No `Async` suffix on async methods; no XML docs on members; comments only for non-obvious constraints; ≤120 columns; mixed brace style per surrounding code.
+- **Invariant (must hold everywhere):** for a call, `Kind == Dialing ⟺ SessionStartedAt == null`. The two fields are written together only in `StartCall` (enter Dialing) and `AcceptCall` (latch), plus the ambient-latch backstop.
+- **Latch is monotonic:** once `SessionStartedAt` is set, a session never returns to Dialing. Promoting an already-latched ambient session to a call yields `Kind == Call`, not `Dialing`.
+- **Latch trigger:** the first invitee to accept (`AcceptCall`). Decline / cancel / no-answer never latch → no block, no notification.
+- **Calls don't send the "voice chat started" conversation banner** (they ring); only ambient sessions banner.
+- **`LiveSessionKind` is a Redis-persisted enum, not a DB column** — adding a value needs no migration.
+- **Build:** `dotnet build ActualChat.CI.slnf`, or trigger the running `dotnet watch` (poll `tmp/watch-dotnet.log` for `C# and Razor changes applied` / `error`). Do not start/restart the server yourself — the user's watch owns it.
+- **Test project:** `tests/Chat.IntegrationTests/LiveSessionsTest.cs` (drives `ILiveSessionsBackend` directly). Run a single test with `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~<TestName>"`.
+
+---
+
+### Task 1: `Dialing` enum, state helpers, `StartCall` enters Dialing, `Get` surfaces it
+
+**Files:**
+- Modify: `src/dotnet/Api/Live/LiveSessionKind.cs`
+- Modify: `src/dotnet/Api/Live/LiveSessionState.cs` (add computed helpers after the existing `ConversationId` computed, ~line 63)
+- Modify: `src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs` (`StartCall` ~L477-486; `Get` early-out ~L131 and projection `Conversation` ~L199)
+- Test: `tests/Chat.IntegrationTests/LiveSessionsTest.cs` (`StartCallRingsInvitee` ~L597; `StartCallPromotesExistingSession` ~L754 stays green unchanged)
+
+**Interfaces:**
+- Produces: `LiveSessionKind.Dialing = 2`; `LiveSessionState.IsCall => Kind is Call or Dialing`; `LiveSessionState.IsDialing => Kind == Dialing`. Task 2/3/4 consume these.
+
+- [ ] **Step 1: Update the `StartCallRingsInvitee` test to the new dialing contract**
+
+In `tests/Chat.IntegrationTests/LiveSessionsTest.cs`, replace the assertion block in `StartCallRingsInvitee` (currently lines ~614-621):
+
+```csharp
+        // assert — a fresh call is Dialing: the session exists (Call tab works) but no live conversation
+        // is surfaced yet, so SessionStartedAt stays null until someone answers.
+        var state = await backend.GetState(chatId, default);
+        state.Should().NotBeNull();
+        state!.Kind.Should().Be(LiveSessionKind.Dialing);
+        state.SessionStartedAt.Should().BeNull();
+        // the Call tab still gets a projection while dialing, with the ring visible and no conversation
+        var live = await backend.Get(chatId, default);
+        live.Should().NotBeNull();
+        live!.Conversation.Should().BeNull();
+        live.Invites.Should().ContainSingle(i =>
+            i.InviteeId == aliceAuthor.Id && i.Status == CallInviteStatus.Ringing);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~StartCallRingsInvitee"`
+Expected: FAIL — `Kind` is `Call` (not `Dialing`) and `SessionStartedAt` is not null (old `StartCall` behavior).
+
+- [ ] **Step 3: Add the `Dialing` enum value**
+
+`src/dotnet/Api/Live/LiveSessionKind.cs`:
+
+```csharp
+namespace ActualChat.Live;
+
+public enum LiveSessionKind
+{
+    Ambient = 0,
+    Call = 1,
+    Dialing = 2,
+}
+```
+
+- [ ] **Step 4: Add `IsCall` / `IsDialing` computed helpers**
+
+`src/dotnet/Api/Live/LiveSessionState.cs`, immediately after the `ConversationId` computed property (the last `[IgnoreDataMember, MemoryPackIgnore, IgnoreMember]` member, ~line 63):
+
+```csharp
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public bool IsCall => Kind is LiveSessionKind.Call or LiveSessionKind.Dialing;
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public bool IsDialing => Kind == LiveSessionKind.Dialing;
+```
+
+- [ ] **Step 5: `StartCall` — enter Dialing instead of latching**
+
+`src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs`, the `with` block in `StartCall` (~L477-486). Replace the two comment lines and the `with` initializer as follows (leave `lidRangeEnd`/`startEntryLid` above it unchanged — `lidRangeEnd` is still used for `startEntryLid`):
+
+```csharp
+            // A fresh call is Dialing: the session exists (for the Call tab and the ring) but no live
+            // conversation is surfaced until someone answers, so SessionStartedAt stays null. Promoting an
+            // already-latched (ambient) session keeps it connected so its block and ring/close paths persist.
+            state = (state ?? new LiveSessionState { ChatId = chatId, StartEntryLid = startEntryLid }) with {
+                EndEntryLid = state?.EndEntryLid ?? startEntryLid,
+                StartedAt = state?.StartedAt ?? now,
+                SessionStartedAt = state?.SessionStartedAt,
+                VisibleStartLid = state?.VisibleStartLid ?? 0,
+                AuthorIds = state?.AuthorIds is { Count: > 0 } ids ? ids : [callerAuthorId],
+                Host = callerAuthorId,
+                Kind = state?.SessionStartedAt is not null ? LiveSessionKind.Call : LiveSessionKind.Dialing,
+                Version = VersionGenerator.NextVersion(state?.Version ?? 0),
+            };
+```
+
+- [ ] **Step 6: `Get` — surface a dialing call, with no conversation**
+
+`src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs`. In `Get`, replace the early-out (~L131):
+
+```csharp
+        if (state.SessionStartedAt is null && !state.IsCall)
+            return null;
+```
+
+and in the returned `LiveSession` (~L199), make the conversation absent while dialing:
+
+```csharp
+            Conversation = state.IsDialing ? null : state.ToConversation(),
+```
+
+- [ ] **Step 7: Run the updated test — verify it passes**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~StartCallRingsInvitee"`
+Expected: PASS.
+
+- [ ] **Step 8: Fix the promotion test (unlatched → Dialing) and add a latched-promotion test**
+
+`StartCallPromotesExistingSession` registers only one streamer, so its ambient session is **unlatched** (`SessionStartedAt == null`). Promoting an unlatched session is now Dialing (a solo recorder ringing others is not a connected conversation). Replace that test's assertion block (~L773-776) with:
+
+```csharp
+        // assert — promoting an unlatched (solo) ambient session gives a Dialing call: ring/close paths
+        // apply (via IsCall) but no block is surfaced until someone answers.
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Dialing);
+        state.SessionStartedAt.Should().BeNull();
+        state.Host.Should().Be(bobAuthor.Id);
+```
+
+Then add a test for the latched case (an already-2-party ambient session promotes to a connected `Call`, keeping its block), after `StartCallPromotesExistingSession`:
+
+```csharp
+    [Fact]
+    public async Task StartCallOnLatchedSessionStaysConnected()
+    {
+        // arrange — a 2-party ambient session is already latched (block visible) when a call starts
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(true);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        await backend.OnStreamRegistered(chatId, bobAuthor!.Id, null, true, default);
+        await backend.OnStreamRegistered(chatId, aliceAuthor!.Id, null, true, default);
+        var latched = await backend.GetState(chatId, default);
+        latched!.SessionStartedAt.Should().NotBeNull("two streamers latched the ambient session");
+        var startedAt = latched.SessionStartedAt;
+
+        // act — Bob rings a third-party author id while that session is live
+        await backend.StartCall(
+            chatId, bobAuthor.Id, new[] { AuthorId.New(chatId, 777_055) }.ToApiArray(), false, default);
+
+        // assert — monotonic: it stays a connected Call with its latch preserved (block stays)
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Call);
+        state.SessionStartedAt.Should().Be(startedAt);
+    }
+```
+
+- [ ] **Step 9: Run both promotion tests — verify they pass**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~StartCallPromotesExistingSession|FullyQualifiedName~StartCallOnLatchedSessionStaysConnected"`
+Expected: PASS — unlatched promotion → `Dialing`; latched promotion → `Call` with `SessionStartedAt` unchanged.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/dotnet/Api/Live/LiveSessionKind.cs src/dotnet/Api/Live/LiveSessionState.cs \
+  src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs \
+  tests/Chat.IntegrationTests/LiveSessionsTest.cs
+git commit -m "feat(live): calls enter a Dialing phase with no live conversation block"
+```
+
+---
+
+### Task 2: `AcceptCall` latches Dialing → Connected
+
+**Files:**
+- Modify: `src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs` (`AcceptCall` ~L505-524)
+- Test: `tests/Chat.IntegrationTests/LiveSessionsTest.cs` (`AcceptCallJoinsCall` ~L625; add `AcceptLatchesDialingCallToConnected`)
+
+**Interfaces:**
+- Consumes: `LiveSessionKind.Dialing`, `LiveSessionState.IsDialing` (Task 1).
+- Produces: after the first `AcceptCall`, `Kind == Call`, `SessionStartedAt` set, `VisibleStartLid` = chat end at answer, invitee in `AuthorIds`.
+
+- [ ] **Step 1: Extend `AcceptCallJoinsCall` and add the latch test**
+
+In `tests/Chat.IntegrationTests/LiveSessionsTest.cs`, add to `AcceptCallJoinsCall` (after its existing assertions, ~L647) assertions that the call is now connected:
+
+```csharp
+        // the answer latches the dialing call to Connected: block now surfaced
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Call);
+        state.SessionStartedAt.Should().NotBeNull();
+        state.AuthorIds.Should().Contain(aliceAuthor.Id);
+```
+
+Then add a dedicated test after `AcceptCallJoinsCall`. `SessionStartedAt` is the backend-level block signal (`ToConversation` is only surfaced when it is non-null — see `LiveSessionUI.GetConversation`), so the test asserts it directly rather than the client `GetConversation` (which is on `LiveSessionUI`, not `ILiveSessionsBackend`):
+
+```csharp
+    [Fact]
+    public async Task AcceptLatchesDialingCallToConnected()
+    {
+        // arrange — Bob dials Alice; while ringing the session is Dialing (no block: SessionStartedAt null)
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(false);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var chatsBackend = bob.AppServices.GetRequiredService<IChatsBackend>();
+        await backend.StartCall(
+            chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
+
+        // assert — dialing: no live conversation is surfaced (SessionStartedAt gates every block path)
+        (await backend.GetState(chatId, default))!.SessionStartedAt.Should().BeNull();
+
+        // act — Alice answers
+        var chatEnd = (await chatsBackend.GetLidRange(chatId, false, default)).End;
+        await backend.AcceptCall(chatId, aliceAuthor.Id, default);
+
+        // assert — latched: Connected, block surfaced (SessionStartedAt set), VisibleStartLid = answer's chat end
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Call);
+        state.SessionStartedAt.Should().NotBeNull();
+        state.VisibleStartLid.Should().Be(chatEnd);
+        state.AuthorIds.Should().Contain(aliceAuthor.Id);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~AcceptLatchesDialingCallToConnected|FullyQualifiedName~AcceptCallJoinsCall"`
+Expected: FAIL — `AcceptCall` does not set `Kind`/`SessionStartedAt`/`VisibleStartLid` yet, so the call stays Dialing.
+
+- [ ] **Step 3: Implement the latch in `AcceptCall`**
+
+`src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs`, replace the body of `AcceptCall` (~L505-524) with:
+
+```csharp
+    public virtual async Task AcceptCall(ChatId chatId, AuthorId inviteeAuthorId, CancellationToken cancellationToken)
+    {
+        ConversationId? conversationId = null;
+        using (Computed.BeginIsolation())
+        using (await _changeLocks.Lock(chatId, cancellationToken).ConfigureAwait(false)) {
+            var invite = await SafeGetInvite(chatId, inviteeAuthorId).ConfigureAwait(false);
+            if (invite is not { Status: CallInviteStatus.Ringing })
+                return;
+
+            var now = Clocks.SystemClock.Now;
+            await _invites.Set(chatId.Value, inviteeAuthorId.Value,
+                    invite with { Status = CallInviteStatus.Accepted, RespondedAt = now })
+                .ConfigureAwait(false);
+            // Answering joins the call - register now so it's two-party and stays alive before the client streams.
+            await EnsureParticipant(chatId, inviteeAuthorId).ConfigureAwait(false);
+
+            var state = await SafeGet(chatId).ConfigureAwait(false);
+            if (state is { SessionStartedAt: null }) {
+                // The first answer latches a dialing call to Connected: it's now a live conversation, so
+                // surface the block from the chat end at answer time and make it genuinely two-party.
+                var visibleStartLid = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
+                var authorIds = state.AuthorIds.Contains(inviteeAuthorId)
+                    ? state.AuthorIds
+                    : [..state.AuthorIds, inviteeAuthorId];
+                state = state with {
+                    Kind = LiveSessionKind.Call,
+                    SessionStartedAt = now,
+                    VisibleStartLid = visibleStartLid,
+                    AuthorIds = authorIds,
+                    Version = VersionGenerator.NextVersion(state.Version),
+                };
+                await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
+            }
+            conversationId = state?.ConversationId;
+            InvalidateState(chatId);
+        }
+        if (conversationId is { } cid)
+            await DismissRing(cid, [inviteeAuthorId], cancellationToken).ConfigureAwait(false);
+    }
+```
+
+- [ ] **Step 4: Run the tests — verify they pass**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~AcceptLatchesDialingCallToConnected|FullyQualifiedName~AcceptCallJoinsCall"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs tests/Chat.IntegrationTests/LiveSessionsTest.cs
+git commit -m "feat(live): first AcceptCall latches a dialing call to Connected"
+```
+
+---
+
+### Task 3: Ring/close guards honor Dialing; ambient-latch keeps the invariant
+
+**Files:**
+- Modify: `src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs` (ring-timeout guard ~L118; ambient latch ~L290-302; `CloseNow` guard ~L821; `CloseAndMaterialize` call-branch ~L867)
+- Modify: `src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs` (guard ~L47)
+- Test: `tests/Chat.IntegrationTests/LiveSessionsTest.cs` (add `StreamBeforeAcceptLatchesDialingCallToConnected`; `AllDeclinedEndsCall` / `CancelCallEndsTheCall` stay green)
+
+**Interfaces:**
+- Consumes: `LiveSessionState.IsCall`, `LiveSessionKind.Dialing` (Task 1).
+
+- [ ] **Step 1: Add the backstop-latch test (stream before a formal accept)**
+
+In `tests/Chat.IntegrationTests/LiveSessionsTest.cs`, add:
+
+```csharp
+    [Fact]
+    public async Task StreamBeforeAcceptLatchesDialingCallToConnected()
+    {
+        // A dialing call reaching the 2-party stream latch (both parties stream before a formal Accept)
+        // must become Connected - never left as Dialing with SessionStartedAt set (invariant).
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(false);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        await backend.StartCall(
+            chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
+        (await backend.GetState(chatId, default))!.Kind.Should().Be(LiveSessionKind.Dialing);
+
+        // act — both parties stream (no explicit AcceptCall)
+        await backend.OnStreamRegistered(chatId, bobAuthor.Id, null, false, default);
+        await backend.OnStreamRegistered(chatId, aliceAuthor.Id, null, false, default);
+
+        // assert — invariant holds: latched → Connected, not Dialing-with-SessionStartedAt
+        var state = await backend.GetState(chatId, default);
+        state!.SessionStartedAt.Should().NotBeNull();
+        state.Kind.Should().Be(LiveSessionKind.Call);
+    }
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~StreamBeforeAcceptLatchesDialingCallToConnected"`
+Expected: FAIL — the ambient latch sets `SessionStartedAt` but leaves `Kind == Dialing`, violating the invariant.
+
+- [ ] **Step 3: Ambient latch — keep the invariant and gate the banner**
+
+`src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs`, the latch block (~L290-301). Replace it with:
+
+```csharp
+        if (state.SessionStartedAt is null && state.AuthorIds.Count >= 2) {
+            var visibleStartLid = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
+            state = state with {
+                // A dialing call latching here (streamed before a formal accept) becomes a connected call,
+                // never a Dialing session with SessionStartedAt set.
+                Kind = state.Kind == LiveSessionKind.Dialing ? LiveSessionKind.Call : state.Kind,
+                SessionStartedAt = now,
+                VisibleStartLid = visibleStartLid,
+                Version = VersionGenerator.NextVersion(state.Version),
+            };
+            // Calls announce themselves by ringing, not a conversation banner; only ambient sessions banner.
+            if (state.Kind == LiveSessionKind.Ambient)
+                await EnqueueLiveNotification(
+                    state, ConversationNotificationPhase.Started, "Voice chat started", cancellationToken)
+                    .ConfigureAwait(false);
+        }
+```
+
+- [ ] **Step 4: Ring-timeout and close guards — treat Dialing as a call**
+
+Same file. Ring-timeout guard in `GetState` (~L118):
+
+```csharp
+        if (state.IsCall && await HasStaleRinging(chatId).ConfigureAwait(false))
+            _ = ExpireRings(chatId);
+```
+
+`CloseAndMaterialize` call-branch (~L867):
+
+```csharp
+        if (state.IsCall) {
+```
+
+`CloseNow` grace decision (~L821) — a latched transcription session that hands its close to the flow is only ever ambient (a latched call is `Kind == Call`), so state the positive kind for clarity and to keep dialing out:
+
+```csharp
+            if (state is { TranscriptionOn: true, SessionStartedAt: not null, Kind: LiveSessionKind.Ambient }) {
+```
+
+- [ ] **Step 5: Summary-flow guard — same clarity change**
+
+`src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs` (~L47):
+
+```csharp
+            if (live is { TranscriptionOn: true, SessionStartedAt: not null, Kind: LiveSessionKind.Ambient })
+```
+
+- [ ] **Step 6: Run the new test plus the abandoned-close regressions**
+
+Run: `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~StreamBeforeAcceptLatchesDialingCallToConnected|FullyQualifiedName~AllDeclinedEndsCall|FullyQualifiedName~CancelCallEndsTheCall"`
+Expected: PASS — the backstop latches to Connected; a fully-declined or cancelled dialing call still tears down (routes through `CloseAndMaterialize`'s `IsCall` branch, dismisses rings, closes).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs \
+  src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs \
+  tests/Chat.IntegrationTests/LiveSessionsTest.cs
+git commit -m "fix(live): ring/close guards honor Dialing; ambient latch keeps the invariant"
+```
+
+---
+
+### Task 4: Call tab shows "Dialing…"
+
+**Files:**
+- Modify: `src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor`
+- Modify: `src/dotnet/UI.Blazor.App/Components/RightPanel/call-list.css` (only if a new class is introduced; otherwise skip)
+
+**Interfaces:**
+- Consumes: `LiveSession.Kind` (already on the projection) and `LiveSessionKind.Dialing` (Task 1). The projection carries `Kind = state.Kind`, so no new plumbing is needed.
+
+- [ ] **Step 1: Render a "Dialing…" state when the call is dialing**
+
+`src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor`. At the top of the markup, after `var live = m.Session;` and the null guard (~L6-10), the `live` is non-null for a dialing call (Task 1 relaxed `Get`). Add a dialing banner just inside `<div class="call-list-tab">` (before `<div class="c-rules">`):
+
+```razor
+    @if (live.Kind == LiveSessionKind.Dialing) {
+        <div class="c-dialing">Dialing…</div>
+    }
+```
+
+The ringing invitees already render from `live.Invites` in the existing member/invite sections, so no further markup is required. If `call-list.css` exists next to the component, add a minimal rule (padding + muted color) mirroring `.c-empty`; otherwise the default text styling is acceptable and this step needs no CSS.
+
+- [ ] **Step 2: Validate the frontend build**
+
+If the user's `dotnet watch` is running, edit and watch `tmp/watch-web.log` / `tmp/watch-dotnet.log` for `C# and Razor changes applied` (no `error`). Otherwise run:
+
+Run: `npm run build:Verify`
+Expected: clean (no tsc/eslint/build errors). A `.razor`-only change compiles via the .NET build; `build:Verify` is required only if CSS/TS changed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor
+git commit -m "feat(live): Call tab shows a Dialing… state while a call rings"
+```
+
+---
+
+## Verification (after all tasks)
+
+1. `dotnet build ActualChat.CI.slnf` (or the watch loop) — clean.
+2. `dotnet test tests/Chat.IntegrationTests --filter "FullyQualifiedName~LiveSessionsTest"` — all green (existing + new/updated: `StartCallRingsInvitee`, `AcceptCallJoinsCall`, `AcceptLatchesDialingCallToConnected`, `StreamBeforeAcceptLatchesDialingCallToConnected`, `StartCallPromotesExistingSession` (now → Dialing), `StartCallOnLatchedSessionStaysConnected`, `AllDeclinedEndsCall`, `CancelCallEndsTheCall`, `LeaveCallEndsCallBelowTwo`).
+3. Manual two-device pass (peer chat): Bob dials Alice → **Bob sees no conversation block**, Call tab shows "Dialing…", Alice gets the incoming-call ring → Alice accepts → the block appears for both, starting at the answer point. Alice declines/Bob cancels instead → the call vanishes, no block, no notification.
+
+## Reuse
+
+- **Existing abstractions reused:** `SessionStartedAt` (the block/latch signal — untouched at its ~20 gates), `LiveSessionKind` (extended by one value), the invite state machine (`CallInviteStatus`), `IsSessionLive` / `IsCallAbandoned` (keepalive + abandoned-close — unchanged), `LiveSession.Kind` (already projected to the client), `ChatsBackend.GetLidRange` (visible-start lid), `CloseAndMaterialize`/`CloseCall` (close path). No new service, storage, or DB migration.
+- **New components:** `LiveSessionKind.Dialing` (enum value) and the `IsCall` / `IsDialing` computed helpers — both on the shared API model `LiveSessionState` in `ActualChat.Api`, so they are inherently shared; no feature-local-vs-shared placement decision to make.
+```

--- a/docs/superpowers/specs/2026-07-23-live-session-dialing-state-design.md
+++ b/docs/superpowers/specs/2026-07-23-live-session-dialing-state-design.md
@@ -1,0 +1,253 @@
+# Live-Session Dialing State — Design
+
+**Status:** Approved (2026-07-23)
+**Author:** Alexey Kochetov (with Claude)
+**Area:** Live sessions / calls (`LiveSessionsBackend`, `LiveSession*` models, Call tab)
+
+## Problem
+
+When a peer starts a call, `LiveSessionsBackend.StartCall` immediately sets
+`SessionStartedAt = now`. Throughout the codebase `SessionStartedAt != null` is
+*the* "there is a live conversation" signal (~20 gates: client block rendering,
+server conversation projection, split-flow, summary-flow, notifications). So the
+caller's chat shows a **live conversation block the instant they dial**, before
+the other peer has answered — a block for a conversation that isn't happening yet.
+
+The session itself *should* exist while dialing: it drives the Call tab (rules,
+members, mute, ring state). Only the *conversation block* is premature.
+
+## Goal
+
+Introduce an explicit **Dialing** phase for calls: the live session is created
+(so the Call tab works and rings fire) but no live conversation block is
+surfaced until the call is answered. On answer, the session latches and the
+block appears — for all calls (peer and group), uniformly.
+
+## Core model
+
+A call has two phases, distinguished by an explicit `LiveSessionKind` value and,
+in lockstep, by `SessionStartedAt`:
+
+| Phase | `Kind` | `SessionStartedAt` | Block visible? | Call tab? |
+|-------|--------|--------------------|----------------|-----------|
+| Dialing | `Dialing` | `null` | No | Yes |
+| Connected | `Call` | set | Yes | Yes |
+
+**Invariant:** for a call, `Kind == Dialing ⟺ SessionStartedAt == null`. Both
+fields are written together at exactly two sites — `StartCall` (enter Dialing)
+and `AcceptCall` (latch to Connected) — so they cannot drift.
+
+The latch is **monotonic**: once Connected, a session never returns to Dialing.
+Promoting an already-connected ambient session to a call (an already-2-party
+group already showing its block) yields `Kind = Call`, not `Dialing` — its block
+stays.
+
+**Latch trigger:** the first invitee to **accept** (`AcceptCall`). Decline,
+cancel, and no-answer never latch, so those paths leave no block and no
+notification.
+
+### Why this shape
+
+`SessionStartedAt == null` already means "session state exists in Redis, but no
+live conversation yet" everywhere in the code. Keeping `SessionStartedAt` null
+during dialing therefore suppresses the block/summary/split/conversation-
+notification across all ~20 existing gates **by construction** — no gate needs a
+`&& !dialing` clause, so there is no risk of missing one and re-leaking the block.
+
+The explicit `Kind = Dialing` rides on top for legibility: it is inspectable in
+Redis and logs, it already flows to the client via the `LiveSession` projection
+(`Kind = state.Kind`) so the Call tab needs no new field, and it lets the two
+ring-related guards distinguish a call from an ambient session without inferring
+it from `SessionStartedAt`.
+
+## Changes
+
+All server changes are in
+`src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs` unless noted.
+
+### 1. `LiveSessionKind` — add `Dialing`
+
+`src/dotnet/Api/Live/LiveSessionKind.cs`:
+
+```csharp
+public enum LiveSessionKind
+{
+    Ambient = 0,
+    Call = 1,
+    Dialing = 2,
+}
+```
+
+Redis-persisted enum (MemoryPack/MessagePack), **not** a DB column — a new enum
+value is backward compatible and needs no migration. Old Redis states never
+carry `Dialing`.
+
+### 2. `LiveSessionState` — `IsCall` helper
+
+`src/dotnet/Api/Live/LiveSessionState.cs`, alongside the other computed
+(`[IgnoreDataMember, MemoryPackIgnore, IgnoreMember]`) members:
+
+```csharp
+public bool IsCall => Kind is LiveSessionKind.Call or LiveSessionKind.Dialing;
+```
+
+`IsCall` means "this session is a call (dialing or connected)" — the sense the
+ring/close guards need. Bare `Kind == LiveSessionKind.Call` continues to mean
+"connected call".
+
+### 3. `StartCall` — enter Dialing, don't pre-latch
+
+In the `with` that builds the call state (currently ~L477–486):
+
+- `Kind = state?.SessionStartedAt is not null ? LiveSessionKind.Call : LiveSessionKind.Dialing`
+  — a fresh call is Dialing; promoting an already-connected session stays Call.
+- `SessionStartedAt = state?.SessionStartedAt` — preserve an existing latch, but
+  do **not** force `?? now`. A fresh call keeps `SessionStartedAt == null`.
+- `VisibleStartLid = state?.VisibleStartLid ?? 0` — do not compute the chat-end
+  lid here for a fresh call; it is set at the latch (`AcceptCall`). Preserve an
+  existing value for the promotion case.
+
+Everything else in `StartCall` (invites set to `Ringing`, `EnsureParticipant`
+for the caller, `NotifyCall` ring) is unchanged.
+
+### 4. `AcceptCall` — latch Dialing → Connected
+
+In `AcceptCall`, after marking the invite `Accepted` and before/around
+`EnsureParticipant`, when the session is still dialing (`SessionStartedAt is null`):
+
+- `SessionStartedAt = now`
+- `VisibleStartLid` = `ChatsBackend.GetLidRange(chatId, false, ct).End` (chat end
+  at answer — the block starts from the moment the conversation connects)
+- `Kind = LiveSessionKind.Call`
+- add `inviteeAuthorId` to `AuthorIds` if absent (the answer makes it 2-party)
+- bump `Version`
+- write the updated state to Redis
+
+If the session is already connected (`SessionStartedAt` set — a second invitee
+accepting, or a promoted session), accept the invite as today without touching
+the latch fields. Ring dismissal for the accepting invitee is unchanged.
+
+### 5. Ring guards — use `IsCall`
+
+- Ring-timeout, `GetState` (~L118): `state.Kind == LiveSessionKind.Call` →
+  `state.IsCall`. A dialing call must still time out stale rings.
+- `CloseAndMaterialize` (~L867): the call branch `if (state.Kind == LiveSessionKind.Call)`
+  → `if (state.IsCall)`. An abandoned dial must dismiss its rings and close via
+  the call branch (it never materializes: the branch already skips materialize,
+  and `SessionStartedAt is null` would skip it regardless).
+
+The ambient closing-grace guard (~L821, `Kind: not LiveSessionKind.Call`) and the
+summary-flow guard (`LiveConversationSummaryFlow.cs:47`, `Kind: not Call`) already
+exclude dialing calls via their `SessionStartedAt: not null` condition; update them
+to the negated `IsCall` sense (`Kind is not (Call or Dialing)` /
+`not { Kind: Call or Dialing }`) for clarity so a dialing call is never treated as
+ambient. Behavior is unchanged.
+
+### 6. `Get` projection — surface dialing calls
+
+Backend `Get` (~L131): replace the early-out
+
+```csharp
+if (state.SessionStartedAt is null)
+    return null;
+```
+
+with
+
+```csharp
+if (state.SessionStartedAt is null && !state.IsCall)
+    return null;
+```
+
+so a dialing call (null `SessionStartedAt`, `Kind == Dialing`) still projects a
+`LiveSession` for the Call tab. The projection already tolerates a null
+`SessionStartedAt` (`StartedAt = state.SessionStartedAt ?? state.StartedAt`) and
+builds members/invites from participants and the invite map, both populated
+during dialing.
+
+Set `Conversation = state.IsDialing ? null : state.ToConversation()` in the
+projected `LiveSession` so no consumer of `LiveSession.Conversation` can render a
+block while dialing. (Add `IsDialing => Kind == LiveSessionKind.Dialing` as a
+computed helper on `LiveSessionState` for this and the UI.)
+
+### 7. Ambient latch — no "started" banner for calls
+
+The ambient latch (`OnStreamRegistered`, ~L290) fires when
+`SessionStartedAt is null && AuthorIds.Count >= 2`. This is now reachable by a
+dialing call if two parties stream before a formal `AcceptCall` (a backstop). In
+that case it should promote `Dialing → Call` and set `SessionStartedAt`, but must
+**not** send the "voice chat started" *conversation* notification — calls
+announce themselves by ringing, not by a conversation banner (today's behavior).
+
+Gate the notification (currently unconditional at ~L298) on `Kind == Ambient`,
+and in the latch's `with` set `Kind = state.IsCall ? LiveSessionKind.Call : Kind`
+so a backstop-latched dialing call ends up Connected.
+
+### 8. Call tab — "Dialing…" affordance
+
+`src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor`: when
+`live.Kind == LiveSessionKind.Dialing`, show a "Dialing…" state (the ringing
+invitees already render from `live.Invites`). `live.Kind` is already on the
+projection — no new plumbing. Copy/visuals kept minimal.
+
+## What is deliberately unchanged
+
+- The ~20 `SessionStartedAt != null` block/summary/split/notification gates —
+  they suppress during dialing for free because `SessionStartedAt` stays null.
+- Keepalive: `IsSessionLive` keeps a ringing call alive with no streams;
+  `IsCallAbandoned` closes a call once nothing rings and it is still <2-party.
+- `CloseAndMaterialize`: a missed/declined dial has `SessionStartedAt == null`
+  and an empty title → vanishes with no block and no notification.
+- Peer-chat live-session notification suppression (prior commit) — orthogonal.
+- The `IncomingCall` ring path (callee's modal), driven by `NotifyCall` + invite
+  state, not `SessionStartedAt`.
+
+## Edge cases
+
+- **Peer call, answered:** dial (no block, Call tab "Dialing") → accept → latch →
+  block appears for both peers, starting at the answer lid.
+- **Peer call, declined/cancelled/missed:** no ringing invite + <2 participants →
+  `IsCallAbandoned` → close via `IsCall` branch → rings dismissed, session
+  dropped, nothing left.
+- **Group call from a live ambient session:** `StartCall` sees
+  `SessionStartedAt` set → `Kind = Call` (not Dialing) → the existing block stays;
+  new invitees ring.
+- **Stream-before-accept backstop:** two parties stream without a formal accept →
+  ambient latch promotes `Dialing → Call`, sets `SessionStartedAt`, no banner.
+- **Second invitee accepts an already-connected group call:** `SessionStartedAt`
+  already set → accept only, latch untouched.
+
+## Testing
+
+Streaming-backend integration tests (drive `ILiveSessionsBackend`, pattern
+`LiveSessionsTest.cs`):
+
+- `DialingCallHasNoSessionStartedAtAndNoConversation` — after `StartCall`,
+  `Kind == Dialing`, `SessionStartedAt == null`, `GetConversation`/`ToConversation`
+  path yields no block; `Get` is **non-null** (Call tab works).
+- `AcceptLatchesToConnectedCall` — after `AcceptCall`, `Kind == Call`,
+  `SessionStartedAt` set, `VisibleStartLid` = chat end, invitee in `AuthorIds`,
+  the conversation is now surfaced.
+- `DeclinedOrMissedCallVanishesWithoutBlock` — decline / ring-timeout → close;
+  no conversation materialized, no `NotifyConversation` enqueued.
+- `StartCallOnLiveAmbientKeepsBlock` — ambient session already latched → `StartCall`
+  → `Kind == Call`, `SessionStartedAt` preserved, block still surfaced.
+- `RingTimeoutFiresWhileDialing` — a dialing call's stale ring still times out
+  (guards use `IsCall`).
+
+Client display test (`Chat.UI.Blazor.IntegrationTests`, pattern
+`LiveConversationDisplayTest.cs`): a dialing call renders no conversation block;
+after the latch the block renders.
+
+## Reuse
+
+- **Existing abstractions:** `SessionStartedAt` (latch/block signal),
+  `LiveSessionKind` (extended), the invite state machine
+  (`CallInviteStatus.Ringing/Accepted/Declined/Missed`), `IsSessionLive` /
+  `IsCallAbandoned` (keepalive/close), the `LiveSession.Kind` projection
+  (already carries Kind to the client), `ChatsBackend.GetLidRange` (visible-start
+  lid). No new service, storage, or DB migration.
+- **New components:** `LiveSessionKind.Dialing` (enum member) and the computed
+  `IsCall` / `IsDialing` helpers on `LiveSessionState` — inherently shared (they
+  live on the API model in `ActualChat.Api`), no feature-local placement to weigh.
+```

--- a/src/dotnet/Api/Live/LiveSessionKind.cs
+++ b/src/dotnet/Api/Live/LiveSessionKind.cs
@@ -4,4 +4,5 @@ public enum LiveSessionKind
 {
     Ambient = 0,
     Call = 1,
+    Dialing = 2,
 }

--- a/src/dotnet/Api/Live/LiveSessionState.cs
+++ b/src/dotnet/Api/Live/LiveSessionState.cs
@@ -62,6 +62,9 @@ public sealed partial record LiveSessionState
         => new(EffectiveVisibleStartLid, Math.Max(EndEntryLid, EffectiveVisibleStartLid) + 1);
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public ConversationId ConversationId => ConversationId.New(ChatId, EffectiveVisibleStartLid);
+    // Ring id must stay fixed for the whole call, unlike ConversationId, which jumps at the latch.
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public ConversationId RingConversationId => ConversationId.New(ChatId, StartEntryLid);
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public bool IsCall => Kind is LiveSessionKind.Call or LiveSessionKind.Dialing;
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]

--- a/src/dotnet/Api/Live/LiveSessionState.cs
+++ b/src/dotnet/Api/Live/LiveSessionState.cs
@@ -62,6 +62,10 @@ public sealed partial record LiveSessionState
         => new(EffectiveVisibleStartLid, Math.Max(EndEntryLid, EffectiveVisibleStartLid) + 1);
     [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
     public ConversationId ConversationId => ConversationId.New(ChatId, EffectiveVisibleStartLid);
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public bool IsCall => Kind is LiveSessionKind.Call or LiveSessionKind.Dialing;
+    [IgnoreDataMember, MemoryPackIgnore, IgnoreMember]
+    public bool IsDialing => Kind == LiveSessionKind.Dialing;
 
     public Conversation ToConversation()
         => new(ConversationId, Version) {

--- a/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/LiveConversationSummaryFlow.cs
@@ -44,7 +44,7 @@ public sealed partial class LiveConversationSummaryFlow : Flow<Unit>
 
         if (live.IsClosing) {
             // A latched transcription session hands its close to this flow; other shapes are the backend's.
-            if (live is { TranscriptionOn: true, SessionStartedAt: not null, Kind: not LiveSessionKind.Call })
+            if (live is { TranscriptionOn: true, SessionStartedAt: not null, Kind: LiveSessionKind.Ambient })
                 await Finalize(live, cancellationToken).ConfigureAwait(false);
             return;
         }

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -115,7 +115,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
 
         // Prompt ring timeout while this session is observed (the self-heal below re-runs GetState);
         // the RingTtl field expiry in Redis is the backstop when no one observes.
-        if (state.Kind == LiveSessionKind.Call && await HasStaleRinging(chatId).ConfigureAwait(false))
+        if (state.IsCall && await HasStaleRinging(chatId).ConfigureAwait(false))
             _ = ExpireRings(chatId);
 
         computed.Invalidate(SelfHealDelay);
@@ -290,14 +290,18 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         if (state.SessionStartedAt is null && state.AuthorIds.Count >= 2) {
             var visibleStartLid = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
             state = state with {
+                // A dialing call latching here (streamed before a formal accept) becomes a connected call,
+                // never a Dialing session with SessionStartedAt set.
+                Kind = state.Kind == LiveSessionKind.Dialing ? LiveSessionKind.Call : state.Kind,
                 SessionStartedAt = now,
                 VisibleStartLid = visibleStartLid,
                 Version = VersionGenerator.NextVersion(state.Version),
             };
-            // START fires at the 2+ latch for both modes; transcription's later Titled updates the same banner.
-            await EnqueueLiveNotification(
-                state, ConversationNotificationPhase.Started, "Voice chat started", cancellationToken)
-                .ConfigureAwait(false);
+            // Calls announce themselves by ringing, not a conversation banner; only ambient sessions banner.
+            if (state.Kind == LiveSessionKind.Ambient)
+                await EnqueueLiveNotification(
+                    state, ConversationNotificationPhase.Started, "Voice chat started", cancellationToken)
+                    .ConfigureAwait(false);
         }
 
         await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
@@ -837,7 +841,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 return;
             if (await IsSessionLive(chatId).ConfigureAwait(false))
                 return; // someone is (still) streaming - not empty after all
-            if (state is { TranscriptionOn: true, SessionStartedAt: not null, Kind: not LiveSessionKind.Call }) {
+            if (state is { TranscriptionOn: true, SessionStartedAt: not null, Kind: LiveSessionKind.Ambient }) {
                 // Hand the close to LiveConversationSummaryFlow: it runs the final summary pass, decides the
                 // tier, materializes, then calls FinalizeSession. StartClosingGrace marks IsClosing; the 90s
                 // SelfClose stays the backstop if the flow never finalizes.
@@ -883,7 +887,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
 
     private async Task CloseAndMaterialize(LiveSessionState state, CancellationToken cancellationToken)
     {
-        if (state.Kind == LiveSessionKind.Call) {
+        if (state.IsCall) {
             // A voice call has no transcript to materialize - just stop any lingering rings on the
             // invitees' devices, then drop the session.
             var invitees = (await SafeGetInvites(state.ChatId).ConfigureAwait(false))

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -489,7 +489,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 Version = VersionGenerator.NextVersion(state?.Version ?? 0),
             };
             await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
-            conversationId = state.ConversationId;
+            conversationId = state.RingConversationId;
             await EnsureParticipant(chatId, callerAuthorId).ConfigureAwait(false);
             foreach (var invitee in invitees)
                 await _invites.Set(chatId.Value, invitee.Value,
@@ -539,7 +539,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 };
                 await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
             }
-            conversationId = state?.ConversationId;
+            conversationId = state?.RingConversationId;
             InvalidateState(chatId);
         }
         if (conversationId is { } cid)
@@ -559,7 +559,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             await _invites.Set(chatId.Value, inviteeAuthorId.Value,
                     invite with { Status = CallInviteStatus.Declined, RespondedAt = Clocks.SystemClock.Now })
                 .ConfigureAwait(false);
-            conversationId = (await SafeGet(chatId).ConfigureAwait(false))?.ConversationId;
+            conversationId = (await SafeGet(chatId).ConfigureAwait(false))?.RingConversationId;
             InvalidateState(chatId);
             abandoned = await IsCallAbandoned(chatId).ConfigureAwait(false);
         }
@@ -580,7 +580,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             if (state is null)
                 return;
 
-            conversationId = state.ConversationId;
+            conversationId = state.RingConversationId;
             var now = Clocks.SystemClock.Now;
             foreach (var info in (await SafeGetInvites(chatId).ConfigureAwait(false)).Values) {
                 if (info is not { Status: CallInviteStatus.Ringing })
@@ -717,7 +717,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
                 if (state is null)
                     return;
 
-                conversationId = state.ConversationId;
+                conversationId = state.RingConversationId;
                 var now = Clocks.SystemClock.Now;
                 var cutoff = now - RingTimeout;
                 foreach (var info in (await SafeGetInvites(chatId).ConfigureAwait(false)).Values) {
@@ -893,7 +893,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             var invitees = (await SafeGetInvites(state.ChatId).ConfigureAwait(false))
                 .Values.Where(i => i is not null).Select(i => i!.InviteeId).ToList();
             if (invitees.Count > 0)
-                await DismissRing(state.ConversationId, invitees, cancellationToken).ConfigureAwait(false);
+                await DismissRing(state.RingConversationId, invitees, cancellationToken).ConfigureAwait(false);
             await Close(state.ChatId, cancellationToken).ConfigureAwait(false);
             return;
         }

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -511,12 +511,31 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             if (invite is not { Status: CallInviteStatus.Ringing })
                 return;
 
+            var now = Clocks.SystemClock.Now;
             await _invites.Set(chatId.Value, inviteeAuthorId.Value,
-                    invite with { Status = CallInviteStatus.Accepted, RespondedAt = Clocks.SystemClock.Now })
+                    invite with { Status = CallInviteStatus.Accepted, RespondedAt = now })
                 .ConfigureAwait(false);
             // Answering joins the call - register now so it's two-party and stays alive before the client streams.
             await EnsureParticipant(chatId, inviteeAuthorId).ConfigureAwait(false);
-            conversationId = (await SafeGet(chatId).ConfigureAwait(false))?.ConversationId;
+
+            var state = await SafeGet(chatId).ConfigureAwait(false);
+            if (state is { SessionStartedAt: null }) {
+                // The first answer latches a dialing call to Connected: it's now a live conversation, so
+                // surface the block from the chat end at answer time and make it genuinely two-party.
+                var visibleStartLid = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
+                var authorIds = state.AuthorIds.Contains(inviteeAuthorId)
+                    ? state.AuthorIds
+                    : [..state.AuthorIds, inviteeAuthorId];
+                state = state with {
+                    Kind = LiveSessionKind.Call,
+                    SessionStartedAt = now,
+                    VisibleStartLid = visibleStartLid,
+                    AuthorIds = authorIds,
+                    Version = VersionGenerator.NextVersion(state.Version),
+                };
+                await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);
+            }
+            conversationId = state?.ConversationId;
             InvalidateState(chatId);
         }
         if (conversationId is { } cid)

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -128,7 +128,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
         var state = await GetState(chatId, cancellationToken).ConfigureAwait(false);
         if (state is null)
             return null;
-        if (state.SessionStartedAt is null)
+        if (state.SessionStartedAt is null && !state.IsCall)
             return null;
 
         var audio = await LiveAudioBackend.List(chatId, cancellationToken).ConfigureAwait(false);
@@ -196,7 +196,7 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             StartedAt = state.SessionStartedAt ?? state.StartedAt,
             Rules = state.Rules ?? SessionRules.Default,
             Members = members,
-            Conversation = state.ToConversation(),
+            Conversation = state.IsDialing ? null : state.ToConversation(),
             TranscriptionOn = state.TranscriptionOn,
             Version = state.Version,
             Kind = state.Kind,
@@ -471,17 +471,17 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
             var state = await SafeGet(chatId).ConfigureAwait(false);
             var lidRangeEnd = (await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false)).End;
             var startEntryLid = state?.StartEntryLid ?? lidRangeEnd;
-            // A call latches immediately: it is "live" the moment it rings, with the caller alone.
-            // Promote an already-live (ambient) session to a call too, so ring dismissal/close - gated
-            // on Kind == Call - runs for it.
+            // A fresh call is Dialing: the session exists (for the Call tab and the ring) but no live
+            // conversation is surfaced until someone answers, so SessionStartedAt stays null. Promoting an
+            // already-latched (ambient) session keeps it connected so its block and ring/close paths persist.
             state = (state ?? new LiveSessionState { ChatId = chatId, StartEntryLid = startEntryLid }) with {
                 EndEntryLid = state?.EndEntryLid ?? startEntryLid,
                 StartedAt = state?.StartedAt ?? now,
-                SessionStartedAt = state?.SessionStartedAt ?? now,
-                VisibleStartLid = state?.VisibleStartLid is { } vsl && vsl > 0 ? vsl : lidRangeEnd,
+                SessionStartedAt = state?.SessionStartedAt,
+                VisibleStartLid = state?.VisibleStartLid ?? 0,
                 AuthorIds = state?.AuthorIds is { Count: > 0 } ids ? ids : [callerAuthorId],
                 Host = callerAuthorId,
-                Kind = LiveSessionKind.Call,
+                Kind = state?.SessionStartedAt is not null ? LiveSessionKind.Call : LiveSessionKind.Dialing,
                 Version = VersionGenerator.NextVersion(state?.Version ?? 0),
             };
             await _redisScope.Set(chatId.Value, state).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/CallList.razor
@@ -16,6 +16,9 @@
     };
 }
 <div class="call-list-tab">
+    @if (live.Kind == LiveSessionKind.Dialing) {
+        <div class="c-dialing">Dialing…</div>
+    }
     <div class="c-rules">
         <span class="c-rules-title">Rules</span>
         <span class="c-rules-text">@RulesText(live.Rules)</span>

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/call-list.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/call-list.css
@@ -7,6 +7,10 @@
     @apply p-4;
     @apply text-03 text-center;
 }
+.call-list-tab .c-dialing {
+    @apply p-2;
+    @apply text-03 text-center;
+}
 .call-list-tab .c-rules,
 .call-list-tab .c-manage {
     @apply flex-x items-center gap-x-2;

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -774,6 +774,34 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
     }
 
     [Fact]
+    public async Task StreamBeforeAcceptLatchesDialingCallToConnected()
+    {
+        // A dialing call reaching the 2-party stream latch (both parties stream before a formal Accept)
+        // must become Connected - never left as Dialing with SessionStartedAt set (invariant).
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(false);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        await backend.StartCall(
+            chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
+        (await backend.GetState(chatId, default))!.Kind.Should().Be(LiveSessionKind.Dialing);
+
+        // act — both parties stream (no explicit AcceptCall)
+        await backend.OnStreamRegistered(chatId, bobAuthor.Id, null, false, default);
+        await backend.OnStreamRegistered(chatId, aliceAuthor.Id, null, false, default);
+
+        // assert — invariant holds: latched → Connected, not Dialing-with-SessionStartedAt
+        var state = await backend.GetState(chatId, default);
+        state!.SessionStartedAt.Should().NotBeNull();
+        state.Kind.Should().Be(LiveSessionKind.Call);
+    }
+
+    [Fact]
     public async Task LeaveCallEndsCallBelowTwo()
     {
         // arrange

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -694,6 +694,37 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
     }
 
     [Fact]
+    public async Task RingIdSurvivesChatGrowthAcrossLatch()
+    {
+        // arrange — Bob dials Alice
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(false);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        await backend.StartCall(chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
+
+        // the ring is published under this id while dialing; it must stay put for the whole call
+        var dialing = await backend.GetState(chatId, default);
+        var ringId = dialing!.RingConversationId;
+        dialing.ConversationId.Should().Be(ringId, "during dialing the block id and ring id coincide");
+
+        // act — a chat entry lands during the ring, advancing the chat end, then Alice answers
+        await bob.CreateTextEntry(chatId, "grows the chat end during the ring");
+        await backend.AcceptCall(chatId, aliceAuthor.Id, default);
+
+        // assert — the block id moved to the answer point, but the ring id did NOT (so dismissals still match)
+        var connected = await backend.GetState(chatId, default);
+        connected!.RingConversationId.Should()
+            .Be(ringId, "the ring id is latch-stable so DismissRing matches NotifyCall");
+        connected.ConversationId.Should().NotBe(ringId, "the block id legitimately moves to the answer's chat end");
+    }
+
+    [Fact]
     public async Task DeclineKeepsCallWhileAnotherRings()
     {
         // arrange — Bob rings two people

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -680,13 +680,16 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         var chatEnd = (await chatsBackend.GetLidRange(chatId, false, default)).End;
         await backend.AcceptCall(chatId, aliceAuthor.Id, default);
 
+        var chatEndAfter = (await chatsBackend.GetLidRange(chatId, false, default)).End;
+
         // assert — latched: Connected, block surfaced (SessionStartedAt set), VisibleStartLid = answer's chat end
         var state = await backend.GetState(chatId, default);
         state!.Kind.Should().Be(LiveSessionKind.Call);
         state.SessionStartedAt.Should().NotBeNull();
-        // AcceptCall reads the chat end at answer time, strictly after our pre-answer read above,
-        // so a concurrently appended entry can only push it forward, never back.
+        // AcceptCall reads the chat-end lid at answer time, which falls between our pre-answer and
+        // post-answer reads (chat end only grows), so this brackets it without a concurrent-write flake.
         state.VisibleStartLid.Should().BeGreaterThanOrEqualTo(chatEnd);
+        state.VisibleStartLid.Should().BeLessThanOrEqualTo(chatEndAfter);
         state.AuthorIds.Should().Contain(aliceAuthor.Id);
     }
 

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -684,7 +684,9 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         var state = await backend.GetState(chatId, default);
         state!.Kind.Should().Be(LiveSessionKind.Call);
         state.SessionStartedAt.Should().NotBeNull();
-        state.VisibleStartLid.Should().Be(chatEnd);
+        // AcceptCall reads the chat end at answer time, strictly after our pre-answer read above,
+        // so a concurrently appended entry can only push it forward, never back.
+        state.VisibleStartLid.Should().BeGreaterThanOrEqualTo(chatEnd);
         state.AuthorIds.Should().Contain(aliceAuthor.Id);
     }
 

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -649,6 +649,43 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         live!.Invites.Should().ContainSingle(i =>
             i.InviteeId == aliceAuthor.Id && i.Status == CallInviteStatus.Accepted);
         (await backend.ListParticipants(chatId, default)).Should().Contain(aliceAuthor.Id);
+        // the answer latches the dialing call to Connected: block now surfaced
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Call);
+        state.SessionStartedAt.Should().NotBeNull();
+        state.AuthorIds.Should().Contain(aliceAuthor.Id);
+    }
+
+    [Fact]
+    public async Task AcceptLatchesDialingCallToConnected()
+    {
+        // arrange — Bob dials Alice; while ringing the session is Dialing (no block: SessionStartedAt null)
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(false);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        var chatsBackend = bob.AppServices.GetRequiredService<IChatsBackend>();
+        await backend.StartCall(
+            chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
+
+        // assert — dialing: no live conversation is surfaced (SessionStartedAt gates every block path)
+        (await backend.GetState(chatId, default))!.SessionStartedAt.Should().BeNull();
+
+        // act — Alice answers
+        var chatEnd = (await chatsBackend.GetLidRange(chatId, false, default)).End;
+        await backend.AcceptCall(chatId, aliceAuthor.Id, default);
+
+        // assert — latched: Connected, block surfaced (SessionStartedAt set), VisibleStartLid = answer's chat end
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Call);
+        state.SessionStartedAt.Should().NotBeNull();
+        state.VisibleStartLid.Should().Be(chatEnd);
+        state.AuthorIds.Should().Contain(aliceAuthor.Id);
     }
 
     [Fact]

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -611,13 +611,17 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         await backend.StartCall(
             chatId, bobAuthor!.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
 
-        // assert — the call is live at once with the caller alone, and Alice is ringing
+        // assert — a fresh call is Dialing: the session exists (Call tab works) but no live conversation
+        // is surfaced yet, so SessionStartedAt stays null until someone answers.
         var state = await backend.GetState(chatId, default);
         state.Should().NotBeNull();
-        state!.Kind.Should().Be(LiveSessionKind.Call);
-        state.SessionStartedAt.Should().NotBeNull();
+        state!.Kind.Should().Be(LiveSessionKind.Dialing);
+        state.SessionStartedAt.Should().BeNull();
+        // the Call tab still gets a projection while dialing, with the ring visible and no conversation
         var live = await backend.Get(chatId, default);
-        live!.Invites.Should().ContainSingle(i =>
+        live.Should().NotBeNull();
+        live!.Conversation.Should().BeNull();
+        live.Invites.Should().ContainSingle(i =>
             i.InviteeId == aliceAuthor.Id && i.Status == CallInviteStatus.Ringing);
     }
 
@@ -770,10 +774,41 @@ public class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITestOutput
         // act — Bob rings Alice while that session is live
         await backend.StartCall(chatId, bobAuthor.Id, new[] { aliceAuthor!.Id }.ToApiArray(), false, default);
 
-        // assert — the existing session is promoted to a call so ring/close paths apply
+        // assert — promoting an unlatched (solo) ambient session gives a Dialing call: ring/close paths
+        // apply (via IsCall) but no block is surfaced until someone answers.
+        var state = await backend.GetState(chatId, default);
+        state!.Kind.Should().Be(LiveSessionKind.Dialing);
+        state.SessionStartedAt.Should().BeNull();
+        state.Host.Should().Be(bobAuthor.Id);
+    }
+
+    [Fact]
+    public async Task StartCallOnLatchedSessionStaysConnected()
+    {
+        // arrange — a 2-party ambient session is already latched (block visible) when a call starts
+        await using var bob = AppHost.NewBlazorTester(Out);
+        await using var alice = AppHost.NewBlazorTester(Out);
+        await bob.SignInAsUniqueBob();
+        await alice.SignInAsUniqueAlice();
+        var (chatId, inviteId) = await bob.CreateChat(true);
+        await alice.JoinChat(chatId, inviteId);
+        var bobAuthor = await bob.GetOwnAuthor(chatId);
+        var aliceAuthor = await alice.GetOwnAuthor(chatId);
+        var backend = bob.AppServices.GetRequiredService<ILiveSessionsBackend>();
+        await backend.OnStreamRegistered(chatId, bobAuthor!.Id, null, true, default);
+        await backend.OnStreamRegistered(chatId, aliceAuthor!.Id, null, true, default);
+        var latched = await backend.GetState(chatId, default);
+        latched!.SessionStartedAt.Should().NotBeNull("two streamers latched the ambient session");
+        var startedAt = latched.SessionStartedAt;
+
+        // act — Bob rings a third-party author id while that session is live
+        await backend.StartCall(
+            chatId, bobAuthor.Id, new[] { AuthorId.New(chatId, 777_055) }.ToApiArray(), false, default);
+
+        // assert — monotonic: it stays a connected Call with its latch preserved (block stays)
         var state = await backend.GetState(chatId, default);
         state!.Kind.Should().Be(LiveSessionKind.Call);
-        state.Host.Should().Be(bobAuthor.Id);
+        state.SessionStartedAt.Should().Be(startedAt);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

When a peer started a voice call, the live session was created **and** immediately surfaced a live-conversation block — because `StartCall` set `SessionStartedAt`, which is the codebase-wide "there is a live conversation" signal — **before the other peer answered**. The session itself should exist while dialing (it drives the Call tab, rules, members, and the ring), but the conversation block is premature.

## Approach

Introduce an explicit **Dialing** phase for calls:

- **Dialing** = `Kind == Dialing`, `SessionStartedAt == null` → the Call tab works and rings fire, but *no* conversation block (every one of the ~20 `SessionStartedAt != null` gates suppresses it by construction).
- **Connected** = `Kind == Call`, `SessionStartedAt` set → the block appears.

The first invitee to **accept** (`AcceptCall`) latches Dialing → Connected, pinning `VisibleStartLid` to the chat end at answer time. Uniform for peer and group calls; monotonic (promoting an already-latched ambient session stays Connected). Invariant enforced everywhere: for a call, `Kind == Dialing ⟺ SessionStartedAt == null`.

## Changes

- `LiveSessionKind.Dialing` (Redis-only enum value — no DB migration) + computed `IsCall` / `IsDialing` / `RingConversationId` helpers.
- `StartCall` enters Dialing (no pre-latch); `AcceptCall` latches on first answer.
- `Get` projects a dialing call so the Call tab still shows it (with `Conversation = null`).
- Ring-timeout and ring-dismiss guards use `IsCall` (a dialing call still times out / dismisses rings); the ambient-latch backstop promotes Dialing → Call and never banners a call.
- Incoming-call ring notifications key off a **latch-stable** `RingConversationId` (`StartEntryLid`-based), so dismissal still matches publish after the latch moves the conversation id.
- Call tab renders a "Dialing…" affordance while `Kind == Dialing`.

## Tests

`tests/Chat.IntegrationTests/LiveSessionsTest.cs` — dialing shows no conversation; `Get` non-null while dialing; accept latches (Kind/SessionStartedAt/VisibleStartLid/AuthorIds); stream-before-accept backstop keeps the invariant; unlatched-promotion → Dialing, latched-promotion → Connected; ring id survives chat growth across the latch. Full file **38/38**; `npm run build:Verify` clean.

Spec: `docs/superpowers/specs/2026-07-23-live-session-dialing-state-design.md` · Plan: `docs/superpowers/plans/2026-07-23-live-session-dialing-state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)