### PR TITLE
fix(auth, chat): reliable sign-out, a short-lived OAuth cookie, and a "Detecting language" badge that expires

### DIFF
--- a/src/dotnet/App.Maui/Services/MauiAccountUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiAccountUI.cs
@@ -46,19 +46,19 @@ public class MauiAccountUI(UIHub hub) : AccountUI(hub)
 
     protected override async Task SignOutBackend()
     {
-        // Callers are fire-and-forget, so a throw here would be an unobserved task exception.
-        try {
 #if ANDROID
+        // Dropping the native Google session is the only platform-specific part of signing out.
+        try {
             var googleAuth = Hub.Services.GetRequiredService<NativeGoogleAuth>();
             if (googleAuth.IsSignedIn())
                 await googleAuth.SignOut().ConfigureAwait(true);
-#endif
-
-            await Hub.Services.Commander().Call(new NativeAuth_SignOut(Session)).ConfigureAwait(false);
         }
         catch (Exception e) {
-            Log.LogError(e, "SignOutBackend failed");
+            // Callers are fire-and-forget, so a throw here would be an unobserved task exception.
+            Log.LogError(e, "SignOutBackend: native Google sign-out failed");
         }
+#endif
+        await base.SignOutBackend().ConfigureAwait(false);
     }
 
     // Private methods

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -94,7 +94,8 @@
             <StreamingEntryBadge
                 ChatId="@ChatContext.Chat.Id"
                 IsVoiceActive="@true"
-                IsLanguageKnown="@m.IsChatLanguageSelected"/>
+                IsLanguageKnown="@m.IsChatLanguageSelected"
+                VoiceStartedAt="@entry.BeginsAt"/>
         }
         @if (!sm.RetainedText.IsNullOrEmpty()) {
             <span class="retained">@sm.RetainedText</span>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingEntryBadge/StreamingEntryBadge.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingEntryBadge/StreamingEntryBadge.razor
@@ -1,9 +1,10 @@
 @namespace ActualChat.UI.Blazor.App.Components
 @inherits ComponentBase<AppUIHub>
+@implements IDisposable
 @{
     var text = !IsVoiceActive
         ? "Listening"
-        : IsLanguageKnown
+        : IsLanguageKnown || IsDetectingLanguageOver()
             ? "Transcribing"
             : "Detecting language";
 }
@@ -16,10 +17,51 @@
 </p>
 
 @code {
+    // Transcription is already running long before this: every other participant sees the text while
+    // the speaker alone still reads "Detecting language", so the claim expires on its own.
+    private static readonly TimeSpan DetectingLanguageDuration = TimeSpan.FromSeconds(3);
+
+    private CancellationTokenSource? _detectingLanguageCts;
+
     [Parameter] public ChatId ChatId { get; set; } = null!;
     [Parameter] public bool IsLanguageKnown { get; set; }
     [Parameter] public bool IsVoiceActive { get; set; }
+    [Parameter] public Moment VoiceStartedAt { get; set; }
+
+    public void Dispose()
+    {
+        _detectingLanguageCts.CancelAndDisposeSilently();
+        _detectingLanguageCts = null;
+    }
+
+    protected override void OnParametersSet()
+    {
+        _detectingLanguageCts.CancelAndDisposeSilently();
+        _detectingLanguageCts = null;
+        var remaining = VoiceStartedAt + DetectingLanguageDuration - Clocks.ServerClock.Now;
+        if (!IsVoiceActive || IsLanguageKnown || remaining <= TimeSpan.Zero)
+            return;
+
+        // While the transcript stays empty nothing else re-renders this badge, so the expiry above
+        // would never be observed without its own wake-up.
+        _detectingLanguageCts = new CancellationTokenSource();
+        _ = RerenderAfter(remaining, _detectingLanguageCts.Token);
+    }
+
+    // Private methods
 
     private void OnClick()
         => ModalUI.Show(new VoiceSettingsModal.Model(ChatId));
+
+    private bool IsDetectingLanguageOver()
+        => Clocks.ServerClock.Now - VoiceStartedAt >= DetectingLanguageDuration;
+
+    private async Task RerenderAfter(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        await Clocks.CpuClock.Delay(delay, cancellationToken).SilentAwait(false);
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        await InvokeAsync(StateHasChanged).SilentAwait(false);
+    }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingEntryBadge/StreamingEntryBadge.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/StreamingEntryBadge/StreamingEntryBadge.razor
@@ -17,8 +17,7 @@
 </p>
 
 @code {
-    // Transcription is already running long before this: every other participant sees the text while
-    // the speaker alone still reads "Detecting language", so the claim expires on its own.
+    // Everyone else already sees the transcript by then, so the claim expires on its own.
     private static readonly TimeSpan DetectingLanguageDuration = TimeSpan.FromSeconds(3);
 
     private CancellationTokenSource? _detectingLanguageCts;
@@ -42,8 +41,7 @@
         if (!IsVoiceActive || IsLanguageKnown || remaining <= TimeSpan.Zero)
             return;
 
-        // While the transcript stays empty nothing else re-renders this badge, so the expiry above
-        // would never be observed without its own wake-up.
+        // An empty transcript triggers no further render, so the expiry needs its own wake-up.
         _detectingLanguageCts = new CancellationTokenSource();
         _ = RerenderAfter(remaining, _detectingLanguageCts.Token);
     }

--- a/src/dotnet/UI.Blazor.App/NotificationUI.cs
+++ b/src/dotnet/UI.Blazor.App/NotificationUI.cs
@@ -141,9 +141,8 @@ public class NotificationUI : ProcessorBase, INotificationUI, INotificationUIBac
 
     public async Task UnregisterDevice(CancellationToken cancellationToken = default)
     {
-        // Best-effort cleanup that sits on the sign-out path. Every step below is a JS interop call
-        // issued with CancellationToken.None, which disables Blazor's own interop timeout - so an
-        // undelivered call used to hang here forever, and SignOut never reached SignOutBackend.
+        // Best-effort, and on the sign-out path: the JS interop below passes CancellationToken.None,
+        // which disables Blazor's own interop timeout, so an undelivered call used to hang forever.
         Log.LogInformation("-> UnregisterDevice");
         var timeout = new Timeout(Hub.Clocks.CpuClock, UnregisterDeviceTimeout);
         try {

--- a/src/dotnet/UI.Blazor.App/NotificationUI.cs
+++ b/src/dotnet/UI.Blazor.App/NotificationUI.cs
@@ -14,6 +14,7 @@ public class NotificationUI : ProcessorBase, INotificationUI, INotificationUIBac
         $"{BlazorUIAppModule.ImportName}.NotificationUI.registerRequestNotificationHandler";
     private static readonly string JSUnregisterRequestNotificationHandlerMethod =
         $"{BlazorUIAppModule.ImportName}.NotificationUI.unregisterRequestNotificationHandler";
+    private static readonly TimeSpan UnregisterDeviceTimeout = TimeSpan.FromSeconds(5);
 
     private readonly MutableState<bool?> _permissionState;
     private readonly AsyncTaskMethodBuilder _whenPermissionStateReady = AsyncTaskMethodBuilderExt.New();
@@ -138,20 +139,20 @@ public class NotificationUI : ProcessorBase, INotificationUI, INotificationUIBac
         SetIsGranted(state);
     }
 
-    public async Task DeregisterDevice(CancellationToken cancellationToken = default)
+    public async Task UnregisterDevice(CancellationToken cancellationToken = default)
     {
-        Log.LogInformation("-> DeregisterDevice");
-        var deviceId = await DeviceTokenRetriever.GetDeviceToken(cancellationToken).ConfigureAwait(false);
-        if (deviceId == null)
-            return;
-
-        Log.LogInformation("DeregisterDevice. About to execute DeleteDeviceToken");
-        var deleteTokenTask = DeviceTokenRetriever.DeleteDeviceToken(cancellationToken);
-        Log.LogInformation("DeregisterDevice. About to execute DeregisterDevice command");
-        var command = new Notifications_DeregisterDevice(Session, deviceId);
-        var deregisterDeviceTask =  Hub.Commander.Call(command, cancellationToken);
-        await Task.WhenAll(deleteTokenTask, deregisterDeviceTask).ConfigureAwait(false);
-        Log.LogInformation("DeregisterDevice. DeleteDeviceToken and DeregisterDevice command are executed");
+        // Best-effort cleanup that sits on the sign-out path. Every step below is a JS interop call
+        // issued with CancellationToken.None, which disables Blazor's own interop timeout - so an
+        // undelivered call used to hang here forever, and SignOut never reached SignOutBackend.
+        Log.LogInformation("-> UnregisterDevice");
+        var timeout = new Timeout(Hub.Clocks.CpuClock, UnregisterDeviceTimeout);
+        try {
+            await timeout.ApplyTo(UnregisterDeviceUnsafe, cancellationToken).ConfigureAwait(false);
+            Log.LogInformation("UnregisterDevice: done");
+        }
+        catch (TimeoutException) {
+            Log.LogWarning("UnregisterDevice: timed out in {Timeout}, giving up", UnregisterDeviceTimeout.ToShortString());
+        }
     }
 
     public async Task EnsureDeviceRegistered(CancellationToken cancellationToken = default)
@@ -179,6 +180,18 @@ public class NotificationUI : ProcessorBase, INotificationUI, INotificationUIBac
     }
 
     // Private methods
+
+    private async Task UnregisterDeviceUnsafe(CancellationToken cancellationToken)
+    {
+        var deviceId = await DeviceTokenRetriever.GetDeviceToken(cancellationToken).ConfigureAwait(false);
+        if (deviceId == null)
+            return;
+
+        var deleteTokenTask = DeviceTokenRetriever.DeleteDeviceToken(cancellationToken);
+        var command = new Notifications_DeregisterDevice(Session, deviceId);
+        var unregisterDeviceTask = Hub.Commander.Call(command, cancellationToken);
+        await Task.WhenAll(deleteTokenTask, unregisterDeviceTask).ConfigureAwait(false);
+    }
 
     private void RegisterDevice(string? deviceId = null, CancellationToken cancellationToken = default)
     {

--- a/src/dotnet/UI.Blazor.App/notification-ui.ts
+++ b/src/dotnet/UI.Blazor.App/notification-ui.ts
@@ -59,7 +59,6 @@ export class NotificationUI {
     }
 
     /** Called by Blazor */
-    // @ts-expect-error TODO: fix errors
     public static async getDeviceToken(): Promise<string | null>
     {
         let { firebaseApp, firebasePublicKey } = BrowserInit;
@@ -90,6 +89,7 @@ export class NotificationUI {
         }
         catch (error) {
             errorLog?.log(`getDeviceToken: failed to obtain device token for notifications, error:`, error);
+            return null;
         }
     }
 

--- a/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
@@ -150,8 +150,11 @@ public partial class AccountUI : UIWorkerBase<UIHub>, IComputeService, INotifyIn
     // UICommander rather than Commander: NavbarLogoMenu and SettingsPanel call SignOut()
     // fire-and-forget, so a throw would land as an unobserved task exception - this way a failed
     // sign-out is shown to the user instead of vanishing.
+    // Deactivate, because signing in doesn't rotate the session id: without it the id outlives the
+    // sign-out, and the next sign-in on a shared machine lands on the one the previous user's
+    // browser already knows. Expiring it makes AuthHelper mint a fresh session on the reload.
     protected virtual Task SignOutBackend()
-        => Hub.UICommander.Run(new Accounts_SignOut(Session));
+        => Hub.UICommander.Run(new Accounts_SignOut(Session, true));
 
     // Private methods
 

--- a/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
@@ -143,17 +143,10 @@ public partial class AccountUI : UIWorkerBase<UIHub>, IComputeService, INotifyIn
     protected virtual Task SignInBackend(string schema)
         => JS.InvokeVoidAsync($"{AuthJsClassName}.signIn", schema).AsTask();
 
-    // No navigation here: MonitorAccountChange sees OwnAccount flip to guest and reloads (see
-    // ProcessLoginLogout), and the reload is what gets a fresh session cookie from AuthHelper.
-    // This used to go through WebAuth.signOut, whose popup could be blocked or left open - and
-    // then sign-out silently never happened.
-    // UICommander rather than Commander: NavbarLogoMenu and SettingsPanel call SignOut()
-    // fire-and-forget, so a throw would land as an unobserved task exception - this way a failed
-    // sign-out is shown to the user instead of vanishing.
-    // Deactivate, because signing in doesn't rotate the session id: without it the id outlives the
-    // sign-out, and the next sign-in on a shared machine lands on the one the previous user's
-    // browser already knows. Expiring it makes AuthHelper mint a fresh session on the reload.
     protected virtual Task SignOutBackend()
+        // No navigation here: ProcessLoginLogout reloads once OwnAccount flips to guest.
+        // UICommander, not Commander: SignOut() callers are fire-and-forget, so a throw would vanish.
+        // Deactivate, because sign-in doesn't rotate the session id - it would outlive the sign-out.
         => Hub.UICommander.Run(new Accounts_SignOut(Session, true));
 
     // Private methods

--- a/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.cs
@@ -118,11 +118,10 @@ public partial class AccountUI : UIWorkerBase<UIHub>, IComputeService, INotifyIn
     public async Task SignOut()
     {
         try {
-            // TODO(AY): Make it reliable
-            await NotificationUI.DeregisterDevice(CancellationToken.None).ConfigureAwait(false);
+            await NotificationUI.UnregisterDevice(CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) {
-            Log.LogError(e, "SignOut: failed to deregister device");
+            Log.LogError(e, "SignOut: failed to unregister device");
         }
         await SignOutBackend().ConfigureAwait(false);
     }
@@ -144,8 +143,15 @@ public partial class AccountUI : UIWorkerBase<UIHub>, IComputeService, INotifyIn
     protected virtual Task SignInBackend(string schema)
         => JS.InvokeVoidAsync($"{AuthJsClassName}.signIn", schema).AsTask();
 
+    // No navigation here: MonitorAccountChange sees OwnAccount flip to guest and reloads (see
+    // ProcessLoginLogout), and the reload is what gets a fresh session cookie from AuthHelper.
+    // This used to go through WebAuth.signOut, whose popup could be blocked or left open - and
+    // then sign-out silently never happened.
+    // UICommander rather than Commander: NavbarLogoMenu and SettingsPanel call SignOut()
+    // fire-and-forget, so a throw would land as an unobserved task exception - this way a failed
+    // sign-out is shown to the user instead of vanishing.
     protected virtual Task SignOutBackend()
-        => JS.InvokeVoidAsync($"{AuthJsClassName}.signOut").AsTask();
+        => Hub.UICommander.Run(new Accounts_SignOut(Session));
 
     // Private methods
 

--- a/src/dotnet/UI.Blazor/Services/INotificationUI.cs
+++ b/src/dotnet/UI.Blazor/Services/INotificationUI.cs
@@ -2,6 +2,6 @@ namespace ActualChat.UI.Blazor.Services;
 
 public interface INotificationUI
 {
-    Task DeregisterDevice(CancellationToken cancellationToken = default);
+    Task UnregisterDevice(CancellationToken cancellationToken = default);
     Task EnsureDeviceRegistered(CancellationToken cancellationToken = default);
 }

--- a/src/dotnet/Users.Service/AuthHelper.cs
+++ b/src/dotnet/Users.Service/AuthHelper.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using ActualChat.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 
 namespace ActualChat.Users;
@@ -163,9 +164,21 @@ public sealed class AuthHelper
         if (!isSignedIn)
             existingAccount = null;
 
-        if (!IsCloseFlow(httpContext))
-            return; // Actual SignIn/SignOut actions are performed on close flow only
+        if (!IsCloseFlow(httpContext)) {
+            // Actual SignIn/SignOut actions are performed on close flow only.
+            // The cookie principal exists only to be converted into Session-based auth on that
+            // flow, so once the session isn't signed in it's a stale credential - drop it. This
+            // covers both sign-out and a freshly minted session (always a guest), and it closes
+            // the replay: otherwise a later close flow that gets no new principal would sign the
+            // previous identity back in.
+            if (httpIsSignedIn && !isSignedIn)
+                await httpContext.SignOutAsync().ConfigureAwait(false);
+            return;
+        }
 
+        // NOTE: the principal is deliberately NOT discarded here even though it has served its
+        // purpose - the branch below reads "close flow without a principal" as a sign-out, so
+        // clearing it would turn a re-visited close flow (back button, retry) into one.
         if (httpIsSignedIn) {
             if (isSignedIn && IsSameAccount(existingAccount, httpUser, authSchema))
                 return; // Nothing to change

--- a/src/dotnet/Users.Service/AuthHelper.cs
+++ b/src/dotnet/Users.Service/AuthHelper.cs
@@ -165,20 +165,15 @@ public sealed class AuthHelper
             existingAccount = null;
 
         if (!IsCloseFlow(httpContext)) {
-            // Actual SignIn/SignOut actions are performed on close flow only.
-            // The cookie principal exists only to be converted into Session-based auth on that
-            // flow, so once the session isn't signed in it's a stale credential - drop it. This
-            // covers both sign-out and a freshly minted session (always a guest), and it closes
-            // the replay: otherwise a later close flow that gets no new principal would sign the
-            // previous identity back in.
+            // SignIn/SignOut happen on the close flow only. A principal the session no longer
+            // matches is a stale credential a later close flow could replay - drop it.
             if (httpIsSignedIn && !isSignedIn)
                 await httpContext.SignOutAsync().ConfigureAwait(false);
             return;
         }
 
-        // NOTE: the principal is deliberately NOT discarded here even though it has served its
-        // purpose - the branch below reads "close flow without a principal" as a sign-out, so
-        // clearing it would turn a re-visited close flow (back button, retry) into one.
+        // The principal isn't discarded below despite having served its purpose: the else branch
+        // reads "close flow without a principal" as a sign-out, so a re-visit would become one.
         if (httpIsSignedIn) {
             if (isSignedIn && IsSameAccount(existingAccount, httpUser, authSchema))
                 return; // Nothing to change

--- a/src/dotnet/Users.Service/Module/UsersServiceModule.cs
+++ b/src/dotnet/Users.Service/Module/UsersServiceModule.cs
@@ -47,12 +47,8 @@ public sealed class UsersServiceModule(IServiceProvider moduleServices)
                 options.LogoutPath = "/signOut";
                 if (HostInfo.IsDevelopmentInstance)
                     options.Cookie.SecurePolicy = CookieSecurePolicy.None;
-                // This principal has exactly one consumer - AuthHelper.UpdateAuthState on the close
-                // flow, which converts it into Session-based auth. It's a handshake token, not a
-                // login: the durable identity is the Session. So it only has to outlive the hop
-                // from the provider callback to /fusion/close, and AuthHelper drops it as soon as
-                // the session isn't signed in. No browser-level expiration either - a session
-                // cookie means closing the browser forgets it too.
+                // A handshake token, not a login: its only consumer is AuthHelper.UpdateAuthState on
+                // the close flow, so it just has to outlive the callback -> /fusion/close hop.
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
                 options.SlidingExpiration = false;
             });

--- a/src/dotnet/Users.Service/Module/UsersServiceModule.cs
+++ b/src/dotnet/Users.Service/Module/UsersServiceModule.cs
@@ -47,14 +47,14 @@ public sealed class UsersServiceModule(IServiceProvider moduleServices)
                 options.LogoutPath = "/signOut";
                 if (HostInfo.IsDevelopmentInstance)
                     options.Cookie.SecurePolicy = CookieSecurePolicy.None;
-                // This controls the expiration time stored in the cookie itself
-                options.ExpireTimeSpan = TimeSpan.FromDays(14);
-                options.SlidingExpiration = true;
-                // And this controls when the browser forgets the cookie
-                options.Events.OnSigningIn = ctx => {
-                    ctx.CookieOptions.Expires = DateTimeOffset.UtcNow.AddDays(28);
-                    return Task.CompletedTask;
-                };
+                // This principal has exactly one consumer - AuthHelper.UpdateAuthState on the close
+                // flow, which converts it into Session-based auth. It's a handshake token, not a
+                // login: the durable identity is the Session. So it only has to outlive the hop
+                // from the provider callback to /fusion/close, and AuthHelper drops it as soon as
+                // the session isn't signed in. No browser-level expiration either - a session
+                // cookie means closing the browser forgets it too.
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
+                options.SlidingExpiration = false;
             });
             authentication.AddGoogle(options => {
                 options.ClientId = Settings.GoogleClientId;


### PR DESCRIPTION
Four fixes, found while testing live-conversation behaviour with multiple users
and then pulling the thread on why sign-out didn't work.

## 1. Sign-out could silently never happen

`debugUI.signOut()` (and the UI sign-out behind it) would leave the user signed
in with the promise unsettled. Two independent causes, both *before* the user is
actually signed out:

**a. An unbounded JS interop call on the critical path.** `AccountUI.SignOut`
awaited `NotificationUI.DeregisterDevice` before `SignOutBackend()`. That awaits
a .NET→JS call issued with `CancellationToken.None`, which disables Blazor's
default interop timeout — so an undelivered call waited forever. The server log
showed `-> DeregisterDevice` and then nothing: no next step, no error, no
timeout. Renamed to `UnregisterDevice` and bounded with a 5s `Timeout`.

**b. The popup.** `SignOutBackend()` went through `WebAuth.signOut`, which
prefers a popup on desktop. `window.open` can return a window that is closed
immediately after the check, so the code skipped its redirect fallback and sat
waiting for a popup that never completed the flow.

Web now does what MAUI already did — call the sign-out command, via
`UICommander` so a failure is shown to the user rather than lost (`NavbarLogoMenu`
and `SettingsPanel` both call `SignOut()` fire-and-forget, where a throw would be
an unobserved task exception).

No navigation is needed here: `MonitorAccountChange` sees `OwnAccount` flip to
guest and `ProcessLoginLogout` issues `ReloadUI.Reload(true, true)`, and that
reload is what gets a fresh session cookie from `AuthHelper`.

That makes `MauiAccountUI`'s override redundant except on Android, where the
native Google session still has to be dropped — it now does only that and defers
to base. `NativeAuth_SignOut` and `Accounts_SignOut` both reduce to
`AccountsBackend_SignOut(session)`, so it's the same call either way.

## 2. The OAuth cookie outlived the sign-in it carries

Following on from (1): the previous `/signOut` round-trip also cleared the
ASP.NET auth cookie via `SignOutAsync`, and the API-based sign-out doesn't.

That cookie isn't this app's auth — Fusion's `SessionMiddleware` is removed and
everything authenticates by `Session`. Its principal has exactly **one** consumer
in the codebase: `AuthHelper.UpdateAuthState` on the close flow, which converts
it into Session-based auth. `httpContext.User` is read nowhere else; there is no
`[Authorize]` or `RequireAuthorization` anywhere.

Despite that it was configured like a login — a 14-day sliding ticket in a cookie
the browser was told to keep for **28 days** — so it long outlived the single
redirect hop it exists for, and survived sign-out.

- `AuthHelper` now drops the principal outside the close flow when the session
  isn't signed in. Covers sign-out and a freshly minted session (always a guest),
  and closes the replay where a later close flow receiving no new principal would
  sign the previous identity back in.
- The ticket is now **30 minutes, non-sliding, in a session cookie**. It only has
  to outlive the provider callback → `/fusion/close` hop, which is sub-second —
  same for MAUI, whose `/fusion/close-app` hop happens in the browser before the
  app resumes.

## 3. "Detecting language" never expired

The badge renders only while a streaming entry has no text, and says "Detecting
language" whenever `IsChatLanguageSelected` is false — which means *"the user
never picked a language for this chat"*, not *"detection is running"*. In a new
chat that stays false, so the label had no expiry.

Measured on the speaker's own screen: `Listening` at 0.6s → `Detecting language`
at 1.5s → **still there at 18s**, while the other participant already had the
full transcript. It now expires 3s after the entry's `BeginsAt` and falls back
to "Transcribing".

## 4. `getDeviceToken` resolved to `undefined`

Its `catch` fell through with no `return` despite being typed
`Promise<string | null>`. Fixing it also retired the `@ts-expect-error` above it.

## Verification

Sign-out, forcing the original hang by patching `getDeviceToken` to a
never-resolving promise:

```
-> UnregisterDevice
UnregisterDevice: timed out in 5s, giving up   → signed out ✓
-> UnregisterDevice
UnregisterDevice: done                          → 5 ms ✓
```

After the popup fix: one page, redirected to `/`, user is a guest — no popup
window at all. Repeatable across five sign-in/sign-out cycles, including after
the switch to `UICommander` and after the cookie changes.

Cookie, with a real Google sign-in:

| step | result |
|---|---|
| Google sign-in | signs in — the 30-min non-sliding session cookie carries the callback → `/fusion/close` hop |
| `signOut()` | guest |
| replay `/fusion/close?flow=Sign-in` | **still guest** — the principal was cleared |

That last step is the replay this fixes: before the change the surviving
principal would have signed the previous identity back in with no
authentication.

Badge: verified live in both states — label still appears while the entry is
young, and yields to "Transcribing" once past the window.

Also re-ran the live-conversation matrix with three users (joined-then-left,
talker, never-joined). All three viewers agree on ordering, typed messages
interleave correctly with spoken entries, and there are no
invisible-but-space-taking rows.

## Notes for review

- **The principal is deliberately not discarded on the close flow itself**, even
  though it has served its purpose there. The branch below it reads "close flow
  without a principal" as a sign-out — that's how the old `/signOut` worked — so
  clearing it would turn a re-visited close flow (back button, retry) into a
  sign-out. There's a NOTE in the code.
- **The session is deactivated on sign-out.** Signing in doesn't rotate the
  session id (`BuildSignInCommand` signs in whatever session the cookie carries),
  so without this the id outlived the sign-out and the next sign-in on a shared
  machine landed on an id the previous user's browser knew. This is safe because
  `Accounts.GetOwn` falls back to the session's guest account when `IsActive` is
  false rather than throwing, so the sign-out still reads as the ordinary
  signed-in → guest flip that drives the reload.
- `Notifications_DeregisterDevice` / `INotifications.OnDeregisterDevice` were
  **not** renamed: the RPC method name is wire-visible, the command's type name
  is persisted in the operation log, and iOS push-to-talk sends that command.
  Only the client-side `INotificationUI` / `NotificationUI` / `AccountUI` names
  changed.
- `WebAuth.signOut()` and the `/signOut` endpoint are now unused by the web
  client but left in place — MAUI's `WebSignIn` still uses that machinery.
- **App.Maui was not compiled** — the server-loop builds App.Server only. The
  `MauiAccountUI` change and the `INotificationUI` rename are unverified against
  a MAUI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bKDwmJhfLtFmM7uE19HhB
