### PR TITLE
fix(location): end location tracking as soon as the share ends

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Location/AndroidLocationForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Location/AndroidLocationForegroundService.cs
@@ -36,14 +36,22 @@ public sealed class AndroidLocationForegroundService : Service, ILocationListene
 
     public override StartCommandResult OnStartCommand(Intent? intent, StartCommandFlags flags, int startId)
     {
-        if ((intent?.Action ?? "") != ActionStart)
+        if ((intent?.Action ?? "") != ActionStart) {
+            // A restart delivers a null intent, so tracking can't resume - the accuracy lived in the extras.
+            // Lingering would pin the process behind a "Sharing your location" FGS that requests no fixes and
+            // nothing stops: LiveLocationReporter, which re-arms this service, only runs once the UI renders.
+            StopForeground(StopForegroundFlags.Remove);
+            StopSelf();
             return StartCommandResult.NotSticky;
+        }
 
         var accuracy = (GeoTrackingAccuracy)intent!.Extras!
             .GetInt(IntentExtras.Accuracy, (int)GeoTrackingAccuracy.Balanced);
         StartForeground1(BuildNotification());
         StartLocationUpdates(accuracy);
-        return StartCommandResult.Sticky;
+        // Not sticky: sharing is driven by LiveLocationReporter, which resumes its persisted
+        // shares on the next launch and starts this service again.
+        return StartCommandResult.NotSticky;
     }
 
     public void OnLocationChanged(Android.Locations.Location location)

--- a/src/dotnet/App.Maui/Platforms/Android/Location/AndroidLocationTracker.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Location/AndroidLocationTracker.cs
@@ -20,8 +20,7 @@ public sealed class AndroidLocationTracker : MauiLocationTrackerBase, IDisposabl
             return;
 
         IsTracking = false;
-        var intent = new Intent(Context, typeof(AndroidLocationForegroundService));
-        Context.StopService(intent);
+        StopService();
     }
 
     public override async Task Start(CancellationToken cancellationToken)
@@ -48,13 +47,13 @@ public sealed class AndroidLocationTracker : MauiLocationTrackerBase, IDisposabl
 
     public override Task Stop(CancellationToken cancellationToken)
     {
-        if (!IsTracking)
-            return Task.CompletedTask;
-
-        IsTracking = false;
-        SetCached(null);
-        var intent = new Intent(Context, typeof(AndroidLocationForegroundService));
-        Context.StopService(intent);
+        if (IsTracking) {
+            IsTracking = false;
+            SetCached(null);
+        }
+        // Unconditional: the service outlives the process that started it, so this instance may have
+        // to stop one it never started - and this is the only path that runs when sharing ends.
+        StopService();
         return Task.CompletedTask;
     }
 
@@ -65,4 +64,9 @@ public sealed class AndroidLocationTracker : MauiLocationTrackerBase, IDisposabl
 
     internal static void ReportError(GeoTrackingError error)
         => _instance?.SetError(error);
+
+    // Private methods
+
+    private static void StopService()
+        => Context.StopService(new Intent(Context, typeof(AndroidLocationForegroundService)));
 }

--- a/src/dotnet/App.Maui/Services/MauiLocationTracker.cs
+++ b/src/dotnet/App.Maui/Services/MauiLocationTracker.cs
@@ -7,9 +7,21 @@ namespace ActualChat.App.Maui.Services;
 /// Foreground-only (no background-service integration), so it's used on platforms that
 /// don't need background sharing (Windows); Android/iOS use native background-capable trackers.
 /// </summary>
-public sealed class MauiLocationTracker(AppUIHub hub) : MauiLocationTrackerBase(hub)
+public sealed class MauiLocationTracker(AppUIHub hub) : MauiLocationTrackerBase(hub), IDisposable
 {
     private readonly IGeolocation _geolocation = Geolocation.Default;
+
+    public void Dispose()
+    {
+        if (!IsTracking)
+            return;
+
+        // Geolocation.Default is process-wide, so both the session and these handlers outlive the
+        // scope this tracker belongs to - a recycled scope would leak them.
+        IsTracking = false;
+        DetachHandlers();
+        _geolocation.StopListeningForeground();
+    }
 
     public override async Task Start(CancellationToken cancellationToken)
     {
@@ -31,8 +43,7 @@ public sealed class MauiLocationTracker(AppUIHub hub) : MauiLocationTrackerBase(
             // Roll back so a later Start can retry from a clean state.
             IsTracking = false;
             SetError(ToTrackingError(e));
-            _geolocation.LocationChanged -= OnLocationChanged;
-            _geolocation.ListeningFailed -= OnListeningFailed;
+            DetachHandlers();
             throw;
         }
     }
@@ -44,11 +55,12 @@ public sealed class MauiLocationTracker(AppUIHub hub) : MauiLocationTrackerBase(
 
         IsTracking = false;
         SetCached(null);
-        _geolocation.LocationChanged -= OnLocationChanged;
-        _geolocation.ListeningFailed -= OnListeningFailed;
+        DetachHandlers();
         _geolocation.StopListeningForeground();
         return Task.CompletedTask;
     }
+
+    // Private methods
 
     private void OnLocationChanged(object? sender, GeolocationLocationChangedEventArgs e)
         => SetCached(e.Location.ToGeoFix());
@@ -58,12 +70,17 @@ public sealed class MauiLocationTracker(AppUIHub hub) : MauiLocationTrackerBase(
         // MAUI stops the underlying session before raising this, so there's no self-heal:
         // reset tracking state and detach so a later Start re-arms from scratch.
         IsTracking = false;
-        _geolocation.LocationChanged -= OnLocationChanged;
-        _geolocation.ListeningFailed -= OnListeningFailed;
+        DetachHandlers();
         SetError(e.Error switch {
             GeolocationError.Unauthorized => GeoTrackingError.PermissionDenied,
             GeolocationError.PositionUnavailable => GeoTrackingError.PositionUnavailable,
             _ => throw new ArgumentOutOfRangeException(nameof(e.Error), e.Error, null),
         });
+    }
+
+    private void DetachHandlers()
+    {
+        _geolocation.LocationChanged -= OnLocationChanged;
+        _geolocation.ListeningFailed -= OnListeningFailed;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/Location/LiveLocationReporter.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LiveLocationReporter.cs
@@ -167,7 +167,7 @@ public class LiveLocationReporter : UIWorkerBase<AppUIHub>, IComputeService
     }
 
     private ValueTask<ActiveShare[]> DropExpired(ActiveShare[] shares, CancellationToken cancellationToken)
-        => new (shares.Where(x => x.ExpiresAt > ServerNow).ToArray());
+        => new (WithoutExpired(shares));
 
     private async Task ReportLoop(ActiveShare[] activeShares, CancellationToken cancellationToken)
     {
@@ -182,15 +182,24 @@ public class LiveLocationReporter : UIWorkerBase<AppUIHub>, IComputeService
         await Tracker.Start(cancellationToken).ConfigureAwait(false);
         var timeout = activeShares.Max(x => x.ExpiresAt) - ServerNow;
         using var cts = cancellationToken.CreateLinkedTokenSource(timeout < MaxReportLoopTimeout ? timeout : null);
-        // Waits for the first live fix, so the cycle below doesn't re-post the cached one as fresh.
-        await Tracker.Get(true, cts.Token).ConfigureAwait(false);
-        await AsyncChain.From(ReportForChats)
-            .Log(LogLevel.Debug, Log)
-            .RetryForever(RetryDelaySeq.Exp(0.5, 10), Log)
-            .AppendDelay(Constants.Location.UpdatePeriod)
-            .CycleForever()
-            .RunIsolated(cts.Token)
-            .ConfigureAwait(false);
+        try {
+            // Waits for the first live fix, so the cycle below doesn't re-post the cached one as fresh.
+            await Tracker.Get(true, cts.Token).ConfigureAwait(false);
+            await AsyncChain.From(ReportForChats)
+                .Log(LogLevel.Debug, Log)
+                .RetryForever(RetryDelaySeq.Exp(0.5, 10), Log)
+                .AppendDelay(Constants.Location.UpdatePeriod)
+                .CycleForever()
+                .RunIsolated(cts.Token)
+                .ConfigureAwait(false);
+        }
+        finally {
+            // cts fired on its own = the last share expired. Nothing re-reads _shares on a timer, so
+            // without this DispatchShares never sees the change - and the tracker (on Android a
+            // foreground service that outlives this loop) would run on until the next launch.
+            if (!cancellationToken.IsCancellationRequested)
+                DropExpiredShares();
+        }
         return;
 
         async Task ReportForChats(CancellationToken cancellationToken1) {
@@ -283,6 +292,17 @@ public class LiveLocationReporter : UIWorkerBase<AppUIHub>, IComputeService
                     : x)
                 .ToArray();
     }
+
+    private void DropExpiredShares()
+    {
+        // The server ends an expired share on its own - its LiveDuration is what ListLive filters by -
+        // so unlike StopSharing this needs no StopServerShares call.
+        lock (_lock)
+            _shares.Value = WithoutExpired(_shares.Value);
+    }
+
+    private ActiveShare[] WithoutExpired(ActiveShare[] shares)
+        => shares.Where(x => x.ExpiresAt > ServerNow).ToArray();
 
     // Nested types
 


### PR DESCRIPTION
## Why

Live location tracking kept running long after the share that justified it was over.

Found on an attached Android device: the location foreground service had been up for **~22 hours with no share behind it**, holding the process at `PERCEPTIBLE_APP_ADJ` (`curProcState=4`, `oom_score_adj=200`) so it never unloaded — with a silent "Sharing your location" notification nobody notices, because the channel is `IMPORTANCE_LOW` with no body text and no tap action.

## What was wrong

Three independent causes, all ending the same way.

**1. Sticky restart left a zombie service** — `AndroidLocationForegroundService`

`OnStartCommand` returned `START_STICKY`, so AMS revived the service after a process kill with a **null intent**. The guard then returned without stopping it, leaving a service that was foreground — notification and all — while requesting no location fixes at all.

Nothing could ever reap it: a service-only restart creates no `MainActivity` → Blazor never renders → `AppScopedServiceStarter.AfterFirstRender` never runs → `LiveLocationReporter.Start()` never runs. So the service had to refuse to linger on its own.

**2. `Stop()` could not reap a leftover** — `AndroidLocationTracker`

`Stop()` early-returned on `!IsTracking`. That flag is in-memory, so a fresh process always read `false` and could never stop a service left behind by the previous one — even though `DispatchShares` calls `Tracker.Stop()` at exactly the moment we want it gone.

**3. Expiry never stopped tracking** — `LiveLocationReporter` (all platforms)

`ReportLoop` ends when its linked token fires at `ExpiresAt`, but nothing rewrote `_shares`. The `DropExpired` corrector runs only inside `StoredState.KvasOptions.Read`, i.e. once at load — so `DispatchShares` saw no change and never called `Tracker.Stop()`.

Three of the four durations in `Constants.Location.Durations` are finite (15 min / 1 h / 8 h), so this was the common path. On Android it left GPS updates registered; on iOS it left `StartUpdatingLocation` running with `AllowsBackgroundLocationUpdates = true`, so the app kept claiming background running time and showing the blue location indicator indefinitely.

## The fixes

- **`AndroidLocationForegroundService.OnStartCommand`** — `NotSticky` on the success path so it is never revived behind the app's back, plus `StopForeground(Remove)` + `StopSelf()` on the unexpected-intent path for an instance the system revives anyway. Mirrors the existing pattern in `AndroidAudioWidgetForegroundService`.
- **`AndroidLocationTracker.Stop`** — `StopService()` now runs unconditionally. `Dispose()` keeps its `IsTracking` guard **on purpose**: scope teardown isn't "sharing ended", and going unconditional there would let a disposing old scope kill the service an incoming scope just started.
- **`LiveLocationReporter.ReportLoop`** — a `finally` drops expired shares when the loop ends on its own timeout; `!cancellationToken.IsCancellationRequested` distinguishes expiry from "worker replaced / shutting down". No `StopServerShares` call needed — the server filters by `LiveDuration` in `ListLive`, unlike an early stop where the id lives only on the device.
- **`MauiLocationTracker` (Windows)** — same class of leak, found while auditing the other platforms. It implemented neither `IDisposable` nor `IAsyncDisposable`, and `UIServiceBase` only implements `IHasDisposeStatus`, so DI never disposed it — while `Geolocation.Default` is a process-wide singleton that kept the session and both handlers alive across a scope recycle (a normal event: `MauiWebView.SetScopedServices`/`ResetScopedServices`, and `MauiLivenessProbe` rebuilding the WebView).

## iOS

No change needed. `CLLocationManager` is in-process; standard `StartUpdatingLocation` (unlike significant-change or region monitoring) does not relaunch a terminated app; and `DisposeAsync` already tears the manager down unconditionally. iOS was affected only by cause 3, which the shared fix covers.

## Testing

- `dotnet build src/dotnet/App.Maui/App.Maui.csproj -f net11.0-android` — 0 errors, no new warnings
- `dotnet build src/dotnet/App.Maui/App.Maui.csproj -f net11.0-windows10.0.22621.0` — 0 errors, no new warnings
- **Not yet verified on a device.** Confirming the Android fix needs a fresh install, which force-stops the app; the device under investigation carries the release-signed `chat.actual.app`.

## Follow-ups (not in this PR)

- `RestartTrackerIfBroken` is a no-op on Android: `Tracker.Start` early-returns while `IsTracking` is true, and the `SecurityException` from a denied permission is caught inside the *service*, so it never clears the tracker's flag. The self-heal described at `LiveLocationReporter.cs:207-210` only works on iOS/Windows.
- `MauiLocationTracker.Start` attaches its handlers and sets `IsTracking = true` before an `await` that sits outside the `try`; if that await throws (cancellation), the tracker is left marked tracking with nothing listening. Self-corrects on the next `Stop()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6uPece6vrHrxr6TpQxX6w
