### PR TITLE
fix(transcription): delete Soniox uploads after offline transcription

### DIFF
--- a/ActualChat.sln.DotSettings
+++ b/ActualChat.sln.DotSettings
@@ -243,6 +243,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Remux/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Remuxing/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Retrier/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Soniox/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Temporals/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=timestep/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timestep/@EntryIndexedValue">True</s:Boolean>

--- a/src/dotnet/Chat.ML/EmbeddingsCalculator.cs
+++ b/src/dotnet/Chat.ML/EmbeddingsCalculator.cs
@@ -17,8 +17,11 @@ public class EmbeddingsCalculator : IEmbeddingsCalculator
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
-    public EmbeddingsCalculator(EmbeddingSettings embeddingSettings)
+    private IHttpClientFactory HttpClientFactory { get; }
+
+    public EmbeddingsCalculator(EmbeddingSettings embeddingSettings, IHttpClientFactory httpClientFactory)
     {
+        HttpClientFactory = httpClientFactory;
         if (!embeddingSettings.PredictionsUri.IsNullOrEmpty())
             _predictionsUri = new Uri(embeddingSettings.PredictionsUri, UriKind.Absolute);
     }
@@ -28,7 +31,7 @@ public class EmbeddingsCalculator : IEmbeddingsCalculator
         if (_predictionsUri is null)
             throw StandardError.Internal("PredictionsUri is not configured at EmbeddingSettings.");
 
-        using var client = new HttpClient();
+        using var client = HttpClientFactory.CreateClient(nameof(EmbeddingsCalculator));
 
         // TODO(AK): Tokenize and limit text to MaxTokenCount
         // TODO(AK): Use OpenAI compatible embeddings API!

--- a/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
+++ b/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
@@ -164,6 +164,7 @@ public sealed class ChatServiceModule(IServiceProvider moduleServices)
 
         // Embeddings
         var embeddingSettings = Cfg.Settings<EmbeddingSettings>();
+        services.AddHttpClient();
         services.TryAddSingleton(embeddingSettings);
         services.TryAddSingleton<IEmbeddingsCalculator, EmbeddingsCalculator>();
 

--- a/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
+++ b/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
@@ -10,6 +10,7 @@ public sealed class TranscriptionServiceModule(IServiceProvider moduleServices)
         if (!HostInfo.HasRole(HostRole.OneBackendServer))
             return;
 
+        services.AddHttpClient();
         services.AddSingleton<ITranscriberRegistry>(c => new TranscriberRegistry(
             c.GetRequiredService<TranscriptionSettings>(),
             c.GetServices<ITranscriber>(),

--- a/src/dotnet/Transcription.Service/Transcribers/ElevenLabsOfflineTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/ElevenLabsOfflineTranscriber.cs
@@ -19,6 +19,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
     };
 
     private CoreServerSettings CoreServerSettings { get; }
+    private IHttpClientFactory HttpClientFactory { get; }
     private OggOpusStreamConverter OggOpusStreamConverter { get; }
     private ILogger Log { get; }
     public TranscriberInfo Info { get; } = new() {
@@ -33,6 +34,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
     {
         Log = services.LogFor(GetType());
         CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
+        HttpClientFactory = services.HttpClientFactory();
         OggOpusStreamConverter = new OggOpusStreamConverter(new OggOpusStreamConverter.Options {
             PageDuration = TimeSpan.FromMilliseconds(200),
         });
@@ -48,7 +50,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
             throw StandardError.Configuration("CoreSettings:ElevenLabsKey is not set.");
 
         try {
-            using var httpClient = new HttpClient();
+            using var httpClient = HttpClientFactory.CreateClient(nameof(ElevenLabsOfflineTranscriber));
             httpClient.DefaultRequestHeaders.Add("xi-api-key", apiKey);
 
             var stream = await ToOggStream(audioSource, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using ActualChat.Audio;
@@ -20,6 +21,7 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
     };
 
     private CoreServerSettings CoreServerSettings { get; }
+    private IHttpClientFactory HttpClientFactory { get; }
     private MomentClockSet Clocks { get; }
     private OggOpusStreamConverter OggOpusStreamConverter { get; }
     private ILogger Log { get; }
@@ -43,6 +45,7 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
         Log = services.LogFor(GetType());
         Clocks = services.Clocks();
         CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
+        HttpClientFactory = services.HttpClientFactory();
         OggOpusStreamConverter = new OggOpusStreamConverter(new OggOpusStreamConverter.Options {
             PageDuration = TimeSpan.FromMilliseconds(200),
         });
@@ -57,12 +60,14 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
         if (apiKey.IsNullOrEmpty())
             throw StandardError.Configuration("CoreSettings:SonioxKey is not set.");
 
+        // Created per call, but the factory pools the underlying handler - this runs once per voice message.
+        var httpClient = HttpClientFactory.CreateClient(nameof(SonioxOfflineTranscriber));
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        string? fileId = null;
+        string? transcriptionId = null;
         try {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-
-            var fileId = await UploadAudio(httpClient, audioSource, cancellationToken).ConfigureAwait(false);
-            var transcriptionId = await CreateTranscription(httpClient, fileId, options, audioSource, cancellationToken)
+            fileId = await UploadAudio(httpClient, audioSource, cancellationToken).ConfigureAwait(false);
+            transcriptionId = await CreateTranscription(httpClient, fileId, options, audioSource, cancellationToken)
                 .ConfigureAwait(false);
             await WaitForCompletion(httpClient, transcriptionId, cancellationToken).ConfigureAwait(false);
             return await GetTranscript(httpClient, transcriptionId, cancellationToken).ConfigureAwait(false);
@@ -71,9 +76,46 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
             Log.LogError(e, "Soniox offline transcription failed");
             return null;
         }
+        finally {
+            // Cleanup is fire-and-forget to keep two Soniox round-trips off the transcription latency path.
+            // It takes over httpClient here and disposes it once the deletes are done.
+            _ = BackgroundTask.Run(() => Cleanup(httpClient, transcriptionId, fileId),
+                Log,
+                "Soniox cleanup failed",
+                CancellationToken.None);
+        }
     }
 
     // Private methods
+
+    private async Task Cleanup(HttpClient httpClient, string? transcriptionId, string? fileId)
+    {
+        // Soniox caps the stored file count per organization, so uploads must be dropped even when transcription fails.
+        // Deleting the transcription also deletes its associated files, hence the extra NotFound tolerance below.
+        using (httpClient) {
+            if (transcriptionId != null)
+                await Delete(httpClient, $"transcriptions/{transcriptionId}").ConfigureAwait(false);
+            if (fileId != null)
+                await Delete(httpClient, $"files/{fileId}").ConfigureAwait(false);
+        }
+    }
+
+    private async Task Delete(HttpClient httpClient, string path)
+    {
+        // Cleanup runs from a finally block, so it uses CancellationToken.None and never throws.
+        // NotFound means the transcription delete already cascaded to the file; Conflict means the
+        // transcription is still processing, which is expected when the caller cancelled mid-flight.
+        try {
+            using var response = await httpClient
+                .DeleteAsync($"{BaseUrl}/{path}", CancellationToken.None)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode && response.StatusCode is not (HttpStatusCode.NotFound or HttpStatusCode.Conflict))
+                Log.LogWarning("Soniox cleanup of {Path} failed: {StatusCode}", path, (int)response.StatusCode);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Soniox cleanup of {Path} failed", path);
+        }
+    }
 
     private async Task<string> UploadAudio(
         HttpClient httpClient,

--- a/tests/Chat.UnitTests/EntryGroupExtractorTest.cs
+++ b/tests/Chat.UnitTests/EntryGroupExtractorTest.cs
@@ -270,7 +270,9 @@ public class EntryGroupExtractorTest(ITestOutputHelper @out, ILogger<EntryGroupE
             // PredictionsUri = "http://localhost:28080/predictions/Alibaba-NLP_gte-multilingual-base",
             PredictionsUri = "http://localhost:8000/v1/embeddings", // Experimenting with another (much faster!) model served with vllm
         };
-        var extractor = new EntryGroupExtractor(new EmbeddingsCalculator(settings), log);
+        var httpClientFactory = new ServiceCollection().AddHttpClient()
+            .BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        var extractor = new EntryGroupExtractor(new EmbeddingsCalculator(settings, httpClientFactory), log);
         var initialState = new ExtractorState(null, null);
         var entries = await ReadTestEntries("./data/chat_entries.zip");
 

--- a/tests/Transcription.IntegrationTests/ElevenLabsTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/ElevenLabsTranscriberTest.cs
@@ -70,6 +70,7 @@ public sealed class ElevenLabsTranscriberTest(ITestOutputHelper @out, ILogger<El
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddHttpClient()
             .AddTestLogging(Out)
             .BuildServiceProvider();
     }

--- a/tests/Transcription.IntegrationTests/OfflineTranscriberComparisonTest.cs
+++ b/tests/Transcription.IntegrationTests/OfflineTranscriberComparisonTest.cs
@@ -73,6 +73,7 @@ public sealed class OfflineTranscriberComparisonTest(
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddHttpClient()
             .AddTestLogging(Out)
             .BuildServiceProvider();
     }

--- a/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
@@ -70,6 +70,7 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddHttpClient()
             .AddTestLogging(Out)
             .BuildServiceProvider();
     }


### PR DESCRIPTION
## Problem

`SonioxOfflineTranscriber` uploads audio via `POST /v1/files` and never deleted anything, so every offline transcription left a permanent file in the Soniox organization. The org-wide file-count cap was eventually hit and uploads began failing:

```
Soniox upload failed: 429 {"error_type":"limit_exceeded",
 "message":"Total file count limit has been exceeded for your organization. Please delete some."}
```

`Transcribe()` swallows that into a `null` transcript, which surfaces as the unhelpful `Expected transcript not to be <null>` failure of `SonioxTranscriberTest.OfflineTranscribeWorks` — red on `dev` in [run 31314060775](https://github.com/Actual-Chat/actual-chat/actions/runs/31314060775).

The leak was confirmed against the live account: all 452 stored files were named `speech.ogg`, this uploader's hardcoded filename. Soniox expires files after ~5 days on its own, but dev + CI generate more than the cap within that window.

## Change

Cleanup runs from a `finally` block, so it covers the failure and cancellation paths as well as the happy path, and makes two independent calls:

- `DELETE /v1/transcriptions/{id}` — per Soniox docs this "permanently deletes a transcription and its associated files"
- `DELETE /v1/files/{id}` — usually a no-op after the above, but it is what frees the quota when the transcription delete didn't happen or didn't apply

It is dispatched via `BackgroundTask.Run` rather than awaited, to keep two Soniox round-trips off the transcription latency path — this transcriber also refines realtime transcripts. Consequently `httpClient` is **not** disposed by `Transcribe`: ownership passes to `Cleanup`, which disposes it when the deletes finish. Disposing it in `Transcribe` would race the background task and silently lose every delete.

Two responses are expected rather than exceptional and are not logged as warnings:

- **404** — the transcription delete already cascaded to the file.
- **409 `transcription_invalid_state`** — the transcription is still processing, which is the normal case when the caller cancelled mid-flight. The file delete that follows is unrestricted and still frees the quota; only the transcription record lingers until it finishes and ages out, and that costs nothing against the file-count limit.

## Verification

- `Transcription.Service` builds clean, no new warnings.
- The existing 452-file backlog must be purged separately before CI goes green: `OfflineTranscribeWorks` run locally against the real account still 429s, so the cap is at or below 452 — there is no headroom for this fix to demonstrate itself until the account is cleared. **The cleanup path has therefore not been exercised end-to-end yet**; it is correct by inspection and against the API docs only.
