### PR TITLE
feat(chat): stream a text entry's content as it arrives

### DIFF
--- a/src/dotnet/Api.Contracts/Chat/IChats.cs
+++ b/src/dotnet/Api.Contracts/Chat/IChats.cs
@@ -117,6 +117,16 @@ public interface IChats : IComputeService
     [CommandHandler, RpcMethod(ConnectTimeout = double.PositiveInfinity)]
     Task<ChatEntry> OnUpsertEntry(Chats_UpsertEntry command, CancellationToken cancellationToken);
 
+    // Editing an entry older than Constants.Chat.MaxStreamingEditAge still succeeds, but lands as
+    // one ordinary update rather than re-animating a settled message.
+    [RpcMethod(ConnectTimeout = double.PositiveInfinity)]
+    Task<ChatEntry> StreamEntry(
+        Session session,
+        ChatId chatId,
+        long? localId,
+        RpcStream<string> textChunks,
+        CancellationToken cancellationToken);
+
     [CommandHandler, RpcMethod(ConnectTimeout = double.PositiveInfinity), LegacyName("OnRemoveTextEntry")]
     Task OnRemoveEntry(Chats_RemoveEntry command, CancellationToken cancellationToken);
 

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -73,6 +73,9 @@ public static partial class Constants
         public static readonly TileStack<int> ChatTileStack = TileStacks.Int5To20;
         public static readonly TimeSpan MaxEntryDuration = TimeSpan.FromMinutes(3);
         public static readonly TimeSpan StreamingEntryFixupDelay = MaxEntryDuration + TimeSpan.FromSeconds(30);
+        // Past this age an entry is settled enough that re-animating it would read as a glitch,
+        // so a streamed edit still succeeds but lands as one ordinary update.
+        public static readonly TimeSpan MaxStreamingEditAge = TimeSpan.FromMinutes(15);
         // 2x the editor's large-paste threshold, which is per paste rather than per message
         public const int MaxEntryTextLength = 64 * 1024;
         public const int NonContactPeerMessageLimit = 2;

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -2,6 +2,7 @@ using ActualChat.Contacts;
 using ActualChat.Hosting;
 using ActualChat.Logging;
 using ActualChat.Transcription;
+using ActualLab.Rpc;
 
 namespace ActualChat.Chat;
 
@@ -20,6 +21,7 @@ public partial class Chats(IServiceProvider services) : IChats
     private IConversationsBackend ConversationsBackend { get; } = services.GetRequiredService<IConversationsBackend>();
 
     private IAuthorsBackend AuthorsBackend { get; } = services.GetRequiredService<IAuthorsBackend>();
+    private TextEntryStreamer TextEntryStreamer { get; } = services.GetRequiredService<TextEntryStreamer>();
     private IChatPositionsBackend ChatPositionsBackend { get; } = services.GetRequiredService<IChatPositionsBackend>();
     private IContactsBackend ContactsBackend { get; } = services.GetRequiredService<IContactsBackend>();
     private IRolesBackend RolesBackend { get; } = services.GetRequiredService<IRolesBackend>();
@@ -30,6 +32,7 @@ public partial class Chats(IServiceProvider services) : IChats
         = services.KeyedFactory<IBackendChatMarkupHub, ChatId>();
 
     private ICommander Commander { get; } = services.Commander();
+    private MomentClockSet Clocks { get; } = services.Clocks();
     private HostInfo HostInfo => field ??= services.HostInfo();
     private ILogger Log { get; } = services.LogFor<Chats>();
 
@@ -396,6 +399,51 @@ public partial class Chats(IServiceProvider services) : IChats
             chatDiff.AllowGuestAuthors.HasValue.RequireFalse("AllowGuestAuthors");
             chatDiff.PlaceId.RequireNull("PlaceId");
         }
+    }
+
+    public virtual async Task<ChatEntry> StreamEntry(
+        Session session,
+        ChatId chatId,
+        long? localId,
+        RpcStream<string> textChunks,
+        CancellationToken cancellationToken)
+    {
+        ThrowIfPlaceRootChat(chatId);
+        var author = await Authors.EnsureJoined(session, chatId, cancellationToken).ConfigureAwait(false);
+        var chat = await Get(session, chatId, cancellationToken).Require().ConfigureAwait(false);
+        chat.Rules.Permissions.Require(ChatPermissions.Write);
+
+        if (localId is not { } vLocalId)
+            return await TextEntryStreamer
+                .Stream(chatId, author.Id, textChunks, cancellationToken)
+                .ConfigureAwait(false);
+
+        var entry = await this
+            .GetEntry(session, ChatEntryId.New(chatId, vLocalId), cancellationToken)
+            .Require(ChatEntry.MustNotBeRemoved)
+            .ConfigureAwait(false);
+        if (entry.AuthorId != author.Id)
+            throw StandardError.Unauthorized("You can edit only your own messages.");
+        if (entry.IsContentStreaming)
+            throw StandardError.Constraint("Streaming messages cannot be edited.");
+        if (entry.Forwarded is not null)
+            throw StandardError.Constraint("Forwarded messages cannot be edited.");
+
+        var age = Clocks.SystemClock.Now - entry.BeginsAt;
+        if (age <= Constants.Chat.MaxStreamingEditAge)
+            return await TextEntryStreamer
+                .Stream(chatId, author.Id, entry, textChunks, cancellationToken)
+                .ConfigureAwait(false);
+
+        // Too old to animate: collect everything, then apply it through the ordinary edit path so
+        // the audio, markup and attachment handling there still applies.
+        var sb = ActualLab.Text.StringBuilderExt.Acquire();
+        await foreach (var chunk in textChunks.WithCancellation(cancellationToken).ConfigureAwait(false))
+            sb.Append(chunk);
+        var upsertCommand = new Chats_UpsertEntry(session, chatId, vLocalId) {
+            Text = sb.ToStringAndRelease(),
+        };
+        return await Commander.Call(upsertCommand, true, cancellationToken).ConfigureAwait(false);
     }
 
     // [CommandHandler]

--- a/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
+++ b/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
@@ -127,6 +127,7 @@ public sealed class ChatServiceModule(IServiceProvider moduleServices)
         services.AddSingleton<Translator>();
         services.AddKeyedSingleton<Translator>(Constants.Translation.RealtimeServiceKey);
         services.AddSingleton<LanguageDetector>();
+        services.AddSingleton<TextEntryStreamer>();
         services.AddAIServices();
         services.AddChatMLServices();
 

--- a/src/dotnet/Chat.Service/TextEntryStreamer.cs
+++ b/src/dotnet/Chat.Service/TextEntryStreamer.cs
@@ -1,0 +1,126 @@
+using ActualChat.Mesh;
+using ActualChat.Streaming;
+using ActualChat.Transcription;
+using ActualLab.Rpc;
+
+namespace ActualChat.Chat;
+
+/// <summary>
+/// Posts a text entry whose content arrives over time: the entry appears immediately with an
+/// empty body and a content stream readers can subscribe to, and is finalized with the full text.
+/// </summary>
+public class TextEntryStreamer(IServiceProvider services)
+{
+    // 5 outbound updates per second at most, regardless of how fast chunks arrive
+    private static readonly TimeSpan OutboundUpdateInterval = TimeSpan.FromMilliseconds(200);
+
+    private IServiceProvider Services { get; } = services;
+
+    private ICommander Commander => field ??= Services.Commander();
+    private IAudioStreamingBackend StreamingBackend => field ??= Services.GetRequiredService<IAudioStreamingBackend>();
+    private MeshWatcher MeshWatcher => field ??= Services.MeshWatcher();
+    private MomentClockSet Clocks => field ??= Services.Clocks();
+    protected ILogger Log => field ??= Services.LogFor(GetType());
+
+    public virtual Task<ChatEntry> Stream(
+        ChatId chatId,
+        AuthorId authorId,
+        IAsyncEnumerable<string> textChunks,
+        CancellationToken cancellationToken = default)
+        => Stream(chatId, authorId, null, textChunks, cancellationToken);
+
+    public virtual async Task<ChatEntry> Stream(
+        ChatId chatId,
+        AuthorId authorId,
+        ChatEntry? entryToUpdate,
+        IAsyncEnumerable<string> textChunks,
+        CancellationToken cancellationToken = default)
+    {
+        var streamId = StreamId.New(MeshWatcher.ThisNode.Ref);
+        using var stream = ToTranscriptDiffs(textChunks, cancellationToken)
+            .Memoize(cancellationToken);
+        var rpcStream = RpcStream.New(stream.Replay(cancellationToken));
+        var publishStreamTask = StreamingBackend.PushTranscript(streamId, rpcStream, cancellationToken);
+
+        // The entry has to exist before the stream is drained: readers find the stream through
+        // its ContentStreamId, so anything published earlier has no subscriber to reach.
+        var entry = entryToUpdate is null
+            ? await CreateEntry().ConfigureAwait(false)
+            : await StartStreamingInto(entryToUpdate).ConfigureAwait(false);
+        var transcript = Transcript.Empty;
+        try {
+            await foreach (var diff in stream.Replay(cancellationToken).ConfigureAwait(false))
+                transcript = diff.ApplyTo(transcript);
+            await publishStreamTask.ConfigureAwait(false);
+        }
+        finally {
+            // Finalized even on failure, otherwise the entry stays empty and streaming forever.
+            entry = await FinalizeEntry(entry, transcript.Text).ConfigureAwait(false);
+        }
+        return entry;
+
+        Task<ChatEntry> CreateEntry() {
+            var diff = new ChatEntryDiff {
+                AuthorId = authorId,
+                Content = "",
+                ContentStreamId = streamId.Value,
+                BeginsAt = Clocks.SystemClock.Now,
+            };
+            var command = new ChatsBackend_ChangeEntry(
+                ChatEntryId.New(chatId, 0),
+                null,
+                Change.Create(diff));
+            return Commander.Call(command, true, cancellationToken);
+        }
+
+        Task<ChatEntry> StartStreamingInto(ChatEntry entry1) {
+            // Content is left as it was: until the stream finalizes, a reader that doesn't follow
+            // it still sees the previous text rather than an empty message.
+            var diff = new ChatEntryDiff {
+                ContentStreamId = streamId.Value,
+            };
+            var command = new ChatsBackend_ChangeEntry(entry1.Id, null, Change.Update(diff));
+            return Commander.Call(command, true, cancellationToken);
+        }
+
+        Task<ChatEntry> FinalizeEntry(ChatEntry entryToFinalize, string text) {
+            var diff = new ChatEntryDiff {
+                Content = text,
+                ContentStreamId = "",
+                EndsAt = Clocks.SystemClock.Now,
+            };
+            var command = new ChatsBackend_ChangeEntry(
+                entryToFinalize.Id,
+                null, // No version check: the entry may have changed while streaming, and that's fine
+                Change.Update(diff));
+            return Commander.Call(command, true, CancellationToken.None);
+        }
+    }
+
+    // Private methods
+
+    private async IAsyncEnumerable<TranscriptDiff> ToTranscriptDiffs(
+        IAsyncEnumerable<string> textChunks,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // Producers may push at any rate - an LLM emits a token at a time - but every diff costs a
+        // fan-out to every reader, so a window's worth of chunks is coalesced into one update.
+        var text = "";
+        var batches = textChunks
+            .Buffer(OutboundUpdateInterval, Clocks.CpuClock, cancellationToken: cancellationToken);
+        await foreach (var batch in batches.ConfigureAwait(false)) {
+            if (batch.Count == 0)
+                continue;
+
+            var newText = text + string.Concat(batch);
+            if (newText == text)
+                continue;
+
+            yield return new TranscriptDiff(StringDiff.New(newText, text), LinearMapDiff.None) {
+                IsStable = true,
+            };
+
+            text = newText;
+        }
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -4,6 +4,10 @@
 @{
     var m = State.Value;
     var sm = m.Streaming;
+    // Streamed text is a prefix, so its tail is mid-token: parsed in incomplete mode it renders as
+    // markup right away instead of showing raw '**' - and a spoiler is masked rather than exposed.
+    // Plain text keeps the per-character animation below; there's no markup to lose.
+    var streamingMarkup = StreamingMarkupExt.ParseOrNullIfPlainText(sm.RetainedText + sm.ChangedText + sm.AnimatedText);
     var message = Message;
     var entry = m.Entry;
     // The server fills a location entry's content with a maps-link fallback for clients that don't
@@ -96,24 +100,28 @@
                 IsVoiceActive="@true"
                 IsLanguageKnown="@m.IsChatLanguageSelected"/>
         }
-        @if (!sm.RetainedText.IsNullOrEmpty()) {
-            <span class="retained">@sm.RetainedText</span>
-        }
-        <span class="changes">
-            <span class="changed-item">@sm.ChangedText</span>
-            @{
-                for (var spanIndex = 0; spanIndex < AnimationSpanCount; spanIndex++) {
-                    var spanStart = sm.AnimatedText.Length * spanIndex / AnimationSpanCount;
-                    var spanEnd = sm.AnimatedText.Length * (spanIndex + 1) / AnimationSpanCount;
-                    if (spanStart >= spanEnd)
-                        continue;
-
-                    var spanDelay = (int)Math.Round(AnimationSpanDurationMs * spanIndex);
-                    var style = $"transition-delay: {spanDelay}ms;";
-                    <span class="change-item" style="@style">@sm.AnimatedText[spanStart..spanEnd]</span>
-                }
+        @if (streamingMarkup is not null) {
+            <MarkupView Markup="@streamingMarkup"/>
+        } else {
+            @if (!sm.RetainedText.IsNullOrEmpty()) {
+                <span class="retained">@sm.RetainedText</span>
             }
-        </span>
+            <span class="changes">
+                <span class="changed-item">@sm.ChangedText</span>
+                @{
+                    for (var spanIndex = 0; spanIndex < AnimationSpanCount; spanIndex++) {
+                        var spanStart = sm.AnimatedText.Length * spanIndex / AnimationSpanCount;
+                        var spanEnd = sm.AnimatedText.Length * (spanIndex + 1) / AnimationSpanCount;
+                        if (spanStart >= spanEnd)
+                            continue;
+
+                        var spanDelay = (int)Math.Round(AnimationSpanDurationMs * spanIndex);
+                        var style = $"transition-delay: {spanDelay}ms;";
+                        <span class="change-item" style="@style">@sm.AnimatedText[spanStart..spanEnd]</span>
+                    }
+                }
+            </span>
+        }
         @if (!sm.Tail.IsNullOrEmpty()) {
             <span>…@sm.Tail</span>
         }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingMarkupExt.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingMarkupExt.cs
@@ -1,0 +1,19 @@
+using ActualChat.Chat;
+
+namespace ActualChat.UI.Blazor.App.Components;
+
+public static class StreamingMarkupExt
+{
+    private static readonly IMarkupParser Parser = new MarkupParser { AllowIncompleteMarkup = true };
+
+    public static Markup? ParseOrNullIfPlainText(string streamedText)
+    {
+        // Null means "nothing markup-shaped arrived yet", which lets the caller keep the
+        // per-character animation it uses for transcripts.
+        if (streamedText.IsNullOrEmpty())
+            return null;
+
+        var markup = Parser.Parse(streamedText);
+        return markup.IsPlainText() ? null : markup;
+    }
+}

--- a/tests/Chat.IntegrationTests/TextEntryStreamerTest.cs
+++ b/tests/Chat.IntegrationTests/TextEntryStreamerTest.cs
@@ -1,0 +1,302 @@
+using System.Threading.Channels;
+using ActualChat.Streaming;
+using ActualChat.Testing.Host;
+using ActualChat.Transcription;
+using ActualLab.Rpc;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+[Collection(nameof(ChatCollection))]
+public class TextEntryStreamerTest(ChatCollection.AppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<ChatCollection.AppHostFixture>(fixture, @out)
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+
+    private WebClientTester Tester => field ??= AppHost.NewWebClientTester(Out);
+    private TextEntryStreamer Streamer => field ??= AppHost.Services.GetRequiredService<TextEntryStreamer>();
+    private IChatsBackend ChatsBackend => field ??= AppHost.Services.GetRequiredService<IChatsBackend>();
+    private IAudioStreamingBackend StreamingBackend
+        => field ??= AppHost.Services.GetRequiredService<IAudioStreamingBackend>();
+
+    protected override async Task DisposeAsync()
+    {
+        await Tester.DisposeSilentlyAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ShouldFinalizeEntryWithTheWholeText()
+    {
+        // arrange
+        var (chatId, authorId) = await NewChat();
+
+        // act
+        var entry = await Stream(chatId, authorId, "Hello, ", "streamed ", "world!");
+
+        // assert
+        entry.Content.Should().Be("Hello, streamed world!");
+        entry.IsContentStreaming.Should().BeFalse();
+        entry.ContentStreamId.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldExposeEntryAsStreamingWhileItArrives()
+    {
+        // arrange
+        var (chatId, authorId) = await NewChat();
+        var chunks = Channel.CreateUnbounded<string>();
+        var cts = new CancellationTokenSource(WaitTimeout.Debuggable());
+
+        // act
+        var streamTask = Streamer.Stream(chatId, authorId, chunks.Reader.ReadAllAsync(cts.Token), cts.Token);
+        await chunks.Writer.WriteAsync("Partial text", cts.Token);
+
+        // assert - the entry is visible with a content stream and no content of its own
+        var streaming = await WhenEntryAppears(chatId, authorId, cts.Token);
+        streaming.IsContentStreaming.Should().BeTrue();
+        streaming.ContentStreamId.Should().NotBeEmpty();
+        streaming.Content.Should().BeEmpty();
+
+        // act
+        chunks.Writer.Complete();
+        var entry = await streamTask;
+
+        // assert
+        entry.Content.Should().Be("Partial text");
+        entry.IsContentStreaming.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldPublishStreamReadersCanFollow()
+    {
+        // arrange
+        var (chatId, authorId) = await NewChat();
+        var chunks = Channel.CreateUnbounded<string>();
+        var cts = new CancellationTokenSource(WaitTimeout.Debuggable());
+        var streamTask = Streamer.Stream(chatId, authorId, chunks.Reader.ReadAllAsync(cts.Token), cts.Token);
+        await chunks.Writer.WriteAsync("One ", cts.Token);
+        var streaming = await WhenEntryAppears(chatId, authorId, cts.Token);
+
+        // act - subscribe through the entry's stream id, the way a reader discovers the stream
+        var transcriptStream = await StreamingBackend
+            .GetTranscript(StreamId.Parse(streaming.ContentStreamId), cts.Token)
+            .Require();
+        await chunks.Writer.WriteAsync("Two ", cts.Token);
+        await chunks.Writer.WriteAsync("Three", cts.Token);
+        chunks.Writer.Complete();
+
+        var transcript = Transcript.Empty;
+        await foreach (var diff in transcriptStream.ConfigureAwait(false))
+            transcript = diff.ApplyTo(transcript);
+
+        // assert
+        transcript.Text.Should().Be("One Two Three");
+        var entry = await streamTask;
+        entry.Content.Should().Be("One Two Three");
+    }
+
+    [Fact]
+    public async Task ShouldStreamMarkupThatParsesAsIncompleteUntilFinished()
+    {
+        // The point of streaming markup: every prefix has to render, and the finished entry has to
+        // be ordinary complete markup.
+
+        // arrange
+        var (chatId, authorId) = await NewChat();
+        var incompleteParser = new MarkupParser { AllowIncompleteMarkup = true };
+        var parser = new MarkupParser();
+
+        // act
+        var entry = await Stream(chatId, authorId, "Spoiler: ||the ", "butler", " did it||");
+
+        // assert - the finished entry is complete markup, with nothing left incomplete
+        entry.Content.Should().Be("Spoiler: ||the butler did it||");
+        var markup = parser.Parse(entry.Content);
+        markup.ToReadableText().Should().NotContain("butler");
+        GetIncomplete(markup).Should().BeEmpty();
+
+        // assert - the prefix a reader saw mid-stream already hides the spoiler
+        var midStream = incompleteParser.Parse("Spoiler: ||the butler");
+        midStream.ToReadableText().Should().NotContain("butler");
+        GetIncomplete(midStream).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldFinalizeEntryWhenTheProducerFails()
+    {
+        // A producer that dies must not leave an entry streaming forever.
+
+        // arrange
+        var (chatId, authorId) = await NewChat();
+        var cts = new CancellationTokenSource(WaitTimeout.Debuggable());
+
+        // act
+        var streamTask = Streamer.Stream(chatId, authorId, FailingChunks(), cts.Token);
+        await streamTask.SilentAwait();
+
+        // assert
+        var entry = await WhenEntryAppears(chatId, authorId, cts.Token);
+        await ComputedTest.When(async ct => {
+            var current = await ChatsBackend.GetEntry(entry.Id, ct);
+            current!.IsContentStreaming.Should().BeFalse();
+        }, WaitTimeout);
+        return;
+
+        static async IAsyncEnumerable<string> FailingChunks() {
+            yield return "Started";
+            await Task.Yield();
+            throw new InvalidOperationException("Producer failed");
+        }
+    }
+
+    [Fact]
+    public async Task ShouldPostThroughThePublicApi()
+    {
+        // arrange
+        var (chatId, _) = await NewChat();
+
+        // act
+        var entry = await StreamViaApi(chatId, null, "Posted ", "in ", "pieces");
+
+        // assert
+        entry.Content.Should().Be("Posted in pieces");
+        entry.IsContentStreaming.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldStreamEditOfARecentEntry()
+    {
+        // arrange
+        var (chatId, _) = await NewChat();
+        var posted = await Tester.CreateTextEntry(chatId, "Original");
+
+        // act
+        var entry = await StreamViaApi(chatId, posted.Id.LocalId, "Edited ", "text");
+
+        // assert
+        entry.Id.LocalId.Should().Be(posted.Id.LocalId);
+        entry.Content.Should().Be("Edited text");
+        entry.IsContentStreaming.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldRejectEditingSomeoneElsesEntry()
+    {
+        // arrange
+        var (chatId, _) = await NewChat(isPublic: true);
+        var posted = await Tester.CreateTextEntry(chatId, "Alice's message");
+        await using var bob = AppHost.NewWebClientTester(Out);
+        await bob.SignInAsUniqueBob();
+        await bob.Commander.Call(new Authors_Join(bob.Session, chatId, null));
+
+        // act
+        var stream = RpcStream.New(new[] { "Hijacked" }.ToAsyncEnumerable());
+        var streamEntry = () => bob.Chats.StreamEntry(
+            bob.Session, chatId, posted.Id.LocalId, stream, CancellationToken.None);
+
+        // assert
+        await streamEntry.Should().ThrowAsync<Exception>();
+        var current = await ChatsBackend.GetEntry(posted.Id, CancellationToken.None);
+        current!.Content.Should().Be("Alice's message");
+    }
+
+    [Fact]
+    public async Task ShouldApplyStaleEditAsOneOrdinaryUpdate()
+    {
+        // Past MaxStreamingEditAge the edit still succeeds, but must not re-animate a settled
+        // message - so the entry never enters the streaming state.
+
+        // arrange
+        var (chatId, _) = await NewChat();
+        var posted = await Tester.CreateTextEntry(chatId, "Old message");
+        await BackdateEntry(posted.Id, Constants.Chat.MaxStreamingEditAge + TimeSpan.FromMinutes(5));
+        var wasStreaming = false;
+
+        // act
+        var entryTask = StreamViaApi(chatId, posted.Id.LocalId, "Rewritten ", "text");
+        while (!entryTask.IsCompleted) {
+            var current = await ChatsBackend.GetEntry(posted.Id, CancellationToken.None);
+            wasStreaming |= current?.IsContentStreaming ?? false;
+            await Task.Delay(20);
+        }
+        var entry = await entryTask;
+
+        // assert
+        entry.Content.Should().Be("Rewritten text");
+        entry.IsContentStreaming.Should().BeFalse();
+        wasStreaming.Should().BeFalse();
+    }
+
+    // Private methods
+
+    private async Task<(ChatId ChatId, AuthorId AuthorId)> NewChat(bool isPublic = false)
+    {
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(isPublic);
+        var author = await Tester.GetOwnAuthor(chatId).Require();
+        return (chatId, author.Id);
+    }
+
+    private Task<ChatEntry> Stream(ChatId chatId, AuthorId authorId, params string[] chunks)
+    {
+        var cts = new CancellationTokenSource(WaitTimeout.Debuggable());
+        return Streamer.Stream(chatId, authorId, chunks.ToAsyncEnumerable(), cts.Token);
+    }
+
+    private Task<ChatEntry> StreamViaApi(ChatId chatId, long? localId, params string[] chunks)
+    {
+        var cts = new CancellationTokenSource(WaitTimeout.Debuggable());
+        var stream = RpcStream.New(chunks.ToAsyncEnumerable());
+        return Tester.Chats.StreamEntry(Tester.Session, chatId, localId, stream, cts.Token);
+    }
+
+    private async Task BackdateEntry(ChatEntryId entryId, TimeSpan age)
+    {
+        var commander = AppHost.Services.Commander();
+        var beginsAt = AppHost.Services.Clocks().SystemClock.Now - age;
+        await commander.Call(new ChatsBackend_ChangeEntry(
+            entryId,
+            null,
+            Change.Update(new ChatEntryDiff { BeginsAt = beginsAt })));
+    }
+
+    private async Task<ChatEntry> WhenEntryAppears(
+        ChatId chatId,
+        AuthorId authorId,
+        CancellationToken cancellationToken)
+    {
+        ChatEntry entry = null!;
+        await ComputedTest.When(async ct => {
+            var maxLid = await ChatsBackend.GetMaxLid(chatId, false, ct);
+            var found = await ChatsBackend.GetEntry(ChatEntryId.New(chatId, maxLid), ct);
+            found.Should().NotBeNull();
+            found!.AuthorId.Should().Be(authorId);
+            entry = found;
+        }, WaitTimeout);
+        return entry;
+    }
+
+    private static List<Markup> GetIncomplete(Markup markup)
+    {
+        var items = new List<Markup>();
+        Collect(markup);
+        return items;
+
+        void Collect(Markup m) {
+            if (m.IsIncomplete)
+                items.Add(m);
+            switch (m) {
+            case MarkupSeq seq:
+                foreach (var item in seq.Items)
+                    Collect(item);
+                break;
+            case StylizedMarkup stylized:
+                Collect(stylized.Content);
+                break;
+            case ParagraphMarkup paragraph:
+                Collect(paragraph.Content);
+                break;
+            }
+        }
+    }
+}

--- a/tests/Chat.UI.Blazor.UnitTests/StreamingMarkupExtTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/StreamingMarkupExtTest.cs
@@ -1,0 +1,71 @@
+using ActualChat.UI.Blazor.App.Components;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class StreamingMarkupExtTest
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("Just transcribed words")]
+    [InlineData("A sentence that keeps going")]
+    public void PlainTextKeepsTheCharacterAnimation(string text)
+    {
+        // act
+        var markup = StreamingMarkupExt.ParseOrNullIfPlainText(text);
+
+        // assert
+        markup.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Hello **bold")]
+    [InlineData("Hello **bold**")]
+    [InlineData("Check `code")]
+    [InlineData("- one\n- two")]
+    public void MarkupIsRenderedAsMarkup(string text)
+    {
+        // act
+        var markup = StreamingMarkupExt.ParseOrNullIfPlainText(text);
+
+        // assert
+        markup.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void UnterminatedSpoilerIsMaskedWhileStreaming()
+    {
+        // act
+        var markup = StreamingMarkupExt.ParseOrNullIfPlainText("Ending: ||the butler did i");
+
+        // assert
+        markup.Should().NotBeNull();
+        markup!.ToReadableText().Should().NotContain("butler");
+        markup.ToReadableText().Should().Contain(StylizedMarkup.SpoilerMaskChar.ToString());
+    }
+
+    [Fact]
+    public void UnterminatedSpoilerWithHalfArrivedCloserIsAlsoMasked()
+    {
+        // act
+        var markup = StreamingMarkupExt.ParseOrNullIfPlainText("Ending: ||the butler|");
+
+        // assert
+        markup.Should().NotBeNull();
+        markup!.ToReadableText().Should().NotContain("butler");
+    }
+
+    [Fact]
+    public void UnterminatedBoldRendersAsBoldRatherThanRawTokens()
+    {
+        // act
+        var markup = StreamingMarkupExt.ParseOrNullIfPlainText("Hello **wor");
+
+        // assert
+        var seq = markup.Should().BeOfType<ParagraphMarkup>()
+            .Which.Content.Should().BeOfType<MarkupSeq>().Subject;
+        var bold = seq.Items[^1].Should().BeOfType<StylizedMarkup>().Subject;
+        bold.Style.Should().Be(TextStyle.Bold);
+        bold.IsIncomplete.Should().BeTrue();
+        bold.Content.ToReadableText().Should().Be("wor");
+    }
+}

--- a/tests/Chat.UnitTests/IncompleteMarkupParserTest.cs
+++ b/tests/Chat.UnitTests/IncompleteMarkupParserTest.cs
@@ -133,7 +133,8 @@ public class IncompleteMarkupParserTest(ITestOutputHelper @out) : TestBase(@out)
     [InlineData("Hello ||")]
     public void OpeningTokenWithNoContentStaysLiteral(string text)
     {
-        // An incomplete span needs non-empty content - see the note in CreateStylized.
+        // An incomplete span needs non-empty content, otherwise a nested empty match would consume
+        // the closing token of the span enclosing it - so a bare trailing token is still text.
 
         // act
         var markup = Parser.Parse(text);


### PR DESCRIPTION
Phases 1 and 2 of [docs/plans/streaming-markup-messages.md](../blob/dev/docs/plans/streaming-markup-messages.md).

A message can now be posted with its text arriving over time, so an LLM reply appears progressively instead of landing whole — and while it arrives it renders as markup rather than raw `**` tokens.

## Server — `TextEntryStreamer` + `IChats.StreamEntry`

`ContentStreamId` / `IsContentStreaming` were already entry-kind agnostic; only the *producer* was audio-only. `TextEntryStreamer` drives the same lifecycle `ProcessAudio` does, minus the audio: create the entry with a stream id and empty content, publish, accumulate, finalize.

`IChats.StreamEntry(session, chatId, localId, RpcStream<string>, ct)` posts (`localId == null`) or edits an own entry. It's an RPC method rather than a command, since commands can't carry an `RpcStream`. Permission checks are the ones `OnUpsertEntry` already applies.

**Age gate.** Editing an entry older than `Constants.Chat.MaxStreamingEditAge` (15 min) still succeeds, but is drained and applied through `Chats_UpsertEntry` — so it lands as one ordinary update instead of re-animating a settled message, and inherits the audio/markup/attachment handling that path already has.

**Rate.** Inbound chunks are accepted at any rate; outbound is coalesced to one update per 200 ms (5/sec), since every diff costs a fan-out to every reader.

## Client — streamed markup

The streaming branch rendered incoming text as plain spans, so markup showed as literal tokens until its closer arrived — and a spoiler being streamed or translated **displayed exactly what it exists to hide** for the whole duration. The streamed prefix is now parsed with `AllowIncompleteMarkup` and rendered as markup. Plain text keeps the per-character animation, so transcripts are unaffected; markup entries render without it, which is the intended end state.

## Tests

- `TextEntryStreamerTest` — 9 integration tests against live infra: entry visible as streaming with empty content, a reader following the published stream, a producer that throws still finalizing, the age gate never entering the streaming state, an edit of someone else's message refused.
- `StreamingMarkupExtTest` — 5 unit tests covering the parse-and-decide helper, including both spoiler-masking cases.
- `ActualChat.CI.slnf` clean; `Chat.UnitTests` 496 passed / 2 pre-existing skips; `Chat.UI.Blazor.UnitTests` 174.

## Known gaps

- **Transport naming.** Text streaming reuses the `Transcript`-shaped stream with a degenerate time map — `PushTranscript`, `IAudioStreamingBackend`, `TranscriptDiff`. Costs nothing to build, at the price of transport types that all say "transcript". Worth one mechanical rename once this settles.
- **The razor branch itself is untested.** `StreamingMarkupExtTest` covers the helper, not the component; the spoiler fix is verified at unit level and by reading the render path, not observed in a browser.
- Phases 3 and 4 of the plan — the translation streaming gate and keeping markup in streamed translations — are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pu6eCYoTRa4UwH6qGp8v87