### PR TITLE
fix(clocks): base the client ServerClock on the wall clock so sleep can't desync it

### DIFF
--- a/src/dotnet/Streaming.Service/Services/ClientStats.cs
+++ b/src/dotnet/Streaming.Service/Services/ClientStats.cs
@@ -31,7 +31,8 @@ public static class ClientStats
         => value.Clamp(0, MaxByteRate);
 
     public static TimeSpan AudioLatency(TimeSpan value)
-        => value.Clamp(TimeSpan.Zero, MaxAudioLatency);
+        // Signed: a stale-behind client clock reports negative latency — the desync signal this meter surfaces
+        => value.Clamp(-MaxAudioLatency, MaxAudioLatency);
 
     public static ReceiveQuality Quality(ReceiveQuality quality)
         => quality.LayerId <= MaxLayerId

--- a/src/dotnet/UI.Blazor.App/ClientStartup.cs
+++ b/src/dotnet/UI.Blazor.App/ClientStartup.cs
@@ -25,6 +25,19 @@ public static class ClientStartup
         ApiContractsModuleInitializer.Load();
         CoreModuleInitializer.Initialize();
 
+        // C# runs on the client device here, and the default ServerClock rides CpuClock
+        // (performance.now / mach_absolute_time), which freezes during a system sleep —
+        // so server time went stale by exactly the slept span until the next re-sync.
+        // The wall clock keeps running through sleep, so a wall-based ServerClock stays
+        // correct across suspends — the same reason the JS-side clock (Date-relative
+        // serverClockOffsetMs) never drifted. ServerTimeSync measures its offset against
+        // ServerClock.BaseClock, so it follows this swap automatically.
+        MomentClockSet.Default = new MomentClockSet(
+            SystemClock.Instance,
+            CpuClock.Instance,
+            new ServerClock(SystemClock.Instance),
+            CoarseSystemClock.Instance);
+
 #if !DEBUG
         RpcDiagnosticsOptions.Default = RpcDiagnosticsOptions.Default with {
             CallTracerFactory = _ => null // No call tracing in release builds

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoDiagnosticsModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoDiagnosticsModal.razor
@@ -398,6 +398,10 @@
                 <span class="diag-label">source (C#)</span>
                 <span class="diag-value diag-dim">@FormatSignedMs(clock.Offset)</span>
             </div>
+            <div class="diag-row diag-sub">
+                <span class="diag-label">drift since sync</span>
+                <span class="diag-value diag-dim">@FormatClockDrift(clock)</span>
+            </div>
             <div class="diag-row">
                 <span class="diag-label">Precision</span>
                 <span class="diag-value">±@FormatMs(clock.Precision)</span>
@@ -1264,9 +1268,22 @@
             : Math.Abs(ms.Value) < 1 ? $"{ms.Value * 1000:+0;-0;0} µs" : $"{ms.Value:+0.##;-0.##;0} ms";
 
     private string FormatSyncAge(ActualChat.UI.Blazor.Services.ServerClockSyncStats.Snapshot clock)
+        // Wall-clock age: a CpuClock-based age under-reports by exactly the slept time
         => clock.SyncCount == 0
             ? "never"
-            : $"{(Hub.Clocks.CpuClock.Now - clock.LastSyncAt).TotalSeconds:0}s ago";
+            : $"{(Hub.Clocks.SystemClock.Now - clock.LastSyncWallAt).TotalSeconds:0}s ago";
+
+    private string FormatClockDrift(ActualChat.UI.Blazor.Services.ServerClockSyncStats.Snapshot clock)
+    {
+        // Wall-vs-CpuClock divergence since the last sync: non-zero means the device
+        // slept or the wall clock stepped, i.e. a re-sync is due within one drift check.
+        if (clock.SyncCount == 0)
+            return "—";
+
+        var drift = (Hub.Clocks.SystemClock.Now - clock.LastSyncWallAt)
+            - (Hub.Clocks.CpuClock.Now - clock.LastSyncAt);
+        return FormatSignedMs(drift);
+    }
 
     private static string FormatInboundDemand(VideoQualityUI.InboundDemand demand)
     {

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.Players.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.Players.cs
@@ -220,8 +220,13 @@ public partial class ChatAudioUI
             // Bounded: the clock is synced by a background worker, so anything that keeps that worker
             // from running (a wake-driven headless scope used to) would otherwise wedge listening
             // here for the life of the scope - silently, since a hang throws nothing.
+            // EnsureSynced beats waiting for that worker: it forces a fresh measurement right here,
+            // so the startAt anchor below can't be captured off a clock that just woke from a sleep.
             try {
-                await serverClock.WhenReady
+                var whenSynced = Hub.Services.GetService<ServerTimeSync>() is { } serverTimeSync
+                    ? serverTimeSync.EnsureSynced(cancellationToken)
+                    : serverClock.WhenReady;
+                await whenSynced
                     .WaitAsync(Constants.Audio.ServerClockWaitTimeout, cancellationToken)
                     .ConfigureAwait(true);
             }

--- a/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
+++ b/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
@@ -79,8 +79,13 @@ public sealed class BlazorUICoreModule(IServiceProvider moduleServices)
         // WASM has a single, always-ready IJSRuntime, so a hosted service is fine there.
         if (isServer || isMauiApp)
             services.AddScoped(c => new ServerTimeSync(c));
-        else
-            services.AddHostedService(c => new ServerTimeSync(c));
+        else {
+            // Singleton + hosted alias, not AddHostedService alone: that registers only
+            // IHostedService, so GetService<ServerTimeSync>() returned null in WASM and
+            // every EnsureSynced call site silently skipped the sync.
+            services.AddSingleton(c => new ServerTimeSync(c));
+            services.AddHostedService(c => c.GetRequiredService<ServerTimeSync>());
+        }
         services.AddScoped(c => new FontSizeUI(c.UIHub()));
 
         // UI events

--- a/src/dotnet/UI.Blazor/Services/DeviceAwakeUI/DeviceAwakeUI.cs
+++ b/src/dotnet/UI.Blazor/Services/DeviceAwakeUI/DeviceAwakeUI.cs
@@ -75,5 +75,23 @@ public class DeviceAwakeUI : UIServiceBase<UIHub>, ISleepDurationProvider, IDevi
         var totalSleepDuration = TimeSpan.FromMilliseconds(totalSleepDurationMs);
         _totalSleepDuration.Value = totalSleepDuration;
         Hub.ReconnectUI.TryReconnectOnDeviceAwake(totalSleepDuration);
+        _ = ResyncServerTime();
+    }
+
+    // Private methods
+
+    private async Task ResyncServerTime()
+    {
+        // Right on wake the server-clock offset deserves a fresh measurement (the wall
+        // clock may have stepped, and the JS push could've been missed while frozen) —
+        // don't leave it to ServerTimeSync's next drift-check tick, which background-tab
+        // timer throttling can delay far past its nominal cadence.
+        try {
+            if (Services.GetService<ServerTimeSync>() is { } serverTimeSync)
+                await serverTimeSync.EnsureSynced(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Post-wake server time re-sync failed");
+        }
     }
 }

--- a/src/dotnet/UI.Blazor/Services/ServerClockSyncStats.cs
+++ b/src/dotnet/UI.Blazor/Services/ServerClockSyncStats.cs
@@ -2,7 +2,8 @@ namespace ActualChat.UI.Blazor.Services;
 
 public sealed class ServerClockSyncStats
 {
-    private volatile Snapshot _snapshot = new(TimeSpan.Zero, TimeSpan.FromHours(1), TimeSpan.Zero, TimeSpan.Zero, default, 0);
+    private volatile Snapshot _snapshot =
+        new(TimeSpan.Zero, TimeSpan.FromHours(1), TimeSpan.Zero, TimeSpan.Zero, default, default, 0);
 
     public Snapshot Current => _snapshot;
 
@@ -15,5 +16,6 @@ public sealed class ServerClockSyncStats
         TimeSpan RttEma,
         TimeSpan LastRtt,
         Moment LastSyncAt,
+        Moment LastSyncWallAt,
         int SyncCount);
 }

--- a/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
+++ b/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
@@ -48,8 +48,8 @@ public class ServerTimeSync : WorkerBase
     public async Task EnsureSynced(CancellationToken cancellationToken)
     {
         // Forces a sync on demand; call before using server timestamps (e.g. video
-        // startedAtMs). Re-syncs after a device suspend too — the offset measured
-        // before the suspend is off by exactly the slept time.
+        // startedAtMs). Re-syncs after a detected suspend or wall-clock step too —
+        // whichever of the two clocks the offset rides, one of those broke it.
         if (SyncCount > 0 && GetSuspendDrift() < SuspendDriftThreshold)
             return;
 
@@ -103,8 +103,12 @@ public class ServerTimeSync : WorkerBase
         // the browser's Date.now() over the interop channel — this compensates the
         // circuit latency (gap the old serverNow one-way push left uncorrected).
         // WASM/MAUI: C# runs in the browser, so we NTP-probe the remote server via
-        // RPC. Either way `before`/`after` are the LOCAL clock around the round trip.
+        // RPC. Either way `before`/`after` are the LOCAL clock around the round trip —
+        // specifically ServerClock's own base clock, so the measured offset is valid
+        // for whatever base the host configured (clients use a wall-clock base, which
+        // keeps ServerClock correct across suspends; see ClientStartup.Initialize).
         var isServer = HostInfo.HostKind.IsServer();
+        var offsetBaseClock = isServer ? CpuClock : Clocks.ServerClock.BaseClock;
 
         // RTT is the wall-clock (CpuClock) span of the whole burst, not a per-call
         // Stopwatch delta: in the browser the Stopwatch/performance.now granularity
@@ -113,7 +117,7 @@ public class ServerTimeSync : WorkerBase
         var burstStart = CpuClock.Now;
         var offsets = new List<double>(BurstSize); // server − client, in ms
         for (var i = 0; i < BurstSize; i++) {
-            var before = CpuClock.Now.EpochOffset.TotalMilliseconds;
+            var before = offsetBaseClock.Now.EpochOffset.TotalMilliseconds;
             double remoteMs;
             try {
                 // ProbeTimeout keeps a probe hung on a half-dead connection from
@@ -130,7 +134,9 @@ public class ServerTimeSync : WorkerBase
             catch (Exception e) when (isServer && e is JSDisconnectedException or ObjectDisposedException) {
                 return; // Blazor circuit is gone
             }
-            var after = CpuClock.Now.EpochOffset.TotalMilliseconds;
+            var after = offsetBaseClock.Now.EpochOffset.TotalMilliseconds;
+            if (after < before) // A wall-clock base stepped back mid-probe
+                continue;
             if (after - before > 2000) // This call took too long
                 continue;
             var localMid = 0.5 * (before + after);
@@ -180,7 +186,8 @@ public class ServerTimeSync : WorkerBase
         }
 
         Stats.Set(new ServerClockSyncStats.Snapshot(
-            LastOffset, LastPrecision, RttEma, TimeSpan.FromSeconds(avgRtt), LastUpdatedAt, SyncCount));
+            LastOffset, LastPrecision, RttEma, TimeSpan.FromSeconds(avgRtt),
+            LastUpdatedAt, _lastUpdatedWallAt, SyncCount));
 
         try {
             // Always a Date-relative offset, never an absolute server timestamp: an
@@ -201,9 +208,9 @@ public class ServerTimeSync : WorkerBase
     private TimeSpan GetSuspendDrift()
     {
         // The wall clock keeps running through a device suspend while CpuClock
-        // (Stopwatch / CLOCK_MONOTONIC) does not, so the gap between the two
-        // elapsed spans since the last accepted sync equals the time slept since
-        // then — which is exactly the error ServerClock has accumulated.
+        // (Stopwatch / CLOCK_MONOTONIC) does not, so a gap between the two elapsed
+        // spans since the last accepted sync means a suspend or a wall-clock step
+        // happened — either way the offset deserves a fresh measurement.
         var wallElapsed = Clocks.SystemClock.Now - _lastUpdatedWallAt;
         var cpuElapsed = CpuClock.Now - LastUpdatedAt;
         return wallElapsed - cpuElapsed;

--- a/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
+++ b/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
@@ -210,10 +210,12 @@ public class ServerTimeSync : WorkerBase
         // The wall clock keeps running through a device suspend while CpuClock
         // (Stopwatch / CLOCK_MONOTONIC) does not, so a gap between the two elapsed
         // spans since the last accepted sync means a suspend or a wall-clock step
-        // happened — either way the offset deserves a fresh measurement.
+        // happened — either way the offset deserves a fresh measurement. Magnitude,
+        // not the signed value: a backward NTP step yields a negative gap, and the
+        // callers' >= threshold comparisons would never see it.
         var wallElapsed = Clocks.SystemClock.Now - _lastUpdatedWallAt;
         var cpuElapsed = CpuClock.Now - LastUpdatedAt;
-        return wallElapsed - cpuElapsed;
+        return (wallElapsed - cpuElapsed).Duration();
     }
 
     private static double Median(List<double> values)

--- a/tests/Streaming.UnitTests/LiveVideoStreamsTest.cs
+++ b/tests/Streaming.UnitTests/LiveVideoStreamsTest.cs
@@ -169,7 +169,8 @@ public class LiveVideoStreamsTest
         ClientStats.LayerCount(1000).Should().Be(ClientStats.MaxLayerCount);
         ClientStats.ByteRate(-1).Should().Be(0);
         ClientStats.ByteRate(long.MaxValue).Should().Be(ClientStats.MaxByteRate);
-        ClientStats.AudioLatency(TimeSpan.FromSeconds(-10)).Should().Be(TimeSpan.Zero);
+        ClientStats.AudioLatency(TimeSpan.FromSeconds(-10)).Should().Be(TimeSpan.FromSeconds(-10));
+        ClientStats.AudioLatency(TimeSpan.MinValue).Should().Be(-ClientStats.MaxAudioLatency);
         ClientStats.AudioLatency(TimeSpan.MaxValue).Should().Be(ClientStats.MaxAudioLatency);
         ClientStats.Quality(new ReceiveQuality(9999, isThumbnail: true))
             .Should().Be(new ReceiveQuality(ClientStats.MaxLayerId, isThumbnail: true));


### PR DESCRIPTION
## Problem

2026-08-12 dev call: a WASM peer's diag panel showed "Offset (JS) 20ms / source (C#) 1.3s". Investigation showed C#-side server time rides `CpuClock` (`performance.now` / `mach_absolute_time`), which **freezes during a system sleep** — every suspend left `ServerClock` stale by exactly the slept span until the next re-sync, and anything anchored in that window (listening `startAt`, `playAt` math, latency reports) baked the error in. The JS clock never had this problem because its offset is Date-relative.

The panel reading itself was also misleading: the C# row showed the CpuClock-relative measured offset, which legitimately diverges from the JS row by all accumulated sleep-stall since page load — so a *successful* post-sleep resync looked like a broken one.

## Changes

- **ClientStartup**: `MomentClockSet.Default` on WASM/MAUI now carries a `ServerClock` based on `SystemClock`; `ServerTimeSync` measures its offset against `ServerClock.BaseClock`, so the two always agree, and a probe sample is dropped if the wall clock steps back mid-probe. Sleep can no longer desync C# server time. Blazor Server hosts are untouched.
- **BlazorUICoreModule**: WASM registers `ServerTimeSync` as a singleton with a hosted-service alias — `AddHostedService` alone hid the type, so every `GetService<ServerTimeSync>()` call site (recording, video, walkie) got **null** and silently skipped `EnsureSynced` on WASM.
- **DeviceAwakeUI**: a detected wake triggers `EnsureSynced` immediately instead of waiting out the drift-check tick, which background-tab timer throttling can stretch far past its nominal 15s.
- **StartListeningPlayer**: forces a bounded `EnsureSynced` before capturing the `startAt` anchor rather than merely awaiting the first-ever sync.
- **Video diag panel**: the C# offset row is now wall-relative — directly comparable to the JS row, divergence means a real bug; new drift-since-sync row; sync age measured on the wall clock so it can't under-report across sleeps.
- **ClientStats**: audio latency is recorded signed (clamped to ±60s) — a stale-behind listener clock used to clamp to zero and self-mask in the `app_audio_latency_milliseconds` histogram.

## Safety

No Fusion-internal `ServerClock` consumers exist (checked), so the wall rebase only affects app code, where every consumer compares against server-issued timestamps and becomes *more* correct (incl. `TotpUI`/`SessionTokens` after sleeps). The only tradeoff: `ServerClock.Now` can step back a few ms on NTP adjustments; no consumer paces on it.

## Testing

- `UI.Blazor.App` + `App.Wasm` build clean.
- `Streaming.UnitTests` 13/13 incl. updated signed-clamp assertions.
- Field check after deploy: the panel's two offset rows should read near-identical on healthy clients; "drift since sync" ≠ 0 means a sleep/step happened since the last measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)