### PR TITLE
feat: send a place picked on the map, not just where you are #4042

### DIFF
--- a/src/dotnet/Api/Chat/SharedLocation.cs
+++ b/src/dotnet/Api/Chat/SharedLocation.cs
@@ -7,7 +7,8 @@ namespace ActualChat.Chat;
 /// Live while <see cref="LiveUntil"/> — its expiry or the moment it was stopped, whichever
 /// comes first — is in the future; its <see cref="Point"/> keeps updating until then, after
 /// which the last point is frozen as a static pin. A zero <see cref="Duration"/> means it was
-/// never a live share, just a pin.
+/// never a live share, just a pin; <see cref="IsPlace"/> tells a pin the author picked on the
+/// map apart from where the author actually was.
 /// </summary>
 [DataContract, MessagePackObject]
 public sealed partial record SharedLocation(
@@ -21,6 +22,7 @@ public sealed partial record SharedLocation(
     [DataMember, Key(5)] public required Moment ModifiedAt { get; init; }
     [DataMember, Key(6)] public required TimeSpan Duration { get; init; }
     [DataMember, Key(7)] public Moment? StoppedAt { get; init; }
+    [DataMember, Key(8)] public bool IsPlace { get; init; }
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore]
     [IgnoreDataMember, IgnoreMember]
@@ -39,7 +41,8 @@ public sealed partial record SharedLocation(
 
 /// <summary>
 /// Change to a <see cref="SharedLocation"/>: create/update carries a new <see cref="Point"/>
-/// (and <see cref="LiveDuration"/> on create); a Remove change stops it (freezes the last point).
+/// (and <see cref="LiveDuration"/> / <see cref="IsPlace"/> on create); a Remove change stops it
+/// (freezes the last point).
 /// </summary>
 [DataContract, MessagePackObject(true)]
 public sealed partial record SharedLocationDiff : RecordDiff
@@ -53,4 +56,5 @@ public sealed partial record SharedLocationDiff : RecordDiff
 
     [DataMember] public GeoPoint? Point { get; init; }
     [DataMember] public TimeSpan? LiveDuration { get; init; }
+    [DataMember] public bool IsPlace { get; init; }
 }

--- a/src/dotnet/Chat.Service.Migration/Migrations/20260811061412_Add_SharedLocation_IsPlace.Designer.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20260811061412_Add_SharedLocation_IsPlace.Designer.cs
@@ -4,6 +4,7 @@ using ActualChat.Chat.Db;
 using ActualChat.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,14 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ActualChat.Chat.Migrations;
 
 [DbContext(typeof(ChatDbContext))]
-partial class ChatDbContextModelSnapshot : ModelSnapshot
+[Migration("20260811061412_Add_SharedLocation_IsPlace")]
+partial class _20260811061412_Add_SharedLocation_IsPlace
 {
-    // If you encounter a merge conflict in the line below, it means you need to
-    // discard one of the migration branches and recreate its migrations on top of
-    // the other branch. See https://aka.ms/efcore-docs-migrations-conflicts for more info.
-    public override string LastMigrationId => "20260811061412_Add_SharedLocation_IsPlace";
-
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder

--- a/src/dotnet/Chat.Service.Migration/Migrations/20260811061412_Add_SharedLocation_IsPlace.cs
+++ b/src/dotnet/Chat.Service.Migration/Migrations/20260811061412_Add_SharedLocation_IsPlace.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ActualChat.Chat.Migrations;
+
+/// <inheritdoc />
+public partial class _20260811061412_Add_SharedLocation_IsPlace : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "is_place",
+            table: "shared_locations",
+            type: "boolean",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "is_place",
+            table: "shared_locations");
+    }
+}

--- a/src/dotnet/Chat.Service/Db/DbSharedLocation.cs
+++ b/src/dotnet/Chat.Service/Db/DbSharedLocation.cs
@@ -30,6 +30,7 @@ public class DbSharedLocation : IHasId<string>, IHasVersion<long>, IRequirementT
         set => field = value.DefaultKind(DateTimeKind.Utc);
     }
     public TimeSpan Duration { get; set; }
+    public bool IsPlace { get; set; }
     public DateTime? StoppedAt {
         get => field?.DefaultKind(DateTimeKind.Utc);
         set => field = value?.DefaultKind(DateTimeKind.Utc);
@@ -49,6 +50,7 @@ public class DbSharedLocation : IHasId<string>, IHasVersion<long>, IRequirementT
                 ? Constants.Location.UnlimitedDuration
                 : Duration,
             StoppedAt = StoppedAt?.ToMoment(),
+            IsPlace = IsPlace,
         };
 
     public void UpdateFrom(SharedLocation model)
@@ -66,6 +68,7 @@ public class DbSharedLocation : IHasId<string>, IHasVersion<long>, IRequirementT
         CreatedAt = model.CreatedAt;
         ModifiedAt = model.ModifiedAt;
         Duration = model.Duration;
+        IsPlace = model.IsPlace;
         StoppedAt = model.StoppedAt?.ToDateTime();
     }
 }

--- a/src/dotnet/Chat.Service/SharedLocationsBackend.cs
+++ b/src/dotnet/Chat.Service/SharedLocationsBackend.cs
@@ -107,6 +107,7 @@ public class SharedLocationsBackend(IServiceProvider services)
                 CreatedAt = now,
                 ModifiedAt = now,
                 Duration = duration,
+                IsPlace = createDiff.IsPlace,
             };
             dbContext.Add(new DbSharedLocation(sharedLocation));
         }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LocationMessageView/LocationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LocationMessageView/LocationMessageView.razor
@@ -44,7 +44,7 @@
                 <i class="icon-marker-pin c-pin"></i>
             }
             <div class="c-info">
-                <div class="c-title">@(m.IsLive ? "Live location" : "Location")</div>
+                <div class="c-title">@m.Title</div>
                 <div class="c-caption">
                     @if (m.DistanceText.IsNullOrEmpty()) {
                         @m.Center.ToDisplayText()
@@ -105,7 +105,8 @@
             countdown,
             isOwnLive,
             distanceText,
-            trackingError);
+            trackingError,
+            location.IsPlace);
     }
 
     // Private methods
@@ -132,7 +133,13 @@
         LocationCountdown? Countdown,
         bool IsOwnLive,
         string DistanceText = "",
-        GeoTrackingError? TrackingError = null) {
+        GeoTrackingError? TrackingError = null,
+        bool IsPlace = false) {
         public bool IsLive => Countdown is not null;
+        public string Title => IsPlace
+            ? "Place"
+            : IsLive
+                ? "Live location"
+                : "Location";
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/LocationMapModal/LocationMapModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LocationMapModal/LocationMapModal.razor
@@ -4,7 +4,9 @@
 @{
     var m = State.Value;
     var markers = m.Participants
-        .Where(p => !(m.OwnMarker is not null && p.IsOwn))
+        // OwnMarker stands in for my own live share and only for that one: a frozen pin — a place,
+        // or where I was earlier — keeps its marker, or the point just opened would show nothing.
+        .Where(p => !(m.OwnMarker is not null && p.Location.Id == m.OwnLiveId))
         .Select(p => p.MapMarker)
         .ToList();
     if (m.OwnMarker is { } ownMarker)
@@ -136,6 +138,7 @@
             ownPoint,
             ownMarker,
             center.Point,
+            ownLocation?.Id,
             mapType,
             isMapTypeMenuOpen,
             isLocating);
@@ -182,6 +185,7 @@
         GeoPoint? OwnPoint,
         MapMarker? OwnMarker,
         GeoPoint Center,
+        SharedLocationId? OwnLiveId = null,
         MapType MapType = MapType.Map,
         bool IsMapTypeMenuOpen = false,
         bool IsLocating = false

--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/ShareLocationModal.razor
@@ -6,27 +6,34 @@
 }
 
 <DialogFrame
-    Class="share-location-modal modal-sm"
+    Class="@(m.IsPicking ? "share-location-modal picking" : "share-location-modal modal-sm")"
+    NarrowViewSettings="@(m.IsPicking ? DialogFrameNarrowViewSettings.Default : DialogFrameNarrowViewSettings.Bottom)"
     HasHeader="false">
     <Body>
         <div class="c-map-area">
-            @if (m.OwnMarker is not null) {
+            @if (m.OwnMarker is not null || m.IsPicking) {
                 <MapView
                     @ref="_mapView"
                     Class="c-map"
-                    Center="@m.OwnMarker.Point"
-                    Zoom="15"
-                    Markers="@([m.OwnMarker])"/>
+                    Center="@m.MapCenter"
+                    Zoom="@m.MapZoom"
+                    Markers="@m.Markers"
+                    CenterChanged="@OnMapCenterChanged"/>
             } else if (m.MustRequestPermission) {
                 <button type="button" class="c-permission-prompt" @onclick="@OnEnablePermission">
                     <i class="icon-marker-pin"></i>
                     <span>Enable location permission to show map.</span>
                 </button>
             }
-            <ButtonRound Class="c-close" Click="@OnClose">
-                <i class="icon-close"></i>
+            @if (m.IsPicking) {
+                <div class="c-center-pin">
+                    <map-marker-pin></map-marker-pin>
+                </div>
+            }
+            <ButtonRound Class="c-close" Click="@OnCloseOrBack">
+                <i class="@(m.IsPicking ? "icon-arrow-left" : "icon-close")"></i>
             </ButtonRound>
-            @if (!m.MustRequestPermission) {
+            @if (!m.MustRequestPermission || m.IsPicking) {
                 <div class="c-map-menu">
                     @if (m.EnableIncompleteUI) {
                         <button type="button" class="c-map-menu-item" @onclick="@OnOpenMapTypeMenu">
@@ -46,30 +53,49 @@
                 </div>
             }
         </div>
-        <div class="c-actions">
-            <ButtonTile
-                Class="c-send-current"
-                Click="@OnSendCurrent">
-                <Icon>
-                    @if (m.IsLocating) {
-                        <Spinner/>
-                    } else {
-                        <i class="icon-marker-pin"></i>
-                    }
-                </Icon>
-                <Content>
-                    <div class="c-text">Send my current location</div>
-                    <div class="c-caption">@m.AccuracyText</div>
-                </Content>
-            </ButtonTile>
-            <ButtonTile Class="c-share-live" Click="@OnShareLive">
-                <Icon><marker-pin-live-svg></marker-pin-live-svg></Icon>
-                <Content>
-                    <div class="c-text">Share my location for…</div>
-                    <div class="c-caption">Updated in real time as you move</div>
-                </Content>
-            </ButtonTile>
-        </div>
+        @if (m.IsPicking) {
+            <div class="c-actions">
+                <ButtonTile Class="c-send-place" Click="@OnSendPicked">
+                    <Icon><i class="icon-map-point"></i></Icon>
+                    <Content>
+                        <div class="c-text">Send this location</div>
+                        <div class="c-caption">@m.PickedText</div>
+                    </Content>
+                </ButtonTile>
+            </div>
+        } else {
+            <div class="c-actions">
+                <ButtonTile
+                    Class="c-send-current"
+                    Click="@OnSendCurrent">
+                    <Icon>
+                        @if (m.IsLocating) {
+                            <Spinner/>
+                        } else {
+                            <i class="icon-marker-pin"></i>
+                        }
+                    </Icon>
+                    <Content>
+                        <div class="c-text">Send my current location</div>
+                        <div class="c-caption">@m.AccuracyText</div>
+                    </Content>
+                </ButtonTile>
+                <ButtonTile Class="c-share-live" Click="@OnShareLive">
+                    <Icon><marker-pin-live-svg></marker-pin-live-svg></Icon>
+                    <Content>
+                        <div class="c-text">Share my location for…</div>
+                        <div class="c-caption">Updated in real time as you move</div>
+                    </Content>
+                </ButtonTile>
+                <ButtonTile Class="c-pick-place" Click="@OnPickPlace">
+                    <Icon><i class="icon-map-point"></i></Icon>
+                    <Content>
+                        <div class="c-text">Choose a place on the map</div>
+                        <div class="c-caption">Any point — not necessarily where you are</div>
+                    </Content>
+                </ButtonTile>
+            </div>
+        }
         @if (m.IsDurationMenuOpen) {
             <div class="c-menu-backdrop" @onclick="@OnCloseDurationMenu"></div>
             <div class="c-menu c-duration-menu">
@@ -106,6 +132,8 @@
     private MutableState<MapType> _mapType = null!;
     private MutableState<bool> _isMapTypeMenuOpen = null!;
     private MutableState<bool> _isDurationMenuOpen = null!;
+    private MutableState<bool> _isPicking = null!;
+    private MutableState<GeoPoint?> _pickedPoint = null!;
     private MapView? _mapView;
     private FuncWorker? _refreshWorker;
 
@@ -132,6 +160,12 @@
         _isDurationMenuOpen = StateFactory.NewMutable(
             false,
             StateCategories.Get(GetType(), nameof(_isDurationMenuOpen)));
+        _isPicking = StateFactory.NewMutable(
+            false,
+            StateCategories.Get(GetType(), nameof(_isPicking)));
+        _pickedPoint = StateFactory.NewMutable(
+            (GeoPoint?)null,
+            StateCategories.Get(GetType(), nameof(_pickedPoint)));
         _refreshWorker = FuncWorker.Start(ct => LocationUI.RunLocationRefreshLoop(true, ct), Hub.StopToken);
     }
 
@@ -147,10 +181,15 @@
         var mapType = await _mapType.Use(cancellationToken).ConfigureAwait(false);
         var isMapTypeMenuOpen = await _isMapTypeMenuOpen.Use(cancellationToken).ConfigureAwait(false);
         var isDurationMenuOpen = await _isDurationMenuOpen.Use(cancellationToken).ConfigureAwait(false);
+        var isPicking = await _isPicking.Use(cancellationToken).ConfigureAwait(false);
+        var pickedPoint = await _pickedPoint.Use(cancellationToken).ConfigureAwait(false);
         var ownMarker = await LocationUI.GetOwnMarker(ModalModel.ChatId, cancellationToken).ConfigureAwait(false);
         var isPermissionGranted = await LocationUI.IsPermissionGranted(cancellationToken).ConfigureAwait(false);
         var isLocating = ownMarker is null && await LocationUI.IsRefreshing(cancellationToken).ConfigureAwait(false);
         var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
+        var fallbackCenter = ownMarker is null
+            ? await GetLastSharedPoint(cancellationToken).ConfigureAwait(false)
+            : null;
         return new ComputedModel {
             OwnMarker = ownMarker,
             MustRequestPermission = ownMarker is null && isPermissionGranted != true,
@@ -159,6 +198,9 @@
             IsDurationMenuOpen = isDurationMenuOpen,
             MapType = mapType,
             EnableIncompleteUI = enableIncompleteUI,
+            IsPicking = isPicking,
+            PickedPoint = pickedPoint,
+            FallbackCenter = fallbackCenter,
         };
     }
 
@@ -167,8 +209,12 @@
     private Task OnEnablePermission()
         => LocationPermission.CheckOrRequest(Hub.StopToken).AsTask();
 
-    private void OnClose()
-        => Modal.Close();
+    private void OnCloseOrBack() {
+        if (_isPicking.Value)
+            _isPicking.Value = false;
+        else
+            Modal.Close();
+    }
 
     private void OnSendCurrent() {
         // Any staleness is handled by SendCurrentLocation, which re-takes the fix when it's not recent.
@@ -184,6 +230,26 @@
 
     private void OnPickDuration(TimeSpan duration) {
         ModalModel.SelectedDuration = duration;
+        Modal.Close();
+    }
+
+    private async Task OnPickPlace() {
+        // CenterChanged only fires on moveend, so the point under the pin has to be seeded here.
+        var center = _mapView is { } mapView
+            ? await mapView.GetCenter().ConfigureAwait(true)
+            : State.Value.MapCenter;
+        _pickedPoint.Value = new GeoPoint(center.Latitude, center.Longitude);
+        _isPicking.Value = true;
+    }
+
+    private void OnMapCenterChanged(GeoPoint center)
+        => _pickedPoint.Value = center;
+
+    private void OnSendPicked() {
+        if (_pickedPoint.Value is not { } point)
+            return;
+
+        ModalModel.PickedPoint = point;
         Modal.Close();
     }
 
@@ -206,6 +272,12 @@
             await mapView.FlyTo(point).ConfigureAwait(false);
     }
 
+    private async Task<GeoPoint?> GetLastSharedPoint(CancellationToken cancellationToken) {
+        var participants = await LocationUI.ListParticipants(ModalModel.ChatId, cancellationToken)
+            .ConfigureAwait(false);
+        return participants.Count == 0 ? null : participants[0].Location.Point;
+    }
+
     // Nested types
 
     public sealed record ComputedModel {
@@ -213,6 +285,8 @@
             OwnMarker = null,
             IsLocating = true,
         };
+        private static readonly GeoPoint WorldCenter = new(0, 0);
+        private const double WorldZoom = 2;
 
         public required MapMarker? OwnMarker { get; init; }
         public string? AccuracyText
@@ -225,12 +299,30 @@
         public bool IsMapTypeMenuOpen { get; init; }
         public bool IsDurationMenuOpen { get; init; }
         public bool EnableIncompleteUI { get; init; }
+        public bool IsPicking { get; init; }
+        public GeoPoint? PickedPoint { get; init; }
+        public GeoPoint? FallbackCenter { get; init; }
+        public IReadOnlyList<MapMarker> Markers => OwnMarker is { } marker ? [marker] : [];
+        public GeoPoint MapCenter => OwnMarker?.Point ?? FallbackCenter ?? WorldCenter;
+        public double MapZoom => OwnMarker is null && FallbackCenter is null ? WorldZoom : 15;
+        public string PickedText {
+            get {
+                if (PickedPoint is not { } point)
+                    return "";
+
+                var coordinatesText = point.ToCoordinatesText();
+                return OwnMarker is { } marker
+                    ? $"{coordinatesText} · {point.DistanceTextTo(marker.Point)} from you"
+                    : coordinatesText;
+            }
+        }
     }
 
     public sealed class Model {
         public required ChatId ChatId { get; init; }
         public bool IsSharing { get; init; }
         public bool SendCurrentRequested { get; set; }
+        public GeoPoint? PickedPoint { get; set; }
         public TimeSpan? SelectedDuration { get; set; }
         public bool StopRequested { get; set; }
     }

--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
@@ -12,6 +12,38 @@
 .share-location-modal .c-map {
     @apply w-full h-full;
 }
+/* Picker mode grows the map to the LocationMapModal sizing; device-ios/android force
+   .modal-frame to the full viewport height even when wide (tablets, landscape). */
+.share-location-modal.picking .c-map-area {
+    @apply h-128 max-h-[70vh];
+}
+body.narrow .share-location-modal.picking .c-map-area,
+body.device-ios .share-location-modal.picking .c-map-area,
+body.device-android .share-location-modal.picking .c-map-area {
+    @apply flex-1;
+    @apply h-auto max-h-none;
+}
+/* Not a MapLibre marker: it must stay at the map center while the map moves under it.
+   The pin's dot sits 8px above its bottom edge, so the bottom hangs 8px below center. */
+.share-location-modal .c-center-pin {
+    @apply absolute left-1/2 z-10;
+    @apply pointer-events-none;
+    bottom: calc(50% - 0.5rem);
+    margin-left: -1.125rem;
+    transition: transform 150ms ease-out;
+}
+.share-location-modal .c-center-pin::after {
+    @apply absolute left-1/2;
+    @apply w-3 h-1.5;
+    @apply rounded-full;
+    bottom: -0.75rem;
+    margin-left: -0.375rem;
+    background: var(--black-05);
+    content: '';
+}
+.share-location-modal .c-map-area .map-view.moving ~ .c-center-pin {
+    transform: translateY(-0.375rem);
+}
 .share-location-modal .c-permission-prompt {
     @apply flex-y items-center justify-center gap-y-2;
     @apply w-full h-full;

--- a/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
@@ -242,6 +242,12 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
             return;
         }
 
+        // A place the user picked on the map isn't their position, so it needs no location permission.
+        if (model.PickedPoint is { } pickedPoint) {
+            await SendLocation(chatId, pickedPoint, true, Hub.StopToken).ConfigureAwait(true);
+            return;
+        }
+
         if (model.SelectedDuration is not { } duration)
             return;
 
@@ -265,7 +271,20 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
         if (await Tracker.Get(false, cancellationToken).ConfigureAwait(false) is not { Point: var point })
             return;
 
-        var change = Change.Create(new SharedLocationDiff { Point = point, LiveDuration = TimeSpan.Zero });
+        await SendLocation(chatId, point, false, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SendLocation(
+        ChatId chatId,
+        GeoPoint point,
+        bool isPlace,
+        CancellationToken cancellationToken)
+    {
+        var change = Change.Create(new SharedLocationDiff {
+            Point = point,
+            LiveDuration = TimeSpan.Zero,
+            IsPlace = isPlace,
+        });
         var shared = await Commander.Call(
                 new SharedLocations_Change(Session, chatId, null, change),
                 cancellationToken)
@@ -332,7 +351,10 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
     // Private methods
 
     private MapMarker ToMapMarker(SharedLocation location, Author author)
-        => ToMapMarker(location.Id.Value, location.Point, author);
+        // A place isn't where its author is, so it must not wear their avatar.
+        => location.IsPlace
+            ? new MapMarker(location.Id.Value, location.Point)
+            : ToMapMarker(location.Id.Value, location.Point, author);
 
     private MapMarker ToMapMarker(string id, GeoPoint point, Author author, bool isOwnLocation = false)
     {

--- a/src/dotnet/UI.Blazor/Components/MapView/MapView.razor
+++ b/src/dotnet/UI.Blazor/Components/MapView/MapView.razor
@@ -1,6 +1,7 @@
 @namespace ActualChat.UI.Blazor.Components
 @using ActualChat.UI.Blazor.Module
 @using ActualChat.UI.Blazor.Services
+@using System.Diagnostics.CodeAnalysis
 @inherits ComputedStateComponent<UIHub, MapView.Model?>
 
 <div @ref="Ref" class="map-view @Class" data-no-side-nav-pull="@Interactive"></div>
@@ -9,6 +10,7 @@
     private static readonly string JSCreateMethod = $"{BlazorUICoreModule.ImportName}.MapView.create";
 
     private IJSObjectReference? _jsRef;
+    private DotNetObjectReference<MapView>? _blazorRef;
     private string? _appliedStyleUrl;
 
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
@@ -20,6 +22,10 @@
     [Parameter] public double Zoom { get; set; } = 12;
     [Parameter] public bool Interactive { get; set; } = true;
     [Parameter] public IReadOnlyList<MapMarker> Markers { get; set; } = [];
+    [Parameter] public EventCallback<GeoPoint> CenterChanged { get; set; }
+
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(MapView))]
+    public MapView() { }
 
     protected override ComputedState<Model?>.Options GetStateOptions()
         => ComputedStateComponent.GetStateOptions(GetType(),
@@ -44,7 +50,12 @@
                 zoom = Zoom,
                 interactive = Interactive,
             };
-            _jsRef = await JS.InvokeAsync<IJSObjectReference>(JSCreateMethod, Ref, options).ConfigureAwait(true);
+            // A chat renders dozens of maps; only the ones tracking their center pay for the interop ref.
+            if (CenterChanged.HasDelegate)
+                _blazorRef = DotNetObjectReference.Create(this);
+            _jsRef = await JS
+                .InvokeAsync<IJSObjectReference>(JSCreateMethod, Ref, options, _blazorRef)
+                .ConfigureAwait(true);
             await _jsRef.InvokeVoidAsync("setMarkers", Markers).ConfigureAwait(true);
             return;
         }
@@ -61,13 +72,27 @@
     public ValueTask FlyTo(GeoPoint point)
         => _jsRef?.InvokeVoidAsync("flyTo", point.Latitude, point.Longitude) ?? ValueTask.CompletedTask;
 
+    public async ValueTask<GeoPoint> GetCenter() {
+        if (_jsRef is not { } jsRef)
+            return Center;
+
+        var center = await jsRef.InvokeAsync<double[]>("getCenter").ConfigureAwait(true);
+        return new GeoPoint(center[0], center[1]);
+    }
+
     public override async ValueTask DisposeAsync() {
         if (_jsRef is { } jsRef) {
             _jsRef = null;
             await jsRef.DisposeSilentlyAsync("dispose").ConfigureAwait(false);
         }
+        _blazorRef.DisposeSilently();
+        _blazorRef = null;
         await base.DisposeAsync().ConfigureAwait(false);
     }
+
+    [JSInvokable]
+    public Task OnCenterChanged(double latitude, double longitude)
+        => CenterChanged.InvokeAsync(new GeoPoint(latitude, longitude));
 
     // Private methods
 

--- a/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
+++ b/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
@@ -50,19 +50,25 @@ export class MapView {
     private readonly markers = new Map<string, MlMarker>();
     private readonly resizeObserver: ResizeObserver;
     private readonly visibilityObserver: IntersectionObserver;
+    // Null unless the map's center is actually being tracked — see MapView.CenterChanged.
+    private readonly blazorRef: DotNet.DotNetObject | null;
     private map: MlMap | null = null;
     private lastMarkers: MapMarker[] = [];
     private isVisible = false;
     private isDisposed = false;
     private recreateTimer: ReturnType<typeof setTimeout> | null = null;
 
-    public static create(element: HTMLElement, options: MapViewOptions): MapView {
-        return new MapView(element, options);
+    public static create(
+        element: HTMLElement,
+        options: MapViewOptions,
+        blazorRef: DotNet.DotNetObject | null): MapView {
+        return new MapView(element, options, blazorRef);
     }
 
-    constructor(element: HTMLElement, options: MapViewOptions) {
+    constructor(element: HTMLElement, options: MapViewOptions, blazorRef: DotNet.DotNetObject | null) {
         this.element = element;
         this.options = options;
+        this.blazorRef = blazorRef;
         // The map is often created while its container is still 0-sized (e.g. inside a
         // modal that's mid-open-animation); MapLibre then loads no tiles and stays blank.
         // Re-measure whenever the container resizes so tiles load once it has real size.
@@ -93,6 +99,14 @@ export class MapView {
         this.map?.flyTo({ center: [longitude, latitude] });
     }
 
+    // Returns [latitude, longitude]; options hold the last known center while the map is destroyed.
+    public getCenter(): number[] {
+        const center = this.map?.getCenter();
+        return center != null
+            ? [center.lat, center.lng]
+            : [this.options.centerLatitude, this.options.centerLongitude];
+    }
+
     public dispose(): void {
         this.isDisposed = true;
         if (this.recreateTimer != null)
@@ -112,6 +126,16 @@ export class MapView {
             this.destroyMap();
     }
 
+    private onMoveEnd(): void {
+        this.element.classList.remove('moving');
+        const map = this.map;
+        if (map == null || this.blazorRef == null)
+            return;
+
+        const center = map.getCenter();
+        void this.blazorRef.invokeMethodAsync('OnCenterChanged', center.lat, center.lng);
+    }
+
     private createMap(): void {
         if (this.map != null || this.isDisposed)
             return;
@@ -128,6 +152,8 @@ export class MapView {
         this.map.on('webglcontextlost', () => this.onContextLost());
         // An accuracy circle is a metric radius, so its pixel size changes with zoom.
         this.map.on('move', () => this.applyAccuracyCircles(this.lastMarkers));
+        this.map.on('movestart', () => this.element.classList.add('moving'));
+        this.map.on('moveend', () => this.onMoveEnd());
         this.applyMarkers(this.lastMarkers);
     }
 
@@ -137,6 +163,7 @@ export class MapView {
             return;
 
         this.map = null;
+        this.element.classList.remove('moving');
         // Keep the user's pan/zoom, so the map reappears where they left it.
         const center = map.getCenter();
         this.options.centerLatitude = center.lat;

--- a/tests/Chat.IntegrationTests/SharedLocationsTest.cs
+++ b/tests/Chat.IntegrationTests/SharedLocationsTest.cs
@@ -54,6 +54,32 @@ public class SharedLocationsTest(ChatCollection.AppHostFixture fixture, ITestOut
     }
 
     [Fact]
+    public async Task PlaceIsPersistedAndDoesNotAffectOrdinaryShares()
+    {
+        // arrange
+        var sharedLocations = Alice.AppServices.GetRequiredService<ISharedLocations>();
+        var session = Alice.Session;
+        var (chatId, _) = await Alice.CreateChat(x => x with { Title = "Picked place" });
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var ct = cts.Token;
+        var placePoint = new GeoPoint(51.5007, -0.1246);
+        var ownPoint = new GeoPoint(51.5074, -0.1278, 12f, 90f);
+
+        // act
+        var place = await Alice.ReportLocation(chatId, placePoint, isPlace: true, cancellationToken: ct);
+        var own = await Alice.ReportLocation(chatId, ownPoint, cancellationToken: ct);
+
+        // assert - IsPlace survives the DB round-trip, and only the picked point carries it
+        (await sharedLocations.Get(session, chatId, place.Id, ct))!.IsPlace.Should().BeTrue();
+        (await sharedLocations.Get(session, chatId, own.Id, ct))!.IsPlace.Should().BeFalse();
+
+        // assert - a place is still a frozen one-shot pin, so it never joins the live shares
+        place.Duration.Should().Be(TimeSpan.Zero);
+        place.IsLive(Clocks.SystemClock.Now).Should().BeFalse();
+        (await sharedLocations.ListLive(session, chatId, ct)).Count.Should().Be(0);
+    }
+
+    [Fact]
     public async Task LiveLocationShareLifecycle()
     {
         // arrange
@@ -82,7 +108,7 @@ public class SharedLocationsTest(ChatCollection.AppHostFixture fixture, ITestOut
 
         // act - update position
         var point2 = new GeoPoint(48.8566, 2.3522);
-        await Alice.ReportLocation(chatId, point2, TimeSpan.FromHours(1), locationId, ct);
+        await Alice.ReportLocation(chatId, point2, TimeSpan.FromHours(1), locationId, cancellationToken: ct);
 
         // assert - position reflects the update
         await cList.When(x => Math.Abs(x.Single().Point.Latitude - point2.Latitude) < 1e-9, ct)

--- a/tests/Testing.Host/SharedLocationOperations.cs
+++ b/tests/Testing.Host/SharedLocationOperations.cs
@@ -8,10 +8,15 @@ public static class SharedLocationOperations
         GeoPoint point,
         TimeSpan liveDuration = default,
         SharedLocationId? id = null,
+        bool isPlace = false,
         CancellationToken cancellationToken = default)
     {
         var change = id is null
-            ? Change.Create(new SharedLocationDiff { Point = point, LiveDuration = liveDuration })
+            ? Change.Create(new SharedLocationDiff {
+                Point = point,
+                LiveDuration = liveDuration,
+                IsPlace = isPlace,
+            })
             : Change.Update(new SharedLocationDiff { Point = point });
         var cmd = new SharedLocations_Change(tester.Session, chatId, id, change);
         var result = await tester.Commander.Call(cmd, cancellationToken);


### PR DESCRIPTION
Closes #4042.

`ShareLocationModal` could only send *where you are*. This adds a third action — **"Choose a place on the map"** — that sends any point: "here's the restaurant", not "here's me".

## How it works

Tapping the new tile expands the modal **in place** into a picker: the same `MapView` instance grows to the sizing `LocationMapModal` already uses, so there's no map re-creation, no tile reload and no flash — the map just grows under your finger, keeping the center and zoom you were already looking at. A fixed pin sits at the map center (a plain DOM overlay, not a MapLibre `Marker`, so dragging moves the *point*, not the pin) and the footer shows the coordinates, the distance from you, and **"Send this location"**.

The picker **needs no location permission** — that's the point of the issue. Its center falls back: current fix → the chat's last shared point → a world view.

## Commits

- **`feat(maps)`** — `MapView` gains `CenterChanged` (pushed on `moveend` only; `move` would be ~60 interop calls/sec) and `GetCenter`, plus a `moving` class while the map is in motion. The `DotNetObjectReference` is created only when `CenterChanged` has a delegate, since a chat renders dozens of maps and none but a picker cares about its center.
- **`feat(chat)`** — the picker UI, `LocationUI.SendLocation`, and `IsPlace`.

## Why `IsPlace` (one DB column)

`GetMarker` attaches the author's avatar to every `SharedLocation`, so "here's the restaurant" would have arrived looking exactly like "I am at this restaurant" — precisely the confusion this issue is about. `SharedLocation.IsPlace` distinguishes the two: places render with the avatar-less `<map-marker-pin>` and are titled **"Place"**. `Duration == 0` could not double as the flag — current-location sends use zero too.

It defaults to `false`, so **every existing row keeps its current meaning**. Old clients show a place as an avatar pin — degraded, not broken. The map modal also had to stop substituting `OwnMarker` for a place you authored yourself: that dropped the pin from the very point you had tapped, leaving your own avatar as the only marker.

Server logic is otherwise untouched — `SharedLocations.OnChange` already accepted any point.

## Verification

Built and run against a live dev server, driven end-to-end with Playwright in both permission states:

| | geolocation granted | geolocation denied |
|---|---|---|
| third tile available | yes | yes |
| footer seeded from | current fix | world view (`0,0`) |
| `moving` class during / after drag | true / false | true / false |
| coordinates follow the drag | yes | yes |
| sent entry | "Place", avatar-less pin | "Place", avatar-less pin |

The preview pin measures pixel-identical to the real marker (both `36×52` at the same rect), so a point looks the same before and after sending. Opening a place lands on it with the pin dead centre — checked with the place both 267 m and ~5000 km from the current fix.

`tests/Chat.IntegrationTests` `SharedLocationsTest`: **10 passed**, including a new `IsPlace` round-trip test.

## Note for the reviewer

`ChatDbContextModelSnapshot.cs` is fully reformatted (~2700 lines). It was last generated with EF **10.0.8** while `.config/dotnet-tools.json` now pins EF **11**, so the first migration after that bump rewrites it: file-scoped namespace, the new `LastMigrationId` override, `var index =` locals, updated `ProductVersion`. `is_place` is the only model change in it — verified by whitespace-insensitive comparison of the two snapshots.

## Deliberately out of scope

- **Search / address names** — no geocoder exists in the repo and the self-hosted map host serves tiles and styles only, so the footer shows coordinates + distance.
- Tap-to-move-the-pin on desktop; long-press on an existing chat map to pin a point.
- The participants row still describes a place as a person ("You · Updated few seconds ago"); fixing that means reworking what that list means, since a place has no sharer.
- `LocationTroubleshooterModal` still pops over the share modal when permission is denied, now in front of an action that needs no permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
