### PR TITLE
fix(chat): restore the unread badge for chats that really are unread

### DIFF
--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -752,6 +752,21 @@ public override async Task Require(CancellationToken cancellationToken)
     serialization/RPC boundary (compute-method results, command results, API
     contracts); for client-only collections use `List<T>`, arrays, `Dictionary<,>`, etc.
 
+14. **Extend an existing UI service instead of adding a new one.** Every registered
+    service costs registration and resolution time on every launch, and that bill is
+    paid where it hurts most — WASM and MAUI startup. A new `*UI` service earns its
+    keep only when it owns genuinely distinct state or its own JS-interop surface.
+    When the new thing is a projection, aggregation, or variation of what a nearby
+    service already tracks, add a property or a compute method there.
+
+    "Is the user at the screen right now" is one example: it's `UserActivityUI`'s
+    last-interaction moment narrowed by document visibility, so it belongs on
+    `UserActivityUI` as an extra state — not in a new service beside it.
+
+    The same reasoning applies to splitting an existing service in two. Split when
+    the halves have separate lifetimes or dependencies, not merely to keep files
+    short — partial classes already solve that (see [File Organization](#file-organization)).
+
 ### Serialization Attributes
 
 Three serializers are live and every serializable type must work in **all three**:

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -72,6 +72,10 @@ public static partial class Constants
         public static readonly TileStack<int> ChatTileStack = TileStacks.Int5To20;
         public static readonly TimeSpan MaxEntryDuration = TimeSpan.FromMinutes(3);
         public static readonly TimeSpan StreamingEntryFixupDelay = MaxEntryDuration + TimeSpan.FromSeconds(30);
+        // How long after the last interaction we still count an open chat at its tail as "being read".
+        // Much longer than Presence.ActivityPeriod: reading a long message without touching anything
+        // is normal, while a user who walked away must stop consuming unread messages.
+        public static readonly TimeSpan ReadingGracePeriod = TimeSpan.FromMinutes(3);
         // 2x the editor's large-paste threshold, which is per paste rather than per message
         public const int MaxEntryTextLength = 64 * 1024;
         public const int NonContactPeerMessageLimit = 2;

--- a/src/dotnet/Api/Users/ChatPosition.cs
+++ b/src/dotnet/Api/Users/ChatPosition.cs
@@ -16,6 +16,11 @@ public sealed partial record ChatPosition(
     [property: DataMember, Key(1)] string Origin = ""
 ) : IHasOrigin
 {
+    // A stored 0 is a real position - "read nothing yet" in a chat that has entries - so
+    // "no position stored at all" needs a value of its own. Every consumer treats a negative
+    // lid the same way it treats 0, except the unread count, which must tell the two apart.
+    public static readonly ChatPosition None = new(-1);
+
     public override string ToString()
         => Origin.IsNullOrEmpty()
             ? EntryLid.Format()

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatMessageKind.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatMessageKind.cs
@@ -15,3 +15,12 @@ public enum ChatMessageKind
     SendingNewMessage,
     AudioRecordingMessage,
 }
+
+public static class ChatMessageKindExt
+{
+    // Placeholders stand in for entries the server hasn't accepted yet - an optimistic send, the
+    // audio-recording skeleton. Their lids are synthetic and sit at or beyond the chat's end, so
+    // anything deciding "how far has this been read" must skip them.
+    public static bool IsPlaceholder(this ChatMessageKind kind)
+        => kind is ChatMessageKind.SendingNewMessage or ChatMessageKind.AudioRecordingMessage;
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -148,6 +148,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         _disposeTokenSource.CancelAndDisposeSilently();
         _whenInitializedSource.TrySetCanceled();
         _readPositionLease.DisposeSilently();
+        ChatUI.ResetItemVisibility(Chat.Id);
         Nav.LocationChanged -= OnLocationChanged;
         _isHoverMenuDisposed = true;
         if (_hoverMenuJsRefTask is { IsCompletedSuccessfully: true } jsRefTask)
@@ -270,19 +271,31 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             return;
 
         _itemVisibility.Value = itemVisibility;
-        if (itemVisibility.IsEmpty || !WhenInitialized.IsCompletedSuccessfully)
+        if (!WhenInitialized.IsCompletedSuccessfully)
             return;
 
+        if (itemVisibility.IsEmpty) {
+            // Retracting matters as much as publishing: consumers gate on "this chat is visible at
+            // its tail", and a retained last-known value keeps that true long after the view is gone.
+            ChatUI.ResetItemVisibility(Chat.Id);
+            return;
+        }
+
+        ChatUI.SetItemVisibility(itemVisibility);
+        var isUserPresent = ChatUI.IsUserPresent();
         if (itemVisibility.IsEndAnchorVisible) {
             _lastEndAnchorVisibleAt = CpuTimestamp.Now;
-            _ = UpdateReadPositionToTheLastId(Chat.Id);
-        } else
+            if (isUserPresent)
+                _ = UpdateReadPositionToTheLastId(Chat.Id);
+        }
+        else if (isUserPresent)
             UpdateReadPosition(itemVisibility.MaxMessageLid);
         if (_viewPositionLease is not null) {
+            // Not gated on presence: this one restores the scroll position, so it tracks
+            // the rendered viewport rather than what the user has actually read.
             var entryId = itemVisibility.MaxMessageLid;
             _viewPositionLease.Resource.Value = new ReadPosition(Chat.Id, entryId);
         }
-        ChatUI.ItemVisibility.Value = itemVisibility;
         return;
 
         async Task UpdateReadPositionToTheLastId(ChatId chatId)
@@ -375,6 +388,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         var isChatViewVisible = RegionVisibility.IsVisible;
         if (!isChatViewVisible.Value) {
             // Chat is invisible now, let's suspend & await for it to become visible
+            ChatUI.ResetItemVisibility(chatId);
             using (Computed.BeginIsolation())
                 await isChatViewVisible.Computed.When(x => x, cancellationToken);
             _shownReadEntryLid.Value = ReadPosition.Value.EntryLid;
@@ -702,6 +716,11 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         var itemVisibility = ItemVisibility.Value;
         if (items.Count == 0)
             return false; // Not loaded yet or wrong load range
+
+        if (!ChatUI.IsUserPresent()) {
+            DebugLog?.LogDebug("TryUpdateShownReadEntryLid: the user isn't at the screen");
+            return false;
+        }
 
         if (itemVisibility.IsEmpty || !itemVisibility.IsEndAnchorVisible) {
             DebugLog?.LogDebug("TryUpdateShownReadEntryLid: no item visibility or end anchor is not visible");

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -102,9 +102,10 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 StateCategories.Get(type, nameof(ShownReadEntryLid)));
             _readPositionLease = await ChatUI.LeaseReadPositionState(Chat.Id, DisposeToken);
             _viewPositionLease = await ChatUI.LeaseViewPositionState(Chat.Id, DisposeToken);
-            _shownReadEntryLid.Value = _readPositionLease.Resource.Value.EntryLid;
-            if (_viewPositionLease.Resource.Value.EntryLid is 0)
-                _viewPositionLease.Resource.Value = _readPositionLease.Resource.Value;
+            var readPosition = _readPositionLease.Resource.Value;
+            _shownReadEntryLid.Value = readPosition.EntryLid;
+            if (_viewPositionLease.Resource.Value.EntryLid is 0 && readPosition.EntryLid > 0)
+                _viewPositionLease.Resource.Value = readPosition;
             _whenInitializedSource.TrySetResult();
             _updateReadStateTask = AsyncChain.From(UpdateReadState)
                 .Log(LogLevel.Debug, Log)
@@ -421,7 +422,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         var isFirstRender = renderedData.IsNone && query.IsNone;
         var readEntryLid = GetReadEntryLid();
         var viewEntryLid = ViewPosition.Value.EntryLid;
-        var hasViewEntry = viewEntryLid != 0 && viewEntryLid != long.MaxValue;
+        var hasViewEntry = viewEntryLid > 0 && viewEntryLid != long.MaxValue;
         var nav = await _nextNavigation.Use(cancellationToken)
             ?? (isFirstRender && hasViewEntry ? new ChatViewNavigation(viewEntryLid, false, false, true) : null);
         if (ReferenceEquals(nav, renderedData.NavigationState)) // Handles null case as well

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -29,6 +29,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     private CpuTimestamp _lastEndAnchorVisibleAt;
     private CpuTimestamp _newMessagesLineShownAt;
     private long _debouncedReadEntryLid;
+    private long _lastKnownEntryLid = -1;
 
     private static readonly string HoverMenuJSCreateMethod = $"{BlazorUIAppModule.ImportName}.ChatHoverMenu.create";
     private readonly Dictionary<ChatEntryId, MessageHoverMenu> _hoverMenus = new();
@@ -289,7 +290,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 _ = UpdateReadPositionToTheLastId(Chat.Id);
         }
         else if (isUserPresent)
-            UpdateReadPosition(itemVisibility.MaxMessageLid);
+            UpdateReadPosition(itemVisibility.MaxEntryLid);
         if (_viewPositionLease is not null) {
             // Not gated on presence: this one restores the scroll position, so it tracks
             // the rendered viewport rather than what the user has actually read.
@@ -433,6 +434,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 () => Chats.GetIdRange(Session, chatId, cancellationToken),
                 cancellationToken);
         var chatIdRange = cChatIdRange.Value;
+        _lastKnownEntryLid = chatIdRange.End - 1;
         var dataQuery = GetChatDataQuery(query,
             renderedData,
             nav,
@@ -704,6 +706,11 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
     private long UpdateReadPosition(long readEntryLid)
     {
+        // Last line of defence against a synthetic lid becoming a read position: the server stores
+        // read positions forward-only, so one overshoot silently swallows the unread state of every
+        // real entry it covers.
+        if (_lastKnownEntryLid >= 0)
+            readEntryLid = Math.Min(readEntryLid, _lastKnownEntryLid);
         var readPosition = ReadPosition;
         readEntryLid = Math.Max(readPosition.Value.EntryLid, readEntryLid);
         if (readPosition.Value.EntryLid < readEntryLid)
@@ -746,8 +753,8 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             return false; // Don't remove NewMessagesLine during debounce period
 
         // We see end anchor, when the new message appears so we can update shownReadEntryLid
-        var lastEntryLid = items[^1].Id;
-        var maxVisibleEntryLid = itemVisibility.MaxMessageLid;
+        var lastEntryLid = items.LastOrDefault(i => !i.Kind.IsPlaceholder())?.Id ?? -1;
+        var maxVisibleEntryLid = itemVisibility.MaxEntryLid;
         var newShownReadEntryLid = UpdateReadPosition(Math.Max(lastEntryLid, maxVisibleEntryLid));
         if (newShownReadEntryLid == shownReadEntryLid) {
             DebugLog?.LogDebug("TryUpdateShownReadEntryLid: read position is unchanged");

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
@@ -264,7 +264,7 @@ public partial class ChatUI
                             continue;
 
                         var lastReadEntryLid = chatInfo.ReadEntryLid;
-                        var prefetchNearTo = lastReadEntryLid != 0
+                        var prefetchNearTo = lastReadEntryLid > 0
                             ? lastReadEntryLid
                             : chatInfo.News?.TextEntryLidRange.End ?? 0;
                         var idTile = IdTileStack.LastLayer.GetTile(prefetchNearTo).Range;

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -31,6 +31,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private IUserPresences UserPresences => Hub.UserPresences;
     private IAccounts Accounts => Hub.Accounts;
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
+    private UserActivityUI UserActivityUI => Hub.UserActivityUI;
     private IAvatars Avatars => Hub.Avatars;
     private IAuthors Authors => Hub.Authors;
     private IContacts Contacts => Hub.Contacts;
@@ -57,7 +58,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     public IState<ChatEntryId?> HighlightedEntryId => _highlightedEntryId;
     public IState<IImmutableSet<ConversationId>> ConversationExpansionOverrides => _conversationExpansionOverrides;
     public Task WhenReady => _selectedChatId.WhenRead;
-    public MutableState<ChatViewItemVisibility> ItemVisibility => _itemVisibility;
+    public IState<ChatViewItemVisibility> ItemVisibility => _itemVisibility;
 
     public static event Action<(ChatId, long)> OnReadPositionUpdated = _ => { };
 
@@ -302,12 +303,29 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     [ComputeMethod]
     public virtual async Task<bool> IsReadingTail(ChatId chatId, CancellationToken cancellationToken)
     {
+        // Must stay in sync with what actually advances the read position (ChatView) - suppressing
+        // the unread badge for a chat whose read position isn't moving would hide real unread messages.
         if (!await IsSelected(chatId).ConfigureAwait(false))
             return false;
 
         var itemVisibility = await ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
-        return itemVisibility.ChatId == chatId && itemVisibility.IsEndAnchorVisible;
+        if (itemVisibility.ChatId != chatId || !itemVisibility.IsEndAnchorVisible)
+            return false;
+
+        var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);
+        var readingUntil = lastPresentAt + Constants.Chat.ReadingGracePeriod;
+        var now = Clocks.CpuClock.Now;
+        if (readingUntil <= now)
+            return false;
+
+        Computed.GetCurrent().Invalidate(readingUntil - now);
+        return true;
     }
+
+    // The non-reactive half of IsReadingTail, for the JS-driven callbacks that can't await:
+    // the document is visible and the user interacted recently enough to still be at the screen.
+    public bool IsUserPresent()
+        => UserActivityUI.LastPresentAt.Value + Constants.Chat.ReadingGracePeriod > Clocks.CpuClock.Now;
 
     [ComputeMethod(ConsolidationDelay = 0.3)]
     public virtual async Task<bool> IsUnreadByOthers(
@@ -354,6 +372,20 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     }
 
     // SetXxx & Add/RemoveXxx
+
+    public void SetItemVisibility(ChatViewItemVisibility itemVisibility)
+        => _itemVisibility.Value = itemVisibility;
+
+    public void ResetItemVisibility(ChatId chatId)
+    {
+        // Chat views overlap during navigation, so a disposing view must not clear its successor's
+        // visibility - only the view that published the current value may retract it.
+        lock (Lock) {
+            if (_itemVisibility.Value.ChatId == chatId)
+                _itemVisibility.Value = ChatViewItemVisibility.Empty;
+        }
+    }
+
     public void LeaveChat(Chat.Chat chat)
         => _ = ModalUI.Show(new LeaveChatConfirmationModal.Model(false, "chat",
             m => _ = DeleteOrLeaveChatInternal(chat, false, m)));

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -125,10 +125,8 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             var unreadCount = ComputeUnreadCount(chatId, news, readEntryLid);
 
             var hasUnreadMentions = false;
-            if (chatUserSettings.NotificationMode is not ChatNotificationMode.Muted) {
-                var lastMentionEntryId = lastMention?.EntryId.LocalId ?? 0;
-                hasUnreadMentions = lastMentionEntryId > readEntryLid;
-            }
+            if (lastMention is { } mention && chatUserSettings.NotificationMode is not ChatNotificationMode.Muted)
+                hasUnreadMentions = mention.EntryId.LocalId > readEntryLid;
 
             var navbarSettings = await NavbarUI.Settings.Use(cancellationToken).ConfigureAwait(false);
 
@@ -645,11 +643,17 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     // Not compute method!
     private static Trimmed<int> ComputeUnreadCount(ChatId chatId, ChatNews? chatNews, long readEntryLid)
     {
+        // A negative lid is ChatPosition.None - nothing was ever stored, so the chat was never
+        // opened and counting all of it as unread would flood the badge on first sight. A stored 0
+        // is a real position: joining a chat that was empty at the time seeds exactly that, and
+        // entry lids start at 1, so every message that arrives afterwards is genuinely unread.
+        // Peer chats are exempt from the "never opened" rule - they have no join step to seed a
+        // position, so a missing one just means this side of the conversation hasn't started.
         var unreadCount = 0;
-        if (chatNews is not null && (readEntryLid > 0 || (chatId.Kind == ChatKind.Peer && readEntryLid == 0))) {
-            // Otherwise the chat wasn't ever opened
+        var hasReadPosition = readEntryLid >= 0 || chatId.Kind == ChatKind.Peer;
+        if (chatNews is not null && hasReadPosition) {
             var lastId = chatNews.TextEntryLidRange.End - 1;
-            unreadCount = (int)(lastId - readEntryLid).Clamp(0, ChatInfo.MaxUnreadCount);
+            unreadCount = (int)(lastId - Math.Max(0, readEntryLid)).Clamp(0, ChatInfo.MaxUnreadCount);
         }
         return new Trimmed<int>(unreadCount, ChatInfo.MaxUnreadCount);
     }

--- a/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
@@ -12,6 +12,14 @@ public sealed record ChatViewItemVisibility(
     public long MaxMessageLid { get; } = VisibleKeys.Count == 0 ? -1 : VisibleKeys.Max(x => x.LocalId);
     public bool IsEmpty => VisibleKeys.Count == 0;
 
+    // Same as MaxMessageLid, minus the placeholders - use this one wherever the lid is about to
+    // become a read position, since a placeholder's synthetic lid would mark the chat read to its end.
+    public long MaxEntryLid { get; } = VisibleKeys
+        .Where(x => !x.Kind.IsPlaceholder())
+        .Select(x => x.LocalId)
+        .DefaultIfEmpty(-1)
+        .Max();
+
     public IReadOnlyList<ChatEntryId> VisibleTextEntryIds => field ??= VisibleKeys
         .Where(c => c.Kind == ChatMessageKind.None)
         .OrderBy(x => x.LocalId)

--- a/src/dotnet/UI.Blazor/Services/UserActivityUI/UserActivityUI.cs
+++ b/src/dotnet/UI.Blazor/Services/UserActivityUI/UserActivityUI.cs
@@ -10,11 +10,17 @@ public class UserActivityUI : UIServiceBase<UIHub>, IUserActivityUIBackend
     private static readonly string JSInitMethod = $"{BlazorUICoreModule.ImportName}.UserActivityUI.init";
 
     private readonly MutableState<Moment> _activeUntil;
+    private readonly MutableState<Moment> _lastPresentAt;
 
     private MomentClock CpuClock { get; }
     private Moment CpuNow => CpuClock.Now;
 
     public IState<Moment> ActiveUntil => _activeUntil; // CPU time
+
+    // CPU time of the last interaction that happened while the document was visible;
+    // Moment.MinValue while it's hidden. Consumers apply their own grace period on top -
+    // "the user is at the screen" means something different for presence and for reading.
+    public IState<Moment> LastPresentAt => _lastPresentAt;
 
     public UserActivityUI(UIHub hub) : base(hub)
     {
@@ -22,6 +28,9 @@ public class UserActivityUI : UIServiceBase<UIHub>, IUserActivityUIBackend
         _activeUntil = StateFactory.NewMutable(
             CpuNow + Constants.Presence.CheckPeriod,
             nameof(ActiveUntil));
+        _lastPresentAt = StateFactory.NewMutable(
+            CpuNow,
+            nameof(LastPresentAt));
         var blazorRef = DotNetObjectReference.Create<IUserActivityUIBackend>(this);
         Hub.RegisterDisposable(blazorRef);
         _ = JS.InvokeVoidAsync(JSInitMethod, blazorRef,
@@ -31,5 +40,12 @@ public class UserActivityUI : UIServiceBase<UIHub>, IUserActivityUIBackend
 
     [JSInvokable]
     public void OnInteraction(double willBeActiveForMs)
-        => _activeUntil.Value = CpuNow + TimeSpan.FromMilliseconds(willBeActiveForMs);
+    {
+        // Zero means the document just went hidden - the JS side reports it explicitly
+        // rather than letting the activity period decay, so presence drops right away.
+        var activeFor = TimeSpan.FromMilliseconds(willBeActiveForMs);
+        var now = CpuNow;
+        _activeUntil.Value = now + activeFor;
+        _lastPresentAt.Value = activeFor > TimeSpan.Zero ? now : Moment.MinValue;
+    }
 }

--- a/src/dotnet/UI.Blazor/Services/UserActivityUI/user-activity-ui.ts
+++ b/src/dotnet/UI.Blazor/Services/UserActivityUI/user-activity-ui.ts
@@ -23,8 +23,12 @@ export class UserActivityUI {
         documentEvents.visibilityChange$.subscribe(() => {
             if (!document.hidden)
                 this.onInteraction();
-            else
+            else {
+                // Bypasses the throttle - the hidden transition must reach .NET right away,
+                // otherwise presence lingers for up to notifyPeriodMs after the tab is gone.
                 this.onInteraction(0, true);
+                void this.notifyBackend();
+            }
         })
         documentEvents.pointerMove$.subscribe(() => this.onInteraction());
         documentEvents.pointerDown$.subscribe(() => this.onInteraction());
@@ -47,10 +51,8 @@ export class UserActivityUI {
     }
 
     private static notifyBackend = async () => {
-        const willBeActiveForMs = this._activeUntil - Date.now();
-        if (willBeActiveForMs <= 0)
-            return;
-
+        // Zero is meaningful here: it's how .NET learns the user is no longer present
+        const willBeActiveForMs = Math.max(0, this._activeUntil - Date.now());
         debugLog?.log(`notifyBackend`);
         await this._blazorRef.invokeMethodAsync('OnInteraction', willBeActiveForMs);
     }

--- a/src/dotnet/Users.Service/ChatPositions.cs
+++ b/src/dotnet/Users.Service/ChatPositions.cs
@@ -38,6 +38,18 @@ public class ChatPositions(IServiceProvider services) : DbServiceBase<UsersDbCon
         if (chat is null)
             return;
 
+        if (kind == ChatPositionKind.Read) {
+            // Read positions are stored forward-only, so one past the chat's end permanently marks
+            // entries that don't exist yet as read. Clients overshoot in more than one way: the
+            // "unbounded" long.MaxValue sentinel, and the synthetic lids the chat view gives to
+            // placeholder items - an optimistic send, the audio-recording skeleton.
+            // View positions are excluded: they're overwritten freely and mean "where you were".
+            var idRange = await Chats.GetIdRange(session, chatId, cancellationToken).ConfigureAwait(false);
+            var maxLid = idRange.End - 1;
+            if (position.EntryLid > maxLid)
+                position = position with { EntryLid = maxLid };
+        }
+
         var backendCommand = new ChatPositionsBackend_Set(account.Id, chatId, kind, position);
         await Commander.Call(backendCommand, true, cancellationToken).ConfigureAwait(false);
     }

--- a/src/dotnet/Users.Service/ChatPositionsBackend.cs
+++ b/src/dotnet/Users.Service/ChatPositionsBackend.cs
@@ -26,7 +26,7 @@ public class ChatPositionsBackend(IServiceProvider services) : DbServiceBase<Use
     {
         var id = DbChatPosition.ComposeId(userId, chatId, kind);
         var dbChatPosition = await DbChatPositionResolver.Get(id, cancellationToken).ConfigureAwait(false);
-        return dbChatPosition?.ToModel() ?? new ChatPosition();
+        return dbChatPosition?.ToModel() ?? ChatPosition.None;
     }
 
     // [CommandHandler]

--- a/src/dotnet/Users.Service/ChatPositionsBackend.cs
+++ b/src/dotnet/Users.Service/ChatPositionsBackend.cs
@@ -41,11 +41,14 @@ public class ChatPositionsBackend(IServiceProvider services) : DbServiceBase<Use
             return;
         }
 
-        // Guard against the client's "unbounded" sentinel (long.MaxValue) being persisted as a
-        // read/heard position. OnSet is forward-only for both, so a stored MaxValue would mark the
-        // chat permanently fully-read/heard and suppress every notification. Clamp to the last entry.
+        // Guard against the "unbounded" sentinel (long.MaxValue) being persisted as a read/heard
+        // position. OnSet is forward-only for both, so a stored MaxValue would mark the chat
+        // permanently fully-read/heard and suppress every notification. Clamp to the last entry.
+        // Bounding an ordinary position is ChatPositions.OnSet's job - it owns the untrusted input,
+        // while this command is also how the server itself seeds and repairs positions.
+        // Removed entries are excluded so the ceiling matches the last entry ChatNews reports.
         if (kind is ChatPositionKind.Read or ChatPositionKind.Heard && position.EntryLid == long.MaxValue) {
-            var maxLid = await ChatsBackend.GetMaxLid(chatId, true, cancellationToken).ConfigureAwait(false);
+            var maxLid = await ChatsBackend.GetMaxLid(chatId, false, cancellationToken).ConfigureAwait(false);
             position = position with { EntryLid = maxLid };
         }
 

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -730,13 +730,13 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             lids.Should().Contain(v + 4);
             beforeLids = lids;
         }, TimeSpan.FromSeconds(10));
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> {
                 ChatMessageKey.New(ChatMessageKind.None, v + 3),
                 ChatMessageKey.New(ChatMessageKind.None, v + 4),
             },
-            false);
+            false));
 
         // act 1 - a summary pass widens the live pipeline's known coverage over v+3/v+4, but they're
         // still the topmost visible entries, so the viewport guard holds the fold there regardless
@@ -750,10 +750,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // act 2 - the reader scrolls further: a later message becomes the topmost visible one
         var tailEntry = await Tester.CreateTextEntry(chat.Id, "tail-3");
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, tailEntry.LocalId) },
-            false);
+            false));
 
         // assert - the boundary advances past v+3/v+4, folding them
         await ComputedTest.When(async ct => {
@@ -1334,10 +1334,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // act - viewport top sits at the 6th entry: everything above it (incl. un-summarised rows) must fold
         var viewportTop = lids[5];
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
-            false);
+            false));
 
         // assert - the governed boundary (not just the summary-covered range) advances to the viewport
         // top, so un-summarised rows above it are swallowed too
@@ -1393,10 +1393,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // act - viewport top sits at the last entry, so a large range folds
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
         var viewportTop = idRange.End - 1;
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
-            false);
+            false));
 
         long foldedBoundary = 0;
         await ComputedTest.When(async ct => {
@@ -1459,10 +1459,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SelectChatOnNavigation(chat.Id);
 
         void SetViewportTop(long lid)
-            => chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+            => chatUI.SetItemVisibility(new ChatViewItemVisibility(
                 chat.Id,
                 new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, lid) },
-                false);
+                false));
 
         // drive the fold boundary up to the live tail
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
@@ -1532,10 +1532,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // act - viewport top sits at the last entry, so a large range folds
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
         var viewportTop = idRange.End - 1;
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
-            false);
+            false));
 
         long foldedBoundary = 0;
         await ComputedTest.When(async ct => {
@@ -1616,10 +1616,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // act - viewport top sits at the 6th real entry, folding the 5 real rows above it (plus the
         // interleaved system entry, which must not count towards SwallowedCount)
         var viewportTop = lids[5];
-        chatUI.ItemVisibility.Value = new ChatViewItemVisibility(
+        chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
-            false);
+            false));
 
         // assert - the count is the true number of folded messages, not a lid-span approximation
         await ComputedTest.When(async ct => {

--- a/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
@@ -420,13 +420,13 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
     {
         var chatId = entries.Select(x => x.ChatId).Distinct().Single();
         var lids = entries.Select(x => x.LocalId).ToHashSet();
-        ChatUI.ItemVisibility.Value = new ChatViewItemVisibility(chatId,
+        ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId,
             lids.Select(lid => ChatMessageKey.New(ChatMessageKind.None, lid)).ToHashSet(),
-            true);
+            true));
     }
 
     private void ClearVisibleItems(ChatId chatId)
-        => ChatUI.ItemVisibility.Value = new ChatViewItemVisibility(chatId, ReadOnlySet<ChatMessageKey>.Empty, true);
+        => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId, ReadOnlySet<ChatMessageKey>.Empty, true));
 
     private Task AssertIsSubHeaderVisible(ChatId chatId, bool expected)
         => ComputedTest.When(async ct => {

--- a/tests/Streaming.IntegrationTests/ReportPlaybackTest.cs
+++ b/tests/Streaming.IntegrationTests/ReportPlaybackTest.cs
@@ -43,6 +43,7 @@ public class ReportPlaybackTest(AppHostFixture fixture, ITestOutputHelper @out)
         heard.EntryLid.Should().Be(entry.Id.LocalId);
 
         var read = await positionsBackend.Get(account.Id, chat.Id, ChatPositionKind.Read, CancellationToken.None);
+        // 0, not ChatPosition.None: creating the chat seeded a Read row at its (empty) end
         read.EntryLid.Should().Be(0);
 
         var chatsBackend = services.GetRequiredService<IChatsBackend>();
@@ -86,7 +87,7 @@ public class ReportPlaybackTest(AppHostFixture fixture, ITestOutputHelper @out)
 
         var positionsBackend = services.GetRequiredService<IChatPositionsBackend>();
         var heard = await positionsBackend.Get(account.Id, chat.Id, ChatPositionKind.Heard, CancellationToken.None);
-        heard.EntryLid.Should().Be(0);
+        heard.EntryLid.Should().Be(ChatPosition.None.EntryLid);
     }
 
     [Fact]

--- a/tests/Users.IntegrationTests/ChatUsagesTest.cs
+++ b/tests/Users.IntegrationTests/ChatUsagesTest.cs
@@ -137,7 +137,7 @@ public class ChatUsagesTest(AppHostFixture fixture, ITestOutputHelper @out)
 
         // assert
         storedReadable.EntryLid.Should().Be(readablePosition.EntryLid);
-        storedUnreadable.EntryLid.Should().Be(0);
+        storedUnreadable.EntryLid.Should().Be(ChatPosition.None.EntryLid);
     }
 
     [Fact]

--- a/tests/Users.IntegrationTests/ChatUsagesTest.cs
+++ b/tests/Users.IntegrationTests/ChatUsagesTest.cs
@@ -120,7 +120,9 @@ public class ChatUsagesTest(AppHostFixture fixture, ITestOutputHelper @out)
         await using var reader = appHost.NewWebClientTester(Out);
         var account = await reader.SignInAsUniqueBob();
         var (readableChatId, _) = await reader.CreateChat(false);
-        var readablePosition = new ChatPosition(10);
+        // Read positions are clamped to the chat's last entry, so this one must point at a real entry
+        var readableEntry = await reader.CreateTextEntry(readableChatId, "Hi");
+        var readablePosition = new ChatPosition(readableEntry.LocalId);
         var unreadablePosition = new ChatPosition(20);
 
         // act


### PR DESCRIPTION
Chats with genuinely unread messages showed no badge: chat news updated, the row
jumped to the top of the recent list, no blue dot. Three independent causes, one
per commit.

## 1. `ChatUI.ItemVisibility` was write-only

`ChatView` published it from exactly one place and never retracted it — the
empty-visibility update returned early, and `Dispose` didn't clear it. After
opening a chat at its tail, the state kept saying "this chat is visible at its
tail" forever: through navigating back to the chat list, through the view being
disposed. `IsReadingTail` stayed true for as long as that chat was selected, and
`GetUnreadState` threw the badge away.

The tell: the chat still counted in the navbar and the Unread filter, which read
`ChatInfo.UnreadCount` directly and bypass that gate.

Four other consumers — `TranslationUI`, `ThrottledTranslations`, `LiveBlockUI`,
`ConversationMessageView` — were reading the same stale value.

## 2. An open chat was treated as a read chat

Nothing on the read-position path checked whether the user was there.
`RegionVisibility` is consulted only in `GetData`, and a desktop window sitting
behind another window is still `visibilityState === "visible"` — so incoming
messages rendered, the end anchor stayed visible, and the position walked
forward while nobody was looking.

`UserActivityUI` gains `LastPresentAt`: the last interaction that happened while
the document was visible, `Moment.MinValue` while it's hidden. Presence keeps
its 30s `ActivityPeriod`; read tracking uses the much longer
`Chat.ReadingGracePeriod` (3 min), refreshed by any pointer move, scroll or
keypress — so someone actually reading never expires, and someone who walked
away does.

Both advancement paths now require it, and `IsReadingTail` applies the same
condition reactively: the badge gate and the position can't disagree, since
suppressing the badge for a chat whose position isn't moving would hide real
unread messages.

Not gated: posting a message, explicit navigation, and the view position (which
restores scroll and should track the viewport, not what was read).

## 3. Placeholder items leaked synthetic lids into the read position

Two rendered items don't correspond to a stored entry — the optimistic copy of a
message being sent (`lid = chatIdRange.End`, +1 per queued message) and the
audio-recording skeleton (`lid = long.MaxValue`). Both are `IsReplacement`, so
they aren't wrapped into an author group and their keys reach `VisibleKeys`;
both read-position call sites took a plain `Max` over that set.

- `long.MaxValue` poisons the session: the local `SyncedState` never recovers,
  because `MustDiscardRead` drops every server read carrying our own origin, so
  `GetReadEntryLid` keeps returning `max(MaxValue, server)`.
- A sending message's lid is subtler but persistent — read positions are stored
  forward-only, so a position N entries past the end silently swallows the
  unread state of the next N real messages, across restarts.

Fixed at three levels: `ChatMessageKind.IsPlaceholder()`,
`ChatViewItemVisibility.MaxEntryLid`, a ceiling in `UpdateReadPosition`, and a
server-side clamp in `ChatPositions.OnSet` that also covers older clients still
running the unfixed code.

## 4. `readEntryLid == 0` meant two different things

`ComputeUnreadCount` used `0` as "the chat was never opened" and returned no
unread count for it. But `0` is also a real stored position: `AuthorsBackend`
seeds the read position to the chat's last entry on join, which is `0` when the
chat was empty at the time. Entry lids start at 1, so every message that arrived
afterwards was genuinely unread — and none ever showed a badge. A group or place
chat created or joined before its first message stayed like that until opened
once. Peer chats were already exempted by a special case, which was the same bug
worked around one kind at a time.

`ChatPositionsBackend.Get` now returns `ChatPosition.None` (lid `-1`) when there
is no row, so "nothing stored" has a value of its own.

Swept every consumer of the lid. The server-side ones — digest, chat copy, the
upgrade fixup, both notification read checks — already guard with `<= 0`, so
`-1` lands exactly where `0` did. Four client-side spots took `0` as "absent"
and needed adjusting: the mention check (no mention at all would have read as an
unread one), tail prefetch (built a tile around `-1`), the view-position restore,
and its seeding from the read position.

## Notes

- The clamp is in the session-facing handler, not `ChatPositionsBackend.OnSet`
  — that command also seeds positions on join, repairs them on upgrade, and is
  how tests fabricate them, none of which should be bounded by chat content.
- `ChatPositionsBackend`'s `long.MaxValue` guard drops `includeRemoved`: it was
  clamping to a max counting removed entries while `ChatNews` — what the unread
  count is measured against — excludes them.
- Existing over-advanced rows aren't migrated; the table is forward-only and
  real lids overtake them as the chat grows.
- `docs/CODING_STYLE.md` gains Project-Specific Patterns #14: extend an existing
  UI service rather than registering a new one, since that cost is paid on every
  WASM/MAUI launch. This PR follows it — `LastPresentAt` went onto
  `UserActivityUI` instead of into a new service.

## Test plan

Rebased onto `dev` (incl. the FiniteList/InfiniteList split) and re-verified.

- [x] `dotnet build ActualChat.CI.slnf` — full CI filter, 0 errors
- [x] `Chat.IntegrationTests` — 380/380
- [x] `Users.IntegrationTests` — 151/151
- [x] `Notifications.IntegrationTests` — 119/119
- [x] `Chat.UI.Blazor.IntegrationTests` — 79/79
- [x] `Streaming.IntegrationTests` — 41/41
- [x] `Chat.UnitTests` 521/521, `Users.UnitTests` 216/216, `UI.Blazor.UnitTests` 27/27
- [x] `tsc --noEmit` + eslint

Live two-user run against `local.voxt.ai` (server render mode), users A and B in
a shared group chat, read positions read straight from `chat_positions`:

- [x] A reads to the tail → position lands on the chat head exactly (620), badge clears
- [x] A goes away (document hidden), B posts 2 messages → **position stays at 620**
      while the head moves to 622; A shows a `2` badge and the title reads `Voxt (1)`.
      This is the reported bug — before the fix the badge was suppressed here.
- [x] A returns (visible + interaction) → position advances 620 → 622, badge clears
- [x] A sends a message → position lands on the real lid (623), not the optimistic
      placeholder's; `select count(*) from chat_positions where entry_lid > 1e8` → 0

Not covered live: the audio-recording placeholder (would mean holding a mic open
and billing transcription for a path already covered by the `MaxEntryLid` filter
and the server clamp), and mobile/MAUI.