### PR TITLE
feat(location): drop outdated troubleshooter screenshots, keep text g…

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/AndroidAppLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/AndroidAppLocationGuideContent.razor
@@ -6,35 +6,6 @@
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
-    Here is the guide how to enable location permission in your Phone Settings.
+    Tap "Settings" below to open @CoreConstants.AppName settings,
+    then go to "Permissions" &gt; "Location" and allow location access.
 </div>
-
-<div class="c-text text-headline-1">
-    1. Open Settings on your Phone
-</div>
-<img draggable="false" src="/dist/images/guide/android-app-01.png" alt="Android/App/01">
-
-<div class="c-text text-headline-1">
-    2. Go to Apps section
-</div>
-<img draggable="false" src="/dist/images/guide/android-app-02.png" alt="Android/App/02">
-
-<div class="c-text text-headline-1">
-    3. Go to Manage apps
-</div>
-<img draggable="false" src="/dist/images/guide/android-app-03.png" alt="Android/App/03">
-
-<div class="c-text text-headline-1">
-    4. Choose @CoreConstants.AppName
-</div>
-<img draggable="false" src="/dist/images/guide/android-app-04.png" alt="Android/App/04">
-
-<div class="c-text text-headline-1">
-    5. Tap on App permissions
-</div>
-<img draggable="false" src="/dist/images/guide/android-app-05.png" alt="Android/App/05">
-
-<div class="c-text text-headline-1">
-    6. Allow @CoreConstants.AppName app to access location
-</div>
-<img draggable="false" src="/dist/images/guide/loc-android-app-06.png" alt="Android/App/06">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/IosAppLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/IosAppLocationGuideContent.razor
@@ -6,20 +6,6 @@
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
-    Here is the guide how to enable location permission in your Phone Settings.
+    Tap "Settings" below to open @CoreConstants.AppName settings,
+    then tap "Location" and allow location access.
 </div>
-
-<div class="c-text text-headline-1">
-    1. Open Settings on your Phone
-</div>
-<img draggable="false" src="/dist/images/guide/ios-app-01.png" alt="Ios/App/01">
-
-<div class="c-text text-headline-1">
-    2. Scroll to Apps and open @CoreConstants.AppName
-</div>
-<img draggable="false" src="/dist/images/guide/ios-app-02.png" alt="Ios/App/02">
-
-<div class="c-text text-headline-1">
-    3. Allow @CoreConstants.AppName app to access your location
-</div>
-<img draggable="false" src="/dist/images/guide/loc-ios-app-03.png" alt="Ios/App/03">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileChromeAndroidLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileChromeAndroidLocationGuideContent.razor
@@ -2,7 +2,7 @@
 
 <img draggable="false" src="/dist/images/guide/loc-access.png" alt="Location access is blocked">
 <div class="c-text text-title-1">
-   Location access is blocked, but you can fix this!
+    Location access is blocked, but you can fix this!
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
@@ -12,24 +12,19 @@
 <div class="c-text text-headline-1">
     1. Tap on "⋮"
 </div>
-<img draggable="false" src="/dist/images/guide/android-chrome-01.png" alt="Android/Chrome/01">
 
 <div class="c-text text-headline-1">
     2. Click "Settings"
 </div>
-<img draggable="false" src="/dist/images/guide/android-chrome-02.png" alt="Android/Chrome/02">
 
 <div class="c-text text-headline-1">
     3. Open "Site settings"
 </div>
-<img draggable="false" src="/dist/images/guide/android-chrome-03.png" alt="Android/Chrome/03">
 
 <div class="c-text text-headline-1">
     4. Tap on "Location"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-android-chrome-04.png" alt="Android/Chrome/04">
 
 <div class="c-text text-headline-1">
     5. Enable "Ask first before allowing sites to use your location" option
 </div>
-<img draggable="false" src="/dist/images/guide/loc-android-chrome-05.png" alt="Android/Chrome/05">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileEdgeAndroidLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileEdgeAndroidLocationGuideContent.razor
@@ -12,39 +12,31 @@
 <div class="c-text text-headline-1">
     1. Tap middle button on the navigation bar
 </div>
-<img draggable="false" src="/dist/images/guide/android-edge-01.png" alt="Android/Edge/01">
 
 <div class="c-text text-headline-1">
     2. Go to "Settings"
 </div>
-<img draggable="false" src="/dist/images/guide/android-edge-02.png" alt="Android/Edge/02">
 
 <div class="c-text text-headline-1">
     3. Choose "Privacy and security"
 </div>
-<img draggable="false" src="/dist/images/guide/android-edge-03.png" alt="Android/Edge/03">
 
 <div class="c-text text-headline-1">
     4. Go to "Site permissions"
 </div>
-<img draggable="false" src="/dist/images/guide/android-edge-04.png" alt="Android/Edge/04">
 
 <div class="c-text text-headline-1">
     5. Choose "Location"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-android-edge-05.png" alt="Android/Edge/05">
 
 <div class="c-text text-headline-1">
     6. Enable "Ask first before allowing sites to use your location" option
 </div>
-<img draggable="false" src="/dist/images/guide/loc-android-edge-06.png" alt="Android/Edge/06">
 
 <div class="c-text text-headline-1">
     7. Check if Edge itself has location access permission
 </div>
-<img draggable="false" src="/dist/images/guide/android-edge-07.png" alt="Android/Edge/07">
 
 <div class="c-text text-headline-1">
     8. If not, allow Edge to use location
 </div>
-<img draggable="false" src="/dist/images/guide/loc-android-edge-08.png" alt="Android/Edge/08">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileSafariIosLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/MobileSafariIosLocationGuideContent.razor
@@ -2,7 +2,7 @@
 
 <img draggable="false" src="/dist/images/guide/loc-access.png" alt="Location access is blocked">
 <div class="c-text text-title-1">
-   Location access is blocked, but you can fix this!
+    Location access is blocked, but you can fix this!
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
@@ -12,14 +12,11 @@
 <div class="c-text text-headline-1">
     1. Open iOS Settings app, then "Safari" section
 </div>
-<img draggable="false" src="/dist/images/guide/ios-safari-01.png" alt="iOS/Safari/01">
 
 <div class="c-text text-headline-1">
-    2. Go to "Settings for websites" (section) > Location
+    2. Go to "Settings for websites" (section) &gt; Location
 </div>
-<img draggable="false" src="/dist/images/guide/loc-ios-safari-02.png" alt="iOS/Safari/02">
 
 <div class="c-text text-headline-1">
     3. Change "Location access on all websites" to "Ask"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-ios-safari-03.png" alt="iOS/Safari/03">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebChromeLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebChromeLocationGuideContent.razor
@@ -2,7 +2,7 @@
 
 <img draggable="false" src="/dist/images/guide/loc-access.png" alt="Location access is blocked">
 <div class="c-text text-title-1">
-   Location access is blocked, but you can fix this!
+    Location access is blocked, but you can fix this!
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
@@ -12,34 +12,27 @@
 <div class="c-text text-headline-1">
     1. Click "More" button in the upper right corner, and then click "Settings"
 </div>
-<img draggable="false" src="/dist/images/guide/web-chrome-01.png" alt="Web/Chrome/01">
 
 <div class="c-text text-headline-1">
     2. Choose "Privacy and security" on the left side
 </div>
-<img draggable="false" src="/dist/images/guide/web-chrome-02.png" alt="Web/Chrome/02">
 
 <div class="c-text text-headline-1">
     3. Select "Site settings"
 </div>
-<img draggable="false" src="/dist/images/guide/web-chrome-03.png" alt="Web/Chrome/03">
 
 <div class="c-text text-headline-1">
     4. Select "Location"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-chrome-04.png" alt="Web/Chrome/04">
 
 <div class="c-text text-headline-1">
     5. Check that you allow sites to ask to use your location
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-chrome-05.png" alt="Web/Chrome/05">
 
 <div class="c-text text-headline-1">
     6. If "@Constants.Hosts.Voxt" is not allowed to use location, select it
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-chrome-06.png" alt="Web/Chrome/06">
 
 <div class="c-text text-headline-1">
-    7. Change "Permissions" > "Location" value from "Deny" to "Allow" or "Ask"
+    7. Change "Permissions" &gt; "Location" value from "Deny" to "Allow" or "Ask"
 </div>
-<img draggable="false" src="/dist/images/guide/web-chrome-07.png" alt="Web/Chrome/07">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebEdgeLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebEdgeLocationGuideContent.razor
@@ -2,7 +2,7 @@
 
 <img draggable="false" src="/dist/images/guide/loc-access.png" alt="Location access is blocked">
 <div class="c-text text-title-1">
-   Location access is blocked, but you can fix this!
+    Location access is blocked, but you can fix this!
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
@@ -10,27 +10,22 @@
 </div>
 
 <div class="c-text text-headline-1">
-    1. Click "⋯" > "Settings" on Windows,
-       or "Microsoft Edge" > "Preferences" on MacOS
+    1. Click "⋯" &gt; "Settings" on Windows,
+       or "Microsoft Edge" &gt; "Preferences" on MacOS
 </div>
-<img draggable="false" src="/dist/images/guide/web-edge-01.png" alt="Web/Edge/01">
 
 <div class="c-text text-headline-1">
     2. Choose "Cookies and Site Permissions"
 </div>
-<img draggable="false" src="/dist/images/guide/web-edge-02.png" alt="Web/Edge/02">
 
 <div class="c-text text-headline-1">
     3. Select "Location"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-edge-03.png" alt="Web/Edge/03">
 
 <div class="c-text text-headline-1">
     4. Delete "@Constants.Hosts.Voxt" from "Block" list
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-edge-04.png" alt="Web/Edge/04">
 
 <div class="c-text text-headline-1">
     5. Reopen @CoreConstants.AppName and allow it to use location
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-edge-05.png" alt="Web/Edge/05">

--- a/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebSafariLocationGuideContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationPermission/Guides/WebSafariLocationGuideContent.razor
@@ -2,7 +2,7 @@
 
 <img draggable="false" src="/dist/images/guide/loc-access.png" alt="Location access is blocked">
 <div class="c-text text-title-1">
-   Location access is blocked, but you can fix this!
+    Location access is blocked, but you can fix this!
 </div>
 <div class="c-text font-normal">
     @CoreConstants.AppName needs access to your location to share it with others.
@@ -12,19 +12,15 @@
 <div class="c-text text-headline-1">
     1. Go to Safari Preferences
 </div>
-<img draggable="false" src="/dist/images/guide/web-safari-01.png" alt="Web/Safari/01">
 
 <div class="c-text text-headline-1">
     2. Choose "Websites" category
 </div>
-<img draggable="false" src="/dist/images/guide/web-safari-02.png" alt="Web/Safari/02">
 
 <div class="c-text text-headline-1">
     3. Select "Location" on the left
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-safari-03.png" alt="Web/Safari/03">
 
 <div class="c-text text-headline-1">
     4. Change "@Constants.Hosts.Voxt" entry's value from "Deny" to "Allow" or "Ask"
 </div>
-<img draggable="false" src="/dist/images/guide/loc-web-safari-04.png" alt="Web/Safari/04">

--- a/src/nodejs/images/guide/loc-android-app-06.png
+++ b/src/nodejs/images/guide/loc-android-app-06.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06267eb1dfa8a51f0e1789c41bcd3f757a519054938b50201495fd0097da69e7
-size 24213

--- a/src/nodejs/images/guide/loc-android-chrome-04.png
+++ b/src/nodejs/images/guide/loc-android-chrome-04.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d452d3ec926c02f0494ad00890907b22708f365bbb999c3d43ff6dd5a98f5161
-size 31879

--- a/src/nodejs/images/guide/loc-android-chrome-05.png
+++ b/src/nodejs/images/guide/loc-android-chrome-05.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3fa860575b6efa1286d4d27029a3c462af8586a408899408b21aa7b9fb61742
-size 55666

--- a/src/nodejs/images/guide/loc-android-edge-05.png
+++ b/src/nodejs/images/guide/loc-android-edge-05.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11828e78fd1b7ff41144aa532aba4d1c0313b4c98a9d5ab42f7b18e7884babb3
-size 15355

--- a/src/nodejs/images/guide/loc-android-edge-06.png
+++ b/src/nodejs/images/guide/loc-android-edge-06.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04931d846ce0ef89b644927d825b0eff0cd0f8ce24cafe823d3afb66fe071871
-size 17873

--- a/src/nodejs/images/guide/loc-android-edge-08.png
+++ b/src/nodejs/images/guide/loc-android-edge-08.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b7feb8c3c9a5d0535cff2da42497b34e9c7cbf36b17f2b9b6fa83254aa549b8
-size 21061

--- a/src/nodejs/images/guide/loc-ios-app-03.png
+++ b/src/nodejs/images/guide/loc-ios-app-03.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:534974fade70c5e5a81edcef19cb62d23a4fce58af182191a799f651c54cd301
-size 40783

--- a/src/nodejs/images/guide/loc-ios-safari-02.png
+++ b/src/nodejs/images/guide/loc-ios-safari-02.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe0bb861c707e46d453080d6671edc3b2a3d3d8c009ff85d1935cd0ec24b777f
-size 20790

--- a/src/nodejs/images/guide/loc-ios-safari-03.png
+++ b/src/nodejs/images/guide/loc-ios-safari-03.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcd791a9a781f5aa0958b0800ff7f7bced7687b3b6badabc892b4e1ee2b1e604
-size 6539

--- a/src/nodejs/images/guide/loc-web-chrome-04.png
+++ b/src/nodejs/images/guide/loc-web-chrome-04.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d222c00d2eff2cc3b89f61612d23c1f193e0889ffba3d7d13f7110cfaaa09c6
-size 15944

--- a/src/nodejs/images/guide/loc-web-chrome-05.png
+++ b/src/nodejs/images/guide/loc-web-chrome-05.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a3640828ce9035d3b15b7d00e9487230c78fb8a190d9aaaeb685a0fc5564dc2
-size 14842

--- a/src/nodejs/images/guide/loc-web-chrome-06.png
+++ b/src/nodejs/images/guide/loc-web-chrome-06.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b15e60253bd89339a599b8fc610aa631049b2cf17646781459e5e4a2330c8b9
-size 6842

--- a/src/nodejs/images/guide/loc-web-edge-03.png
+++ b/src/nodejs/images/guide/loc-web-edge-03.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fb7e71ac8cec6541710c5cb25c76a35cc4bfc832144922712023a7a0775b884
-size 15775

--- a/src/nodejs/images/guide/loc-web-edge-04.png
+++ b/src/nodejs/images/guide/loc-web-edge-04.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68c5835fd48fe683ee41e15bc2d66659997b43813976e4a79b61279b754f8657
-size 9736

--- a/src/nodejs/images/guide/loc-web-edge-05.png
+++ b/src/nodejs/images/guide/loc-web-edge-05.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:430ad1575fa972a1ea77c635318c94791ae286f67b27a50797bf5debfdd15bb3
-size 14801

--- a/src/nodejs/images/guide/loc-web-safari-03.png
+++ b/src/nodejs/images/guide/loc-web-safari-03.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3cf302af2089939e93d6a770da525e43d2f89614c4492998069f40ce3bd832e
-size 26465

--- a/src/nodejs/images/guide/loc-web-safari-04.png
+++ b/src/nodejs/images/guide/loc-web-safari-04.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1454032cae20bea903e41a14ac610ac55b6ef0565b767c0b8a7681521884013
-size 25533


### PR DESCRIPTION
…uides #4023

The loc-* step screenshots were doctored mockups with old Actual Chat branding, the actual.chat domain, and ancient OS/browser UI. Keep the generic loc-access hero image and per-platform text steps; condense the native app guides to a single instruction pointing at the Settings button, which deep-links into system settings.


Claude-Session: https://claude.ai/code/session_01MJnp1mYgrRSUY8twBcgThH