### PR TITLE
feat(chat): parse #hashtags and search them on click #4121

### DIFF
--- a/docs/plans/hashtags.md
+++ b/docs/plans/hashtags.md
@@ -1,0 +1,273 @@
+# Hashtags (#4121)
+
+## TLDR
+
+Add first-class `#hashtag` support in three phases:
+
+1. **Markup + click-to-search (MVP, client + Api only).** A new
+   `HashtagMarkup : TextMarkup` parsed by `MarkupParser`, rendered by a new
+   `HashtagMarkupView` as a clickable link. Clicking it opens the left-panel
+   search, puts `#hashtag` into the search field, sets the type filter to
+   Messages, and runs the existing search. No DB, no new backend. Search
+   quality is "whatever OpenSearch does with the word today" (the `#` is
+   stripped by the analyzer, so it finds the word `hashtag` anywhere).
+2. **Exact hashtag search.** A `HashtagExtractor` visitor (mirror of
+   `MentionExtractor`) feeds an exact-match hashtag index, and a single-
+   `#hashtag` search criteria queries it instead of the full-text match.
+   **Where that index lives depends on timing**: OpenSearch is slated for
+   wholesale retirement in favor of the Postgres-based `Search.Service`
+   ([mlsearch-postgres-fts.md](./mlsearch-postgres-fts.md), decisions agreed
+   Jul 2026). Preferred: fold hashtag token preservation into the new
+   service's application-level analyzer (trivial there); only if exact
+   hashtag search is needed *before* that lands, add a small throwaway
+   `Hashtags` keyword field to the OpenSearch `IndexedEntry`.
+3. **(Deferred, optional) Hashtag registry in DB.** A `Hashtags` table
+   mirroring `Mentions` (`DbMention` / `MentionsBackend` pattern), enabling
+   `#`-autocomplete in the editor, per-chat hashtag lists, and usage counts.
+   Not needed for phases 1–2; decide after the MVP ships.
+
+Phase 1 is fully shippable on its own and delivers everything the issue asks
+for; phase 2 makes the search *correct*; phase 3 is a product decision.
+
+## Current state (verified against source)
+
+- **Parsing.** `MarkupParser` (`src/dotnet/Api/Chat/Markup/MarkupParser.cs`)
+  is a Pidgin combinator grammar. `#` is currently *not* a special char:
+  `NotSpecialOrWhitespaceChar` consumes it, so `#tag` is plain text today.
+  `#` only matters at line start as a header token (`HeaderLevel`), and a
+  header requires whitespace after the `#`s — so `#tag` (no space) never
+  collides with `# Title`.
+- **Markup model.** `Markup` (`Markup.cs`) is a MessagePack union with 18
+  registered subtypes; `TextMarkup` subtypes are dispatched in the generic
+  visitors' `VisitText` switch (`Visitors/Generic/MarkupVisitor.cs:21`,
+  plus `MarkupVisitorWithState` ×2 and `AsyncMarkupVisitor`). An unknown
+  subtype falls into `VisitUnknown`, which throws — so every visitor base
+  needs a `VisitHashtag` case.
+- **Rendering.** `MarkupView` resolves a Blazor component per markup type via
+  `TypeMapper<IMarkupView>` registered in
+  `BlazorUIAppModule.cs:100` — adding a view is one `.Add<,>()` line plus a
+  `.razor` file in `Components/MarkupParts/`.
+- **Mentions precedent for extraction + storage.** `MentionsBackend`
+  (`Chat.Service/MentionsBackend.cs`) listens to `ChatEntryChangedEvent`,
+  re-parses the entry, extracts ids with `MentionExtractor`
+  (a `MarkupVisitorWithState<HashSet<MentionRef>>`), and diffs them into the
+  `Mentions` table (`Db/DbMention.cs`). This is the exact template for a
+  phase-3 hashtag registry.
+- **Search.** Left-panel search field (`LeftSearchPanel/LeftChatSearchInput.razor`)
+  writes into `SearchUI.Text`; `SearchUI.StateSync` debounces, queries
+  `ISearch.FindEntries` → `MLSearch.Service/SearchBackend.FindEntriesInOpenSearch`,
+  which runs a `MatchBoolPrefix` on `IndexedEntry.Content` (a standard-analyzed
+  `text` field, mapping in `OpenSearchConfigurator.ConfigureEntryIndex`).
+  The standard analyzer drops `#`, so searching `#promo` today ≈ searching
+  `promo`. ACL filtering is done by restricting to the user's chat ids
+  (`ListChatIds`), and that part is reusable as-is for hashtag search.
+- **Editor.** The message editor round-trips markup through
+  `MarkupEditorHtmlConverter` (a `MarkupHtmlFormatterBase`). Hashtags need no
+  editor-side special casing in phase 1: they can render as plain editable
+  text in the editor and re-parse on send/save.
+
+## Design decisions
+
+### Markup: `HashtagMarkup : TextMarkup`
+
+- `Text` holds the **full token including `#`** (e.g. `#promo`), so
+  `Format()` is inherited behavior returning `Text` and copy/edit round-trips
+  are trivial. A computed `Tag` property returns `Text[1..]`.
+- New `TextMarkupKind.Hashtag` enum member; `Kind` override returns it.
+- `[Union(19, typeof(HashtagMarkup))]` on `Markup`; `[DataContract,
+  MessagePackObject]` like the siblings. Run `App.AotHelper -g` after adding
+  the type (AOT serializer registry).
+- Not a `MentionMarkup`: mentions carry a resolvable `MentionRef` identity and
+  a resolver pipeline; a hashtag is just text with behavior. `TextMarkup` fit
+  keeps every text-ish code path (trimming, normalizing) sane.
+
+### Token grammar
+
+`#` followed by a tag body, recognized only at word start (which the grammar
+gives us for free — mid-word `#`, as in `C#5` or `item#2`, stays inside the
+plain-text run because `#` remains a non-special char for `NotSpecialOrWhitespaceChar`):
+
+- Body: first char is a Unicode letter or `_`, then letters, digits, `_`, `-`.
+- All-digit tokens (`#4121`) are **not** hashtags — they're issue/number
+  references people paste all the time.
+- Max length 64 chars; longer → plain text.
+- `# Title` stays a header (hashtag parser fails on the space, header wins at
+  block level). `#tag` at line start becomes a hashtag — behavior change from
+  "plain text", which is the point.
+- Inside code blocks / preformatted spans nothing changes (those parsers
+  consume first).
+- Matching is case-preserving for display; comparison/search lowercases
+  (invariant) — same choice every major chat product makes.
+
+Implementation: a `Hashtag` parser added to the `nonStylizedMarkup` chain in
+`InternalParsers.Build` (before `NonWhitespaceText`), analogous to `Mention`.
+The token is atomic, so the incomplete-markup grammar variants need nothing
+extra.
+
+### Click behavior
+
+New `HashtagMarkupView.razor` renders `<a class="hashtag-markup">#tag</a>`.
+On click:
+
+1. `PanelsUI.Left.SetIsVisible(true)` — brings the left panel up on mobile;
+   no-op on desktop.
+2. `SearchUI.PlaceId.Value` ← current place (same rule as
+   `LeftChatSearchInput.OnClick`), `SearchUI.ShowRecent(true)` to open the
+   search panel.
+3. `SearchUI.Text.Value = markup.Text` — the existing
+   `SearchUI.StateSync.SyncSearch` debouncer picks it up and runs the search;
+   `IsSearchModeOn` flips automatically once results land.
+4. `SearchUI.SetTypeFilter(SearchTypeFilter.Messages)` — hashtags live in
+   messages; the badge lets the user widen it back.
+
+One wrinkle: `LeftChatSearchInput` reads `SearchUI.Text.Value` (deliberately
+not `.Use()`, see the `AY: why?` comment at `LeftChatSearchInput.razor:99`),
+so an externally-set text may not appear in the input box if the panel is
+already open. Fix by publishing a UI event (mirror of the existing
+`SearchClearedEvent` → e.g. `SearchTextSetEvent`) that the input handles by
+setting its `TextInput` content. The whole click handler belongs in `SearchUI`
+(e.g. `SearchUI.SearchFor(string text)`) rather than in the view, so other
+callers (deep links, place search overlay) can reuse it.
+
+### Storage: is a DB table warranted?
+
+Investigated the `Mentions` precedent. Verdict: **not for search** — search
+already flows through OpenSearch with ACL handling, and duplicating that in
+Postgres means building a parallel result pipeline for `FoundChatEntry`.
+A keyword field on the existing entry index (phase 2) is strictly less code
+and lands in the existing results UI untouched.
+
+A DB registry (phase 3) becomes worth it only for features OpenSearch serves
+poorly: `#`-autocomplete while typing, per-chat "browse by hashtag", counts /
+trending. The `MentionsBackend` + `DbMention` pattern transfers 1:1
+(`DbHashtag { ChatId, EntryLid, Tag }`, same event handler, same diffing).
+Defer until those features are actually wanted.
+
+## Reuse
+
+**Existing abstractions to reuse:**
+
+- `MarkupParser` grammar + `SafeTryOneOf` combinator infra — extend, not fork.
+- `TextMarkup` / `TextMarkupKind` — base for the new markup.
+- Generic visitor bases (`MarkupVisitor`, `MarkupVisitorWithState` ×2,
+  `AsyncMarkupVisitor`, `MarkupRewriter`, `AsyncMarkupRewriter`) — add the
+  `VisitHashtag` hook once in the bases; rewriters get identity defaults like
+  `VisitUrl` already has.
+- `MentionExtractor` — template for `HashtagExtractor` (phase 2/3).
+- `TypeMapper<IMarkupView>` + `MarkupViewBase<T>` — view registration/dispatch.
+- `SearchUI` (`Text`, `PlaceId`, `ShowRecent`, `SetTypeFilter`) +
+  `UIEventHub` events (`SearchClearedEvent` pattern) — click-to-search.
+- `PanelsUI.Left.SetIsVisible` — mobile panel handling.
+- `SearchBackend.FindEntriesInOpenSearch` incl. `ListChatIds` ACL scoping and
+  `OpenSearchConfigurator.ConfigureEntryIndex` — phase 2 lands inside them.
+- `MentionsBackend` / `DbMention` — phase 3 template, if it happens.
+
+No existing abstraction covers "hashtag" itself — verified by repo-wide
+search (`rg -i hashtag`): nothing outside icon fonts.
+
+**Reusability of new components:**
+
+- `HashtagMarkup`, parser rule, `TextMarkupKind.Hashtag`, `HashtagExtractor`
+  → `src/dotnet/Api/Chat/Markup/` next to their siblings. That project *is*
+  the shared home for markup; nothing to promote.
+- `HashtagMarkupView` → `UI.Blazor.App/Components/MarkupParts/` with the
+  other markup views (they are only used via `TypeMapper`, already shared
+  across all app targets).
+- `SearchUI.SearchFor(text)` — placed on `SearchUI` (shared UI service)
+  precisely so it's reusable beyond the hashtag click.
+- No TypeScript components are needed (rendering and click handling are
+  Blazor; the TS editor treats hashtags as plain text).
+
+## Phase 1 — markup + click-to-search
+
+**Status: implemented** (Aug 2026, `feat/4121-support-hashtags`). Notable
+deltas from the design below: `TextMarkupKind.Hashtag` was appended *after*
+`Unknown` to keep existing enum wire values stable; `TextInput` gained a
+`SetText` method (backed by the previously unused JS `set`) instead of a
+custom sync path; a hex color like `#f3f4f6` is an accepted hashtag
+false positive (pinned in `SpecialTest_CssRuleCase` — round-trip text stays
+exact); and tags must be whitespace-separated — `#a#b` is plain text, not
+two tags (a trailing `Lookahead(Not('#'))` guard backtracks the whole run).
+
+1. `Api/Chat/Markup/HashtagMarkup.cs` — new type as designed above;
+   `TextMarkupKind.Hashtag`; `Union(19)` on `Markup`.
+2. `MarkupParser` — `Hashtag` parser in the `nonStylizedMarkup` chain.
+3. Visitor bases — `HashtagMarkup` case in the `VisitText` switches; abstract
+   `VisitHashtag` in visitor bases, identity default in the rewriter bases.
+   Concrete visitors (all 1-liners):
+   - `MarkupFormatter` — append `Text` (both variants).
+   - `MarkupHtmlFormatterBase` — emit `<span class="hashtag">`-wrapped text;
+     `MarkupEditorHtmlConverter` inherits it and needs nothing extra (plain
+     editable text in the editor is the phase-1 behavior).
+   - `MentionExtractor`, `LinkExtractor` — no-op.
+   - `MarkupTrimmer` — atomic like `VisitUrl` (don't split the tag).
+   - `MarkupValidator` — predicate hook.
+   - `MarkupNormalizer` — must *not* merge a hashtag into adjacent plain text
+     (different `Kind` should already prevent it; add a test).
+4. `App.AotHelper -g` regeneration.
+5. `HashtagMarkupView.razor` + CSS (style ~like `mention-markup`) +
+   `TypeMapper` registration in `BlazorUIAppModule`.
+6. `SearchUI.SearchFor(string text)` + `SearchTextSetEvent` + handler in
+   `LeftChatSearchInput`; wire the view's click to it.
+7. Tests:
+   - `MarkupParserTest`: `#tag`, `#tag-two_3`, mid-word `c#5`/`item#2` (not a
+     tag), `#4121` (not a tag), `# Title` (header), `#tag` at line start,
+     `**#tag**`, `` `#tag` `` (preformatted, not a tag), 64+ chars, `#тег`
+     (Unicode), `#a#b`.
+   - `MarkupFormatterTest` / `MarkupNormalizerTest` round-trips.
+   - Serialization round-trip test alongside the existing markup
+     serialization tests in `tests/Chat.UnitTests`.
+
+## Phase 2 — exact search
+
+The search engine is in flux: OpenSearch/MLSearch will be **retired
+wholesale** and replaced by a Postgres FTS `Search.Service` with
+application-level text analysis ([mlsearch-postgres-fts.md](./mlsearch-postgres-fts.md)).
+That plan already indexes **raw tokens** alongside stems — exact hashtag
+search there is just (a) making the tokenizer keep `#tag` as one raw token
+(the standard behavior would split it) and (b) routing a single-hashtag
+criteria to a raw-token exact match. Both are small, and belong *in that
+plan* — when phase 2 is approved, add a "hashtag tokens" note to the
+Search.Service analyzer spec rather than building anything hashtag-specific.
+
+Common piece, buildable now:
+
+1. `Api/Chat/Markup/Visitors/HashtagExtractor.cs` — mirror of
+   `MentionExtractor`, returns lowercased tags. Used by whichever indexing
+   pipeline is current, and by phase 3 if it happens.
+
+Only if exact search is wanted **before** `Search.Service` lands (throwaway,
+~3 files, drop at MLSearch retirement):
+
+2. `IndexedEntry.Hashtags : string[]` + keyword mapping in
+   `OpenSearchConfigurator.ConfigureEntryIndex`; populate in the
+   `ToIndexedEntry` mapping used by `EntryIndexingFlow`.
+3. `SearchBackend.FindEntriesInOpenSearch` — when `query.Criteria` is exactly
+   one hashtag token, replace the `MatchBoolPrefix` on `Content` with a
+   `Term` on `Hashtags` (keep the chat-id parent filter). Highlighting: keep
+   highlighting `Content` with the raw tag text.
+4. Mapping migration: adding a field to an existing index is a compatible
+   put-mapping change; existing documents simply lack the field until the
+   entry is re-indexed. Check how `OpenSearchConfigurator.EnsureIndex` treats
+   an existing index (update vs create-only) — if create-only, bump the entry
+   index version / trigger the existing reindex flow.
+5. Integration test: index entries with `#promo` and with plain `promo`,
+   assert `#promo` finds only the former and `promo` finds both.
+
+## Phase 3 (deferred) — DB registry + autocomplete
+
+Only if `#`-autocomplete / per-chat hashtag browsing / trending is wanted:
+`DbHashtag` + `HashtagsBackend` on the `MentionsBackend` template, editor
+autocomplete on `#` reusing the `MentionListManager` + `MentionList` machinery
+with a hashtag candidate source. Not designed further here on purpose.
+
+## Open questions
+
+- Click scoping: current plan searches with the ambient place scope +
+  Messages filter. Alternative: scope to the *current chat*
+  (`SearchLocationFilter.Chat`). Recommendation: ambient scope — matches what
+  the search field itself would do, and the filter badges make narrowing one
+  tap away.
+- Should `#tag` in a *voice transcript* (`PlayableTextMarkup`) be linkified
+  too? Phase 1 doesn't touch transcript rendering; transcripts rarely contain
+  literal `#`. Skip until asked.

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -13,6 +13,14 @@ candidate tasks. A plan is removed from here once its work ships.
 
 Recently added, larger efforts — in progress or next up.
 
+### Hashtags
+
+[Hashtags](./hashtags.md) — `#hashtag` markup parsed into a new
+`HashtagMarkup`, rendered as a clickable link that opens the left-panel
+search with the tag and the Messages filter applied. Exact-match hashtag
+search folds into the `Search.Service` analyzer (below); an optional DB
+registry for autocomplete/trending is deferred. (#4121)
+
 ### AI search & indexing — MLSearch → PostgreSQL
 
 [MLSearch: OpenSearch → PostgreSQL](./mlsearch-postgres-fts.md) — replace

--- a/src/dotnet/Api/Chat/Markup/HashtagMarkup.cs
+++ b/src/dotnet/Api/Chat/Markup/HashtagMarkup.cs
@@ -1,0 +1,19 @@
+﻿using ActualLab.Fusion.Blazor;
+
+namespace ActualChat.Chat;
+
+/// <summary>
+/// Represents a #hashtag token; <see cref="TextMarkup.Text"/> includes the leading '#'.
+/// </summary>
+[ParameterComparer(typeof(ByRefParameterComparer))]
+[DataContract, MessagePackObject]
+public sealed class HashtagMarkup(string text) : TextMarkup(text)
+{
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
+    public string Tag => Text.Length > 0 ? Text[1..] : "";
+
+    public override TextMarkupKind Kind => TextMarkupKind.Hashtag;
+
+    public override TextMarkup WithText(string text)
+        => new HashtagMarkup(text);
+}

--- a/src/dotnet/Api/Chat/Markup/Markup.cs
+++ b/src/dotnet/Api/Chat/Markup/Markup.cs
@@ -26,6 +26,7 @@ namespace ActualChat.Chat;
 [Union(16, typeof(MarkupSeq))]
 [Union(17, typeof(StylizedMarkup))]
 [Union(18, typeof(UrlMarkup))]
+[Union(19, typeof(HashtagMarkup))]
 public abstract class Markup : ISanitized
 {
     protected static ArrayPool<Markup> MarkupArrayPool = ArrayPool<Markup>.Shared;

--- a/src/dotnet/Api/Chat/Markup/MarkupParser.cs
+++ b/src/dotnet/Api/Chat/Markup/MarkupParser.cs
@@ -179,6 +179,25 @@ public partial class MarkupParser : IMarkupParser
     private static readonly Parser<char, Markup> Mention =
         SafeTryOneOf(NamedMention, UnnamedMention);
 
+    // Hashtag: '#' + a letter or '_', then letters, digits, '_', '-'. Only matches at an element
+    // boundary — a mid-word '#' (c#5, item#2) stays inside the plain-text run because '#' is not
+    // a special char for NotSpecialOrWhitespaceChar. All-digit tokens (#4121) are not hashtags,
+    // and adjacent tags must be whitespace-separated — the trailing guard fails on '#a#b', which
+    // then backtracks into a single plain-text run.
+    private const int MaxHashtagLength = 64;
+    private static readonly Parser<char, char> HashtagFirstChar =
+        Token(c => char.IsLetter(c) || c is '_').Labelled("letter or '_'");
+    private static readonly Parser<char, char> HashtagChar =
+        Token(c => char.IsLetterOrDigit(c) || c is '_' or '-').Labelled("letter, digit, '_', or '-'");
+    private static readonly Parser<char, Markup> Hashtag = (
+        from head in Char('#').Then(HashtagFirstChar)
+        from tail in HashtagChar.ManyString()
+        select "#" + head + tail)
+        .Where(s => s.Length <= 1 + MaxHashtagLength)
+        .Before(Lookahead(Not(Char('#'))))
+        .Select(s => (Markup)new HashtagMarkup(s))
+        .Debug("#");
+
     // Preformatted text opener - the guard keeps a ``` code block fence out of an inline code span
     private static readonly Parser<char, Pidgin.Unit> PreformattedTextStart =
         Lookahead(Not(CodeBlockToken.Before(NotPreToken.OrEnd())));
@@ -316,7 +335,7 @@ public partial class MarkupParser : IMarkupParser
             var textMarkupKind = UseUnparsedTextMarkup ? TextMarkupKind.Unparsed : TextMarkupKind.Plain;
 
             var preformattedText = CreatePreformattedText();
-            var nonStylizedMarkup = SafeTryOneOf(Mention, preformattedText, Url, NonWhitespaceText).Debug("T");
+            var nonStylizedMarkup = SafeTryOneOf(Mention, preformattedText, Url, Hashtag, NonWhitespaceText).Debug("T");
             var boldMarkup = CreateStylized(Try(BoldToken), TextStyle.Bold).Debug("**");
             var italicMarkup = CreateStylized(ItalicToken, TextStyle.Italic).Debug("*");
             var spoilerMarkup = CreateStylized(Try(SpoilerToken), TextStyle.Spoiler).Debug("||");

--- a/src/dotnet/Api/Chat/Markup/TextMarkupKind.cs
+++ b/src/dotnet/Api/Chat/Markup/TextMarkupKind.cs
@@ -10,4 +10,5 @@ public enum TextMarkupKind
     Unparsed,
     NewLine,
     Unknown,
+    Hashtag,
 }

--- a/src/dotnet/Api/Chat/Markup/Visitors/Generic/AsyncMarkupRewriter.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/Generic/AsyncMarkupRewriter.cs
@@ -82,4 +82,6 @@ public abstract record AsyncMarkupRewriter : AsyncMarkupVisitor<Markup>
         => new (markup);
     protected override ValueTask<Markup> VisitUnparsed(UnparsedTextMarkup markup, CancellationToken cancellationToken)
         => new (markup);
+    protected override ValueTask<Markup> VisitHashtag(HashtagMarkup markup, CancellationToken cancellationToken)
+        => new (markup);
 }

--- a/src/dotnet/Api/Chat/Markup/Visitors/Generic/AsyncMarkupVisitor.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/Generic/AsyncMarkupVisitor.cs
@@ -25,6 +25,7 @@ public abstract record AsyncMarkupVisitor<TResult>
             PreformattedTextMarkup preformattedTextMarkup => VisitPreformattedText(preformattedTextMarkup, cancellationToken),
             NewLineMarkup newLineMarkup => VisitNewLine(newLineMarkup, cancellationToken),
             UnparsedTextMarkup unparsedMarkup => VisitUnparsed(unparsedMarkup, cancellationToken),
+            HashtagMarkup hashtagMarkup => VisitHashtag(hashtagMarkup, cancellationToken),
             _ => VisitUnknown(markup, cancellationToken),
         };
 
@@ -47,6 +48,7 @@ public abstract record AsyncMarkupVisitor<TResult>
     protected abstract ValueTask<TResult> VisitPreformattedText(PreformattedTextMarkup markup, CancellationToken cancellationToken);
     protected abstract ValueTask<TResult> VisitNewLine(NewLineMarkup markup, CancellationToken cancellationToken);
     protected abstract ValueTask<TResult> VisitUnparsed(UnparsedTextMarkup markup, CancellationToken cancellationToken);
+    protected abstract ValueTask<TResult> VisitHashtag(HashtagMarkup markup, CancellationToken cancellationToken);
 
     protected virtual ValueTask<TResult> VisitUnknown(Markup markup, CancellationToken cancellationToken)
         => throw new ArgumentOutOfRangeException(nameof(markup));

--- a/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupRewriter.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupRewriter.cs
@@ -66,6 +66,7 @@ public abstract record MarkupRewriter<TState> : MarkupVisitorWithState<TState, M
     protected override Markup VisitPreformattedText(PreformattedTextMarkup markup, ref TState state) => markup;
     protected override Markup VisitNewLine(NewLineMarkup markup, ref TState state) => markup;
     protected override Markup VisitUnparsed(UnparsedTextMarkup markup, ref TState state) => markup;
+    protected override Markup VisitHashtag(HashtagMarkup markup, ref TState state) => markup;
 
     protected override Markup VisitUnknown(Markup markup, ref TState state) => markup;
 }

--- a/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupVisitor.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupVisitor.cs
@@ -25,6 +25,7 @@ public abstract record MarkupVisitor<TResult>
             PreformattedTextMarkup preformattedTextMarkup => VisitPreformattedText(preformattedTextMarkup),
             NewLineMarkup newLineMarkup => VisitNewLine(newLineMarkup),
             UnparsedTextMarkup unparsedMarkup => VisitUnparsed(unparsedMarkup),
+            HashtagMarkup hashtagMarkup => VisitHashtag(hashtagMarkup),
             _ => VisitUnknown(markup),
         };
 
@@ -47,6 +48,7 @@ public abstract record MarkupVisitor<TResult>
     protected abstract TResult VisitPreformattedText(PreformattedTextMarkup markup);
     protected abstract TResult VisitNewLine(NewLineMarkup markup);
     protected abstract TResult VisitUnparsed(UnparsedTextMarkup markup);
+    protected abstract TResult VisitHashtag(HashtagMarkup markup);
 
     protected virtual TResult VisitUnknown(Markup markup)
         => throw new ArgumentOutOfRangeException(nameof(markup));

--- a/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupVisitorWithState.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/Generic/MarkupVisitorWithState.cs
@@ -25,6 +25,7 @@ public abstract record MarkupVisitorWithState<TState, TResult>
             PreformattedTextMarkup preformattedTextMarkup => VisitPreformattedText(preformattedTextMarkup, ref state),
             NewLineMarkup newLineMarkup => VisitNewLine(newLineMarkup, ref state),
             UnparsedTextMarkup unparsedMarkup => VisitUnparsed(unparsedMarkup, ref state),
+            HashtagMarkup hashtagMarkup => VisitHashtag(hashtagMarkup, ref state),
             _ => VisitUnknown(markup, ref state),
         };
 
@@ -47,6 +48,7 @@ public abstract record MarkupVisitorWithState<TState, TResult>
     protected abstract TResult VisitPreformattedText(PreformattedTextMarkup markup, ref TState state);
     protected abstract TResult VisitNewLine(NewLineMarkup markup, ref TState state);
     protected abstract TResult VisitUnparsed(UnparsedTextMarkup markup, ref TState state);
+    protected abstract TResult VisitHashtag(HashtagMarkup markup, ref TState state);
 
     protected virtual TResult VisitUnknown(Markup markup, ref TState state)
         => throw new ArgumentOutOfRangeException(nameof(markup));
@@ -114,6 +116,9 @@ public abstract record MarkupVisitorWithState<TState>
         case UnparsedTextMarkup unparsedMarkup:
             VisitUnparsed(unparsedMarkup, ref state);
             break;
+        case HashtagMarkup hashtagMarkup:
+            VisitHashtag(hashtagMarkup, ref state);
+            break;
         default:
             VisitUnknown(markup, ref state);
             break;
@@ -148,6 +153,7 @@ public abstract record MarkupVisitorWithState<TState>
     protected abstract void VisitPreformattedText(PreformattedTextMarkup markup, ref TState state);
     protected abstract void VisitNewLine(NewLineMarkup markup, ref TState state);
     protected abstract void VisitUnparsed(UnparsedTextMarkup markup, ref TState state);
+    protected abstract void VisitHashtag(HashtagMarkup markup, ref TState state);
 
     protected virtual void VisitUnknown(Markup markup, ref TState state)
         => throw new ArgumentOutOfRangeException(nameof(markup));

--- a/src/dotnet/Api/Chat/Markup/Visitors/LinkExtractor.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/LinkExtractor.cs
@@ -17,9 +17,7 @@ public record LinkExtractor : MarkupVisitorWithState<HashSet<string>>
 
     protected override void VisitHeader(HeaderMarkup markup, ref HashSet<string> state)
         => Visit(markup.Content, ref state);
-
     protected override void VisitMention(MentionMarkup markup, ref HashSet<string> state) { }
-
     protected override void VisitStylized(StylizedMarkup markup, ref HashSet<string> state)
         => Visit(markup.Content, ref state);
 
@@ -31,5 +29,6 @@ public record LinkExtractor : MarkupVisitorWithState<HashSet<string>>
     protected override void VisitPreformattedText(PreformattedTextMarkup markup, ref HashSet<string> state) { }
     protected override void VisitNewLine(NewLineMarkup markup, ref HashSet<string> state) { }
     protected override void VisitUnparsed(UnparsedTextMarkup markup, ref HashSet<string> state) { }
+    protected override void VisitHashtag(HashtagMarkup markup, ref HashSet<string> state) { }
     protected override void VisitUnknown(Markup markup, ref HashSet<string> state) { }
 }

--- a/src/dotnet/Api/Chat/Markup/Visitors/MarkupFormatter.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/MarkupFormatter.cs
@@ -141,6 +141,9 @@ public abstract record MarkupFormatterBase : MarkupVisitorWithState<StringBuilde
 
     protected override void VisitUnparsed(UnparsedTextMarkup markup, ref StringBuilder state)
         => state.Append(markup.Format());
+
+    protected override void VisitHashtag(HashtagMarkup markup, ref StringBuilder state)
+        => state.Append(markup.Format());
 }
 
 public sealed record MarkupFormatter(

--- a/src/dotnet/Api/Chat/Markup/Visitors/MarkupHtmlFormatterBase.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/MarkupHtmlFormatterBase.cs
@@ -121,6 +121,9 @@ public abstract partial record MarkupHtmlFormatterBase : MarkupFormatterBase
     protected override void VisitUnparsed(UnparsedTextMarkup markup, ref StringBuilder state)
         => AddText(markup.Format(), ref state);
 
+    protected override void VisitHashtag(HashtagMarkup markup, ref StringBuilder state)
+        => AddText(markup.Text, ref state);
+
     protected override void VisitUnknown(Markup markup, ref StringBuilder state)
         => AddText(markup.Format(), ref state);
 

--- a/src/dotnet/Api/Chat/Markup/Visitors/MarkupValidator.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/MarkupValidator.cs
@@ -1,6 +1,6 @@
 namespace ActualChat.Chat;
 
-public record MarkupValidator : MarkupVisitor<bool>
+public sealed record MarkupValidator : MarkupVisitor<bool>
 {
     public enum AggregationMode { All, Any }
 
@@ -60,6 +60,7 @@ public record MarkupValidator : MarkupVisitor<bool>
     protected override bool VisitPreformattedText(PreformattedTextMarkup markup) => _predicate(markup);
     protected override bool VisitNewLine(NewLineMarkup markup) => _predicate(markup);
     protected override bool VisitUnparsed(UnparsedTextMarkup markup) => _predicate(markup);
+    protected override bool VisitHashtag(HashtagMarkup markup) => _predicate(markup);
 
     protected override bool VisitUnknown(Markup markup) => _predicate(markup);
 }

--- a/src/dotnet/Api/Chat/Markup/Visitors/MentionExtractor.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/MentionExtractor.cs
@@ -33,5 +33,6 @@ public record MentionExtractor : MarkupVisitorWithState<HashSet<MentionRef>>
     protected override void VisitPreformattedText(PreformattedTextMarkup markup, ref HashSet<MentionRef> state) { }
     protected override void VisitNewLine(NewLineMarkup markup, ref HashSet<MentionRef> state) { }
     protected override void VisitUnparsed(UnparsedTextMarkup markup, ref HashSet<MentionRef> state) { }
+    protected override void VisitHashtag(HashtagMarkup markup, ref HashSet<MentionRef> state) { }
     protected override void VisitUnknown(Markup markup, ref HashSet<MentionRef> state) { }
 }

--- a/src/dotnet/Api/Module/ApiAotSource.g.cs
+++ b/src/dotnet/Api/Module/ApiAotSource.g.cs
@@ -54,6 +54,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.ConversationRangeMeta>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.EmojiMention>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.FileItem>();
+        CodeKeeper.KeepSerializable<global::ActualChat.Chat.HashtagMarkup>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.HeaderMarkup>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.LinkItem>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.ListItemMarkup>();
@@ -379,6 +380,9 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.FileItem>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.FileItem>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.FileItem>>>>();
+        CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HashtagMarkup>>();
+        CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HashtagMarkup>>>();
+        CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HashtagMarkup>>>>();
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HeaderMarkup>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HeaderMarkup>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.HeaderMarkup>>>>();
@@ -1530,6 +1534,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+ConversationRangeMetaFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+EmojiMentionFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+FileItemFormatter, ActualChat.Api");
+        CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+HashtagMarkupFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+HeaderMarkupFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+LinkItemFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+ListItemMarkupFormatter, ActualChat.Api");
@@ -1735,6 +1740,7 @@ internal partial class ApiAotSource : IAotSource
             (typeof(global::ActualChat.Chat.ConversationRangeMeta), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.EmojiMention), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.FileItem), AotTypeKind.Serializable),
+            (typeof(global::ActualChat.Chat.HashtagMarkup), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.HeaderMarkup), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.LinkItem), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.ListItemMarkup), AotTypeKind.Serializable),

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
@@ -2,6 +2,7 @@
 @using ActualChat.UI.Blazor.App.Events
 @inherits ComputedStateComponent<AppUIHub, LeftChatSearchInput.Model>
 <OnUIEvent TEvent="SearchClearedEvent" Handler="OnSearchCleared" />
+<OnUIEvent TEvent="SearchTextSetEvent" Handler="OnSearchTextSet" />
 @{
     var m = State.Value;
     var cls = m.IsOpen ? "open" : "closed";
@@ -156,6 +157,11 @@
 
     private void OnTypeBadgeClick()
         => SearchUI.SetTypeFilter(SearchTypeFilter.Anything);
+
+    private Task OnSearchTextSet(SearchTextSetEvent e, CancellationToken cancellationToken) {
+        UpdateHasText(e.Text);
+        return _inputRef?.SetText(e.Text).AsTask() ?? Task.CompletedTask;
+    }
 
     private static string LocationBadgeText(SearchLocationFilter filter) => filter switch {
         SearchLocationFilter.Chat => "Chat",

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/HashtagMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/HashtagMarkupView.razor
@@ -1,0 +1,27 @@
+@using ActualChat.Search
+@inherits ComputedMarkupViewBase<HashtagMarkup, SearchMatch>
+
+<a class="hashtag-markup" @onclick="@OnClick"><SearchMatchHighlighter
+    Match="@State.Value"
+    HighlightedClass="highlight"/></a>
+
+@code {
+    private SearchUI SearchUI => Hub.SearchUI;
+
+    protected override ComputedState<SearchMatch>.Options GetStateOptions()
+        => ComputedStateComponent.GetStateOptions(GetType(),
+            t => new ComputedState<SearchMatch>.Options {
+                InitialValue = SearchMatch.Matchless(Markup.Text),
+                Category = GetStateCategory(t),
+            });
+
+    protected override async Task<SearchMatch> ComputeState(CancellationToken cancellationToken) {
+        var markupText = Markup.Text;
+        var searchMatch = await HighlightUI.GetSearchMatch(Entry.Id, markupText, cancellationToken)
+            .ConfigureAwait(false);
+        return searchMatch.IsMatch ? searchMatch : SearchMatch.Matchless(markupText);
+    }
+
+    private void OnClick()
+        => SearchUI.SearchFor(Markup.Text);
+}

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
@@ -62,6 +62,14 @@
     @apply cursor-pointer no-underline hover:underline text-primary;
 }
 
+.hashtag-markup {
+    @apply text-primary font-medium;
+    @apply cursor-pointer no-underline hover:underline;
+}
+.hashtag-markup .highlight {
+    @apply bg-[var(--highlighted)];
+}
+
 /* Spoiler (masked) text: an SVG stencil (blur → alpha threshold → re-blur, see SpoilerFilterDefs)
    turns the text into an unreadable frosted blob until tapped; auto-hides later, tap again to hide. */
 :root, .theme-light {

--- a/src/dotnet/UI.Blazor.App/Events/SearchTextSetEvent.cs
+++ b/src/dotnet/UI.Blazor.App/Events/SearchTextSetEvent.cs
@@ -1,0 +1,3 @@
+namespace ActualChat.UI.Blazor.App.Events;
+
+public sealed record SearchTextSetEvent(string Text) : IUIEvent;

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppAotSource.g.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppAotSource.g.cs
@@ -244,6 +244,7 @@ internal partial class BlazorUIAppAotSource : IAotSource
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.ChatMentionView>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.CodeBlockMarkupView.CodeBlockMarkupView>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.EmojiMentionView>();
+        CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.HashtagMarkupView>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.HeaderMarkupView>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.ListMarkupView>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.MarkupParts.MarkupSeqView>();
@@ -975,6 +976,7 @@ internal partial class BlazorUIAppAotSource : IAotSource
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.ChatMentionView), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.CodeBlockMarkupView.CodeBlockMarkupView), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.EmojiMentionView), AotTypeKind.Component),
+            (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.HashtagMarkupView), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.HeaderMarkupView), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.ListMarkupView), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.MarkupParts.MarkupSeqView), AotTypeKind.Component),

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
@@ -100,6 +100,7 @@ public sealed class BlazorUIAppModule(IServiceProvider moduleServices)
         services.AddTypeMapper<IMarkupView>(map => map
             .Add<NewLineMarkup, NewLineMarkupView>()
             .Add<UrlMarkup, UrlMarkupView>()
+            .Add<HashtagMarkup, HashtagMarkupView>()
             .Add<MentionMarkup, AuthorMentionView>()
             .Add<UserMention, UserMentionView>()
             .Add<ChatMention, ChatMentionView>()

--- a/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.cs
@@ -38,7 +38,6 @@ public partial class SearchUI : UIWorkerBase<AppUIHub>, IComputeService, INotify
 
     private ISearch Search => Hub.Search;
     private LocalSearchUI LocalSearch => field ??= Services.GetRequiredService<LocalSearchUI>();
-    private BrowserInfo BrowserInfo => Hub.BrowserInfo;
     private NavbarUI NavbarUI => Hub.NavbarUI;
     private HighlightUI HighlightUI => Hub.HighlightUI;
 
@@ -96,6 +95,21 @@ public partial class SearchUI : UIWorkerBase<AppUIHub>, IComputeService, INotify
     {
         var expandedScopes = await ExtendedLimits.Use(StopToken).ConfigureAwait(false);
         return expandedScopes.Contains(scope);
+    }
+
+    public void SearchFor(string text)
+    {
+        var wasOpen = _isShowRecentOn.Value || _isSearchModeOn.Value;
+        PanelsUI.Left.SetIsVisible(true);
+        ShowRecent(true);
+        _placeId.Value = NavbarUI.IsPlaceSelected(out var placeId) ? placeId : null;
+        if (!wasOpen)
+            ResetFilters();
+        _typeFilter.Value = SearchTypeFilter.Messages;
+        _text.Value = text;
+        // The left panel's search input deliberately doesn't track Text changes,
+        // so an externally set text must be pushed into it explicitly.
+        _ = UIEventHub.Publish(new SearchTextSetEvent(text));
     }
 
     public void Clear()

--- a/src/dotnet/UI.Blazor/Components/TextInput/TextInput.razor
+++ b/src/dotnet/UI.Blazor/Components/TextInput/TextInput.razor
@@ -74,6 +74,11 @@
     public ValueTask Clear()
         => JSRef?.InvokeVoidAsync("clear") ?? default;
 
+    public ValueTask SetText(string text) {
+        Text = text;
+        return JSRef?.InvokeVoidAsync("set", text) ?? default;
+    }
+
     [JSInvokable]
     public Task OnTextChanged(string text) {
         Text = text;

--- a/src/dotnet/UI.Blazor/Components/TextInput/text-input.ts
+++ b/src/dotnet/UI.Blazor/Components/TextInput/text-input.ts
@@ -28,14 +28,16 @@ export class TextInput implements Disposable {
             .pipe(
                 takeUntil(this.disposed$),
                 debounceTime(this.options.debounce),
-                switchMap((e: InputEvent) => this.blazorRef.invokeMethodAsync('OnTextChanged', (e.target as HTMLInputElement).value))
+                switchMap((e: InputEvent) =>
+                    this.blazorRef.invokeMethodAsync('OnTextChanged', (e.target as HTMLInputElement).value))
             ).subscribe();
 
         fromEvent(this.element, 'paste')
             .pipe(
                 takeUntil(this.disposed$),
                 debounceTime(this.options.debounce),
-                switchMap((e: ClipboardEvent) => this.blazorRef.invokeMethodAsync('OnPaste', e.clipboardData?.getData('Text'))),
+                switchMap((e: ClipboardEvent) =>
+                    this.blazorRef.invokeMethodAsync('OnPaste', e.clipboardData?.getData('Text'))),
             ).subscribe();
 
         const closeOnBlurSelector = this.options.closeOnBlurSelector;
@@ -47,6 +49,7 @@ export class TextInput implements Disposable {
                     const related = e.relatedTarget as Node | null;
                     if (boundary && related && boundary.contains(related))
                         return;
+
                     void this.blazorRef.invokeMethodAsync('NotifyBlur');
                 });
         }
@@ -65,8 +68,7 @@ export class TextInput implements Disposable {
         await this.blazorRef.invokeMethodAsync('OnTextChanged', '');
     }
 
-    /** Called by Blazor */
-    // TODO: looks like it's not used anymore, remove it?
+    // Called by Blazor
     public set(value: string | undefined): void {
         this.element.value = value ?? '';
     }

--- a/tests/Chat.UnitTests/HashtagMarkupSerializationTest.cs
+++ b/tests/Chat.UnitTests/HashtagMarkupSerializationTest.cs
@@ -1,0 +1,19 @@
+namespace ActualChat.Chat.UnitTests;
+
+public class HashtagMarkupSerializationTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    [Fact]
+    public void PassesThroughMessagePack()
+    {
+        // arrange
+        Markup markup = new HashtagMarkup("#promo");
+
+        // act
+        var result = markup.PassThroughModernSerializers(Out);
+
+        // assert
+        var hashtag = result.Should().BeOfType<HashtagMarkup>().Subject;
+        hashtag.Text.Should().Be("#promo");
+        hashtag.Tag.Should().Be("promo");
+    }
+}

--- a/tests/Chat.UnitTests/MarkupParserTest.cs
+++ b/tests/Chat.UnitTests/MarkupParserTest.cs
@@ -454,9 +454,12 @@ code
     [Fact]
     public void SpecialTest_CssRuleCase()
     {
-        var p = Parse<ParagraphMarkup>("--background-message-hover: #f3f4f6;", out var text);
-        var m = p.Content.Should().BeOfType<PlainTextMarkup>().Subject;
-        m.Text.Should().Be(text);
+        // A hex color is an unavoidable hashtag false positive; the round-trip text stays exact.
+        var p = Parse<ParagraphMarkup>("--background-message-hover: #f3f4f6;", out _);
+        var seq = p.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[0].Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be("--background-message-hover: ");
+        seq.Items[1].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#f3f4f6");
+        seq.Items[2].Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(";");
     }
 
     [Fact]
@@ -466,7 +469,6 @@ code
         var m = p.Content.Should().BeOfType<PlainTextMarkup>().Subject;
         m.Text.Should().Be(text);
     }
-
 
     [Fact]
     public void SpecialTest_DoubleSmileCase()
@@ -864,9 +866,9 @@ code
     [Fact]
     public void HeaderRequiresWhitespaceAfterHashes()
     {
-        // No space after # means it's not a header
+        // No space after # means it's not a header (it's a hashtag now)
         var m = Parse<ParagraphMarkup>("#NotAHeader");
-        m.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be("#NotAHeader");
+        m.Content.Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#NotAHeader");
     }
 
     [Fact]
@@ -1304,6 +1306,129 @@ code
         var mention = seq.Items[0].Should().BeAssignableTo<MentionMarkup>().Subject;
         mention.Id.Value.Should().Be(id);
         MarkupFormatter.Default.Format(seq.Items[1]).Should().Be(tail);
+    }
+
+    [Fact]
+    public void HashtagTest()
+    {
+        var p = Parse<ParagraphMarkup>("#promo", out var text);
+        p.Content.Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be(text);
+
+        p = Parse<ParagraphMarkup>("#promo-2_x", out text);
+        var m = p.Content.Should().BeOfType<HashtagMarkup>().Subject;
+        m.Text.Should().Be(text);
+        m.Tag.Should().Be("promo-2_x");
+
+        p = Parse<ParagraphMarkup>("#тег", out text);
+        p.Content.Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be(text);
+
+        p = Parse<ParagraphMarkup>("see #promo now", out _);
+        var seq = p.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[1].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#promo");
+    }
+
+    [Fact]
+    public void HashtagFollowedByPunctuationTest()
+    {
+        var p = Parse<ParagraphMarkup>("#promo, right", out _);
+        var seq = p.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[0].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#promo");
+        seq.Items[1].Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(", right");
+    }
+
+    [Fact]
+    public void HashtagInStylizedTextTest()
+    {
+        var p = Parse<ParagraphMarkup>("**#promo**", out _);
+        var m = p.Content.Should().BeOfType<StylizedMarkup>().Subject;
+        m.Content.Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#promo");
+    }
+
+    [Fact]
+    public void AdjacentHashtagsArePlainTextTest()
+    {
+        // Tags must be whitespace-separated; a '#' run with no separator is not a tag at all
+        var p = Parse<ParagraphMarkup>("#a#b", out var text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void WhitespaceSeparatedHashtagsTest()
+    {
+        var p = Parse<ParagraphMarkup>("#a #b", out _);
+        var seq = p.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[0].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#a");
+        seq.Items[1].Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(" ");
+        seq.Items[2].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#b");
+    }
+
+    [Fact]
+    public void MidWordHashIsNotAHashtagTest()
+    {
+        var p = Parse<ParagraphMarkup>("c#5", out var text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+
+        p = Parse<ParagraphMarkup>("item#2", out text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void AllDigitTokenIsNotAHashtagTest()
+    {
+        var p = Parse<ParagraphMarkup>("#4121", out var text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void LoneOrTrailingHashIsPlainTextTest()
+    {
+        var p = Parse<ParagraphMarkup>("#", out var text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+
+        p = Parse<ParagraphMarkup>("#-x", out text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+
+        p = Parse<ParagraphMarkup>("#promo#", out text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void TooLongHashtagIsPlainTextTest()
+    {
+        var tooLong = "#" + new string('a', 65);
+        var p = Parse<ParagraphMarkup>(tooLong, out var text);
+        p.Content.Should().BeOfType<PlainTextMarkup>().Which.Text.Should().Be(text);
+
+        var maxLength = "#" + new string('a', 64);
+        p = Parse<ParagraphMarkup>(maxLength, out text);
+        p.Content.Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be(text);
+    }
+
+    [Fact]
+    public void HashtagDoesNotBreakHeadersTest()
+    {
+        var h = Parse<HeaderMarkup>("# Title");
+        h.Level.Should().Be(1);
+        MarkupFormatter.Default.Format(h.Content).Should().Be("Title");
+
+        h = Parse<HeaderMarkup>("# Title with #tag", validateFormat: false);
+        var seq = h.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[^1].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#tag");
+    }
+
+    [Fact]
+    public void HashtagInPreformattedTextStaysTextTest()
+    {
+        var p = Parse<ParagraphMarkup>("`#promo`", out _);
+        p.Content.Should().BeOfType<PreformattedTextMarkup>().Which.Text.Should().Be("#promo");
+    }
+
+    [Fact]
+    public void HashtagAtLineStartIsNotAHeaderTest()
+    {
+        var p = Parse<ParagraphMarkup>("#promo\nmore", false);
+        var seq = p.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items[0].Should().BeOfType<HashtagMarkup>().Which.Text.Should().Be("#promo");
     }
 
     [Theory]

--- a/tests/ts/e2e/hashtag-click-search.test.ts
+++ b/tests/ts/e2e/hashtag-click-search.test.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E test: a #hashtag in a posted message renders as clickable markup, and
+ * clicking it opens the left-panel search with the tag as the query and the
+ * Messages type filter applied. #4121
+ *
+ * Prerequisites:
+ * - Server running (or AC_E2E_SERVER=managed)
+ * - Optionally, Chrome with remote debugging: `ai chrome` (port 9222)
+ *
+ * Run:
+ *   npx vitest run tests/ts/e2e/hashtag-click-search.test.ts --config vitest.config.e2e.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Page } from 'playwright';
+import {
+    BASE_URL, connectBrowser, ensureSignedIn, skipOnboarding,
+    screenshot, waitForChatReady, waitForEditor, type BrowserConnection,
+} from './helpers';
+
+const CHAT_URL = `${BASE_URL}/chat/the-actual-one`;
+const tag = `#e2etag${Date.now()}`;
+
+async function openChat(page: Page) {
+    await page.goto(CHAT_URL, { waitUntil: 'domcontentloaded' });
+    await waitForChatReady(page);
+    await skipOnboarding(page);
+}
+
+describe('hashtag click-to-search', () => {
+    let conn: BrowserConnection;
+    let page: Page;
+
+    beforeAll(async () => {
+        conn = await connectBrowser();
+        page = await conn.context.newPage();
+        await ensureSignedIn(page);
+    }, 90_000);
+
+    afterAll(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- page may be unset if beforeAll fails
+        if (page)
+            await page.close();
+
+        if (conn.ownsBrowser) {
+            await conn.context.close();
+            await conn.browser.close();
+        }
+    });
+
+    it('posts a message with a hashtag and renders it as hashtag markup', async () => {
+        await openChat(page);
+
+        const joinButton = page.locator('button:has-text("Join this chat")');
+        if (await joinButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+            await joinButton.click();
+            await page.waitForTimeout(2000);
+        }
+
+        await waitForEditor(page);
+        const messageInput = page.locator('#message-input .editor-content[contenteditable="true"]').first();
+        await messageInput.click({ force: true });
+        await page.waitForTimeout(200);
+        // Clear leftover draft: ChatMessageEditor restores per-chat drafts across page loads,
+        // so a previous run's typed-but-unsent text appends to ours otherwise.
+        await messageInput.evaluate(el => {
+            el.innerHTML = '';
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+        await messageInput.click({ force: true });
+        await page.keyboard.type(`checking ${tag} rendering`);
+        await page.screenshot({ path: screenshot('hashtag', '01-before-send') });
+
+        // dispatchEvent skips actionability checks (a tutorial overlay can land on top of
+        // the editor right after typing); MarkupEditor posts on the Enter 'keypress'.
+        await messageInput.dispatchEvent('keypress', {
+            key: 'Enter', code: 'Enter', bubbles: true, cancelable: true,
+        });
+        await page.waitForTimeout(2000);
+
+        // The chat panel can unmount briefly after a post; re-navigate to re-mount it.
+        await openChat(page);
+        const hashtag = page.locator(`.chat-message-markup .hashtag-markup:has-text("${tag}")`).first();
+        await hashtag.waitFor({ state: 'visible', timeout: 15_000 });
+        await page.screenshot({ path: screenshot('hashtag', '02-rendered') });
+    }, 90_000);
+
+    it('clicking the hashtag opens search with the tag and the Messages filter', async () => {
+        await openChat(page);
+        const hashtag = page.locator(`.chat-message-markup .hashtag-markup:has-text("${tag}")`).first();
+        await hashtag.waitFor({ state: 'visible', timeout: 15_000 });
+        await hashtag.click({ force: true });
+        await page.screenshot({ path: screenshot('hashtag', '03-after-click') });
+
+        const searchPanel = page.locator('.left-chat-search-input.open').first();
+        await searchPanel.waitFor({ state: 'visible', timeout: 10_000 });
+
+        const input = page.locator('.left-chat-search-input input[type="text"]').first();
+        await expect.poll(() => input.inputValue(), { timeout: 10_000 }).toBe(tag);
+
+        const messagesBadge = page
+            .locator('.left-chat-search-input .search-filter-badge:has-text("Messages")')
+            .first();
+        await messagesBadge.waitFor({ state: 'visible', timeout: 10_000 });
+        await page.screenshot({ path: screenshot('hashtag', '04-search-open') });
+    }, 60_000);
+});


### PR DESCRIPTION
A #hashtag in a message becomes HashtagMarkup, rendered as a clickable link; clicking opens the left-panel search with the tag and the Messages filter applied. Tags are whitespace-separated word-start tokens: mid-word '#' (c#5), all-digit refs (#4121), and adjacent runs (#a#b) stay plain text. Hashtags participate in search-match highlighting like plain text. Covered by parser/serialization unit tests and an e2e spec (post -> render -> click -> search opens). See docs/plans/hashtags.md for the full design and later phases.