### PR TITLE
Soniox transcriber artifacts cleanup #4143

### DIFF
--- a/ActualChat.sln.DotSettings
+++ b/ActualChat.sln.DotSettings
@@ -243,6 +243,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Remux/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Remuxing/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Retrier/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Soniox/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Temporals/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=timestep/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Timestep/@EntryIndexedValue">True</s:Boolean>

--- a/src/dotnet/Chat.ML/EmbeddingsCalculator.cs
+++ b/src/dotnet/Chat.ML/EmbeddingsCalculator.cs
@@ -11,14 +11,19 @@ public interface IEmbeddingsCalculator
 
 public class EmbeddingsCalculator : IEmbeddingsCalculator
 {
+    public const string HttpClientName = nameof(EmbeddingsCalculator);
+
     private readonly Uri? _predictionsUri;
 
     private readonly JsonSerializerOptions _jsonSerializerOptions = new (JsonSerializerOptions.Default) {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
-    public EmbeddingsCalculator(EmbeddingSettings embeddingSettings)
+    private IHttpClientFactory HttpClientFactory { get; }
+
+    public EmbeddingsCalculator(EmbeddingSettings embeddingSettings, IHttpClientFactory httpClientFactory)
     {
+        HttpClientFactory = httpClientFactory;
         if (!embeddingSettings.PredictionsUri.IsNullOrEmpty())
             _predictionsUri = new Uri(embeddingSettings.PredictionsUri, UriKind.Absolute);
     }
@@ -28,7 +33,7 @@ public class EmbeddingsCalculator : IEmbeddingsCalculator
         if (_predictionsUri is null)
             throw StandardError.Internal("PredictionsUri is not configured at EmbeddingSettings.");
 
-        using var client = new HttpClient();
+        using var client = HttpClientFactory.CreateClient(HttpClientName);
 
         // TODO(AK): Tokenize and limit text to MaxTokenCount
         // TODO(AK): Use OpenAI compatible embeddings API!

--- a/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
+++ b/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
@@ -164,6 +164,7 @@ public sealed class ChatServiceModule(IServiceProvider moduleServices)
 
         // Embeddings
         var embeddingSettings = Cfg.Settings<EmbeddingSettings>();
+        services.AddHttpClient(EmbeddingsCalculator.HttpClientName);
         services.TryAddSingleton(embeddingSettings);
         services.TryAddSingleton<IEmbeddingsCalculator, EmbeddingsCalculator>();
 

--- a/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
+++ b/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
@@ -28,10 +28,12 @@ public sealed class TranscriptionServiceModule(IServiceProvider moduleServices)
         services.AddSingleton<ITranscriber, GoogleTranscriber>();
         services.AddSingleton<ITranscriber, DeepgramTranscriber>();
         if (!coreSettings.SonioxKey.IsNullOrEmpty()) {
+            services.AddSoniox();
             services.AddSingleton<ITranscriber, SonioxTranscriber>();
             services.AddSingleton<IOfflineTranscriber, SonioxOfflineTranscriber>();
         }
         if (!coreSettings.ElevenLabsKey.IsNullOrEmpty()) {
+            services.AddHttpClient(ElevenLabsOfflineTranscriber.HttpClientName);
             services.AddSingleton<ITranscriber, ElevenLabsTranscriber>();
             services.AddSingleton<IOfflineTranscriber, ElevenLabsOfflineTranscriber>();
         }

--- a/src/dotnet/Transcription.Service/ServiceCollectionExt.cs
+++ b/src/dotnet/Transcription.Service/ServiceCollectionExt.cs
@@ -1,0 +1,14 @@
+namespace ActualChat.Transcription;
+
+public static class ServiceCollectionExt
+{
+    // Also called by the tests that construct SonioxOfflineTranscriber from a hand-built container
+    public static IServiceCollection AddSoniox(this IServiceCollection services)
+    {
+        services.AddHttpClient(SonioxClient.HttpClientName);
+        services.AddSingleton<SonioxClient>();
+        services.AddSingleton(_ => new SonioxCleaner.Options());
+        services.AddSingleton<SonioxCleaner>();
+        return services;
+    }
+}

--- a/src/dotnet/Transcription.Service/Transcribers/ElevenLabsOfflineTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/ElevenLabsOfflineTranscriber.cs
@@ -12,6 +12,8 @@ namespace ActualChat.Transcription;
 /// </summary>
 public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
 {
+    public const string HttpClientName = nameof(ElevenLabsOfflineTranscriber);
+
     private const string Url = "https://api.elevenlabs.io/v1/speech-to-text";
     private const string Model = "scribe_v2";
     private static readonly JsonSerializerOptions JsonOptions = new() {
@@ -19,6 +21,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
     };
 
     private CoreServerSettings CoreServerSettings { get; }
+    private IHttpClientFactory HttpClientFactory { get; }
     private OggOpusStreamConverter OggOpusStreamConverter { get; }
     private ILogger Log { get; }
     public TranscriberInfo Info { get; } = new() {
@@ -33,6 +36,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
     {
         Log = services.LogFor(GetType());
         CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
+        HttpClientFactory = services.HttpClientFactory();
         OggOpusStreamConverter = new OggOpusStreamConverter(new OggOpusStreamConverter.Options {
             PageDuration = TimeSpan.FromMilliseconds(200),
         });
@@ -48,7 +52,7 @@ public sealed class ElevenLabsOfflineTranscriber : IOfflineTranscriber
             throw StandardError.Configuration("CoreSettings:ElevenLabsKey is not set.");
 
         try {
-            using var httpClient = new HttpClient();
+            using var httpClient = HttpClientFactory.CreateClient(HttpClientName);
             httpClient.DefaultRequestHeaders.Add("xi-api-key", apiKey);
 
             var stream = await ToOggStream(audioSource, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxCleaner.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxCleaner.cs
@@ -1,0 +1,74 @@
+namespace ActualChat.Transcription;
+
+/// <summary>
+/// Deletes what <see cref="SonioxOfflineTranscriber"/> leaves on Soniox - the organization has a
+/// hard cap on the number of stored files. Ids are queued as each transcription ends, so the two
+/// deletes stay off its latency path, and the queue is drained on shutdown.
+/// </summary>
+public sealed class SonioxCleaner : SafeAsyncDisposableBase
+{
+    public sealed record Options
+    {
+        public TimeSpan FlushDelay { get; init; } = TimeSpan.FromMilliseconds(100);
+        public TimeSpan DrainTimeout { get; init; } = TimeSpan.FromSeconds(10);
+        public RetryDelaySeq FlushRetryDelays { get; init; } = RetryDelaySeq.Exp(1, 60);
+    }
+
+    private SonioxClient Client { get; }
+    private LazyWriter<(string? TranscriptionId, string? FileId)> Writer { get; }
+    private ILogger Log { get; }
+
+    public SonioxCleaner(Options settings, IServiceProvider services)
+    {
+        Client = services.GetRequiredService<SonioxClient>();
+        Log = services.LogFor(GetType());
+        Writer = new LazyWriter<(string? TranscriptionId, string? FileId)>() {
+            FlushDelay = settings.FlushDelay,
+            DisposeTimeout = settings.DrainTimeout,
+            FlushRetryDelays = settings.FlushRetryDelays,
+            Implementation = DeleteBatch,
+            FlushErrorSeverityProvider = static _ => LogLevel.Warning,
+            Log = Log,
+        };
+    }
+
+    // Enqueue may still be called while the queue drains, so it tolerates an already disposed
+    // Writer: a dropped id just leaves its artifacts on Soniox until the cap forces a manual sweep.
+    public void Enqueue(string? transcriptionId, string? fileId)
+    {
+        if (transcriptionId == null && fileId == null)
+            return;
+
+        try {
+            Writer.Add((transcriptionId, fileId));
+        }
+        catch (Exception e) {
+            Log.LogWarning(e,
+                "Enqueue failed, leaving transcription {TranscriptionId} and file {FileId} on Soniox",
+                transcriptionId, fileId);
+        }
+    }
+
+    public Task Flush(CancellationToken cancellationToken = default)
+        => Writer.Flush(cancellationToken);
+
+    // Protected methods
+
+    protected override Task DisposeAsync(bool disposing)
+        => Writer.DisposeAsync().AsTask();
+
+    // Private methods
+
+    private async Task DeleteBatch(List<(string? TranscriptionId, string? FileId)> batch)
+    {
+        // A throw hands the batch back to the Writer's retry, which is the only retry these deletes
+        // get - so both must be idempotent, and they are: a repeat gets 404, which counts as success.
+        // Soniox deletes the transcription's file along with it, hence the file delete second.
+        foreach (var (transcriptionId, fileId) in batch) {
+            if (transcriptionId != null)
+                await Client.DeleteTranscription(transcriptionId, CancellationToken.None).ConfigureAwait(false);
+            if (fileId != null)
+                await Client.DeleteFile(fileId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using ActualChat.Module;
+
+namespace ActualChat.Transcription;
+
+/// <summary>
+/// Soniox async REST API: uploads, transcription jobs, and the deletes that dispose of both.
+/// Shared by <see cref="SonioxOfflineTranscriber"/> and <see cref="SonioxCleaner"/>.
+/// </summary>
+public sealed class SonioxClient
+{
+    public const string HttpClientName = nameof(SonioxClient);
+
+    private const string BaseUrl = "https://api.soniox.com/v1";
+    private static readonly JsonSerializerOptions JsonOptions = new() {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private CoreServerSettings CoreServerSettings { get; }
+    private IHttpClientFactory HttpClientFactory { get; }
+
+    public SonioxClient(IServiceProvider services)
+    {
+        CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
+        HttpClientFactory = services.HttpClientFactory();
+    }
+
+    public async Task<string> UploadFile(Stream stream, string fileName, CancellationToken cancellationToken)
+    {
+        using var httpClient = CreateHttpClient();
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/ogg");
+        content.Add(fileContent, "file", fileName);
+
+        using var response = await httpClient
+            .PostAsync($"{BaseUrl}/files", content, cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccess(response, "upload", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsync<SonioxIdResponse>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Id ?? throw StandardError.External("Soniox returned no file id.");
+    }
+
+    public async Task<string> CreateTranscription(
+        Dictionary<string, object?> request,
+        CancellationToken cancellationToken)
+    {
+        using var httpClient = CreateHttpClient();
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await httpClient
+            .PostAsync($"{BaseUrl}/transcriptions", content, cancellationToken)
+            .ConfigureAwait(false);
+        await EnsureSuccess(response, "create transcription", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsync<SonioxIdResponse>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Id ?? throw StandardError.External("Soniox returned no transcription id.");
+    }
+
+    public async Task<SonioxStatusResponse> GetTranscriptionStatus(
+        string transcriptionId,
+        CancellationToken cancellationToken)
+    {
+        using var httpClient = CreateHttpClient();
+        var status = await httpClient
+            .GetFromJsonAsync<SonioxStatusResponse>(
+                $"{BaseUrl}/transcriptions/{transcriptionId}", JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return status ?? throw StandardError.External("Soniox returned no transcription status.");
+    }
+
+    public async Task<SonioxResponse?> GetTranscript(string transcriptionId, CancellationToken cancellationToken)
+    {
+        using var httpClient = CreateHttpClient();
+        return await httpClient
+            .GetFromJsonAsync<SonioxResponse>(
+                $"{BaseUrl}/transcriptions/{transcriptionId}/transcript", JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task DeleteTranscription(string transcriptionId, CancellationToken cancellationToken)
+        => Delete($"transcriptions/{transcriptionId}", cancellationToken);
+
+    public Task DeleteFile(string fileId, CancellationToken cancellationToken)
+        => Delete($"files/{fileId}", cancellationToken);
+
+    // Private methods
+
+    private async Task Delete(string path, CancellationToken cancellationToken)
+    {
+        // NotFound is success: deleting a transcription cascades to its file, and the caller deletes
+        // both. Anything else throws - the caller's queue is the only retry these deletes get, and
+        // that includes the Conflict returned while a cancelled transcription is still processing.
+        using var httpClient = CreateHttpClient();
+        using var response = await httpClient
+            .DeleteAsync($"{BaseUrl}/{path}", cancellationToken)
+            .ConfigureAwait(false);
+        if (response.StatusCode is HttpStatusCode.NotFound)
+            return;
+
+        await EnsureSuccess(response, $"delete of {path}", cancellationToken).ConfigureAwait(false);
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        var apiKey = CoreServerSettings.SonioxKey;
+        if (apiKey.IsNullOrEmpty())
+            throw StandardError.Configuration("CoreSettings:SonioxKey is not set.");
+
+        // Created per call, but the factory pools the underlying handler.
+        var httpClient = HttpClientFactory.CreateClient(HttpClientName);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        return httpClient;
+    }
+
+    private static async Task EnsureSuccess(
+        HttpResponseMessage response,
+        string step,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        throw StandardError.External($"Soniox {step} failed: {(int)response.StatusCode} {body}");
+    }
+}

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
@@ -1,7 +1,4 @@
-using System.Net.Http.Headers;
-using System.Text;
 using ActualChat.Audio;
-using ActualChat.Module;
 using Microsoft.IO;
 
 namespace ActualChat.Transcription;
@@ -12,14 +9,11 @@ namespace ActualChat.Transcription;
 /// </summary>
 public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
 {
-    private const string BaseUrl = "https://api.soniox.com/v1";
     private const string Model = "stt-async-v5";
     private static readonly TimeSpan PollPeriod = TimeSpan.FromSeconds(1);
-    private static readonly JsonSerializerOptions JsonOptions = new() {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
 
-    private CoreServerSettings CoreServerSettings { get; }
+    private SonioxClient Client { get; }
+    private SonioxCleaner Cleaner { get; }
     private MomentClockSet Clocks { get; }
     private OggOpusStreamConverter OggOpusStreamConverter { get; }
     private ILogger Log { get; }
@@ -42,7 +36,8 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
     {
         Log = services.LogFor(GetType());
         Clocks = services.Clocks();
-        CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
+        Client = services.GetRequiredService<SonioxClient>();
+        Cleaner = services.GetRequiredService<SonioxCleaner>();
         OggOpusStreamConverter = new OggOpusStreamConverter(new OggOpusStreamConverter.Options {
             PageDuration = TimeSpan.FromMilliseconds(200),
         });
@@ -53,53 +48,36 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
         TranscriptionOptions options,
         CancellationToken cancellationToken = default)
     {
-        var apiKey = CoreServerSettings.SonioxKey;
-        if (apiKey.IsNullOrEmpty())
-            throw StandardError.Configuration("CoreSettings:SonioxKey is not set.");
-
+        string? fileId = null;
+        string? transcriptionId = null;
         try {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-
-            var fileId = await UploadAudio(httpClient, audioSource, cancellationToken).ConfigureAwait(false);
-            var transcriptionId = await CreateTranscription(httpClient, fileId, options, audioSource, cancellationToken)
+            fileId = await UploadAudio(audioSource, cancellationToken).ConfigureAwait(false);
+            transcriptionId = await CreateTranscription(fileId, options, audioSource, cancellationToken)
                 .ConfigureAwait(false);
-            await WaitForCompletion(httpClient, transcriptionId, cancellationToken).ConfigureAwait(false);
-            return await GetTranscript(httpClient, transcriptionId, cancellationToken).ConfigureAwait(false);
+            await WaitForCompletion(transcriptionId, cancellationToken).ConfigureAwait(false);
+            return await GetTranscript(transcriptionId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (e is not OperationCanceledException) {
             Log.LogError(e, "Soniox offline transcription failed");
             return null;
         }
+        finally {
+            // Soniox caps the stored file count per organization, so uploads must be dropped even
+            // when transcription fails. The cleaner keeps the two deletes off the latency path.
+            Cleaner.Enqueue(transcriptionId, fileId);
+        }
     }
 
     // Private methods
 
-    private async Task<string> UploadAudio(
-        HttpClient httpClient,
-        AudioSource audioSource,
-        CancellationToken cancellationToken)
+    private async Task<string> UploadAudio(AudioSource audioSource, CancellationToken cancellationToken)
     {
         var stream = await ToOggStream(audioSource, cancellationToken).ConfigureAwait(false);
-        await using (stream.ConfigureAwait(false)) {
-            using var content = new MultipartFormDataContent();
-            using var fileContent = new StreamContent(stream);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/ogg");
-            content.Add(fileContent, "file", "speech.ogg");
-
-            using var response = await httpClient
-                .PostAsync($"{BaseUrl}/files", content, cancellationToken)
-                .ConfigureAwait(false);
-            await EnsureSuccess(response, "upload", cancellationToken).ConfigureAwait(false);
-            var result = await response.Content
-                .ReadFromJsonAsync<SonioxIdResponse>(JsonOptions, cancellationToken)
-                .ConfigureAwait(false);
-            return result?.Id ?? throw StandardError.External("Soniox returned no file id.");
-        }
+        await using (stream.ConfigureAwait(false))
+            return await Client.UploadFile(stream, "speech.ogg", cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<string> CreateTranscription(
-        HttpClient httpClient,
+    private Task<string> CreateTranscription(
         string fileId,
         TranscriptionOptions options,
         AudioSource audioSource,
@@ -118,30 +96,14 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
             request["context"] = context;
         if (options.GetLanguageHints(SonioxLanguage.ToSoniox) is { Length: > 0 } languageHints)
             request["language_hints"] = languageHints;
-        var json = JsonSerializer.Serialize(request, JsonOptions);
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await httpClient
-            .PostAsync($"{BaseUrl}/transcriptions", content, cancellationToken)
-            .ConfigureAwait(false);
-        await EnsureSuccess(response, "create transcription", cancellationToken).ConfigureAwait(false);
-        var result = await response.Content
-            .ReadFromJsonAsync<SonioxIdResponse>(JsonOptions, cancellationToken)
-            .ConfigureAwait(false);
-        return result?.Id ?? throw StandardError.External("Soniox returned no transcription id.");
+
+        return Client.CreateTranscription(request, cancellationToken);
     }
 
-    private async Task WaitForCompletion(
-        HttpClient httpClient,
-        string transcriptionId,
-        CancellationToken cancellationToken)
+    private async Task WaitForCompletion(string transcriptionId, CancellationToken cancellationToken)
     {
         while (true) {
-            var status = await httpClient
-                .GetFromJsonAsync<SonioxStatusResponse>(
-                    $"{BaseUrl}/transcriptions/{transcriptionId}", JsonOptions, cancellationToken)
-                .ConfigureAwait(false);
-            if (status == null)
-                throw StandardError.External("Soniox returned no transcription status.");
+            var status = await Client.GetTranscriptionStatus(transcriptionId, cancellationToken).ConfigureAwait(false);
             if (status.Status == "completed")
                 return;
             if (status.Status == "error")
@@ -151,15 +113,9 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
         }
     }
 
-    private static async Task<Transcript?> GetTranscript(
-        HttpClient httpClient,
-        string transcriptionId,
-        CancellationToken cancellationToken)
+    private async Task<Transcript?> GetTranscript(string transcriptionId, CancellationToken cancellationToken)
     {
-        var response = await httpClient
-            .GetFromJsonAsync<SonioxResponse>(
-                $"{BaseUrl}/transcriptions/{transcriptionId}/transcript", JsonOptions, cancellationToken)
-            .ConfigureAwait(false);
+        var response = await Client.GetTranscript(transcriptionId, cancellationToken).ConfigureAwait(false);
         if (response?.Tokens is not { Length: > 0 } tokens)
             return null;
 
@@ -169,18 +125,6 @@ public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
             token.IsFinal = true;
         builder.Update(tokens);
         return builder.Complete();
-    }
-
-    private static async Task EnsureSuccess(
-        HttpResponseMessage response,
-        string step,
-        CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-            return;
-
-        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        throw StandardError.External($"Soniox {step} failed: {(int)response.StatusCode} {body}");
     }
 
     private async Task<RecyclableMemoryStream> ToOggStream(AudioSource audioSource, CancellationToken cancellationToken)

--- a/tests/Chat.UnitTests/EntryGroupExtractorTest.cs
+++ b/tests/Chat.UnitTests/EntryGroupExtractorTest.cs
@@ -270,7 +270,10 @@ public class EntryGroupExtractorTest(ITestOutputHelper @out, ILogger<EntryGroupE
             // PredictionsUri = "http://localhost:28080/predictions/Alibaba-NLP_gte-multilingual-base",
             PredictionsUri = "http://localhost:8000/v1/embeddings", // Experimenting with another (much faster!) model served with vllm
         };
-        var extractor = new EntryGroupExtractor(new EmbeddingsCalculator(settings), log);
+        var httpClientServices = new ServiceCollection();
+        httpClientServices.AddHttpClient(EmbeddingsCalculator.HttpClientName);
+        var httpClientFactory = httpClientServices.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+        var extractor = new EntryGroupExtractor(new EmbeddingsCalculator(settings, httpClientFactory), log);
         var initialState = new ExtractorState(null, null);
         var entries = await ReadTestEntries("./data/chat_entries.zip");
 

--- a/tests/Transcription.IntegrationTests/ElevenLabsTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/ElevenLabsTranscriberTest.cs
@@ -66,11 +66,12 @@ public sealed class ElevenLabsTranscriberTest(ITestOutputHelper @out, ILogger<El
         IConfiguration configuration = new ConfigurationManager {
             Sources = { new EnvironmentVariablesConfigurationSource() },
         };
-        return new ServiceCollection()
+        var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
-            .AddTestLogging(Out)
-            .BuildServiceProvider();
+            .AddTestLogging(Out);
+        services.AddHttpClient(ElevenLabsOfflineTranscriber.HttpClientName);
+        return services.BuildServiceProvider();
     }
 }

--- a/tests/Transcription.IntegrationTests/OfflineTranscriberComparisonTest.cs
+++ b/tests/Transcription.IntegrationTests/OfflineTranscriberComparisonTest.cs
@@ -73,6 +73,7 @@ public sealed class OfflineTranscriberComparisonTest(
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddSoniox()
             .AddTestLogging(Out)
             .BuildServiceProvider();
     }

--- a/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
@@ -47,16 +47,45 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
         }
 
         var transcriber = new SonioxOfflineTranscriber(services);
+        var cleaner = services.GetRequiredService<SonioxCleaner>();
         var options = new TranscriptionOptions { Language = Language.Parse(languageId) };
         var audio = await GetAudio(fileName);
 
         // act
         var transcript = await transcriber.Transcribe(audio, options);
+        await cleaner.Flush();
 
         // assert
         WriteLine(transcript?.ToString() ?? "<null>");
         transcript.Should().NotBeNull();
         transcript!.Text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task CleanerDeletesEnqueuedArtifacts()
+    {
+        // arrange
+        var services = CreateServices();
+        if (services.GetRequiredService<CoreServerSettings>().SonioxKey.IsNullOrEmpty()) {
+            WriteLine("CoreSettings__SonioxKey is not set - skipping.");
+            return;
+        }
+
+        var client = services.GetRequiredService<SonioxClient>();
+        var cleaner = services.GetRequiredService<SonioxCleaner>();
+        var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
+        string fileId;
+        await using (stream.ConfigureAwait(false))
+            fileId = await client.UploadFile(stream, "speech.opus", CancellationToken.None);
+        WriteLine($"Uploaded file {fileId}");
+
+        // act
+        cleaner.Enqueue(null, fileId);
+
+        // assert
+        // Flush completing is the assertion: a delete that fails throws, and the writer retries the
+        // batch until it stops throwing, so an unhappy Soniox shows up here as the timeout.
+        await cleaner.Flush().WaitAsync(TimeSpan.FromSeconds(30));
     }
 
     // Private methods
@@ -70,6 +99,7 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
             .AddSingleton<IConfiguration>(_ => configuration)
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddSoniox()
             .AddTestLogging(Out)
             .BuildServiceProvider();
     }


### PR DESCRIPTION
Closes #4143.

## The bug

`SonioxOfflineTranscriber` uploaded audio to `POST /files` and never deleted it, so every offline transcription left a permanent file in the Soniox organization. The org-wide file cap was eventually hit and uploads started failing with `429 limit_exceeded` — which `Transcribe()` swallows into a null transcript, so it surfaced as `SonioxTranscriberTest.OfflineTranscribeWorks` failing rather than as an error.

## What's here

**The delete itself.** Cleanup deletes the transcription and then the file, and runs from a `finally` so it covers the failure and cancellation paths too. 404 is expected there — deleting a transcription cascades to its file.

**`SonioxClient`.** Every Soniox async-REST call — upload, create, status, transcript, delete — in one place, instead of five private methods threading an `HttpClient` through the transcriber.

**`SonioxCleaner`.** The two deletes are queued rather than awaited, keeping them off the transcription latency path, and the queue is drained on shutdown. It's a `LazyWriter` behind `SafeAsyncDisposableBase` — the same shape `BatchingKvas` uses for the same job. `LazyWriter` retries a failing batch with backoff, which is where the retry for these deletes comes from: `SonioxClient`'s deletes throw rather than report failure, so a 409 (transcription still processing after a mid-flight cancellation) is retried until it clears instead of being dropped. Both deletes are idempotent, so replaying a batch is safe.

**Connection pooling.** `SonioxOfflineTranscriber`, `ElevenLabsOfflineTranscriber` and `EmbeddingsCalculator` each built a new `HttpClient` per call — all three are singletons on hot paths, so every call churned a socket and a TLS handshake. They now create clients from `IHttpClientFactory`.

## Deliberately not doing

An earlier revision swept the organization periodically, deleting anything older than `MaxAge`. That's dropped: cleaning up artifacts a host didn't upload means any host — including a dev machine — can delete another's in-flight work.

The cost is a known gap: an id lost to a crash between upload and flush leaks until someone clears the organization by hand. The sweep was the only thing covering that, and it isn't worth what it cost.

## Testing

`CleanerDeletesEnqueuedArtifacts` uploads a file, enqueues it and flushes; `Flush` completing is the assertion, since a failing delete throws and the batch is retried forever, so a broken delete path shows up as the timeout. `OfflineTranscribeWorks` flushes the cleaner so runs don't leak.

Both are gated on `CoreSettings__SonioxKey` and skip without it — **they have not been run against the live API yet**, so the cleanup path is compile-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)