### PR TITLE
feat(chat): make location sharing available to all users #4099

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
@@ -137,8 +137,7 @@
         var watchingChatId = await ChatVideoUI.GetWatchingChatId(cancellationToken).ConfigureAwait(false);
         var isWatchingHere = chat.Id == watchingChatId;
         var canShowAudioDiagnostics = await AudioDiagnosticsUI.IsEnabled(cancellationToken).ConfigureAwait(false);
-        var isSharingOwnLocation = await LocationUI.GetOwnLive(chat.Id, cancellationToken)
-            .ConfigureAwait(false) is not null;
+        var isSharingOwnLocation = await LocationUI.IsOwnLive(chat.Id, cancellationToken).ConfigureAwait(false);
         return new() {
             AudioState = audioState,
             IsAnyoneTalking = isAnyoneTalking,

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
@@ -137,9 +137,8 @@
         var watchingChatId = await ChatVideoUI.GetWatchingChatId(cancellationToken).ConfigureAwait(false);
         var isWatchingHere = chat.Id == watchingChatId;
         var canShowAudioDiagnostics = await AudioDiagnosticsUI.IsEnabled(cancellationToken).ConfigureAwait(false);
-        var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
-        var isSharingOwnLocation = enableIncompleteUI
-            && await LocationUI.GetOwnLive(chat.Id, cancellationToken).ConfigureAwait(false) is not null;
+        var isSharingOwnLocation = await LocationUI.GetOwnLive(chat.Id, cancellationToken)
+            .ConfigureAwait(false) is not null;
         return new() {
             AudioState = audioState,
             IsAnyoneTalking = isAnyoneTalking,

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
@@ -45,8 +45,6 @@
         if (hasRemoteStreams)
             return true;
 
-        var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
-        return enableIncompleteUI
-            && await LocationUI.GetOwnLive(chatId, cancellationToken).ConfigureAwait(false) is not null;
+        return await LocationUI.GetOwnLive(chatId, cancellationToken).ConfigureAwait(false) is not null;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
@@ -45,6 +45,6 @@
         if (hasRemoteStreams)
             return true;
 
-        return await LocationUI.GetOwnLive(chatId, cancellationToken).ConfigureAwait(false) is not null;
+        return await LocationUI.IsOwnLive(chatId, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/StopLocationSharingButton.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/StopLocationSharingButton.razor
@@ -23,8 +23,8 @@
 
     [CascadingParameter] public ChatContext ChatContext { get; set; } = null!;
 
-    protected override async Task<bool> ComputeState(CancellationToken cancellationToken)
-        => await LocationUI.GetOwnLive(Chat.Id, cancellationToken).ConfigureAwait(false) is not null;
+    protected override Task<bool> ComputeState(CancellationToken cancellationToken)
+        => LocationUI.IsOwnLive(Chat.Id, cancellationToken);
 
     private Task OnClick()
         => LocationUI.StopSharing(Chat.Id, CancellationToken.None);

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/StopLocationSharingButton.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/StopLocationSharingButton.razor
@@ -23,13 +23,8 @@
 
     [CascadingParameter] public ChatContext ChatContext { get; set; } = null!;
 
-    protected override async Task<bool> ComputeState(CancellationToken cancellationToken) {
-        var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
-        if (!enableIncompleteUI)
-            return false;
-
-        return await LocationUI.GetOwnLive(Chat.Id, cancellationToken).ConfigureAwait(false) is not null;
-    }
+    protected override async Task<bool> ComputeState(CancellationToken cancellationToken)
+        => await LocationUI.GetOwnLive(Chat.Id, cancellationToken).ConfigureAwait(false) is not null;
 
     private Task OnClick()
         => LocationUI.StopSharing(Chat.Id, CancellationToken.None);

--- a/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
@@ -95,11 +95,9 @@
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
         var hasSelection = await Hub.SelectionUI.HasSelection.Use(cancellationToken).ConfigureAwait(false);
         var isSearchMode = await Hub.PanelsUI.Right.IsSearchMode.Use(cancellationToken).ConfigureAwait(false);
-        var enableIncompleteUI = await Hub.Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
         return new() {
             HasSelection = hasSelection,
             IsSearchMode = isSearchMode,
-            EnableIncompleteUI = enableIncompleteUI,
         };
     }
 
@@ -133,6 +131,5 @@
 
         public bool HasSelection { get; init; }
         public bool IsSearchMode { get; init; }
-        public bool EnableIncompleteUI { get; init; }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditorMenu.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditorMenu.razor
@@ -36,21 +36,14 @@
         Text="Mention"
         Click="@OnMentionClick"/>
 
-    @if (_enableIncompleteUI) {
-        <MenuEntry
-            Icon="icon-map-point"
-            Text="Location"
-            Click="@OnShareLocationClick"/>
-    }
+    <MenuEntry
+        Icon="icon-map-point"
+        Text="Location"
+        Click="@OnShareLocationClick"/>
 </div>
 
 @code {
-    private bool _enableIncompleteUI;
-
     private string EditorId => Arguments.Length > 0 ? Arguments[0] : "";
-
-    protected override async Task OnInitializedAsync()
-        => _enableIncompleteUI = await Features.IsIncompleteUIEnabled();
 
     private async Task OnAttachClick(string acceptTypes = "") {
         await WhenClosed.ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/ActivityPill.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/ActivityPill.razor
@@ -45,8 +45,7 @@
             .ConfigureAwait(false);
         var isOwnScreenCasting = await ChatVideoUI.IsOwnScreenCasting(chatId, cancellationToken)
             .ConfigureAwait(false);
-        var isSharingOwnLocation =
-            await LocationUI.GetOwnLive(chatId, cancellationToken).ConfigureAwait(false) is not null;
+        var isSharingOwnLocation = await LocationUI.IsOwnLive(chatId, cancellationToken).ConfigureAwait(false);
         return new Model(activity.HasCall, isOwnCameraStreaming, isOwnScreenCasting, isSharingOwnLocation);
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanel.razor
@@ -10,8 +10,7 @@
     // unmounting VideoPanel would tear down the streams the pill stands for.
     var showVideo = m.Activity.HasCall && (m.Activity.Tab == VisualActivityTab.Call || isHidden);
     var showMap = !isHidden && m.Activity is { HasMap: true, Tab: VisualActivityTab.Map };
-    // The map half of the pill replaces LiveLocationBanner, which was incomplete-UI-only
-    var showPill = isHidden && (m.Activity.HasCall || (m.Activity.HasMap && m.EnableIncompleteUI));
+    var showPill = isHidden && (m.Activity.HasCall || m.Activity.HasMap);
 
     // TODO(DF): move this logic to ChatVideoUI
     // Clear watching when navigating to a different chat.
@@ -145,8 +144,7 @@
             }
         }
         var panelState = await ChatActivityUI.Get(chatId, cancellationToken).ConfigureAwait(false);
-        var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
-        return new Model(chatContext, isWatching, panelState, enableIncompleteUI);
+        return new Model(chatContext, isWatching, panelState);
     }
 
     // Private methods
@@ -162,9 +160,8 @@
     public sealed record Model(
         ChatContext? ChatContext,
         [property: MemberNotNullWhen(true, nameof(Model.ChatContext))] bool IsWatching,
-        VisualActivity Activity,
-        bool EnableIncompleteUI
+        VisualActivity Activity
     ) {
-        public static readonly Model None = new(null, false, VisualActivity.None, false);
+        public static readonly Model None = new(null, false, VisualActivity.None);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanelTabSwitch.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanelTabSwitch.razor
@@ -33,13 +33,8 @@
                 Category = GetStateCategory(t),
             });
 
-    protected override async Task<VisualActivity> ComputeState(CancellationToken cancellationToken) {
-        var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
-        if (!enableIncompleteUI)
-            return VisualActivity.None;
-
-        return await ChatActivityUI.Get(Chat.Id, cancellationToken).ConfigureAwait(false);
-    }
+    protected override Task<VisualActivity> ComputeState(CancellationToken cancellationToken)
+        => ChatActivityUI.Get(Chat.Id, cancellationToken);
 
     // Private methods
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -170,8 +170,8 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         }
 
         if (lastTextEntry is { HasLocation: true, LocationId: { } locationId }) {
-            var isLive = await LocationUI.IsLive(chatId, locationId, cancellationToken).ConfigureAwait(false);
-            return new ChatPreview { Text = isLive ? "Shared live location" : "Sent a location" };
+            var isOneTime = await LocationUI.IsOneTime(chatId, locationId, cancellationToken).ConfigureAwait(false);
+            return new ChatPreview { Text = isOneTime ? "Sent a location" : "Shared live location" };
         }
 
         var emoji = Emojis.TryGetByIdOrSymbol(lastTextEntry.Content.Trim());

--- a/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
@@ -86,16 +86,14 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
     }
 
     [ComputeMethod]
-    public virtual async Task<bool> IsLive(ChatId chatId, SharedLocationId id, CancellationToken cancellationToken)
+    public virtual async Task<bool> IsOneTime(ChatId chatId, SharedLocationId id, CancellationToken cancellationToken)
     {
-        // Duration is immutable, so capture Get in isolation — IsLiveShare takes no dependency on it
-        // and won't recompute on the per-fix updates that invalidate Get.
         Computed<SharedLocation?> cLocation;
         using (Computed.BeginIsolation())
             cLocation = await Computed
                 .Capture(() => SharedLocations.Get(Session, chatId, id, cancellationToken), cancellationToken)
                 .ConfigureAwait(false);
-        return cLocation.Value is { Duration.Ticks: > 0 };
+        return cLocation.Value?.Duration == TimeSpan.Zero;
     }
 
     [ComputeMethod]
@@ -118,6 +116,10 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
         Computed.GetCurrent().Invalidate(delay, false);
         return new LocationCountdown(remaining, location.Duration);
     }
+
+    [ComputeMethod]
+    public virtual async Task<bool> IsOwnLive(ChatId chatId, CancellationToken cancellationToken)
+        => await GetOwnLive(chatId, cancellationToken).ConfigureAwait(false) != null;
 
     [ComputeMethod]
     public virtual async Task<SharedLocation?> GetOwnLive(ChatId chatId, CancellationToken cancellationToken)
@@ -203,8 +205,7 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
         if (ownAuthor is null)
             return null;
 
-        var ownLive = await GetOwnLive(chatId, cancellationToken).ConfigureAwait(false);
-        if (ownLive is null)
+        if (!await IsOwnLive(chatId, cancellationToken).ConfigureAwait(false))
             return null;
 
         return await Tracker.Error.Use(cancellationToken).ConfigureAwait(false);
@@ -212,7 +213,7 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
 
     public async Task ShowShareModal(ChatId chatId)
     {
-        var isSharing = await GetOwnLive(chatId, Hub.StopToken).ConfigureAwait(true) is not null;
+        var isSharing = await IsOwnLive(chatId, Hub.StopToken).ConfigureAwait(true);
         var model = new ShareLocationModal.Model { ChatId = chatId, IsSharing = isSharing };
         var modalRef = await Hub.ModalUI.Show(model, Hub.StopToken).ConfigureAwait(true);
         await modalRef.WhenClosed.ConfigureAwait(true);


### PR DESCRIPTION
Removes the Features.IsIncompleteUIEnabled gates from the location UI: the Location entry in the message editor menu, the stop-sharing button, the activity panel's location icon (and the narrow-screen wrapper that shows the panel for a location-only activity), the Call/Map tab switch, and the map half of the collapsed ActivityPill.

VisualActivityPanel.Model and ChatHeader.Model lose their now-unused EnableIncompleteUI members.

The rest of the feature — LocationUI, ShareLocationModal, LocationMapModal, MapPanel, LocationMessageView, the map view and permission handlers — was already ungated, so gated users could see others' shares but not start one or switch to the map.


Claude-Session: https://claude.ai/code/session_01JVGaBmorH6WWNB2cyPvVFu