### PR TITLE
fix(location): don't pull side panels when dragging an interactive ma…

### DIFF
--- a/src/dotnet/UI.Blazor/Components/MapView/MapView.razor
+++ b/src/dotnet/UI.Blazor/Components/MapView/MapView.razor
@@ -3,7 +3,7 @@
 @using ActualChat.UI.Blazor.Services
 @inherits ComputedStateComponent<UIHub, MapView.Model?>
 
-<div @ref="Ref" class="map-view @Class"></div>
+<div @ref="Ref" class="map-view @Class" data-no-side-nav-pull="@Interactive"></div>
 
 @code {
     private static readonly string JSCreateMethod = $"{BlazorUICoreModule.ImportName}.MapView.create";

--- a/src/dotnet/UI.Blazor/Components/SideNav/side-nav.ts
+++ b/src/dotnet/UI.Blazor/Components/SideNav/side-nav.ts
@@ -234,6 +234,11 @@ class SideNavPullDetectGesture extends Gesture {
                 }
             }
 
+            // Placed after the block above, so an edge swipe over such an element still
+            // suppresses the browser's history-navigation gesture
+            if (event.target instanceof Element && event.target.closest('[data-no-side-nav-pull]'))
+                return; // The element pans on its own (e.g. an interactive map)
+
             Gestures.addActive(new SideNavPullDetectGesture(sideNav, coords, event, prePullDistance));
         })(); }));
     }


### PR DESCRIPTION
…p #4117

Panning the map activity panel horizontally started the SideNav pull gesture. MapView now marks its root with data-no-side-nav-pull when Interactive, and SideNavPullDetectGesture skips such touches — after the history-navigation block, so edge swipes still suppress the browser's back gesture.


Claude-Session: https://claude.ai/code/session_011RHf4v6cUUnBgNB5Ymz2Ay