### PR TITLE
perf(chat): take range-meta round-trips out of the chat view's hot rebuild path

### DIFF
--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -1263,16 +1263,19 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             if (invChatEntry != null) {
                 InvalidateTiles(chatId, invChatEntry.LocalId, changeKind, invBoundToThreadHasChanged);
 
-                var entryTile = IdTileStack.LastLayer.GetTile(invChatEntry.LocalId);
-                _ = GetEntryRangeMeta(chatId, entryTile.Range.Start, default);
-
-                if (previousEntryId != 0 && !entryTile.Range.Contains(previousEntryId)) {
-                    var previousEntryIdTile = IdTileStack.LastLayer.GetTile(previousEntryId);
-                    _ = GetEntryRangeMeta(chatId, previousEntryIdTile.Range.Start, default);
-                }
-                if (nextEntryId != 0 && !entryTile.Range.Contains(nextEntryId)) {
-                    var nextIdTile = IdTileStack.LastLayer.GetTile(nextEntryId);
-                    _ = GetEntryRangeMeta(chatId, nextIdTile.Range.Start, default);
+                // Range meta is pure lid structure, so only changes that add or drop a lid can touch it.
+                // A content-only Update used to invalidate it anyway, which forced every tail-following
+                // client into a ~RTT range-meta refetch per utterance finalization and per message edit.
+                if (changeKind is ChangeKind.Create or ChangeKind.Remove || invBoundToThreadHasChanged) {
+                    var entryTile = IdTileStack.LastLayer.GetTile(invChatEntry.LocalId);
+                    if (previousEntryId != 0 && !entryTile.Range.Contains(previousEntryId)) {
+                        var previousEntryIdTile = IdTileStack.LastLayer.GetTile(previousEntryId);
+                        _ = GetEntryRangeMeta(chatId, previousEntryIdTile.Range.Start, default);
+                    }
+                    if (nextEntryId != 0 && !entryTile.Range.Contains(nextEntryId)) {
+                        var nextIdTile = IdTileStack.LastLayer.GetTile(nextEntryId);
+                        _ = GetEntryRangeMeta(chatId, nextIdTile.Range.Start, default);
+                    }
                 }
             }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -199,7 +199,7 @@ public partial class ChatUI
             using (Computed.BeginIsolation())
                 _ = BackgroundTask.Run(
                     () => PrefetchLoadZone(chatId, lastIdTiles, lastShowConversations, cancellationToken),
-                    Log, "Speculative load-zone prefetch failed.", CancellationToken.None);
+                    Log, "Speculative load-zone prefetch failed.", cancellationToken);
         }
 
         var chat = await chatTask.ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -106,6 +106,15 @@ public partial class ChatUI
     // would let a stale snapshot clobber accumulated entries.
     private readonly ConcurrentDictionary<ConversationId, bool> _knownConversationDefaultExpanded = new();
 
+    // Serve-stale caches for the meta phase of GetChatItemsInternal: per chat, the last fresh range-meta
+    // list, conversation tiles, and load zone. A rebuild whose meta is being refetched (typically because
+    // a new entry invalidated it) renders from these instead of waiting a round-trip; UseIfReady
+    // guarantees a follow-up rebuild from the fresh values.
+    private readonly ConcurrentDictionary<ChatId, List<ChatRangeMeta>> _lastChatRangeMetas = new();
+    private readonly ConcurrentDictionary<ChatId, Conversation[][]> _lastConversationTiles = new();
+    private readonly ConcurrentDictionary<ChatId, (List<Range<long>> IdTiles, bool ShowConversations)>
+        _lastLoadZones = new();
+
     public int HalfLoadLimit => BrowserInfo.IsMobile ? SecondTileSize : SecondTileSize * 2; // 20 for mobile
     public int LoadLimit => BrowserInfo.IsMobile ? SecondTileSize * 2 : SecondTileSize * 4; // 40 for mobile
 
@@ -179,6 +188,20 @@ public partial class ChatUI
         using (Computed.BeginIsolation())
             chatLidRangeTask = Chats.GetIdRange(Session, chatId, cancellationToken);
 
+        // A rebuild whose range meta was invalidated (typically by a new entry) almost always finds its
+        // load-zone tiles invalidated too, and would otherwise pay those round-trips back to back. Warm
+        // the tiles from the previous build's zone while the meta fetch is in flight - isolated, so a
+        // stale zone can't register dependencies; the dependency-registering pass below joins the same
+        // in-flight computations.
+        if (!isPrefetch && !chatRangeMetaListTask.IsCompleted
+            && _lastLoadZones.TryGetValue(chatId, out var lastLoadZone)) {
+            var (lastIdTiles, lastShowConversations) = lastLoadZone;
+            using (Computed.BeginIsolation())
+                _ = BackgroundTask.Run(
+                    () => PrefetchLoadZone(chatId, lastIdTiles, lastShowConversations, cancellationToken),
+                    Log, "Speculative load-zone prefetch failed.", CancellationToken.None);
+        }
+
         var chat = await chatTask.ConfigureAwait(false);
         if (chat == null) {
             // Everything above is already in flight, so bailing out here would leave those tasks unobserved.
@@ -251,11 +274,21 @@ public partial class ChatUI
                 : default;
         var liveAt = CpuTimestamp.Now;
 
-        var chatRangeMetaList = (await chatRangeMetaListTask.ConfigureAwait(false))
-            .OrderBy(m => m.LidRange.Start)
-            .ThenByDescending(m => m.LidRange.Size()) // ChatRangeMeta can be overlapping, so we need to keep the largest
-            .EnsureMonotonic(Comparer<ChatRangeMeta>.Create((a, b) => a.LidRange.Start.CompareTo(b.LidRange.Start)))
-            .ToList();
+        // Fresh by construction: the view awaited GetIdRange right before calling in, so this is a cache
+        // hit even on the rebuild a new entry just triggered - which is what makes the tail synthesis in
+        // UseRangeMetaOrLastKnown sound.
+        var chatLidRange = await chatLidRangeTask.ConfigureAwait(false);
+        var metaIdTilesRange = metaIdTiles.Count > 0
+            ? new Range<long>(metaIdTiles[0].Range.Start, metaIdTiles[^1].Range.End)
+            : default;
+        var lastKnownRangeMetaList = UseRangeMetaOrLastKnown(
+            chatId, chatRangeMetaListTask, metaIdTilesRange, chatLidRange, isPrefetch);
+        var chatRangeMetaList = lastKnownRangeMetaList
+            ?? (await chatRangeMetaListTask.ConfigureAwait(false))
+                .OrderBy(m => m.LidRange.Start)
+                .ThenByDescending(m => m.LidRange.Size()) // ChatRangeMeta can be overlapping, so we need to keep the largest
+                .EnsureMonotonic(Comparer<ChatRangeMeta>.Create((a, b) => a.LidRange.Start.CompareTo(b.LidRange.Start)))
+                .ToList();
 
         var showConversations = (chat.IsSummarized ?? false) || liveConversation != null;
 
@@ -263,7 +296,12 @@ public partial class ChatUI
         // expandedConversations below is the resolved "render expanded" set, not the raw override set.
         IImmutableSet<ConversationId> defaultExpanded = ImmutableHashSet<ConversationId>.Empty;
         IImmutableSet<ConversationId> expandedConversations = ImmutableHashSet<ConversationId>.Empty;
-        var conversationTiles = await conversationTilesTask.ConfigureAwait(false);
+        // A one-build-stale value is harmless here: conversation tiles only fold into the persistent
+        // expansion cache below, while the conversation ranges the layout uses come from the range meta.
+        var conversationTiles = UseOrLastKnown(_lastConversationTiles, chatId, conversationTilesTask, isPrefetch)
+            ?? await conversationTilesTask.ConfigureAwait(false);
+        if (conversationTilesTask.IsCompletedSuccessfully)
+            _lastConversationTiles[chatId] = conversationTilesTask.Result;
         if (showConversations) {
             // Fold the loaded tiles' IsExpandedByDefault into the persistent cache (loaded tiles are
             // authoritative), then resolve defaultExpanded from the cache - so a conversation whose tile
@@ -332,7 +370,6 @@ public partial class ChatUI
                 hiddenLiveTailRange = default;
         }
 
-        var chatLidRange = await chatLidRangeTask.ConfigureAwait(false);
         if (chatRangeMetaList.Count == 0)
             return ChatItems.Empty;
 
@@ -360,31 +397,14 @@ public partial class ChatUI
                 chatRangeMetaList.Add(nextChatRangeMeta);
         }
 
-        // Prefetch tiles for the loaded id ranges
-        {
-            await Task.Run(async () => {
-                // GetTile widens its request by one tile for the first tile (prevMessage == null, so it
-                // needs the preceding entry to render the block start). Prefetching only idTiles left
-                // that one always uncached, costing a serial round-trip on every rebuild.
-                var prefetchEntriesTask = idTiles
-                    .SelectMany((r, i) => IdTileStack.FirstLayer.GetCoveringTiles(
-                        i == 0 ? r.MoveStart(-IdTileStack.FirstLayer.TileSize) : r))
-                    .Select(t => t.Range)
-                    .Where(r => r.Start >= 0)
-                    .EnsureMonotonic()
-                    .Select(r => Chats.GetTile(Session, chatId, r, cancellationToken))
-                    .Collect(ApiConstants.Concurrency.High, cancellationToken);
-                var prefetchConversationsTask = showConversations
-                    ? idTiles
-                        .Select(r => ServerIdTileStack.LastLayer.GetTile(r.Start).Range)
-                        .EnsureMonotonic()
-                        .Select(r => Conversations.GetTile(Session, chatId, r, cancellationToken))
-                        .Collect(ApiConstants.Concurrency.High, cancellationToken)
-                    : Task.CompletedTask;
-                var prefetchChatInfoTask = PrefetchChatInfo(chatId, cancellationToken);
-                await Task.WhenAll(prefetchEntriesTask, prefetchConversationsTask, prefetchChatInfoTask).ConfigureAwait(false);
-            }, cancellationToken).ConfigureAwait(false);
-        }
+        // A stand-in list is not cached: caching it would compound the synthesis on the next rebuild,
+        // and the fresh result this build is shadowing lands in the follow-up rebuild anyway.
+        if (lastKnownRangeMetaList == null && !isPrefetch)
+            _lastChatRangeMetas[chatId] = chatRangeMetaList;
+
+        if (!isPrefetch)
+            _lastLoadZones[chatId] = (idTiles, showConversations);
+        await PrefetchLoadZone(chatId, idTiles, showConversations, cancellationToken).ConfigureAwait(false);
         var loadAt = CpuTimestamp.Now;
 
         var conversationView = new ConversationViewState(
@@ -1289,6 +1309,106 @@ public partial class ChatUI
 
     private static void RecordPhase(long elapsedMs, string phase)
         => GetChatItemsDuration.Record(elapsedMs, new KeyValuePair<string, object?>("phase", phase));
+
+    private Task PrefetchLoadZone(
+        ChatId chatId,
+        List<Range<long>> idTiles,
+        bool showConversations,
+        CancellationToken cancellationToken)
+        => Task.Run(async () => {
+            // GetTile widens its request by one tile for the first tile (prevMessage == null, so it
+            // needs the preceding entry to render the block start). Prefetching only idTiles left
+            // that one always uncached, costing a serial round-trip on every rebuild.
+            var prefetchEntriesTask = idTiles
+                .SelectMany((r, i) => IdTileStack.FirstLayer.GetCoveringTiles(
+                    i == 0 ? r.MoveStart(-IdTileStack.FirstLayer.TileSize) : r))
+                .Select(t => t.Range)
+                .Where(r => r.Start >= 0)
+                .EnsureMonotonic()
+                .Select(r => Chats.GetTile(Session, chatId, r, cancellationToken))
+                .Collect(ApiConstants.Concurrency.High, cancellationToken);
+            var prefetchConversationsTask = showConversations
+                ? idTiles
+                    .Select(r => ServerIdTileStack.LastLayer.GetTile(r.Start).Range)
+                    .EnsureMonotonic()
+                    .Select(r => Conversations.GetTile(Session, chatId, r, cancellationToken))
+                    .Collect(ApiConstants.Concurrency.High, cancellationToken)
+                : Task.CompletedTask;
+            var prefetchChatInfoTask = PrefetchChatInfo(chatId, cancellationToken);
+            await Task.WhenAll(prefetchEntriesTask, prefetchConversationsTask, prefetchChatInfoTask).ConfigureAwait(false);
+        }, cancellationToken);
+
+    // Serves the last fresh range-meta list while a refetch is in flight, so a rebuild triggered by a
+    // new entry renders before the round-trip instead of after it. The tail is synthesized from
+    // chatLidRange: GetIdRange is the subscribed new-entry signal and the view just read it, so lids past
+    // the cached tail's entry ranges are known to exist before any meta describes them. A lid removed
+    // meanwhile is harmless - the synthesized ranges over-claim, and GetTile (the content source) simply
+    // doesn't return it. UseIfReady invalidates the enclosing computed when the fresh result lands, so a
+    // build made from a stand-in is always followed by one made from fresh meta.
+    private List<ChatRangeMeta>? UseRangeMetaOrLastKnown(
+        ChatId chatId,
+        Task<ChatRangeMeta[]> freshMetaTask,
+        Range<long> metaIdTilesRange,
+        Range<long> chatLidRange,
+        bool isPrefetch)
+    {
+        // The first read still awaits - standing in on nothing would render an empty chat. A failed fetch
+        // also awaits: UseIfReady doesn't invalidate on failure, so standing in for one would pin the
+        // stale value with no retry trigger, while awaiting propagates the error exactly as it did before.
+        var computed = Computed.Current;
+        if (isPrefetch || computed == null || metaIdTilesRange.IsEmpty
+            || freshMetaTask.IsFaulted || freshMetaTask.IsCanceled
+            || !_lastChatRangeMetas.TryGetValue(chatId, out var lastKnown)
+            || lastKnown.Count == 0)
+            return null;
+
+        // UseIfReady before anything else: checking IsCompleted separately would race - a task completing
+        // between the check and the hookup would serve a stand-in that nothing ever invalidates.
+        if (freshMetaTask.UseIfReady(null!, computed) != null)
+            return null;
+
+        var first = lastKnown[0];
+        var last = lastKnown[^1];
+        if (first.LidRange.Start > metaIdTilesRange.Start && first.PreviousLidTileStart != null)
+            return null; // The query reaches above the cached span; only the fresh fetch knows that part
+
+        // Copied so the meta walk in GetChatItemsInternal can't mutate the cached list
+        var result = new List<ChatRangeMeta>(lastKnown);
+        var targetEnd = Math.Min(metaIdTilesRange.End, chatLidRange.End);
+        if (last.NextLidTileStart == null) {
+            // The cached list ended at the chat's tail, so every lid past its entry ranges is a new entry
+            var entryRanges = last.EntryLidRanges;
+            if (entryRanges.Length == 0)
+                return null; // A tail with no entries can't anchor the extension
+
+            if (targetEnd > entryRanges[^1].End)
+                result[^1] = last with {
+                    LidRange = new Range<long>(last.LidRange.Start, Math.Max(last.LidRange.End, targetEnd)),
+                    EntryLidRanges = [..entryRanges[..^1], new Range<long>(entryRanges[^1].Start, targetEnd)],
+                };
+        }
+        else if (last.LidRange.End < targetEnd)
+            return null; // The query reaches below the cached span; only the fresh fetch knows that part
+
+        return result;
+    }
+
+    private static T? UseOrLastKnown<T>(
+        ConcurrentDictionary<ChatId, T> lastKnownValues,
+        ChatId chatId,
+        Task<T> task,
+        bool isPrefetch)
+        where T : class
+    {
+        // The first read still awaits (same contract as LiveSessionUI.UseOrLastKnown), and so does a
+        // failed fetch - standing in for one would pin the stale value with no retry trigger.
+        var computed = Computed.Current;
+        if (isPrefetch || computed == null || task.IsFaulted || task.IsCanceled
+            || !lastKnownValues.TryGetValue(chatId, out var lastKnown))
+            return null;
+
+        return task.UseIfReady(null!, computed) ?? lastKnown;
+    }
 
     private Task PrefetchChatInfo(ChatId chatId, CancellationToken cancellationToken)
         // DebugLog?.LogDebug("PrefetchTiles: {ChatId} {IdRange}", chatId, idRange);

--- a/tests/Chat.UI.Blazor.IntegrationTests/ChatUICacheTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/ChatUICacheTest.cs
@@ -31,7 +31,8 @@ public sealed class ChatUICacheTest(ChatAppHostFixture fixture, ITestOutputHelpe
         var author = await Tester.GetOwnAuthor(chat.Id).Require();
         var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
         await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, true, CancellationToken.None);
-        await liveBackend.OnStreamRegistered(chat.Id, AuthorId.New(chat.Id, 777_072), null, true, true, CancellationToken.None);
+        await liveBackend
+            .OnStreamRegistered(chat.Id, AuthorId.New(chat.Id, 777_072), null, true, true, CancellationToken.None);
         var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
         live!.SessionStartedAt.Should().NotBeNull("the session must latch or this test doesn't bite");
 
@@ -53,5 +54,31 @@ public sealed class ChatUICacheTest(ChatAppHostFixture fixture, ITestOutputHelpe
         // assert
         cRangeMeta.IsConsistent().Should()
             .BeTrue("live-session churn must not force the chat view to reload its range metadata");
+    }
+
+    [Fact]
+    public async Task RangeMetaSurvivesEntryContentUpdate()
+    {
+        // arrange - mirrors the transcription pipeline: ChangeEntry Create at utterance start,
+        // ChangeEntry Update at finalization
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "chat-ui-cache-test-update");
+        var streamingEntry = await Tester.CreateStreamingEntry(chat.Id, Languages.English);
+        var entryLid = streamingEntry.ChatEntrySlim.Id.LocalId;
+        var tileStart = ChatUI.ServerIdTileStack.LastLayer.GetTile(entryLid).Start;
+        var cRangeMeta = await Computed.Capture(
+            () => Tester.Chats.GetChatRangeMeta(Tester.Session, chat.Id, tileStart, CancellationToken.None));
+        cRangeMeta.IsConsistent().Should().BeTrue();
+
+        // act - a content-only update; entry lids don't change, so the range meta can't either
+        await Tester.FinalizeStreamingEntry(streamingEntry, "final transcript");
+
+        // assert
+        cRangeMeta.IsConsistent().Should()
+            .BeTrue("a content update cannot change lid structure, so range meta must stay cached");
+
+        // positive control - a new entry does change lid structure and must invalidate it
+        await Tester.CreateTextEntry(chat.Id, "next entry");
+        await cRangeMeta.WhenInvalidated(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
     }
 }

--- a/tests/Chat.UI.Blazor.IntegrationTests/ChatUICacheTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/ChatUICacheTest.cs
@@ -1,6 +1,7 @@
 using ActualChat.Live;
 using ActualChat.Streaming;
 using ActualChat.Testing.Host;
+using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
 
 namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
@@ -66,8 +67,11 @@ public sealed class ChatUICacheTest(ChatAppHostFixture fixture, ITestOutputHelpe
         var streamingEntry = await Tester.CreateStreamingEntry(chat.Id, Languages.English);
         var entryLid = streamingEntry.ChatEntrySlim.Id.LocalId;
         var tileStart = ChatUI.ServerIdTileStack.LastLayer.GetTile(entryLid).Start;
+        // The backend computed, not the front GetChatRangeMeta: the latter also composes the
+        // conversation range meta, which the summarizer may legitimately invalidate mid-test.
+        var chatsBackend = AppHost.Services.GetRequiredService<IChatsBackend>();
         var cRangeMeta = await Computed.Capture(
-            () => Tester.Chats.GetChatRangeMeta(Tester.Session, chat.Id, tileStart, CancellationToken.None));
+            () => chatsBackend.GetEntryRangeMeta(chat.Id, tileStart, CancellationToken.None));
         cRangeMeta.IsConsistent().Should().BeTrue();
 
         // act - a content-only update; entry lids don't change, so the range meta can't either
@@ -80,5 +84,43 @@ public sealed class ChatUICacheTest(ChatAppHostFixture fixture, ITestOutputHelpe
         // positive control - a new entry does change lid structure and must invalidate it
         await Tester.CreateTextEntry(chat.Id, "next entry");
         await cRangeMeta.WhenInvalidated(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task NewEntryRendersWhileRangeMetaRefetchIsInFlight()
+    {
+        // arrange - a warm build inside a computed populates ChatUI's last-known meta caches
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "chat-ui-cache-test-stale-meta");
+        await Tester.CreateTextEntries(chat.Id, "warmup", 3);
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var items = await BuildChatItems(chatUI, chat.Id);
+        items.Items.Should().NotBeEmpty();
+
+        // act - the new entry invalidates the range meta, so the next build finds its refetch in flight
+        // and must render from the last-known list extended to the fresh id range
+        var newEntry = await Tester.CreateTextEntry(chat.Id, "the new entry");
+
+        // assert - whichever path the rebuild takes (stand-in meta or a fresh fetch that won the race),
+        // the new entry must be in the built items right away
+        items = await BuildChatItems(chatUI, chat.Id);
+        items.Items
+            .SelectMany(m => m is ChatEntryAuthorGroup group ? group.Items : [m as ChatEntryMessage])
+            .Where(m => m?.Entry.LocalId == newEntry.Id.LocalId)
+            .Should().NotBeEmpty("a new entry must render on the very first rebuild after it lands");
+    }
+
+    // Private methods
+
+    private async Task<ChatItems> BuildChatItems(ChatUI chatUI, ChatId chatId)
+    {
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chatId, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var computed = await Computed.New(
+                Tester.ScopedAppServices,
+                ct => chatUI.GetChatItems(chatId, query, 0, ct))
+            .Update();
+        computed.HasError.Should().BeFalse();
+        return computed.Value;
     }
 }


### PR DESCRIPTION
## What

Removes the range-meta round-trips from the chat view's hot rebuild path — the `meta` phase that dominated slow `GetChatItems` builds during live talk (200–350 ms in ~90% of >250 ms builds in the 2026-08-12 dev-session Sentry breadcrumbs, with every live sub-phase at 0 and `build` at ~2 ms).

Three changes, one per concern:

1. **Server — stop invalidating range meta on content-only updates** (`ChatsBackend.OnChangeEntry`). Range meta is pure lid structure, but the handler invalidated `GetEntryRangeMeta` on every change kind, while `InvalidateTiles` already covers exactly the kinds that can alter lids (Create/Remove/thread move). Every utterance finalization and every message edit forced all tail-following clients into a ~RTT `GetChatRangeMeta` refetch for a value that could not have changed.

2. **Client — serve last-known range meta while its refetch is in flight** (`ChatUI.GetChatItemsInternal`). Same `UseIfReady` pattern that already keeps the live phase at zero: the last fresh range-meta list (and conversation tiles) stand in, and the enclosing computed is invalidated when the fresh values land, so a stand-in build is always followed by a fresh one. The stand-in tail is synthesized from `GetIdRange` — the subscribed new-entry signal the view reads fresh on every rebuild — so a new entry renders on the very first rebuild, even across a server-tile boundary. Failed fetches still await (and propagate) exactly as before.

3. **Client — speculative load-zone warm-up.** When a rebuild finds the meta refetch in flight, the previous build's load-zone tiles are prefetched concurrently (dependency-isolated), so on the paths that must await fresh meta the tile round-trip overlaps it instead of following it.

## Why

Phase-decomposed telemetry from the 8:01–9:18 MSK dev session (2026-08-12, chat `s-P7oRNDTeHM-052w3sgrad`, release 2.16.389) pinned the slow-build cost to `meta` + `load` paying serial RTTs on every entry-driven rebuild; server-side GMP shows the same phases flat at ~30 ms on a Blazor Server circuit, so the cost is client round-trips, not server compute.

## Tests

- `RangeMetaSurvivesEntryContentUpdate` — mirrors the transcription pipeline (`ChangeEntry` Create → Update); pins that a content update keeps `GetEntryRangeMeta` cached and a Create still invalidates it.
- `NewEntryRendersWhileRangeMetaRefetchIsInFlight` — builds inside a computed (the serve-stale path), then asserts a brand-new entry is present on the very first rebuild after it lands, whichever path the race takes.
- Full `Chat.UI.Blazor.IntegrationTests` and `Chat.IntegrationTests` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
