### PR TITLE
perf(ios): cut the share extension's startup from ~2.95s to ~0.9s #4132

### DIFF
--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -112,6 +112,35 @@
     <Registrar>managed-static</Registrar>
   </PropertyGroup>
 
+  <!-- The macios SDK never strips an app extension's binaries: Xamarin.Shared.targets sets
+       _PostProcess=false when IsAppExtension, and the host app only post-processes the items an
+       extension hands back with IsAppExtension=true - which is just the .appex executable. That
+       is harmless for every other framework, since App.Maui ships its own copy and strips that,
+       but the R2R composite is ours alone and the SDK relocates it into the app's Frameworks/,
+       so nothing ever touches it: it shipped with a 621k-entry symbol table, 126MB of a 179MB
+       framework. Stripping leaves the _RTR_HEADER_* symbol the module registration links
+       against, exactly as the SDK's own strip does for App.Maui's composite.
+       No dSYM on purpose - managed stack traces come from the runtime, so a second ~180MB
+       symbol bundle per build isn't worth what native symbolication of R2R code would add. -->
+  <Target Name="_StripR2RFramework"
+          Condition="'$(CreateR2RFramework)' == 'true' And '$(IsMacEnabled)' == 'true'"
+          AfterTargets="_CreateR2RFramework"
+          DependsOnTargets="_PrepareR2RModules"
+          Inputs="@(_R2RModule->'%(FrameworkOutput)')"
+          Outputs="@(_R2RModule->'$(_R2RModuleIntermediateOutputPath)%(ShortName).r2r.stripped')">
+    <SymbolStrip
+      SessionId="$(BuildSessionId)"
+      Executable="%(_R2RModule.FrameworkOutput)"
+      Kind="Framework"
+      StripPath="$(StripPath)" />
+    <Touch
+      Files="@(_R2RModule->'$(_R2RModuleIntermediateOutputPath)%(ShortName).r2r.stripped')"
+      AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="@(_R2RModule->'$(_R2RModuleIntermediateOutputPath)%(ShortName).r2r.stripped')" />
+    </ItemGroup>
+  </Target>
+
   <!-- Workaround for excluding C# files from compilation for non-iOS targets -->
   <ItemGroup Condition="!$(TargetFramework.Contains('-ios'))">
     <Using Remove="@(Using)" />

--- a/src/dotnet/App.Maui.IosShareExt/Components/ErrorContentView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ErrorContentView.cs
@@ -1,0 +1,48 @@
+namespace ActualChat.App.Maui.IosShareExt.Components;
+
+/// <summary>
+/// The "something broke" screen - cat, message, Close. Shared by <see cref="ErrorView"/> and by
+/// <see cref="ShareViewController"/>, which can't use ErrorView itself because it needs DI.
+/// </summary>
+public sealed class ErrorContentView : UIView
+{
+    public ErrorContentView(string message, EventHandler onClose)
+    {
+        BackgroundColor = new UIColor(red: 0.11f, green: 0.11f, blue: 0.12f, alpha: 1.0f);
+
+        var label = new UILabel {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            TextAlignment = UITextAlignment.Center,
+            Text = message,
+            Font = UIFont.SystemFontOfSize(24),
+            TextColor = UIColor.White,
+            Lines = 0,
+        };
+        var imageView = new UIImageView(UIImage.FromBundle("error-barrier-image.png")) {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            ContentMode = UIViewContentMode.ScaleAspectFit,
+        };
+        var closeButton = UIButton.FromType(UIButtonType.System);
+        closeButton.TranslatesAutoresizingMaskIntoConstraints = false;
+        closeButton.SetTitle("Close", UIControlState.Normal);
+        closeButton.TitleLabel.Font = UIFont.SystemFontOfSize(20, UIFontWeight.Semibold);
+        closeButton.TouchUpInside += onClose;
+
+        var stackView = new UIStackView([imageView, label, closeButton]) {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            Axis = UILayoutConstraintAxis.Vertical,
+            Alignment = UIStackViewAlignment.Fill,
+            Distribution = UIStackViewDistribution.Fill,
+            Spacing = 20,
+        };
+        AddSubview(stackView);
+
+        NSLayoutConstraint.ActivateConstraints([
+            stackView.CenterYAnchor.ConstraintEqualTo(CenterYAnchor, -25),
+            stackView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, 24),
+            stackView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -24),
+
+            imageView.HeightAnchor.ConstraintEqualTo(164),
+        ]);
+    }
+}

--- a/src/dotnet/App.Maui.IosShareExt/Components/ErrorView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ErrorView.cs
@@ -11,45 +11,16 @@ public class ErrorView(IosHub hub) : ComputedStateView<ErrorView.Model>(hub)
     {
         TranslatesAutoresizingMaskIntoConstraints = false;
 
-        // Label
-        var label = new UILabel {
+        var contentView = new ErrorContentView(model.Message, Safe(UIKitExt.CloseApp)) {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            TextAlignment = UITextAlignment.Center,
-            Text = model.Message,
-            Font = UIFont.SystemFontOfSize(24),
-            TextColor = UIColor.White,
         };
+        AddSubview(contentView);
 
-        // Image
-        var imageView = new UIImageView(UIImage.FromBundle("error-barrier-image.png")) {
-            TranslatesAutoresizingMaskIntoConstraints = false,
-            ContentMode = UIViewContentMode.ScaleAspectFit,
-        };
-
-        // Close button
-        var closeButton = UIButton.FromType(UIButtonType.System);
-        closeButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        closeButton.SetTitle("Close", UIControlState.Normal);
-        closeButton.TitleLabel.Font = UIFont.SystemFontOfSize(20, UIFontWeight.Semibold);
-        closeButton.TouchUpInside += Safe(UIKitExt.CloseApp);
-
-        // Vertical stack view
-        var stackView = new UIStackView([imageView, label, closeButton]) {
-            TranslatesAutoresizingMaskIntoConstraints = false,
-            Axis = UILayoutConstraintAxis.Vertical,
-            Alignment = UIStackViewAlignment.Fill,
-            Distribution = UIStackViewDistribution.Fill,
-            Spacing = 20,
-        };
-        AddSubview(stackView);
-
-        // Layout constraints
         NSLayoutConstraint.ActivateConstraints([
-            stackView.CenterYAnchor.ConstraintEqualTo(CenterYAnchor, -25),
-            stackView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, 24),
-            stackView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -24),
-
-            imageView.HeightAnchor.ConstraintEqualTo(164),
+            contentView.TopAnchor.ConstraintEqualTo(TopAnchor),
+            contentView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
+            contentView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
+            contentView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
         ]);
     }
 

--- a/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
@@ -157,6 +157,13 @@ public class ShareView(IosHub hub) : ComputedStateView<ShareView.Model>(hub)
         animator.StartAnimation();
     }
 
+    protected override ComputedState<Model>.Options GetStateOptions()
+        => GetStateOptions(GetType(),
+            static t => new ComputedState<Model>.Options {
+                Category = GetStateCategory(t),
+                UpdateDelayer = FixedDelayer.MinDelay,
+            });
+
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken)
     {
         var step = await ShareUI.GetStep(cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/App.Maui.IosShareExt/Module/IosShareExtAotSource.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Module/IosShareExtAotSource.cs
@@ -26,6 +26,7 @@ internal class IosShareExtAotSource : IAotSource
         CodeKeeper.Keep<ContactListView>();
         CodeKeeper.Keep<ContactSelectionView>();
         CodeKeeper.Keep<ContactView>();
+        CodeKeeper.Keep<ErrorContentView>();
         CodeKeeper.Keep<ErrorView>();
         CodeKeeper.Keep<PlaceListView>();
         CodeKeeper.Keep<PlaceView>();

--- a/src/dotnet/App.Maui.IosShareExt/ShareExtensionApplication.cs
+++ b/src/dotnet/App.Maui.IosShareExt/ShareExtensionApplication.cs
@@ -1,6 +1,5 @@
 using ActualChat.App.Maui.IosShareExt.Module;
 using ActualChat.App.Maui.IosShareExt.Services;
-using ActualChat.Hosting;
 using ActualChat.Maui;
 using ActualChat.Maui.Module;
 using ActualChat.Module;
@@ -15,28 +14,62 @@ namespace ActualChat.App.Maui.IosShareExt;
 
 public class ShareExtensionApplication(ServiceProvider services) : IHasServices
 {
+    // Both block the main thread on the failure path, and an app extension that stops
+    // responding for too long gets killed - so the worst case has to stay well under that.
+    private static readonly TimeSpan SentryInitTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan SentryFlushTimeout = TimeSpan.FromSeconds(2);
+
     public IServiceProvider Services => services;
 
     public static ShareExtensionApplication? Bootstrap(UIViewController controller)
     {
         var log = new OSLogLogger(nameof(ShareViewController));
+        Task? whenSentryReady = null;
 
         try {
             Platform.Init(() => controller);
             MauiDiagnostics.Initialize();
             ClientStartup.Initialize();
-            MauiDiagnostics.InitSentrySdk();
-            MauiDiagnostics.CreateSentryTraceProvider();
+            whenSentryReady = InitSentry(log);
             var services = CreateServiceProvider();
             _ = services.GetRequiredService<SessionInitializer>();
             return new ShareExtensionApplication(services);
         }
-        catch (Exception e)
-        {
+        catch (Exception e) {
             log.LogCritical(e, "Failed to bootstrap the app");
+            ReportBootstrapFailure(e, whenSentryReady, log);
             return null;
         }
     }
+
+    private static void ReportBootstrapFailure(Exception error, Task? whenSentryReady, ILogger log)
+    {
+        // Sentry is the only way a broken share sheet reaches us, so this path - unlike the
+        // happy one - pays for it. A null task means the failure beat InitSentry to it, which
+        // covers everything before the DI container exists: capturing without initializing
+        // first would no-op against the disabled hub and silently drop the report.
+        try {
+            if (whenSentryReady is null)
+                MauiDiagnostics.InitSentrySdk();
+            else
+                // WaitAny, not Wait: it reports completion, so a failed InitSentry doesn't throw
+                Task.WaitAny([whenSentryReady], SentryInitTimeout);
+            MauiDiagnostics.CaptureAndFlush(error, SentryFlushTimeout);
+        }
+        catch (Exception e) {
+            log.LogError(e, "Failed to report the bootstrap failure");
+        }
+    }
+
+    private static Task InitSentry(ILogger log)
+        // Sentry's SDK init takes ~1s, a third of the time the share sheet needs to show
+        // anything, so it runs off the startup path - the main app does the same via
+        // MauiSentryInitializer, which starts it from a worker 10s after the app is rendered.
+        => BackgroundTask.Run(() => {
+            MauiDiagnostics.InitSentrySdk();
+            MauiDiagnostics.CreateSentryTraceProvider();
+            return Task.CompletedTask;
+        }, log, "Failed to initialize Sentry");
 
     private static ServiceProvider CreateServiceProvider()
     {
@@ -67,8 +100,10 @@ public class ShareExtensionApplication(ServiceProvider services) : IHasServices
             logging.SetMinimumLevel(LogLevel.Information);
             logging.AddFilter("System", LogLevel.Warning);
             logging.AddFilter("Microsoft", LogLevel.Warning);
-
-            logging.AddAppleUnifiedLog();
+            // Serilog writes to the Apple unified log too (MauiDiagnostics.AddPlatformLoggerSinks),
+            // and going through it is what gets warnings and errors to Sentry - AddAppleUnifiedLog
+            // reached os_log only, so nothing the extension logged was ever reported.
+            logging.AddFilteringSerilog(Serilog.Log.Logger);
         });
         services.AddTracers(Tracer.Default, useScopedTracers: true);
         services.AddSingleton(_ => Constants.HostInfo);

--- a/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
+++ b/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
@@ -12,9 +12,12 @@ public class ShareViewController : UIViewController
     public override void LoadView()
     {
         _app = ShareExtensionApplication.Bootstrap(this);
-        if (_app == null)
-            return;
-
-        View = new ShareView(_app.Services.IosHub());
+        // Leaving View unset makes UIKit throw NSInvalidArgumentException ("attempt to insert nil
+        // object"), so a failed bootstrap used to crash the extension outright - which also killed
+        // the failure report Bootstrap had just started sending.
+        View = _app is null
+            ? new ErrorContentView("Something went wrong. Please try again.",
+                (_, _) => _ = ExtensionContext?.CompleteRequestAsync([]))
+            : new ShareView(_app.Services.IosHub());
     }
 }

--- a/src/dotnet/Maui/MauiDiagnostics.cs
+++ b/src/dotnet/Maui/MauiDiagnostics.cs
@@ -149,6 +149,13 @@ public static class MauiDiagnostics
         // disposer.Register(disposable);
     }
 
+    public static void CaptureAndFlush(Exception error, TimeSpan flushTimeout)
+    {
+        // Both calls are no-ops when the SDK isn't initialized, so callers don't have to check
+        SentrySdk.CaptureException(error);
+        SentrySdk.Flush(flushTimeout);
+    }
+
     public static void CreateSentryTraceProvider()
     {
         // TODO: fix PlatformNotSupportedException inside OpenTelemetry.


### PR DESCRIPTION
Closes #4132.

The iOS share extension took ~2.95s from process start to showing a contact list. It now takes ~0.9s, and the list is fully built before UIKit finishes presenting the share sheet — so content is no longer what the user waits for.

### First: it was already on CoreCLR

The starting suspicion was that the extension had been left behind by the .NET 11 / CoreCLR migration. It hadn't — commit `ddc4b9114c` carried it over, and its evaluated MSBuild properties for `Release|net11.0-ios` match App.Maui's on every runtime knob (`UseMonoRuntime=false`, `PublishReadyToRun`/`Composite=true`, `MtouchLink=SdkOnly`, `DynamicCodeSupport=false`). The only difference is the `System.Runtime.TieredCompilation.*` runtimeconfig entries, and those are no-ops on device, where there is no JIT. So the slowness had to be measured rather than guessed, via a temporary startup trace that has since been removed.

### What was actually wrong

**`SentrySdk.Init` — 1.03s, synchronous, inside `Bootstrap`.** It now runs via `BackgroundTask.Run`, which is what App.Maui has always done: `MauiSentryInitializer` calls the same method from a worker, off the UI thread, 10s after the app is rendered.

**A 1-second Fusion update delay.** `ShareView` — the state that decides `ShareStep` and therefore gates the whole UI — was the only view of its kind without an `UpdateDelayer`, so it fell back to the DI default, `UpdateDelayer(UIActionTracker)`, whose `UpdateDelay` is a second and which only short-circuits on a recent UI action — something that never happens during startup. It now sets `FixedDelayer.MinDelay` in its own `GetStateOptions` override, matching `ContactView` and `UploadProgressView`.

(An earlier revision of this branch instead put the delayer into `ComputedStateView.CreateDefaultStateOptionsFactory`. That was wrong on two counts: `ComputedStateView` is a line-for-line port of Fusion's `ComputedStateComponent.Static.cs` and should track it, and this repo sets `UpdateDelayer` per component in 103 places while never overriding `DefaultStateOptionsFactory` anywhere.)

### Measured on device

iPhone 15 Pro Max, Debug + `FilterReadyToRunAssemblies=false` so user assemblies are ReadyToRun-compiled as they are in Release:

| | before | after |
|---|---|---|
| `Bootstrap` | 1.119s | 0.054s |
| `LoadView` | 1.151s | 0.087s |
| first paint | 1.820s | 0.760s |
| **contact list visible** | **2.950s** | **0.916s** |

### Also in here

**The extension never reported anything to Sentry.** Its DI logging was `ClearProviders()` + `AddAppleUnifiedLog()`, which writes to os_log and nowhere else, and it never calls `MauiExceptionHandlers.Use()` — so "Failed to bootstrap the app", `ShareUI`'s "Failed to initialize" and the render-loop catch all went to the device log alone. Logging now goes through Serilog as App.Maui's does (which is what feeds the Sentry sink, and costs nothing in os_log terms since Serilog already writes there via `AppleUnifiedLogSink`), and bootstrap failures additionally wait out Sentry's init and capture and flush explicitly.

**The R2R composite shipped unstripped — 120MB of dead weight** (second commit, separable). `Xamarin.Shared.targets` sets `_PostProcess=false` when `IsAppExtension`, and the host app post-processes only the items an extension hands back with `IsAppExtension=true` — its executable alone. Harmless for every other framework, since App.Maui strips its own copies, but the R2R composite exists only for the extension and the SDK relocates it into the app's `Frameworks/`, out of reach of both projects. It carried a 621,526-entry symbol table.

```
IosShareExt.r2r.framework   179MB -> 59MB   (__LINKEDIT 126.6MB -> 0.4MB)
ActualChat.app              440MB -> 320MB
```

This is a bundle-size fix, not a startup one — `__LINKEDIT` is mapped but never paged in at launch, and the measurements confirm it changed startup not at all. Worth reporting upstream to dotnet/macios (it hits any .NET iOS app with a CoreCLR extension) and reverting the target if they fix it.

### Also: a bootstrap failure used to crash the extension

`LoadView` returned without assigning `View` whenever `Bootstrap` returned null, and UIKit throws on that — `NSInvalidArgumentException: attempt to insert nil object from objects[0]`. Pre-existing on `dev`. Every bootstrap failure therefore killed the extension instead of showing anything, and the crash also cut short the failure report. Reproduced on device with an induced failure: uncaught exception and a corpse 1.3 s later, mid-TLS-handshake. `View` is now always set, to a failure screen mirroring `ErrorView` (same error-cat image, copy, Close), built without DI since this path runs precisely when the service provider is what failed.

### Verified

Each change was checked on a physical device, including the failure path with a temporary induced throw: the extension still loads its R2R image rather than falling back to the interpreter (the stripped binary keeps exactly the `_RTR_HEADER_*` symbol the generated module registration links against), logs arrive once each in Serilog's format, and no errors.

### Not verified — worth knowing before merging

- **All numbers are from a Debug build** with `-p:FilterReadyToRunAssemblies=false`. That matches Release codegen but keeps Debug-only behavior, notably the RPC call tracing that `ClientStartup` disables under `#if !DEBUG`. A Release build would confirm both the timings and the 120MB.
- **Sentry uploads from the extension fail at TLS** — `-1200 [3:-9802]`, retried and failing each time, so the failure report is captured and flushed but does not arrive. This is pre-existing rather than introduced here (the extension has always initialized Sentry; this branch only changed when, and forcing a `Flush` is what made it visible), and the main app shows no such failures. Worth a separate issue: candidates are the custom `CreateHttpMessageHandler` under `UseNativeHttpHandler=true`, ATS, or the extension sandbox.
- **`RpcServerProbe` logs success at `Warning`** ("RPC probe ...: OK (200)"), and Sentry's `MinimumEventLevel` is `Warning`, so the extension now emits a Sentry event per share (throttled to 5 per 5 min by `SentryExt.IsThrottled`). The main app has always done this; the extension now inherits it. Fixing it at the source is a separate call.

### What's left, if anyone picks this up

The remaining ~0.6s before the first line of managed code (dyld + CoreCLR + registrar + UIKit) is now the biggest single block, and it is user-visible. Note the obvious lever is already ruled out: cutting 120MB from the composite moved it not at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
