### PR TITLE
feat(notifications): newest-first coalesced notifications + Android MessagingStyle transcript

### DIFF
--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -279,13 +279,14 @@ public static partial class Constants
             public const string Title = "title";
             public const string Body = "body";
             public const string ImageUrl = "imageUrl";
+            public const string Messages = "messages";
             public const string Timestamp = "timestamp";
             public const string DismissedIds = "dismissedIds";
             public const string DismissedTags = "dismissedTags";
             public const string Silent = "silent";
 
             public static readonly string[] ValidKeys = {
-                Body, ChatId, ChatEntryId, DismissedIds, DismissedTags, LastEntryLocalId, Icon, ImageUrl, Kind, Link, NotificationId, Silent, Tag, Title, Timestamp
+                Body, ChatId, ChatEntryId, DismissedIds, DismissedTags, LastEntryLocalId, Icon, ImageUrl, Kind, Link, Messages, NotificationId, Silent, Tag, Title, Timestamp
             };
 
             public static bool IsValidKey(string key)

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -315,8 +315,10 @@ public static partial class Constants
         // at most MaxMentionReAlerts times per mention.
         public static readonly TimeSpan MentionReAlertInterval = TimeSpan.FromMinutes(10);
         public const int MaxMentionReAlerts = 2;
-        // A first unread message shorter than this rolls the next message into the notification lead.
-        public const int LeadRollInThreshold = 24;
+        // Messages kept verbatim in a coalesced notification (its transcript window); older ones
+        // fold into the "+N earlier messages" tail.
+        public const int MaxRecentMessages = 5;
+        public const int MaxRecentMessageTextLength = 200;
         // Distinct author names shown in a coalesced notification's summary before "+N more".
         public const int MaxSummaryAuthors = 3;
         // Distinct authors tracked on a coalesced notification (bounds the stored set).

--- a/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
+++ b/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
@@ -88,6 +88,21 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
         };
     }
 
+    // Moves the first-unread anchor to newStart: drops now-read messages from the transcript
+    // window and approximates the remaining unread count from the entry span. The caller re-seeds
+    // RecentMessages (from the entry store) when the window empties, then recomposes Text.
+    public ChatEntryRelatedNotification ReAnchorAt(long newStart)
+    {
+        var recentMessages = RecentMessages.Where(m => m.EntryLid >= newStart).ToApiArray();
+        return this with {
+            StartEntryLid = newStart,
+            UnreadCount = (int)Math.Max(1, EntryLid - newStart + 1),
+            RecentMessages = recentMessages,
+            LeadText = recentMessages.IsEmpty ? "" : recentMessages[^1].Text,
+            LeadCount = 1,
+        };
+    }
+
     private static long MinPositive(long a, long b)
         => a <= 0 ? b : b <= 0 ? a : Math.Min(a, b);
 

--- a/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
+++ b/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
@@ -75,7 +75,8 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
         else {
             leadText = e.LeadText;
             leadCount = Math.Max(1, e.LeadCount);
-            var canRollIn = leadText.Length < Constants.Notification.LeadRollInThreshold && !Text.IsNullOrEmpty();
+            var isLeadShort = leadText.Length < Constants.Notification.MaxRecentMessageTextLength;
+            var canRollIn = isLeadShort && !Text.IsNullOrEmpty();
             if (existingUnread == 1 && canRollIn) {
                 leadText = $"{leadText}\n{Text}";
                 leadCount++;

--- a/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
+++ b/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
@@ -19,18 +19,19 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
     public int UnreadCount { get; init; }
     [DataMember(Order = 12), Key(12)]
     public ApiArray<AuthorId> AuthorIds { get; init; }
-    // First unread message body (+ a short next message rolled in) — kept raw so the summary text
-    // can be recomposed without re-reading entries.
+    // Rolling-deploy compat only: old nodes/clients compose from LeadText (= newest message text)
+    // and LeadCount (= 1). New code reads RecentMessages. Remove both in the next release.
     [DataMember(Order = 13), Key(13)]
     public string LeadText { get; init; } = "";
     [DataMember(Order = 14), Key(14)]
     public int BeepCount { get; init; }
     [DataMember(Order = 15), Key(15)]
     public Moment LastBeepAt { get; init; }
-    // Messages included in LeadText (roll-in makes it 2), so the "+N more" tail never counts a
-    // message the lead already shows. Old blobs deserialize this as 0 == 1.
     [DataMember(Order = 17), Key(17)]
     public int LeadCount { get; init; }
+    // The transcript window: last MaxRecentMessages unread messages, oldest -> newest.
+    [DataMember(Order = 18), Key(18)]
+    public ApiArray<NotificationMessage> RecentMessages { get; init; }
 
     // Computed
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
@@ -58,30 +59,10 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
             authorIds = authorIds.With(authorId);
         var startEntryLid = MinPositive(existingStart, incomingStart);
         var entryLid = Math.Max(e.EntryLid, EntryLid);
-
         // Pre-coalescing blobs deserialize UnreadCount as 0 though they represent one unread entry.
         var existingUnread = Math.Max(1, e.UnreadCount);
-        string leadText;
-        int leadCount;
-        if (incomingStart > 0 && incomingStart < existingStart) {
-            leadText = Text; // this message is now the earliest unread -> it becomes the lead
-            leadCount = 1;
-        }
-        else if (e.LeadText.IsNullOrEmpty()) {
-            // A legacy existing without a lead falls back to its own text (its latest message).
-            leadText = e.Text.IsNullOrEmpty() ? Text : e.Text;
-            leadCount = 1;
-        }
-        else {
-            leadText = e.LeadText;
-            leadCount = Math.Max(1, e.LeadCount);
-            var isLeadShort = leadText.Length < Constants.Notification.MaxRecentMessageTextLength;
-            var canRollIn = isLeadShort && !Text.IsNullOrEmpty();
-            if (existingUnread == 1 && canRollIn) {
-                leadText = $"{leadText}\n{Text}";
-                leadCount++;
-            }
-        }
+        var recentMessages = MergeRecentMessages(e, this);
+        var newestIsIncoming = EntryLid >= e.EntryLid;
 
         // A gap between messages long enough to count as a conversation lull resets the beep
         // back-off, so this fresh message alerts immediately instead of inheriting the back-off.
@@ -90,14 +71,18 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
             Version = e.Version,
             CreatedAt = e.CreatedAt,
             HandledAt = null,
-            // An out-of-order earlier message must not regress the newest-activity timestamp.
+            // An out-of-order earlier message must not regress the newest-activity timestamp,
+            // and the banner headline (title/icon) must keep tracking the newest message.
             SentAt = Moment.Max(e.SentAt, SentAt),
+            Title = newestIsIncoming ? Title : e.Title,
+            IconUrl = newestIsIncoming ? IconUrl : e.IconUrl,
             EntryLid = entryLid,
             StartEntryLid = startEntryLid,
             UnreadCount = existingUnread + 1,
             AuthorIds = authorIds,
-            LeadText = leadText,
-            LeadCount = leadCount,
+            RecentMessages = recentMessages,
+            LeadText = recentMessages.IsEmpty ? "" : recentMessages[^1].Text,
+            LeadCount = 1,
             BeepCount = isLull ? 0 : e.BeepCount,
             LastBeepAt = isLull ? default : e.LastBeepAt,
         };
@@ -105,4 +90,31 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
 
     private static long MinPositive(long a, long b)
         => a <= 0 ? b : b <= 0 ? a : Math.Min(a, b);
+
+    private static ApiArray<NotificationMessage> MergeRecentMessages(
+        ChatEntryRelatedNotification existing, ChatEntryRelatedNotification incoming)
+    {
+        var messages = new List<NotificationMessage>(existing.RecentMessages.Count + 1);
+        messages.AddRange(GetRecentMessages(existing));
+        foreach (var message in GetRecentMessages(incoming))
+            if (messages.All(m => m.EntryLid != message.EntryLid))
+                messages.Add(message);
+        messages.Sort((a, b) => a.EntryLid.CompareTo(b.EntryLid));
+        if (messages.Count > Constants.Notification.MaxRecentMessages)
+            messages.RemoveRange(0, messages.Count - Constants.Notification.MaxRecentMessages);
+        return messages.ToApiArray();
+    }
+
+    // Pre-RecentMessages blobs carry their text in LeadText/Text; synthesize a message so the
+    // merge upgrades them in place (empty author name -> the line renders without a prefix).
+    private static IEnumerable<NotificationMessage> GetRecentMessages(ChatEntryRelatedNotification n)
+    {
+        if (!n.RecentMessages.IsEmpty)
+            return n.RecentMessages;
+
+        var text = n.LeadText.IsNullOrEmpty() ? n.Text : n.LeadText;
+        return text.IsNullOrEmpty()
+            ? []
+            : [NotificationMessage.New(n.AuthorId ?? default, "", text, n.EntryLid, n.SentAt)];
+    }
 }

--- a/src/dotnet/Api/Notifications/NotificationMessage.cs
+++ b/src/dotnet/Api/Notifications/NotificationMessage.cs
@@ -1,0 +1,34 @@
+namespace ActualChat.Notifications;
+/// <summary>
+/// One message inside a coalesced chat notification: a display-ready snapshot (author name
+/// resolved at send time) kept in <see cref="ChatEntryRelatedNotification.RecentMessages"/>.
+/// </summary>
+[DataContract, MessagePackObject]
+public sealed partial record NotificationMessage : ISanitized
+{
+    [DataMember(Order = 0), Key(0)]
+    public AuthorId AuthorId { get; init; }
+    [DataMember(Order = 1), Key(1)]
+    public string AuthorName { get => Sanitizer.MaskPrivate(field); init; } = "";
+    [DataMember(Order = 2), Key(2)]
+    public string Text { get => Sanitizer.MaskPrivate(field); init; } = "";
+    [DataMember(Order = 3), Key(3)]
+    public long EntryLid { get; init; }
+    [DataMember(Order = 4), Key(4)]
+    public Moment SentAt { get; init; }
+    public static NotificationMessage New(
+        AuthorId authorId, string authorName, string text,
+        long entryLid, Moment sentAt)
+        => new() {
+            AuthorId = authorId,
+            AuthorName = authorName,
+            Text = Truncate(text),
+            EntryLid = entryLid,
+            SentAt = sentAt,
+        };
+    // Private methods
+    private static string Truncate(string text)
+        => text.Length <= Constants.Notification.MaxRecentMessageTextLength
+            ? text
+            : text[..(Constants.Notification.MaxRecentMessageTextLength - 1)] + "…";
+}

--- a/src/dotnet/Api/Notifications/PushMessage.cs
+++ b/src/dotnet/Api/Notifications/PushMessage.cs
@@ -1,0 +1,44 @@
+namespace ActualChat.Notifications;
+
+/// <summary>
+/// JSON wire form of one <see cref="NotificationMessage"/> in the push payload's "messages" data
+/// key (oldest -> newest); short property names keep the FCM message under its 4KB limit.
+/// </summary>
+public sealed record PushMessage(
+    [property: JsonPropertyName("n")] string AuthorName,
+    [property: JsonPropertyName("t")] string Text,
+    [property: JsonPropertyName("ts")] long SentAtMs)
+{
+    public const int MaxJsonLength = 2500;
+
+    public static List<PushMessage> From(ApiArray<NotificationMessage> messages)
+        => messages
+            .Select(m => new PushMessage(m.AuthorName, m.Text, (long)m.SentAt.EpochOffset.TotalMilliseconds))
+            .ToList();
+
+    public static string ToJson(ApiArray<NotificationMessage> messages)
+    {
+        // Drops oldest messages while the JSON exceeds the budget, so this key alone can't push
+        // the whole FCM message over its 4KB limit.
+        var items = From(messages);
+        var json = JsonSerializer.Serialize(items);
+        while (items.Count > 1 && json.Length > MaxJsonLength) {
+            items.RemoveAt(0);
+            json = JsonSerializer.Serialize(items);
+        }
+        return json;
+    }
+
+    public static IReadOnlyList<PushMessage> FromJson(string? json)
+    {
+        if (json.IsNullOrEmpty())
+            return [];
+
+        try {
+            return JsonSerializer.Deserialize<List<PushMessage>>(json) ?? [];
+        }
+        catch (JsonException) {
+            return [];
+        }
+    }
+}

--- a/src/dotnet/Api/Notifications/PushMessage.cs
+++ b/src/dotnet/Api/Notifications/PushMessage.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace ActualChat.Notifications;
 
 /// <summary>
@@ -16,17 +18,18 @@ public sealed record PushMessage(
             .Select(m => new PushMessage(m.AuthorName, m.Text, (long)m.SentAt.EpochOffset.TotalMilliseconds))
             .ToList();
 
-    public static string ToJson(ApiArray<NotificationMessage> messages, int maxLength = MaxJsonLength)
+    public static string ToJson(ApiArray<NotificationMessage> messages, int maxByteLength = MaxJsonLength)
     {
         // Drops oldest messages while the JSON exceeds the budget; returns "" when even the newest
         // alone can't fit, so this key alone can't push the whole FCM message over its 4KB limit.
+        // The budget is UTF-8 bytes (what FCM counts), not chars.
         var items = From(messages);
         var json = JsonSerializer.Serialize(items);
-        while (items.Count > 1 && json.Length > maxLength) {
+        while (items.Count > 1 && Encoding.UTF8.GetByteCount(json) > maxByteLength) {
             items.RemoveAt(0);
             json = JsonSerializer.Serialize(items);
         }
-        return json.Length > maxLength ? "" : json;
+        return Encoding.UTF8.GetByteCount(json) > maxByteLength ? "" : json;
     }
 
     public static IReadOnlyList<PushMessage> FromJson(string? json)

--- a/src/dotnet/Api/Notifications/PushMessage.cs
+++ b/src/dotnet/Api/Notifications/PushMessage.cs
@@ -16,17 +16,17 @@ public sealed record PushMessage(
             .Select(m => new PushMessage(m.AuthorName, m.Text, (long)m.SentAt.EpochOffset.TotalMilliseconds))
             .ToList();
 
-    public static string ToJson(ApiArray<NotificationMessage> messages)
+    public static string ToJson(ApiArray<NotificationMessage> messages, int maxLength = MaxJsonLength)
     {
-        // Drops oldest messages while the JSON exceeds the budget, so this key alone can't push
-        // the whole FCM message over its 4KB limit.
+        // Drops oldest messages while the JSON exceeds the budget; returns "" when even the newest
+        // alone can't fit, so this key alone can't push the whole FCM message over its 4KB limit.
         var items = From(messages);
         var json = JsonSerializer.Serialize(items);
-        while (items.Count > 1 && json.Length > MaxJsonLength) {
+        while (items.Count > 1 && json.Length > maxLength) {
             items.RemoveAt(0);
             json = JsonSerializer.Serialize(items);
         }
-        return json;
+        return json.Length > maxLength ? "" : json;
     }
 
     public static IReadOnlyList<PushMessage> FromJson(string? json)

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
@@ -1,5 +1,6 @@
 using Android.App;
 using AndroidX.Core.App;
+using ActualChat.Notifications;
 using ActualChat.UI.Blazor.App.Services;
 
 namespace ActualChat.App.Maui;
@@ -38,7 +39,8 @@ public class AndroidDeviceNotifications : IDeviceNotifications
             var info = active.FirstOrDefault(x => x.Tag == tag);
             if (info != null)
                 // Healing a dropped banner must not alert — it's a reconcile, not a new event.
-                NotificationHelper.ShowChatNotification(info.Tag, info.Title, info.Text, info.IconUrl, info.Url, silent: true);
+                NotificationHelper.ShowChatNotification(info.Tag, info.Title, info.Text, info.IconUrl, info.Url,
+                    silent: true, messages: info.Messages.IsEmpty ? null : PushMessage.From(info.Messages));
         }
         return Task.CompletedTask;
     }

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
@@ -181,6 +181,7 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
     private void ShowChatMessageNotification(NotificationData data)
     {
         Log.LogDebug("-> ShowChatMessageNotification, text: '{Text}', silent: {Silent}", data.Body!.ToPrivate(), data.Silent);
-        NotificationHelper.ShowChatNotification(data.Tag!, data.Title!, data.Body!, data.ImageUrl, data.Link, data.Silent);
+        NotificationHelper.ShowChatNotification(
+            data.Tag!, data.Title!, data.Body!, data.ImageUrl, data.Link, data.Silent, data.Messages);
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationData.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationData.cs
@@ -53,6 +53,10 @@ public class NotificationData(string messageId, Dictionary<string, string> data)
     public string? Tag
         => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Tag, "").NullIfEmpty();
 
+    // Structured transcript lines for MessagingStyle rendering; empty when the push predates them.
+    public IReadOnlyList<PushMessage> Messages
+        => PushMessage.FromJson(data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Messages));
+
     // A silent update refreshes the banner content without alerting (sound/vibration).
     public bool Silent
         => bool.TryParse(data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Silent), out var silent) && silent;

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
@@ -1,3 +1,4 @@
+using ActualChat.Notifications;
 using Android.App;
 using Android.Content;
 using Android.Graphics;
@@ -33,7 +34,9 @@ public static class NotificationHelper
 
     // Builds and shows a chat notification under the given tag. Shared by the FCM receive path
     // and the client reconciler's create-missing path so they stay identical.
-    public static void ShowChatNotification(string tag, string title, string body, string? imageUrl, string? link, bool silent = false)
+    public static void ShowChatNotification(
+        string tag, string title, string body, string? imageUrl, string? link,
+        bool silent = false, IReadOnlyList<PushMessage>? messages = null)
     {
         var context = Application.Context;
         var contentIntent = CreateViewIntent(context, link);
@@ -51,15 +54,17 @@ public static class NotificationHelper
             // A silent update re-posts under the same tag without alerting again.
             .SetSilent(silent)!
             .SetPriority((int)NotificationPriority.High)!;
-        builder.SetStyle(CreateStyle(title, body, largeImage));
+        builder.SetStyle(CreateStyle(title, body, largeImage, messages));
         if (largeImage != null)
             builder.SetLargeIcon(largeImage);
         NotificationManagerCompat.From(context)!.Notify(tag, 0, builder.Build());
     }
 
-    // Telegram-style rendering: show the sender + the (possibly multi-line, coalesced) body as a
-    // conversation card that expands to the full text; falls back to a plain expandable block.
-    private static NotificationCompat.Style CreateStyle(string title, string body, Bitmap? largeImage)
+    // Telegram-style rendering: one MessagingStyle line per pushed message (sender + text +
+    // timestamp) when structured messages are present; single-message and BigTextStyle fallbacks
+    // keep old-server pushes and non-chat titles working.
+    private static NotificationCompat.Style CreateStyle(
+        string title, string body, Bitmap? largeImage, IReadOnlyList<PushMessage>? messages)
     {
         var bigText = new NotificationCompat.BigTextStyle().BigText(body)!;
         var (senderName, conversationTitle) = SplitTitle(title);
@@ -67,17 +72,34 @@ public static class NotificationHelper
             return bigText;
 
         try {
-            var senderBuilder = new Person.Builder().SetName(senderName)!;
-            if (largeImage != null)
-                senderBuilder.SetIcon(IconCompat.CreateWithBitmap(largeImage));
-            var sender = senderBuilder.Build();
             var self = new Person.Builder().SetName("You")!.Build();
             var style = new NotificationCompat.MessagingStyle(self);
             if (!conversationTitle.IsNullOrEmpty()) {
                 style.SetGroupConversation(true);
                 style.SetConversationTitle(conversationTitle);
             }
-            style.AddMessage(body, Java.Lang.JavaSystem.CurrentTimeMillis(), sender);
+            if (messages is { Count: > 0 }) {
+                // Only the newest sender carries the avatar — it's the banner headline's icon.
+                var newestName = messages[^1].AuthorName.NullIfEmpty() ?? senderName;
+                var persons = new Dictionary<string, Person>();
+                foreach (var message in messages) {
+                    var name = message.AuthorName.NullIfEmpty() ?? senderName;
+                    if (!persons.TryGetValue(name, out var person)) {
+                        var personBuilder = new Person.Builder().SetName(name)!;
+                        if (name == newestName && largeImage != null)
+                            personBuilder.SetIcon(IconCompat.CreateWithBitmap(largeImage));
+                        person = personBuilder.Build();
+                        persons.Add(name, person);
+                    }
+                    style.AddMessage(message.Text, message.SentAtMs, person);
+                }
+            }
+            else {
+                var senderBuilder = new Person.Builder().SetName(senderName)!;
+                if (largeImage != null)
+                    senderBuilder.SetIcon(IconCompat.CreateWithBitmap(largeImage));
+                style.AddMessage(body, Java.Lang.JavaSystem.CurrentTimeMillis(), senderBuilder.Build());
+            }
             return style;
         }
         catch (Exception e) {

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -80,6 +80,13 @@ public class FirebaseMessagingClient(
         };
         if (lastEntryLocalId > 0)
             data.Add(Constants.Notification.MessageDataKeys.LastEntryLocalId, lastEntryLocalId.ToString());
+        var androidData = new Dictionary<string, string>() {
+            { Constants.Notification.MessageDataKeys.Title, title },
+            { Constants.Notification.MessageDataKeys.Body, content },
+            { Constants.Notification.MessageDataKeys.ImageUrl, absoluteIconUrl },
+        };
+        if (notification is ChatEntryRelatedNotification { RecentMessages.Count: > 0 } coalesced)
+            androidData.Add(Constants.Notification.MessageDataKeys.Messages, PushMessage.ToJson(coalesced.RecentMessages));
         var multicastMessage = new MulticastMessage {
             Tokens = deviceIds.Select(id => id.Value).ToList(),
             // We do not specify Notification instance, because we use Data messages to deliver notifications to Android
@@ -88,11 +95,7 @@ public class FirebaseMessagingClient(
             Android = new AndroidConfig {
                 // We do not specify Notification instance, because we use Data messages to deliver notifications to Android
                 // Notification = default,
-                Data = new Dictionary<string, string>() {
-                    { Constants.Notification.MessageDataKeys.Title, title },
-                    { Constants.Notification.MessageDataKeys.Body, content },
-                    { Constants.Notification.MessageDataKeys.ImageUrl, absoluteIconUrl },
-                },
+                Data = androidData,
                 Priority = Priority.High,
                 // CollapseKey = default, /* We don't use collapsible messages */
                 TimeToLive = TimeSpan.FromDays(10),

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FirebaseAdmin.Messaging;
 
 namespace ActualChat.Notifications;
@@ -9,6 +10,9 @@ public class FirebaseMessagingClient(
     ILogger<FirebaseMessagingClient> log)
     : IFirebaseMessagingClient
 {
+    private const int MaxFcmPayloadBytes = 4096;
+    private const int FcmPayloadMargin = 512;
+
     private UrlMapper UrlMapper { get; } = urlMapper;
     private FirebaseMessaging FirebaseMessaging { get; } = firebaseMessaging;
     private ICommander Commander { get; } = commander;
@@ -85,8 +89,17 @@ public class FirebaseMessagingClient(
             { Constants.Notification.MessageDataKeys.Body, content },
             { Constants.Notification.MessageDataKeys.ImageUrl, absoluteIconUrl },
         };
-        if (notification is ChatEntryRelatedNotification { RecentMessages.Count: > 0 } coalesced)
-            androidData.Add(Constants.Notification.MessageDataKeys.Messages, PushMessage.ToJson(coalesced.RecentMessages));
+        if (notification is ChatEntryRelatedNotification { RecentMessages.Count: > 0 } coalesced) {
+            // FCM rejects messages over 4KB, which would drop the push entirely — so the transcript
+            // key gets only the space the other data values leave, and is omitted when even one
+            // message can't fit (the Body fallback still renders).
+            var usedBytes = data.Concat(androidData)
+                .Sum(kv => Encoding.UTF8.GetByteCount(kv.Key) + Encoding.UTF8.GetByteCount(kv.Value));
+            var budget = Math.Min(PushMessage.MaxJsonLength, MaxFcmPayloadBytes - FcmPayloadMargin - usedBytes);
+            var json = PushMessage.ToJson(coalesced.RecentMessages, budget);
+            if (!json.IsNullOrEmpty())
+                androidData.Add(Constants.Notification.MessageDataKeys.Messages, json);
+        }
         var multicastMessage = new MulticastMessage {
             Tokens = deviceIds.Select(id => id.Value).ToList(),
             // We do not specify Notification instance, because we use Data messages to deliver notifications to Android

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -42,17 +42,25 @@ public static class NotificationHelper
         return names.IsNullOrEmpty() ? "Voice chat started" : $"{names} started a voice chat";
     }
 
-    public static string GetAggregatedText(string leadText, IReadOnlyList<string> authorNames, int moreCount)
+    public static string ComposeAggregatedText(ChatEntryRelatedNotification notification)
     {
-        // moreCount counts messages beyond those LeadText already shows, so a rolled-in lead
-        // never produces a "+1 more" for a message the user is looking at.
-        if (moreCount <= 0)
-            return leadText;
+        var messages = notification.RecentMessages;
+        if (messages.IsEmpty)
+            return notification.LeadText.IsNullOrEmpty() ? notification.Text : notification.LeadText;
 
-        var namePart = string.Join(", ", authorNames.Take(Constants.Notification.MaxSummaryAuthors));
-        var moreText = moreCount == 1 ? "+1 more message" : $"+{moreCount} more messages";
-        var tail = namePart.IsNullOrEmpty() ? moreText : $"{namePart} · {moreText}";
-        return $"{leadText}\n{tail}";
+        // Newest first: collapsed banners show only the first line(s), and that must be the
+        // latest message, not the oldest unread one.
+        var showAuthorNames = notification.ChatId.GetThreadOutermostParentOrSelf().Kind
+            is ChatKind.Group or ChatKind.Place;
+        var lines = new List<string>(messages.Count + 1);
+        for (var i = messages.Count - 1; i >= 0; i--) {
+            var m = messages[i];
+            lines.Add(showAuthorNames && !m.AuthorName.IsNullOrEmpty() ? $"{m.AuthorName}: {m.Text}" : m.Text);
+        }
+        var moreCount = notification.UnreadCount - messages.Count;
+        if (moreCount > 0)
+            lines.Add(moreCount == 1 ? "+1 earlier message" : $"+{moreCount} earlier messages");
+        return string.Join('\n', lines);
     }
 
     public static async ValueTask<(string Content, HashSet<MentionRef> MentionIds)> GetText(

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -1001,6 +1001,9 @@ public class NotificationsBackend(IServiceProvider services)
                     StartEntryLid = entryLid,
                     UnreadCount = 1,
                     AuthorIds = new[] { changeAuthor.Id }.ToApiArray(),
+                    RecentMessages = new[] {
+                        NotificationMessage.New(changeAuthor.Id, changeAuthor.Avatar.Name, content, entryLid, now),
+                    }.ToApiArray(),
                     LeadText = content,
                     LeadCount = 1,
                 };

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -1338,7 +1338,7 @@ public class NotificationsBackend(IServiceProvider services)
                 }
 
                 var shouldBeep = NotificationBeepPolicy.ShouldBeep(related.Kind, related.BeepCount, related.LastBeepAt, now);
-                var text = await ComposeAggregatedText(related, cancellationToken).ConfigureAwait(false);
+                var text = NotificationHelper.ComposeAggregatedText(related);
                 var updated = related with {
                     Text = text,
                     BeepCount = shouldBeep ? related.BeepCount + 1 : related.BeepCount,
@@ -1375,49 +1375,32 @@ public class NotificationsBackend(IServiceProvider services)
         }
     }
 
-    // Moves a coalesced notification's first-unread anchor to newStart, refreshing its lead text
-    // from that entry and approximating the remaining unread count from the entry-id span.
+    // Partial read: drops now-read messages via ReAnchorAt; when every shown message was read,
+    // re-seeds the window from the first still-unread entry so the banner isn't left textless.
     private async Task<ChatEntryRelatedNotification> ReAnchor(
         ChatEntryRelatedNotification related, long newStart, CancellationToken cancellationToken)
     {
-        var unreadCount = (int)Math.Max(1, related.EntryLid - newStart + 1);
-        var leadText = related.LeadText ?? "";
-        var entry = await ChatsBackend
-            .GetEntry(ChatEntryId.New(related.ChatId, newStart), TimeSpan.Zero, cancellationToken)
-            .ConfigureAwait(false);
-        if (entry is { IsSystemEntry: false }) {
-            var (text, _) = await NotificationHelper
-                .GetText(entry, MarkupConsumer.Notification, ChatMarkupHubFactory, cancellationToken)
+        var updated = related.ReAnchorAt(newStart);
+        if (updated.RecentMessages.IsEmpty) {
+            var entry = await ChatsBackend
+                .GetEntry(ChatEntryId.New(related.ChatId, newStart), TimeSpan.Zero, cancellationToken)
                 .ConfigureAwait(false);
-            leadText = text;
+            if (entry is { IsSystemEntry: false }) {
+                var (text, _) = await NotificationHelper
+                    .GetText(entry, MarkupConsumer.Notification, ChatMarkupHubFactory, cancellationToken)
+                    .ConfigureAwait(false);
+                var author = await AuthorsBackend
+                    .Get(related.ChatId, entry.AuthorId, RequestedAuthorKind.Full, cancellationToken)
+                    .ConfigureAwait(false);
+                var message = NotificationMessage.New(
+                    entry.AuthorId, author?.Avatar.Name ?? "", text, entry.LocalId, entry.BeginsAt);
+                updated = updated with {
+                    RecentMessages = new[] { message }.ToApiArray(),
+                    LeadText = message.Text,
+                };
+            }
         }
-        var updated = related with {
-            StartEntryLid = newStart,
-            UnreadCount = unreadCount,
-            LeadText = leadText,
-            LeadCount = 1,
-        };
-        return (ChatEntryRelatedNotification)(updated with {
-            Text = await ComposeAggregatedText(updated, cancellationToken).ConfigureAwait(false),
-        });
-    }
-
-    private async Task<string> ComposeAggregatedText(ChatEntryRelatedNotification notification, CancellationToken cancellationToken)
-    {
-        var leadText = notification.LeadText.IsNullOrEmpty() ? notification.Text : notification.LeadText;
-        var moreCount = notification.UnreadCount - Math.Max(1, notification.LeadCount);
-        if (moreCount <= 0)
-            return leadText;
-
-        var names = new List<string>();
-        foreach (var authorId in notification.AuthorIds.Take(Constants.Notification.MaxSummaryAuthors)) {
-            var author = await AuthorsBackend
-                .Get(notification.ChatId, authorId, RequestedAuthorKind.Full, cancellationToken)
-                .ConfigureAwait(false);
-            if (author is { } a)
-                names.Add(a.Avatar.Name);
-        }
-        return NotificationHelper.GetAggregatedText(leadText, names, moreCount);
+        return updated with { Text = NotificationHelper.ComposeAggregatedText(updated) };
     }
 
     // Banner grouping key = the client push tag. Uses the shared NotificationExt.GetPushTag so

--- a/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
+++ b/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
@@ -1,3 +1,5 @@
+using ActualChat.Notifications;
+
 namespace ActualChat.UI.Blazor.App.Services;
 
 // Per-platform access to the device's OS-level notifications, used by NotificationReconciler to
@@ -23,4 +25,5 @@ public sealed record ActiveNotificationInfo(
     string Title,
     string Text,
     string IconUrl,
-    string Url);
+    string Url,
+    ApiArray<NotificationMessage> Messages = default);

--- a/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
@@ -92,6 +92,7 @@ public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
                 x.Notification.Title,
                 x.Notification.Text,
                 x.Notification.IconUrl,
-                UrlMapper.ToAbsolute(x.Notification.GetChatLink())))
+                UrlMapper.ToAbsolute(x.Notification.GetChatLink()),
+                (x.Notification as ChatEntryRelatedNotification)?.RecentMessages ?? default))
             .ToList();
 }

--- a/tests/Notifications.IntegrationTests/NotificationAggregationTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationAggregationTest.cs
@@ -99,25 +99,26 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
         merged.StartEntryId.Should().Be(ChatEntryId.New(TestChatId, 100));
         merged.UnreadCount.Should().Be(2);
         merged.AuthorIds.Should().BeEquivalentTo(new[] { author1, author2 });
-        merged.LeadText.Should().Be("Hey team, here is the long first message");
+        merged.RecentMessages.Select(m => m.Text)
+            .Should().Equal("Hey team, here is the long first message", "second");
+        merged.LeadText.Should().Be("second");
+        merged.LeadCount.Should().Be(1);
     }
 
     [Fact]
-    public void MergeRollsInShortFirstMessage()
+    public void MergeEvictsOldestBeyondCapacity()
     {
         var author1 = AuthorId.New(TestChatId, 1);
-        var first = NewMessage(100, author1, "Hi");
-        var second = NewMessage(101, author1, "are you there?");
-
-        var info = new UserNotificationInfo(TestUserId)
-            .WithNotification(first)
-            .WithNotification(second);
+        var info = new UserNotificationInfo(TestUserId);
+        for (var lid = 100; lid < 107; lid++)
+            info = info.WithNotification(NewMessage(lid, author1, $"m{lid}"));
 
         var merged = (MessageNotification)info.Displayed.Single();
-        merged.LeadText.Should().Be("Hi\nare you there?");
-        merged.LeadCount.Should().Be(2);
-        merged.AuthorIds.Should().ContainSingle().Which.Should().Be(author1);
-        merged.UnreadCount.Should().Be(2);
+        merged.UnreadCount.Should().Be(7);
+        merged.RecentMessages.Should().HaveCount(Constants.Notification.MaxRecentMessages);
+        merged.RecentMessages.Select(m => m.Text).Should().Equal("m102", "m103", "m104", "m105", "m106");
+        merged.StartEntryLid.Should().Be(100);
+        merged.LeadText.Should().Be("m106");
     }
 
     [Fact]
@@ -136,28 +137,30 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
 
         var merged = (MessageNotification)info.Displayed.Single();
         merged.UnreadCount.Should().Be(2);
-        merged.LeadText.Should().Be("Hi\nare you there?");
-        merged.LeadCount.Should().Be(2);
+        merged.RecentMessages.Select(m => m.Text).Should().Equal("Hi", "are you there?");
+        merged.LeadText.Should().Be("are you there?");
+        merged.LeadCount.Should().Be(1);
         merged.StartEntryLid.Should().Be(100);
         merged.EntryLid.Should().Be(101);
     }
 
     [Fact]
-    public void MergeKeepsNewestSentAtOnOutOfOrderMerge()
+    public void MergeKeepsNewestSentAtAndTitleOnOutOfOrderMerge()
     {
         var author1 = AuthorId.New(TestChatId, 1);
         var t0 = Moment.Now;
         var t1 = t0 + TimeSpan.FromSeconds(30);
-        var existing = NewMessage(101, author1, "second") with { SentAt = t1 };
-        var late = NewMessage(100, author1, "first") with { SentAt = t0 };
+        var existing = NewMessage(101, author1, "second") with { SentAt = t1, Title = "Bob @ Chat" };
+        var late = NewMessage(100, author1, "first") with { SentAt = t0, Title = "Alice @ Chat" };
 
-        // The delayed earlier message becomes the lead, but must not regress the timestamp
-        // (a regressed SentAt would fake a lull and reset the beep back-off mid-burst).
+        // The delayed earlier message extends the window, but must regress neither the timestamp
+        // (a regressed SentAt would fake a lull) nor the headline (title tracks the newest message).
         var merged = (MessageNotification)late.MergeWith(existing);
         merged.SentAt.Should().Be(t1);
+        merged.Title.Should().Be("Bob @ Chat");
         merged.StartEntryLid.Should().Be(100);
-        merged.LeadText.Should().Be("first");
-        merged.LeadCount.Should().Be(1);
+        merged.RecentMessages.Select(m => m.Text).Should().Equal("first", "second");
+        merged.LeadText.Should().Be("second");
         merged.UnreadCount.Should().Be(2);
     }
 
@@ -218,15 +221,16 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
     public void MergeUpgradesLegacyNotification()
     {
         var author1 = AuthorId.New(TestChatId, 1);
-        // A pre-coalescing blob deserializes with UnreadCount=0 and no lead/anchor state.
+        // A pre-RecentMessages blob deserializes with an empty list; its text lives in LeadText/Text.
         var legacy = MessageNotification.New(TestUserId, TestChatId, 100, author1) with { Text = "old text" };
         var incoming = NewMessage(101, author1, "new text");
 
         var merged = (MessageNotification)incoming.MergeWith(legacy);
         merged.UnreadCount.Should().Be(2);
         merged.StartEntryLid.Should().Be(100);
-        merged.LeadText.Should().Be("old text");
-        merged.LeadCount.Should().Be(1);
+        merged.RecentMessages.Select(m => m.Text).Should().Equal("old text", "new text");
+        merged.RecentMessages[0].AuthorName.Should().Be("");
+        merged.LeadText.Should().Be("new text");
     }
 
     [Fact]
@@ -255,6 +259,10 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
             StartEntryLid = 100,
             UnreadCount = 5,
             AuthorIds = new[] { author1, author2 }.ToApiArray(),
+            RecentMessages = new[] {
+                NotificationMessage.New(author1, "Alice", "Lead", 100, Moment.Now),
+                NotificationMessage.New(author2, "Bob", "Body", 101, Moment.Now),
+            }.ToApiArray(),
             LeadText = "Lead",
             LeadCount = 2,
             BeepCount = 3,
@@ -269,8 +277,9 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
         result.LeadCount.Should().Be(2);
         result.BeepCount.Should().Be(3);
         result.LastBeepAt.Should().Be(n.LastBeepAt);
-        // ApiArray equality is by reference, so normalize it before the whole-record value compare.
-        result.Should().Be(n with { AuthorIds = result.AuthorIds });
+        result.RecentMessages.Should().BeEquivalentTo(n.RecentMessages);
+        // ApiArray equality is by reference, so normalize them before the whole-record value compare.
+        result.Should().Be(n with { AuthorIds = result.AuthorIds, RecentMessages = result.RecentMessages });
     }
 
     [Fact]
@@ -294,12 +303,16 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
         result.Actions[1].Target.Should().Be("/chat/x");
     }
 
-    private static MessageNotification NewMessage(long entryLid, AuthorId authorId, string text)
+    private static MessageNotification NewMessage(long entryLid, AuthorId authorId, string text, string authorName = "")
         => MessageNotification.New(TestUserId, TestChatId, entryLid, authorId) with {
             Text = text,
             StartEntryLid = entryLid,
             UnreadCount = 1,
             AuthorIds = new[] { authorId }.ToApiArray(),
+            RecentMessages = new[] {
+                NotificationMessage.New(
+                    authorId, authorName, text, entryLid, Moment.EpochStart + TimeSpan.FromSeconds(entryLid)),
+            }.ToApiArray(),
             LeadText = text,
             LeadCount = 1,
         };

--- a/tests/Notifications.IntegrationTests/NotificationAggregationTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationAggregationTest.cs
@@ -210,11 +210,96 @@ public class NotificationAggregationTest(ITestOutputHelper @out) : TestBase(@out
     }
 
     [Fact]
-    public void AggregatedTextCountsOnlyMessagesBeyondLead()
+    public void AggregatedTextIsNewestFirstWithAuthorPrefixesInGroupChat()
     {
-        NotificationHelper.GetAggregatedText("Hi", ["Alice"], 0).Should().Be("Hi");
-        NotificationHelper.GetAggregatedText("Hi", ["Alice"], 1).Should().Be("Hi\nAlice · +1 more message");
-        NotificationHelper.GetAggregatedText("Hi", [], 2).Should().Be("Hi\n+2 more messages");
+        var author1 = AuthorId.New(TestChatId, 1);
+        var author2 = AuthorId.New(TestChatId, 2);
+        var first = NewMessage(100, author1, "who takes the release?", "Alice");
+        var second = NewMessage(101, author2, "I fixed the flaky test", "Bob");
+
+        var merged = (MessageNotification)second.MergeWith(first);
+
+        NotificationHelper.ComposeAggregatedText(merged)
+            .Should().Be("Bob: I fixed the flaky test\nAlice: who takes the release?");
+    }
+
+    [Fact]
+    public void AggregatedTextSkipsAuthorNamesInPeerChat()
+    {
+        var peerChatId = PeerChatId.New(UserId.New(), UserId.New());
+        var author = AuthorId.New(peerChatId, 1);
+        var first = MessageNotification.New(TestUserId, peerChatId, 100, author) with {
+            StartEntryLid = 100,
+            UnreadCount = 1,
+            RecentMessages = new[] { NotificationMessage.New(author, "Alice", "first", 100, Moment.Now) }.ToApiArray(),
+        };
+        var second = MessageNotification.New(TestUserId, peerChatId, 101, author) with {
+            StartEntryLid = 101,
+            UnreadCount = 1,
+            RecentMessages = new[] { NotificationMessage.New(author, "Alice", "second", 101, Moment.Now) }.ToApiArray(),
+        };
+
+        var merged = (MessageNotification)second.MergeWith(first);
+
+        NotificationHelper.ComposeAggregatedText(merged).Should().Be("second\nfirst");
+    }
+
+    [Fact]
+    public void AggregatedTextCountsOnlyMessagesBeyondWindow()
+    {
+        var author1 = AuthorId.New(TestChatId, 1);
+        var info = new UserNotificationInfo(TestUserId);
+        for (var lid = 100; lid < 106; lid++)
+            info = info.WithNotification(NewMessage(lid, author1, $"m{lid}", "Alice"));
+        var merged = (MessageNotification)info.Displayed.Single();
+
+        var text = NotificationHelper.ComposeAggregatedText(merged);
+
+        text.Should().StartWith("Alice: m105");
+        text.Should().EndWith("+1 earlier message");
+        merged.UnreadCount.Should().Be(6);
+    }
+
+    [Fact]
+    public void AggregatedTextFallsBackForLegacyNotification()
+    {
+        var author1 = AuthorId.New(TestChatId, 1);
+        var legacy = MessageNotification.New(TestUserId, TestChatId, 100, author1) with {
+            Text = "composed old body",
+            LeadText = "old lead",
+        };
+
+        NotificationHelper.ComposeAggregatedText(legacy).Should().Be("old lead");
+    }
+
+    [Fact]
+    public void ReAnchorAtDropsReadMessages()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        var info = new UserNotificationInfo(TestUserId);
+        for (var lid = 100; lid < 105; lid++)
+            info = info.WithNotification(NewMessage(lid, author, $"m{lid}", "Alice"));
+        var merged = (MessageNotification)info.Displayed.Single();
+
+        var reAnchored = merged.ReAnchorAt(103);
+
+        reAnchored.StartEntryLid.Should().Be(103);
+        reAnchored.UnreadCount.Should().Be(2);
+        reAnchored.RecentMessages.Select(m => m.Text).Should().Equal("m103", "m104");
+        reAnchored.LeadText.Should().Be("m104");
+    }
+
+    [Fact]
+    public void ReAnchorAtEmptiesWindowWhenAllShownAreRead()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        var n = NewMessage(100, author, "only", "Alice");
+
+        var reAnchored = n.ReAnchorAt(101);
+
+        reAnchored.RecentMessages.Should().BeEmpty();
+        reAnchored.LeadText.Should().Be("");
+        reAnchored.UnreadCount.Should().Be(1);
     }
 
     [Fact]

--- a/tests/Notifications.IntegrationTests/NotificationContentTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationContentTest.cs
@@ -30,7 +30,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
         aliceNotification.Title.Should().Be($"Bobby @ {chat.Title}");
-        aliceNotification.Text.Should().Be("Ok!");
+        aliceNotification.Text.Should().Be("Bobby: Ok!");
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be($"Alice @ {chat.Title}");
@@ -57,7 +57,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
         aliceNotification.Title.Should().Be("Bobby @ Good chat");
-        aliceNotification.Text.Should().Be("Sent an image");
+        aliceNotification.Text.Should().Be("Bobby: Sent an image");
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be("Alice @ Good chat");

--- a/tests/Notifications.IntegrationTests/NotificationDeliveryTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationDeliveryTest.cs
@@ -106,13 +106,13 @@ public class NotificationDeliveryTest(AppHostFixture fixture, ITestOutputHelper 
         await TestExt.When(async () => {
             var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
             var displayed = info.Displayed.Should().ContainSingle().Subject;
-            displayed.Text.Should().Be("First in chat2");
+            displayed.Text.Should().Be("Bobby: First in chat2");
         }, TimeSpan.FromSeconds(10));
 
         // ...and the chat2 delivery push carries a badge of 1 (chat1 is muted, so excluded).
         await TestExt.When(() => {
             var chat2Push = Sink.Messages
-                .Where(m => !m.IsDismissal && m.DeviceIds.Contains(deviceId) && m.Notification!.Text == "First in chat2")
+                .Where(m => !m.IsDismissal && m.DeviceIds.Contains(deviceId) && m.Notification!.Text == "Bobby: First in chat2")
                 .ToList();
             chat2Push.Should().NotBeEmpty();
             chat2Push[^1].BadgeCount.Should().Be(1);

--- a/tests/Notifications.IntegrationTests/NotificationMessageTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationMessageTest.cs
@@ -1,0 +1,32 @@
+namespace ActualChat.Notifications.IntegrationTests;
+
+public class NotificationMessageTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly ChatId TestChatId = ChatId.Parse("the-actual-one");
+
+    [Fact]
+    public void NewTruncatesLongText()
+    {
+        // arrange
+        var text = new string('x', 300);
+
+        // act
+        var message = NotificationMessage.New(AuthorId.New(TestChatId, 1), "Alice", text, 100, Moment.Now);
+
+        // assert
+        message.Text.Length.Should().Be(Constants.Notification.MaxRecentMessageTextLength);
+        message.Text.Should().EndWith("…");
+    }
+
+    [Fact]
+    public void NewKeepsShortTextVerbatim()
+    {
+        // act
+        var message = NotificationMessage.New(AuthorId.New(TestChatId, 1), "Alice", "hello", 100, Moment.Now);
+
+        // assert
+        message.Text.Should().Be("hello");
+        message.AuthorName.Should().Be("Alice");
+        message.EntryLid.Should().Be(100);
+    }
+}

--- a/tests/Notifications.IntegrationTests/NotificationModeTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationModeTest.cs
@@ -133,7 +133,7 @@ public class NotificationModeTest(AppHostFixture fixture, ITestOutputHelper @out
         await TestExt.When(async () => {
             var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
             var notification = info.Displayed.Should().ContainSingle().Subject;
-            notification.Text.Should().Be("sentinel");
+            notification.Text.Should().Be("Bobby: sentinel");
         }, TimeSpan.FromSeconds(10));
         Sink.Messages.Should().NotContain(m =>
             !m.IsDismissal && m.Notification!.Kind == NotificationKind.Mention && m.DeviceIds.Contains(deviceId));

--- a/tests/Notifications.IntegrationTests/PushMessageTest.cs
+++ b/tests/Notifications.IntegrationTests/PushMessageTest.cs
@@ -1,0 +1,56 @@
+namespace ActualChat.Notifications.IntegrationTests;
+
+public class PushMessageTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly ChatId TestChatId = ChatId.Parse("the-actual-one");
+
+    [Fact]
+    public void JsonRoundtrips()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        var sentAt = Moment.Now;
+        var messages = new[] {
+            NotificationMessage.New(author, "Alice", "first", 100, sentAt),
+            NotificationMessage.New(author, "Bob", "second", 101, sentAt + TimeSpan.FromSeconds(1)),
+        }.ToApiArray();
+
+        var parsed = PushMessage.FromJson(PushMessage.ToJson(messages));
+
+        parsed.Should().HaveCount(2);
+        parsed[0].AuthorName.Should().Be("Alice");
+        parsed[0].Text.Should().Be("first");
+        parsed[1].AuthorName.Should().Be("Bob");
+        parsed[1].SentAtMs.Should().Be((long)(sentAt + TimeSpan.FromSeconds(1)).EpochOffset.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ToJsonDropsOldestOverBudget()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        // NotificationMessage.New truncates, so build oversized entries via the record directly.
+        var messages = Enumerable.Range(0, 5)
+            .Select(i => new NotificationMessage {
+                AuthorId = author,
+                AuthorName = $"author{i}",
+                Text = new string((char)('a' + i), 700),
+                EntryLid = 100 + i,
+                SentAt = Moment.Now,
+            })
+            .ToApiArray();
+
+        var json = PushMessage.ToJson(messages);
+
+        json.Length.Should().BeLessThanOrEqualTo(PushMessage.MaxJsonLength + 800);
+        var parsed = PushMessage.FromJson(json);
+        parsed.Should().HaveCountLessThan(5);
+        parsed[^1].Text.Should().StartWith("e"); // the newest message always survives
+    }
+
+    [Fact]
+    public void FromJsonToleratesGarbage()
+    {
+        PushMessage.FromJson(null).Should().BeEmpty();
+        PushMessage.FromJson("").Should().BeEmpty();
+        PushMessage.FromJson("not json").Should().BeEmpty();
+    }
+}

--- a/tests/Notifications.IntegrationTests/PushMessageTest.cs
+++ b/tests/Notifications.IntegrationTests/PushMessageTest.cs
@@ -47,6 +47,33 @@ public class PushMessageTest(ITestOutputHelper @out) : TestBase(@out)
     }
 
     [Fact]
+    public void ToJsonRespectsExplicitBudget()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        var messages = Enumerable.Range(0, 3)
+            .Select(i => NotificationMessage.New(
+                author, $"a{i}", new string((char)('a' + i), 100), 100 + i, Moment.Now))
+            .ToApiArray();
+
+        var json = PushMessage.ToJson(messages, 300);
+
+        var parsed = PushMessage.FromJson(json);
+        parsed.Should().HaveCountLessThan(3);
+        parsed[^1].Text.Should().StartWith("c");
+    }
+
+    [Fact]
+    public void ToJsonReturnsEmptyWhenNewestCannotFit()
+    {
+        var author = AuthorId.New(TestChatId, 1);
+        var messages = new[] {
+            NotificationMessage.New(author, "Alice", new string('x', 150), 100, Moment.Now),
+        }.ToApiArray();
+
+        PushMessage.ToJson(messages, 50).Should().BeEmpty();
+    }
+
+    [Fact]
     public void FromJsonToleratesGarbage()
     {
         PushMessage.FromJson(null).Should().BeEmpty();

--- a/tests/Notifications.IntegrationTests/RetranscribeNotifyFlowTest.cs
+++ b/tests/Notifications.IntegrationTests/RetranscribeNotifyFlowTest.cs
@@ -31,7 +31,7 @@ public class RetranscribeNotifyFlowTest(
         var entry = await Tester.RecordVoiceEntry(chat.Id, Languages.English);
 
         var notification = await Tester.WaitForChatEntryNotification(alice.Id, entry.Id);
-        notification.Text.Should().StartWith(FakeRefineTranscriber.Marker);
+        notification.Text.Should().StartWith("Bobby: " + FakeRefineTranscriber.Marker);
         notification.EntryId.Should().Be(entry.Id);
     }
 
@@ -50,7 +50,7 @@ public class RetranscribeNotifyFlowTest(
         var entry = await Tester.RecordVoiceEntry(chat.Id, Languages.English);
 
         var notification = await Tester.WaitForChatEntryNotification(alice.Id, entry.Id);
-        notification.Text.Should().NotStartWith(FakeRefineTranscriber.Marker);
+        notification.Text.Should().NotContain(FakeRefineTranscriber.Marker);
         notification.Text.Should().NotBeNullOrEmpty();
         notification.EntryId.Should().Be(entry.Id);
     }
@@ -74,7 +74,7 @@ public class RetranscribeNotifyFlowTest(
         var entry = await Tester.RecordVoiceEntry(chat.Id, Languages.English, VoiceMode.JustText);
 
         var notification = await Tester.WaitForChatEntryNotification(alice.Id, entry.Id);
-        notification.Text.Should().NotStartWith(FakeRefineTranscriber.Marker);
+        notification.Text.Should().NotContain(FakeRefineTranscriber.Marker);
         notification.Text.Should().NotBeNullOrEmpty();
         notification.EntryId.Should().Be(entry.Id);
         transcribeCallCount.Should().Be(0, "no audio → no OpenAI retranscription should be triggered");


### PR DESCRIPTION
## Summary

Coalesced chat notifications currently pin the **first unread** message as the banner text and only bump a "+N more" counter as new messages arrive — the visible text goes stale immediately. This PR flips them to the industry-standard newest-first model (WhatsApp/Telegram/Signal behavior) and gives Android a true per-message transcript.

- **`RecentMessages` transcript window** on `ChatEntryRelatedNotification` (last 5 messages, MessagePack key 18): maintained in `MergeWith` (sorted insert, capacity eviction, idempotent redelivery preserved), seeded at creation with an author-name snapshot. Title/icon now always follow the newest message (fixes a pre-existing bug where an out-of-order earlier message stole the title).
- **Newest-first body composition** (`NotificationHelper.ComposeAggregatedText`): latest message on top — which is what collapsed banners show — earlier still-unseen ones below, then a `+N earlier messages` tail. Sender prefixes in group/place chats only. iOS and web benefit with zero client changes.
- **Partial-read re-anchoring** (`ReAnchorAt`): now-read messages drop out of the window instead of leaving stale text; the window is re-seeded from the entry store when it empties.
- **Android `MessagingStyle` transcript**: a compact `messages` JSON data key (`PushMessage` DTO, `n`/`t`/`ts`) feeds one `MessagingStyle` line per message with real `Person`s, timestamps, and the avatar on the newest sender. Both the FCM receive path and the reconciler heal path render it; old-server pushes fall back to the current single-message style.
- **FCM 4 KB safety**: the `messages` key is budgeted against the actual remaining payload space and omitted when it can't fit (Body fallback still renders) — worst-case total proven ≤ 3,592 bytes.

Rolling-deploy compat: `LeadText`/`LeadCount` stay on the wire this release (new code writes newest text / 1); legacy blobs upgrade in place on first merge; old Android apps ignore the extra data key.

Spec: `docs/superpowers/specs/2026-07-24-notification-newest-first-design.md` · Plan: `docs/superpowers/plans/2026-07-24-notification-newest-first.md`

## Testing

- 30/30 notification unit tests (merge semantics, capacity, out-of-order, redelivery idempotence, legacy upgrade, composition formats, re-anchoring, JSON round-trip, payload budgeting)
- `ActualChat.CI.slnf` build: 0 errors
- **Deferred to host**: App.Maui Android build + on-device MessagingStyle check (no MAUI workload in the dev container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)