### PR TITLE
feat(location): prompt to enable location permission instead of a bla…

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
@@ -17,20 +17,27 @@
                     Center="@m.OwnMarker.Point"
                     Zoom="15"
                     Markers="@([m.OwnMarker])"/>
+            } else if (m.MustRequestPermission) {
+                <button type="button" class="c-permission-prompt" @onclick="@OnEnablePermission">
+                    <i class="icon-marker-pin"></i>
+                    <span>Enable location permission to show map.</span>
+                </button>
             }
             <ButtonRound Class="c-close" Click="@OnClose">
                 <i class="icon-close"></i>
             </ButtonRound>
-            <div class="c-map-menu">
-                @if (m.EnableIncompleteUI) {
-                    <button type="button" class="c-map-menu-item" @onclick="@OnOpenMapTypeMenu">
-                        <i class="icon-map"></i>
+            @if (!m.MustRequestPermission) {
+                <div class="c-map-menu">
+                    @if (m.EnableIncompleteUI) {
+                        <button type="button" class="c-map-menu-item" @onclick="@OnOpenMapTypeMenu">
+                            <i class="icon-map"></i>
+                        </button>
+                    }
+                    <button type="button" class="c-map-menu-item" @onclick="@OnLocate">
+                        <i class="icon-navigation-pointer"></i>
                     </button>
-                }
-                <button type="button" class="c-map-menu-item" @onclick="@OnLocate">
-                    <i class="icon-navigation-pointer"></i>
-                </button>
-            </div>
+                </div>
+            }
         </div>
         <div class="c-actions">
             <ButtonTile Class="c-send-current" Click="@OnSendCurrent">
@@ -88,6 +95,8 @@
 
     private ILocationTracker Tracker => Hub.LocationTracker;
     private LocationUI LocationUI => Hub.LocationUI;
+    private LocationPermissionHandler LocationPermission
+        => field ??= Hub.Services.GetRequiredService<LocationPermissionHandler>();
 
     [CascadingParameter] public Modal Modal { get; set; } = null!;
     [Parameter] public Model ModalModel { get; set; } = null!;
@@ -117,9 +126,11 @@
         var isMapTypeMenuOpen = await _isMapTypeMenuOpen.Use(cancellationToken).ConfigureAwait(false);
         var isDurationMenuOpen = await _isDurationMenuOpen.Use(cancellationToken).ConfigureAwait(false);
         var ownMarker = await LocationUI.GetOwnMarker(ModalModel.ChatId, cancellationToken).ConfigureAwait(false);
+        var isPermissionGranted = await LocationUI.IsPermissionGranted(cancellationToken).ConfigureAwait(false);
         var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
         return new ComputedModel {
             OwnMarker =  ownMarker,
+            MustRequestPermission = ownMarker is null && isPermissionGranted != true,
             IsMapTypeMenuOpen =  isMapTypeMenuOpen,
             IsDurationMenuOpen =  isDurationMenuOpen,
             MapType =  mapType,
@@ -128,6 +139,9 @@
     }
 
     // Private methods
+
+    private Task OnEnablePermission()
+        => LocationPermission.CheckOrRequest(Hub.StopToken).AsTask();
 
     private void OnClose()
         => Modal.Close();
@@ -173,6 +187,7 @@
         public static readonly ComputedModel None = new() { OwnMarker = null };
 
         public required MapMarker? OwnMarker { get; init; }
+        public bool MustRequestPermission { get; init; }
         public MapType MapType { get; init; } = MapType.Map;
         public bool IsMapTypeMenuOpen { get; init; }
         public bool IsDurationMenuOpen { get; init; }

--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
@@ -12,6 +12,18 @@
 .share-location-modal .c-map {
     @apply w-full h-full;
 }
+.share-location-modal .c-permission-prompt {
+    @apply flex-y items-center justify-center gap-y-2;
+    @apply w-full h-full;
+    @apply px-8;
+    @apply text-center;
+}
+.share-location-modal .c-permission-prompt i {
+    @apply text-3xl text-03;
+}
+.share-location-modal .c-permission-prompt span {
+    @apply text-headline-1 text-02;
+}
 .share-location-modal .c-map-area .btn.btn-round {
     @apply absolute;
     @apply w-10 h-10;

--- a/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
@@ -194,10 +194,18 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
         if (await Tracker.LastKnown.Use(cancellationToken).ConfigureAwait(false) is { } lastKnown)
             return lastKnown;
 
-        if (await LocationPermission.Check(cancellationToken).ConfigureAwait(false) != true)
+        if (await IsPermissionGranted(cancellationToken).ConfigureAwait(false) != true)
             return null;
 
         return await Tracker.Get(false, cancellationToken).ConfigureAwait(false);
+    }
+
+    [ComputeMethod]
+    public virtual async Task<bool?> IsPermissionGranted(CancellationToken cancellationToken)
+    {
+        // null means "undetermined" here: web reports it for "prompt", Android - for a soft denial.
+        var isGranted = await LocationPermission.Cached.Use(cancellationToken).ConfigureAwait(false);
+        return isGranted ?? await LocationPermission.Check(cancellationToken).ConfigureAwait(false);
     }
 
     [ComputeMethod]


### PR DESCRIPTION
…nk map

The share-location modal drew an empty gray box whenever there was no own marker, which on mobile is the normal state until the permission is granted. It now shows "Enable location permission to show map." there, as a button that runs CheckOrRequest (so a refusal still opens the troubleshooter), and hides the locate / map-type buttons that would act on a map that isn't there.

The condition is `!= true` rather than `== false`: both handlers report null for "undetermined" - web for the `prompt` state, MAUI for Android's soft denial - and neither shows a map.

GetCurrentLocation used to call LocationPermission.Check directly, which isn't reactive, so granting the permission never invalidated it and the map stayed away until something else moved. It now goes through the new IsPermissionGranted compute method, which Use()s the handler's Cached state.


Claude-Session: https://claude.ai/code/session_01JBkLRpwr5gqZNe8LJLff5B