### PR TITLE
Show a selected-contact counter on the share extension's Send button #4150

### DIFF
--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
@@ -7,6 +7,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
 {
     private ShareUI ShareUI => field ??= Services.GetRequiredService<ShareUI>();
     private UIButton _sendButton = null!;
+    private CounterBadgeView _sendBadge = null!;
     private NSLayoutConstraint _commentBottomConstraint = null!;
     private NSObject? _keyboardShowObserver;
     private NSObject? _keyboardHideObserver;
@@ -39,9 +40,13 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         _sendButton.TranslatesAutoresizingMaskIntoConstraints = false;
         _sendButton.SetTitle("Send", UIControlState.Normal);
         _sendButton.TitleLabel.Font = UIFont.SystemFontOfSize(17, UIFontWeight.Semibold)!;
-        _sendButton.Enabled = model?.CanSend ?? false;
         _sendButton.TouchUpInside += Safe(() => ShareUI.StartSending());
         AddSubview(_sendButton);
+
+        // Selected contact counter, sitting left of the send button
+        _sendBadge = new CounterBadgeView();
+        AddSubview(_sendBadge);
+        UpdateSendButton(model);
 
         // Search field
         var searchField = new UITextField
@@ -133,6 +138,9 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
             _sendButton.CenterYAnchor.ConstraintEqualTo(closeButton.CenterYAnchor),
             _sendButton.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -16),
 
+            _sendBadge.TrailingAnchor.ConstraintEqualTo(_sendButton.LeadingAnchor, -6),
+            _sendBadge.CenterYAnchor.ConstraintEqualTo(_sendButton.CenterYAnchor),
+
             searchField.TopAnchor.ConstraintEqualTo(closeButton.BottomAnchor, 8),
             searchField.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, 16),
             searchField.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -16),
@@ -177,9 +185,13 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
     }
 
     protected override void OnStateChanged(Model? model)
+        => UpdateSendButton(model);
+
+    private void UpdateSendButton(Model? model)
     {
-        var canSend = model?.CanSend ?? false;
-        _sendButton.Enabled = canSend;
+        var selectedCount = model?.SelectedCount ?? 0;
+        _sendButton.Enabled = selectedCount > 0;
+        _sendBadge.Count = selectedCount;
     }
 
     protected override ComputedState<Model?>.Options GetStateOptions()
@@ -192,11 +204,11 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
 
     protected override async Task<Model?> ComputeState(CancellationToken cancellationToken)
     {
-        var canSend = await ShareUI.CanSend.Use(cancellationToken).ConfigureAwait(false);
-        return new Model(canSend);
+        var selectedCount = await ShareUI.GetSelectedCount(cancellationToken).ConfigureAwait(false);
+        return new Model(selectedCount);
     }
 
     // Nested types
 
-    public sealed record Model(bool CanSend);
+    public sealed record Model(int SelectedCount);
 }

--- a/src/dotnet/App.Maui.IosShareExt/Components/CounterBadgeView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/CounterBadgeView.cs
@@ -1,0 +1,43 @@
+namespace ActualChat.App.Maui.IosShareExt.Components;
+
+/// <summary>
+/// A pill-shaped counter label that hides itself when <see cref="Count"/> is zero or less.
+/// </summary>
+public sealed class CounterBadgeView : UILabel
+{
+    private const int MinSize = 18;
+    private const int PaddingX = 5;
+
+    public int Count {
+        get;
+        set {
+            if (field == value)
+                return;
+
+            field = value;
+            Text = value.Format();
+            Hidden = value <= 0;
+            InvalidateIntrinsicContentSize();
+        }
+    }
+
+    public override CGSize IntrinsicContentSize {
+        get {
+            var size = base.IntrinsicContentSize;
+            return new CGSize(Math.Max(MinSize, size.Width + (2 * PaddingX)), MinSize);
+        }
+    }
+
+    public CounterBadgeView()
+    {
+        TranslatesAutoresizingMaskIntoConstraints = false;
+        Font = UIFont.SystemFontOfSize(12, UIFontWeight.Semibold)!;
+        TextColor = UIColor.White;
+        TextAlignment = UITextAlignment.Center;
+        BackgroundColor = UIColor.SystemBlue;
+        Layer.CornerRadius = MinSize / 2f;
+        ClipsToBounds = true;
+        UserInteractionEnabled = false;
+        Hidden = true;
+    }
+}

--- a/src/dotnet/App.Maui.IosShareExt/Module/IosShareExtAotSource.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Module/IosShareExtAotSource.cs
@@ -26,6 +26,7 @@ internal class IosShareExtAotSource : IAotSource
         CodeKeeper.Keep<ContactListView>();
         CodeKeeper.Keep<ContactSelectionView>();
         CodeKeeper.Keep<ContactView>();
+        CodeKeeper.Keep<CounterBadgeView>();
         CodeKeeper.Keep<ErrorContentView>();
         CodeKeeper.Keep<ErrorView>();
         CodeKeeper.Keep<PlaceListView>();

--- a/src/dotnet/App.Maui.IosShareExt/Services/ShareUI.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Services/ShareUI.cs
@@ -13,7 +13,6 @@ namespace ActualChat.App.Maui.IosShareExt.Services;
 public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
 {
     private readonly HashSet<ContactId> _selectedIds = new();
-    private readonly MutableState<bool> _canSend;
     private readonly MutableState<double> _uploadPct;
     private readonly FuncWorker _sendWorker;
     private SearchQuery _searchQuery;
@@ -26,7 +25,6 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
 
     public MutableState<PlaceId?> SelectedPlaceId { get; }
     public IState<double> UploadPct => _uploadPct;
-    public IState<bool> CanSend => _canSend;
     public IState<string> FailureMessage => _failureMessage;
 
     private IosHub Hub { get; }
@@ -51,7 +49,6 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
         _isSent = Hub.StateFactory.NewMutable<bool>();
         _failureMessage = Hub.StateFactory.NewMutable<string>("");
         _uploadPct = Hub.StateFactory.NewMutable<double>();
-        _canSend = Hub.StateFactory.NewMutable<bool>();
         _sendWorker = FuncWorker.New(ct
             => AsyncChain.From(SendInternal)
                 .LogError(Log)
@@ -78,7 +75,9 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
                 return;
 
             _selectedIds.Add(contactId);
-            _canSend.Value = true;
+            using (Invalidation.Begin())
+                _ = GetSelectedCount(default);
+
             if (chatId is PlaceChatId placeChatId)
                 SelectedPlaceId.Value = placeChatId.PlaceId;
         }
@@ -127,6 +126,10 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
     }
 
     [ComputeMethod]
+    public virtual Task<int> GetSelectedCount(CancellationToken cancellationToken)
+        => Task.FromResult(_selectedIds.Count);
+
+    [ComputeMethod]
     public virtual Task<bool> IsContactSelected(ContactId contactId, CancellationToken cancellationToken)
         => Task.FromResult(_selectedIds.Contains(contactId));
 
@@ -158,10 +161,11 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
     {
         if (!_selectedIds.Add(contactId))
             _selectedIds.Remove(contactId);
-        _canSend.Value = _selectedIds.Count > 0;
 
-        using (Invalidation.Begin())
+        using (Invalidation.Begin()) {
             _ = IsContactSelected(contactId, default);
+            _ = GetSelectedCount(default);
+        }
     }
 
     public void SetComment(string comment)


### PR DESCRIPTION
Closes #4150.

## The problem

The iOS share extension's contact picker lets you select several chats at once, but nothing summarized the selection — only the per-row checkmarks, which scroll out of view. You could tap Send without knowing whether you'd armed two chats or five.

## The change

**`ShareUI` had no count to show.** Selection was tracked as a bare `MutableState<bool> CanSend`, so "how many" wasn't observable. That's now a `GetSelectedCount` compute method over `_selectedIds`, invalidated alongside `IsContactSelected` on each toggle — mirroring the pattern already in the file rather than making the set itself a state. That keeps per-contact granularity: toggling a row still recomputes only that row's `ContactView`, while the badge picks up the new count.

**`CounterBadgeView`** is a `UILabel` that hides itself at zero and overrides `IntrinsicContentSize` to add horizontal padding with an 18pt floor, so "1" renders as a circle and "12" grows into a pill. It's `SystemBlue` to match the button's tint — this is a confirmation of intent, not an alert, so the unread-badge red would have read wrong.

**Placement.** The badge sits inline, 6pt to the left of the title, vertically centered on the button. A corner badge was the first attempt and didn't survive the device: the header leaves only ~23pt between the sheet's top and the button, so it collided with the sheet's rounded top-right corner and sat ~4pt from the screen edge.

`ContactSelectionView` drives both `Enabled` and the badge from one `UpdateSendButton(model)`, shared by the initial render and later state changes, so the two can't drift.

## Trimming

`CounterBadgeView` needs a `CodeKeeper.Keep<>` entry in `IosShareExtAotSource`: it's a `UIView` subclass whose `IntrinsicContentSize` override is dispatched from ObjC, so Release would otherwise trim it and the badge would size itself wrong.

## Verification

Built and deployed to a physical iPhone (15 Pro Max), confirming the rebuilt appex carried the new type. The screenshot that caught the corner-badge collision is what drove the inline placement; the current position was re-verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)