### PR TITLE
feat(location): show the accuracy radius on the share-location map #4103

### DIFF
--- a/src/dotnet/Api/GeoPointExt.cs
+++ b/src/dotnet/Api/GeoPointExt.cs
@@ -3,15 +3,15 @@ namespace ActualChat;
 public static class GeoPointExt
 {
     public static string DistanceTextTo(this GeoPoint point, GeoPoint other)
-    {
-        var meters = point.DistanceTo(other);
-        return meters switch {
+        => DistanceText(point.DistanceTo(other));
+
+    public static string DistanceText(double meters)
+        => meters switch {
             < 1 => "1 m",
             < 1000 => $"{meters:F0} m",
             < 10_000 => $"{meters / 1000:F1} km",
             _ => $"{meters / 1000:F0} km",
         };
-    }
 
     public static double DistanceTo(this GeoPoint point, GeoPoint other)
     {

--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
@@ -44,7 +44,9 @@
                 <Icon><i class="icon-marker-pin"></i></Icon>
                 <Content>
                     <div class="c-text">Send my current location</div>
-                    <div class="c-caption">Accurate to 10m</div>
+                    @if (m.AccuracyText is { } accuracyText) {
+                        <div class="c-caption">@accuracyText</div>
+                    }
                 </Content>
             </ButtonTile>
             <ButtonTile Class="c-share-live" Click="@OnShareLive">
@@ -187,6 +189,10 @@
         public static readonly ComputedModel None = new() { OwnMarker = null };
 
         public required MapMarker? OwnMarker { get; init; }
+        public string? AccuracyText
+            => OwnMarker?.Point.Accuracy is { } accuracy and > 0
+                ? $"Accurate to {GeoPointExt.DistanceText(accuracy)}"
+                : null;
         public bool MustRequestPermission { get; init; }
         public MapType MapType { get; init; } = MapType.Map;
         public bool IsMapTypeMenuOpen { get; init; }

--- a/src/dotnet/UI.Blazor/Components/MapView/map-view.css
+++ b/src/dotnet/UI.Blazor/Components/MapView/map-view.css
@@ -41,6 +41,16 @@
     @apply bg-primary;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
+.map-view .map-marker .c-own-accuracy {
+    @apply absolute z-0;
+    @apply rounded-full;
+    @apply pointer-events-none;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+    border: 1px solid color-mix(in srgb, var(--primary) 35%, transparent);
+}
 .map-view .map-marker .c-own-pulse {
     @apply absolute inset-0 z-0;
     @apply rounded-full;

--- a/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
+++ b/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
@@ -2,6 +2,9 @@ import maplibregl, { Map as MlMap, Marker as MlMarker } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Versioning } from 'versioning';
 
+// Below this diameter the accuracy circle just fattens the dot's outline, so it's not drawn.
+const minAccuracyCircleSize = 24;
+
 let isWorkerUrlSet = false;
 
 // The build resolves maplibre-gl to its CSP variant, which has no built-in worker URL.
@@ -123,6 +126,8 @@ export class MapView {
             attributionControl: false,
         });
         this.map.on('webglcontextlost', () => this.onContextLost());
+        // An accuracy circle is a metric radius, so its pixel size changes with zoom.
+        this.map.on('move', () => this.applyAccuracyCircles(this.lastMarkers));
         this.applyMarkers(this.lastMarkers);
     }
 
@@ -196,6 +201,19 @@ export class MapView {
             marker.remove();
             this.markers.delete(id);
         }
+        this.applyAccuracyCircles(markers);
+    }
+
+    private applyAccuracyCircles(markers: MapMarker[]): void {
+        const map = this.map;
+        if (map == null)
+            return;
+
+        for (const m of markers) {
+            const marker = this.markers.get(m.id);
+            if (marker != null)
+                MapView.applyAccuracyCircle(map, marker.getElement(), m.point);
+        }
     }
 
     // Marker styles: the avatar-less own position is a lone blue dot (+ heading fan),
@@ -246,13 +264,16 @@ export class MapView {
     private static createOwnLocationElement(m: MapMarker): HTMLElement {
         const own = document.createElement('div');
         own.className = 'c-own-location';
+        const accuracy = document.createElement('div');
+        accuracy.className = 'c-own-accuracy';
+        accuracy.style.display = 'none';
         const heading = document.createElement('div');
         heading.className = 'c-own-heading';
         const pulse = document.createElement('div');
         pulse.className = 'c-own-pulse';
         const dot = document.createElement('div');
         dot.className = 'c-own-dot';
-        own.append(heading, pulse, dot);
+        own.append(accuracy, heading, pulse, dot);
         MapView.applyHeading(own, m.point.bearing);
         return own;
     }
@@ -271,6 +292,33 @@ export class MapView {
 
         heading.style.display = '';
         heading.style.transform = `rotate(${bearing}deg)`;
+    }
+
+    // The circle covers the area the position may actually be in, so it's sized in meters.
+    private static applyAccuracyCircle(map: MlMap, element: HTMLElement, point: GeoPoint): void {
+        const circle = element.querySelector<HTMLElement>('.c-own-accuracy');
+        if (circle == null)
+            return;
+
+        const size = 2 * MapView.toPixelDistance(map, point, point.accuracy ?? 0);
+        if (size < minAccuracyCircleSize) {
+            circle.style.display = 'none';
+            return;
+        }
+
+        circle.style.display = '';
+        circle.style.width = `${size}px`;
+        circle.style.height = `${size}px`;
+    }
+
+    private static toPixelDistance(map: MlMap, point: GeoPoint, meters: number): number {
+        const metersPerDegree = 111_320 * Math.cos(point.latitude * Math.PI / 180);
+        if (meters <= 0 || metersPerDegree <= 0)
+            return 0;
+
+        const origin = map.project([point.longitude, point.latitude]);
+        const shifted = map.project([point.longitude + (meters / metersPerDegree), point.latitude]);
+        return Math.abs(shifted.x - origin.x);
     }
 
     private static createAvatarElement(m: MapMarker): HTMLElement | null {


### PR DESCRIPTION
The own-location marker now draws a translucent circle covering the area the position may actually be in, sized from GeoPoint.Accuracy. The radius is metric, so it's projected to pixels at the point's latitude and re-applied on every map move; it's hidden when accuracy is unknown or the circle would be smaller than the dot itself.

The "Send my current location" caption reported a hardcoded 10 m — it now reports the real accuracy, and disappears when there is none.


Claude-Session: https://claude.ai/code/session_01RVRCTHekf9rTZpHGUnyetG