### PR TITLE
perf(ui): cut :has() selector matching on iOS

### DIFF
--- a/docs/ios-specific.md
+++ b/docs/ios-specific.md
@@ -712,6 +712,39 @@ per-binary attribution still are, and were enough.
 `sample-time` is the schema *tag*; the column mnemonic is `time`, in nanoseconds. Bucketing
 by the wrong one yields all-zero bins.
 
+### `xctrace` symbolication fails silently — symbolicate the export yourself
+
+`xctrace` sometimes records a trace whose frames are bare addresses (`0x12021f695`) with the
+binary resolving to `?`. It exits 0, the export is full size, and every symbol-matching
+analysis then reports **0 ms for everything** — a broken capture that reads exactly like a
+free lunch. On one afternoon this hit two of four arms in a run, then every capture after
+it; it is not tied to the workload, the app, the screen state, or the arm. `xctrace
+symbolicate` cannot repair it after the fact ("No dSYMs were found or relevant to this
+trace"), and neither can re-exporting.
+
+It does not matter, because **the export still carries everything needed to resolve the
+addresses**: each `<binary>` element keeps its `name`, `UUID`, `path` and — crucially —
+`load-addr`, and each `<frame>` keeps `addr`. So batch the addresses per binary through
+`atos` against the DeviceSupport symbol cache:
+
+```bash
+atos -o "$SYMROOT/System/Library/PrivateFrameworks/WebCore.framework/WebCore" \
+     -arch arm64e -l 0x1b6b24000   # load-addr from the <binary> element
+```
+
+`tmp/ios-profiling/symtime2.py` on the Mac does this: it resolves only the binaries you ask
+about (WebCore/WebKit/JavaScriptCore by default), so one `atos` call per binary covers a
+whole trace. It took a capture from 96% unresolved to 5%, and on a trace that `xctrace` had
+symbolicated correctly it reproduced that tool's numbers **to the digit** (801 ms / 8.39%),
+which is what makes it trustworthy.
+
+Two guards worth keeping in any analysis script, because both failure modes are silent:
+
+- **Report the unresolved fraction and refuse to print numbers above ~20%.** A capture that
+  cannot be symbolicated must fail loudly, not score 0.00% on every pattern.
+- **Pin the analysis to one pid.** Matching the process by substring silently sums two
+  `WebContent` instances when a stale container is alive - see hygiene below.
+
 ### Measurement hygiene
 
 - **Assert exactly one `ActualChat.app/ActualChat` process before trusting any number.** iOS
@@ -720,6 +753,11 @@ by the wrong one yields all-zero bins.
   anything whose container UUID isn't the one you just installed.
 - **A live call is not a repeatable workload.** Two captures of an *identical* build differed
   by 10% (1.235 vs 1.365 cores) - larger than most effects worth chasing.
+- **Most rendering work needs DOM churn, not a call.** Style-invalidation costs are paid per
+  mutation, so a call is only a convenient mutation firehose. A driver injected over the
+  WebView debugger - append/remove one off-screen node at 20 Hz via `setInterval`, so it keeps
+  running after the debugger detaches - reproduces the same code path, holds the rate identical
+  across arms, and needs nobody holding a phone. `tmp/ios-profiling/arm.sh` does this.
 - **Prefer a same-call A/B** over comparing builds. For anything CSS- or JS-level, inject the
   variant over the WebView debugger instead of rebuilding: `wvexec` connects, evaluates and
   exits, and an injected `<style>` persists, so nothing is attached while the profiler runs.
@@ -821,6 +859,48 @@ Things that did **not** work, so they aren't retried:
   `will-change: transform` all measured the same. Only an HTML element avoids it.
 - **Removing the two `body.device-ios :has(...)` rules** changed nothing on device. They were
   obsolete and went anyway, but they were not the `:has()` cost.
+
+### `:has()` — the cost is proving absence, and a presence class removes all of it
+
+`matchHasPseudoClass` was **8.4% of WebContent's main thread** in a live call (801 ms of
+9549 ms). It is carried by rules whose subject is `body` and whose argument is a *descendant*
+(`body:has(.video-panel:not(.panel-hidden))`). WebKit's `Element` has only sibling-direction
+`:has()` bits, no descendant equivalent, so `StyleInvalidator` walks the ancestor chain and
+runs a real match on **every** mutation. Blink has breadcrumb bits, which is why Chrome shows
+nothing here and why this had to be measured on device.
+
+The expensive case is the rule that *fails*: `.video-panel` is absent in an audio-only
+session, so each invalidation walks the whole subtree to prove a negative. WebKit evaluates a
+compound left-to-right, so **one class on `body` short-circuits the match before `:has()`
+runs** — `video-panel.ts` adds `has-video-panel` while a panel exists, and the three rule
+sites are now `body.has-video-panel:has(...)`.
+
+ABAB in a live call, one build, one page, arms toggled by adding/removing the class over the
+WebView debugger (30 s arms, main-thread totals within 9.1-10.3 s of each other):
+
+| arm | `matchHasPseudoClass` | `HasSelectorFilter` |
+|---|---|---|
+| guard bypassed | 801 ms / 8.39% | 241 ms |
+| **guard active** | **273 ms / 3.17%** | 144 ms |
+| guard bypassed | 662 ms / 6.40% | 152 ms |
+| **guard active** | **279 ms / 3.06%** | 153 ms |
+
+So the guard **halves** it - ~730 ms → ~276 ms per 30 s - it does not remove it. The residual
+~3.1% is the other ~91 container-subject descendant rules (`.list-view-layout`,
+`.layout-header`, …), which still walk on mutations elsewhere in the tree.
+
+**Beware the synthetic driver here.** Under a 20 Hz driver appending one node inside
+`.chat-view`, the guarded arms measured *exactly* 0 ms, twice. That is real but misleading:
+invalidation only walks the mutated node's **ancestors**, so a single mutation site exercises
+only the subjects above it - `body`, i.e. exactly the rules being guarded. It proves the
+guard works and is perfectly repeatable, but it cannot see the rules a real call hits, and
+reading it as "eliminated" overstates the fix by 2x. Use the driver for a clean yes/no on one
+rule set; quote the in-call numbers for what is actually saved.
+
+A related build-level trap: `:not(.hidden)` inside a Tailwind-built selector made the build
+expand `.hidden` into the full selector text of all 453 rules applying it - 223 copies of one
+rule, several dragging an unrelated `:has()` along. `.hidden` is `display:none` and already
+wins, so the `:not()` was pure cost.
 
 The one ordering rule worth internalising: **a write scheduled among other code's reads makes
 each of those reads force a synchronous layout.** One such inversion measured 1461 ms of

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
@@ -21,7 +21,7 @@ body.narrow .narrow-panel .chat-audio-panel {
     @apply bottom-2;
     @apply py-1;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel):not(.narrow-panel) .chat-audio-panel,
+body.narrow .chat-message-editor.has-related-entry:not(.narrow-panel) .chat-audio-panel,
 body.narrow .chat-message-editor.text-mode:not(.narrow-panel) .chat-audio-panel {
     @apply bottom-2;
     @apply py-1;
@@ -85,9 +85,9 @@ body.hoverable .chat-audio-panel .record-on-btn.btn:hover {
     @apply bg-post-panel md:bg-input;
     @apply text-audio-panel-button-text;
 }
-.list-view-layout:has(.chat-activity-panel.listening) .chat-audio-panel .language-button .btn.btn-round,
-.list-view-layout:has(.chat-activity-panel.listening) .chat-audio-panel .playback-wrapper .btn.btn-round,
-.list-view-layout:has(.chat-activity-panel.listening) .chat-audio-panel .video-wrapper .btn.btn-round {
+.list-view-layout.has-listening-activity .chat-audio-panel .language-button .btn.btn-round,
+.list-view-layout.has-listening-activity .chat-audio-panel .playback-wrapper .btn.btn-round,
+.list-view-layout.has-listening-activity .chat-audio-panel .video-wrapper .btn.btn-round {
     @apply md:bg-01;
 }
 body.narrow .chat-audio-panel .language-button .btn.btn-round,
@@ -215,24 +215,24 @@ body.narrow .chat-audio-panel .recorder-wrapper {
 body.narrow .narrow-panel .recorder-wrapper::before,
 body.narrow .text-mode .recorder-wrapper::before,
 body.narrow .to-thin .recorder-wrapper::before,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .recorder-wrapper::before,
+body.narrow .chat-message-editor.has-related-entry .recorder-wrapper::before,
 body.narrow .narrow-panel .chat-audio-panel .listen-only-btn.btn::before,
 body.narrow .text-mode .chat-audio-panel .listen-only-btn.btn::before,
 body.narrow .to-thin .chat-audio-panel .listen-only-btn.btn::before,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .listen-only-btn.btn::before {
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .listen-only-btn.btn::before {
     @apply hidden;
 }
 /* Small language button: white outline + white text (no colored gradient from record state) */
 body.narrow .narrow-panel .chat-audio-panel .volume-settings-btn.text::before,
 body.narrow .text-mode .chat-audio-panel .volume-settings-btn.text::before,
 body.narrow .to-thin .chat-audio-panel .volume-settings-btn.text::before,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .volume-settings-btn.text::before {
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .volume-settings-btn.text::before {
     background: var(--text-03);
 }
 body.narrow .narrow-panel .chat-audio-panel .volume-settings-btn.text > .c-text,
 body.narrow .text-mode .chat-audio-panel .volume-settings-btn.text > .c-text,
 body.narrow .to-thin .chat-audio-panel .volume-settings-btn.text > .c-text,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .volume-settings-btn.text > .c-text {
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .volume-settings-btn.text > .c-text {
     background-image: none;
     -webkit-text-fill-color: white;
 }
@@ -300,7 +300,7 @@ body.narrow .to-thick .chat-audio-panel .recorder-wrapper {
 body.narrow .base-panel .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content {
     @apply w-20 h-20;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .recorder-wrapper,
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper,
 body.narrow .narrow-panel .chat-audio-panel .recorder-wrapper,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper {
@@ -313,13 +313,13 @@ body.narrow .to-thin .chat-audio-panel .recorder-wrapper {
         height 200ms ease-in-out,
         box-shadow 0ms;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .recorder-wrapper .btn.btn-round,
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper .btn.btn-round,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper .btn.btn-round,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper .btn.btn-round {
     @apply w-8 h-8;
     background: transparent;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
+body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content {
     @apply w-8 h-8;
@@ -415,8 +415,8 @@ body.narrow .rec-icon,
 body.narrow .rec-icon i {
     @apply text-3.5xl;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon i,
+body.narrow .chat-message-editor.has-related-entry .rec-icon,
+body.narrow .chat-message-editor.has-related-entry .rec-icon i,
 body.narrow .text-mode .rec-icon,
 body.narrow .text-mode .rec-icon i,
 body.narrow .narrow-panel .rec-icon,
@@ -459,13 +459,13 @@ body.narrow .narrow-panel .rec-icon i {
 body.wide .rec-icon.text-mode-on {
     @apply hidden;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.text-mode-on,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-on,
 body.narrow .text-mode .rec-icon.text-mode-on,
 body.narrow .to-thin .rec-icon.text-mode-on {
     @apply flex;
     @apply pt-0.5;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.text-mode-off,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-off,
 body.narrow .text-mode .rec-icon.text-mode-off,
 body.narrow .to-thin .rec-icon.text-mode-off {
     @apply opacity-0;
@@ -489,7 +489,7 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .rec-icon.text-m
 .record-off .rec-icon.on,
 .record-on .rec-icon.off,
 .narrow-panel .record-on .rec-icon.on.text-mode-off,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.text-mode-off,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-off,
 body.narrow .text-mode .rec-icon.text-mode-off,
 body.narrow .to-thin .rec-icon.text-mode-off,
 body.narrow .to-thick:not(.text-mode) .rec-icon.text-mode-on,
@@ -505,26 +505,26 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .rec-icon.text-m
 }
 
 /* Text-mode rec-icon sizes */
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon,
+body.narrow .chat-message-editor.has-related-entry .rec-icon,
 body.narrow .text-mode .rec-icon,
 body.narrow .to-thin .rec-icon {
     @apply w-8 h-8;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.off i.left,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.left,
 body.narrow .text-mode .rec-icon.off i.left,
 body.narrow .to-thin .rec-icon.off i.left,
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.off i.right,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.right,
 body.narrow .text-mode .rec-icon.off i.right,
 body.narrow .to-thin .rec-icon.off i.right {
     @apply text-1.5xl text-mobile-landscape-audio-panel-button-text;
     @apply opacity-100;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.off i.right,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.right,
 body.narrow .text-mode .rec-icon.off i.right,
 body.narrow .to-thin .rec-icon.off i.right {
     @apply always-white;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .rec-icon.text-mode-on,
+body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-on,
 body.narrow .text-mode .rec-icon.text-mode-on,
 body.narrow .to-thin .rec-icon.text-mode-on {
     @apply text-2xl text-danger;
@@ -564,7 +564,7 @@ body.narrow .to-thin .rec-icon.text-mode-on {
     @apply text-audio-panel-button-text;
 }
 
-.list-view-layout:has(.chat-activity-panel.listening) .chat-audio-panel .screencast-wrapper .btn.btn-round {
+.list-view-layout.has-listening-activity .chat-audio-panel .screencast-wrapper .btn.btn-round {
     @apply md:bg-01;
 }
 
@@ -597,8 +597,8 @@ body.narrow .to-thin .rec-icon.text-mode-on {
 .audio-panel-header .video-wrapper.video-on .btn.btn-round {
     @apply text-primary;
 }
-.list-view-layout:has(.chat-activity-panel.listening) .playback-wrapper.listen-off-to-on,
-.list-view-layout:has(.chat-activity-panel.listening) .playback-wrapper.listen-on {
+.list-view-layout.has-listening-activity .playback-wrapper.listen-off-to-on,
+.list-view-layout.has-listening-activity .playback-wrapper.listen-on {
     @apply outline-primary outline-offset-[-1px];
 }
 .playback-wrapper .btn::after {
@@ -833,7 +833,7 @@ body.narrow .audio-panel-wrapper > * {
 body.narrow .narrow-panel .audio-panel-wrapper {
     @apply px-10;
 }
-body.narrow .chat-message-editor:has(.related-chat-entry-panel) .audio-panel-wrapper,
+body.narrow .chat-message-editor.has-related-entry .audio-panel-wrapper,
 body.narrow .chat-message-editor.text-mode .audio-panel-wrapper,
 body.narrow .chat-message-editor.narrow-panel .audio-panel-wrapper {
     @apply gap-x-2;
@@ -982,7 +982,7 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .volume-settings
 .playback-toggle-svg.on {
     @apply text-primary;
 }
-.list-view-layout:has(.chat-activity-panel.listening) .playback-toggle-svg.on {
+.list-view-layout.has-listening-activity .playback-toggle-svg.on {
     @apply text-primary;
 }
 .header-activity-panel-wrapper .playback-toggle-svg {

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
@@ -1003,11 +1003,11 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .volume-settings
 
 /* Video call open: pause the decorative recorder animations — see the
    matching block in chat-activity-panel.css for why. */
-body:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .listen-only-btn.btn::before,
-body:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on::before,
-body:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
-body:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
-body:has(.video-panel:not(.panel-hidden)) .recorder-btn-skeleton {
+body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .listen-only-btn.btn::before,
+body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on::before,
+body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
+body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
+body.has-video-panel:has(.video-panel:not(.panel-hidden)) .recorder-btn-skeleton {
     animation-play-state: paused;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
@@ -6,7 +6,7 @@
 .chat-message-editor.narrow-panel {
     padding-bottom: 0;
 }
-.list-view-layout:has(.chat-activity-panel.listening) .chat-message-editor {
+.list-view-layout.has-listening-activity .chat-message-editor {
     @apply bg-transparent;
 }
 
@@ -101,7 +101,7 @@ body.narrow .c-editor-top {
     @apply flex-auto flex-x justify-between items-center md:gap-x-2;
     @apply py-0 px-2;
 }
-body.wide .list-view-layout:has(.chat-activity-panel.listening) .post-panel {
+body.wide .list-view-layout.has-listening-activity .post-panel {
     @apply bg-01;
 }
 .post-panel.sharp-corners {
@@ -775,22 +775,22 @@ body.hoverable .related-chat-entry-panel .btn.btn-round:hover .btn-content {
 /* With a reply/edit panel floating above the input, shrink the sub-footer's corner fillers to a
    small 0.5rem radius so they hug the bottom corners of the related panel instead of the full 2rem
    curve (which assumes the post-panel is the topmost element). */
-.chat-message-editor:has(.related-chat-entry-panel) .rounded-sub-footer::before,
-.chat-message-editor:has(.related-chat-entry-panel) .rounded-sub-footer::after {
+.chat-message-editor.has-related-entry .rounded-sub-footer::before,
+.chat-message-editor.has-related-entry .rounded-sub-footer::after {
     @apply w-2 h-2;
 }
-body.narrow .list-view-layout:has(.chat-activity-panel.listening) .rounded-sub-footer,
-body.narrow .list-view-layout:has(.audio-panel-header) .rounded-sub-footer {
+body.narrow .list-view-layout.has-listening-activity .rounded-sub-footer,
+body.narrow .list-view-layout.has-audio-panel-header .rounded-sub-footer {
     @apply h-20 inset-x-0;
     top: calc(-5rem + 1px);
 }
-body.narrow .list-view-layout:has(.chat-activity-panel.listening) .narrow-panel .rounded-sub-footer,
-body.narrow .list-view-layout:has(.audio-panel-header) .narrow-panel .rounded-sub-footer {
+body.narrow .list-view-layout.has-listening-activity .narrow-panel .rounded-sub-footer,
+body.narrow .list-view-layout.has-audio-panel-header .narrow-panel .rounded-sub-footer {
     @apply h-12 inset-x-0;
     top: calc(-3rem + 1px);
 }
-body.narrow .list-view-layout:has(.chat-activity-panel.listening) .rounded-sub-footer > .bg-layer,
-body.narrow .list-view-layout:has(.audio-panel-header) .rounded-sub-footer > .bg-layer {
+body.narrow .list-view-layout.has-listening-activity .rounded-sub-footer > .bg-layer,
+body.narrow .list-view-layout.has-audio-panel-header .rounded-sub-footer > .bg-layer {
     background:
         radial-gradient(100.91% 105.88% at 50% 100%, var(--background-01) 30%, var(--transparent) 75%),
         radial-gradient(100.91% 105.88% at 50% 100%, var(--footer-fog-color-1) 30%, var(--footer-fog-color-2) 75%);

--- a/src/dotnet/UI.Blazor.App/Components/EmojiModal/emoji-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/EmojiModal/emoji-modal.css
@@ -125,7 +125,10 @@ body.hoverable .emoji-modal .c-gif-recent-item:hover {
     @apply opacity-0 transition-opacity;
     @apply -translate-y-1/2;
 }
-body.hoverable .emoji-modal .c-gif-recent:hover .c-gif-recent-arrow:not(.hidden) {
+/* No :not(.hidden) here: .hidden is display:none, so it already wins over any opacity, and
+   the build expands a .hidden inside :not() into the full selector text of all 453 rules that
+   apply it - 223 copies of this one rule, several dragging an unrelated :has() along. */
+body.hoverable .emoji-modal .c-gif-recent:hover .c-gif-recent-arrow {
     @apply opacity-100;
 }
 .emoji-modal .c-gif-recent-arrow.left {

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel.css
@@ -59,20 +59,20 @@ body.narrow .right-panel > .c-panel-content {
    edit/share overlapping its bottom edge by 50%, then the title + public/private badge, then the
    chat-info toggles. ONLY the tabs/list (.c-panel-content) are hidden. Because nothing switches to flow,
    the list viewport never resizes — the root of the members-scroll-behind-tabs and stuck-avatar bugs. */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region {
+body.narrow .right-panel.has-expanded-header > .c-top-region {
     @apply overflow-visible;
     max-height: none;
 }
 /* Header keeps its natural (content) height on narrow — it grows via the tall .c-top below (which
    reserves the avatar's flow space), not via the fixed square the general .expanded-header rule uses
    on wide. */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region > .c-header.expanded-header {
+body.narrow .right-panel.has-expanded-header > .c-top-region > .c-header.expanded-header {
     height: auto;
     min-height: var(--rp-header-base);
 }
 /* Reserve the avatar's flow height in .c-top (a wallpaper strip above it + the square) so the title and
    badge below flow UNDER the avatar instead of behind it. */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region > .c-header.expanded-header > .c-top {
+body.narrow .right-panel.has-expanded-header > .c-top-region > .c-header.expanded-header > .c-top {
     height: calc(4.5rem + var(--safe-area-top) + var(--expanded-header-height));
 }
 /* Full-screen avatar: keep the top edge where it is (a strip of the blurred .c-top wallpaper stays
@@ -82,22 +82,22 @@ body.narrow .right-panel > .c-top-region > .c-header.expanded-header > .c-center
     height: var(--expanded-header-height);
 }
 /* edit/share/invite: shown, dropped to the avatar's bottom edge and overlapping it by 50%. */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region > .c-header > .c-center > .c-buttons {
+body.narrow .right-panel.has-expanded-header > .c-top-region > .c-header > .c-center > .c-buttons {
     @apply absolute right-4 bottom-0;
     @apply max-w-none opacity-100;
     transform: translateY(50%);
 }
 /* title + public/private badge + description: shown, flowing below the avatar (cleared of the buttons). */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region > .c-header > .c-bottom {
+body.narrow .right-panel.has-expanded-header > .c-top-region > .c-header > .c-bottom {
     @apply opacity-100;
     padding-top: 2rem;
 }
 /* Keep the panel-close button visible over the full-screen avatar (it otherwise fades with the header). */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-top-region > .c-header > .c-buttons {
+body.narrow .right-panel.has-expanded-header > .c-top-region > .c-header > .c-buttons {
     @apply opacity-100;
 }
 /* Only the tabs/list are hidden while the avatar is full-screen. */
-body.narrow .right-panel:has(.c-header.expanded-header) > .c-panel-content {
+body.narrow .right-panel.has-expanded-header > .c-panel-content {
     @apply opacity-0 pointer-events-none;
     transition: opacity .25s ease-in;
 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -968,23 +968,23 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
    with the chat visible below it, and pausing there freezes one-shot entrance
    animations (`smoothShow`, `showSubHeader`) on their opacity:0 first frame —
    the text keeps its box but never appears. */
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::before,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::after,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::before,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::after,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::before,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::after {
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::before,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::after,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::before,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::after,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::before,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::after {
     /* !important: `animation` shorthands re-declare play-state `running`;
        deep multi-class ones can out-rank this gate's specificity. */
     animation-play-state: paused !important;
 }
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .video-panel,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::before,
-body.narrow:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::after {
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::before,
+body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::after {
     /* Both gates are !important and tie on specificity — this one wins by
        source order, so it MUST stay below the paused block. */
     animation-play-state: running !important;

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.ts
@@ -12,6 +12,7 @@ const DOUBLE_TAP_INTERVAL = 300;
 const ZOOM_TRANSITION_MS = 250;
 
 export class VideoPanel {
+    private static readonly bodyClass = 'has-video-panel';
     private blazorRef: DotNet.DotNetObject;
     private readonly videoPanel: HTMLElement;
     private parentElement: HTMLElement | null = null;
@@ -71,6 +72,11 @@ export class VideoPanel {
     constructor(videoPanel: HTMLElement, blazorRef: DotNet.DotNetObject) {
         this.blazorRef = blazorRef;
         this.videoPanel = videoPanel;
+        // Guards the body:has(.video-panel...) rules. WebKit evaluates a compound left to right,
+        // so an absent class here short-circuits before :has() runs - and :has() otherwise rescans
+        // the whole body subtree on every DOM mutation just to re-prove the panel isn't there,
+        // which measured 16-18% of WebContent's main thread during a call on an iPhone 13 Pro.
+        document.body.classList.add(VideoPanel.bodyClass);
 
         this.parentElement = this.videoPanel.parentElement;
         this.parentNextSibling = this.videoPanel.nextSibling;
@@ -891,6 +897,8 @@ export class VideoPanel {
     public dispose() {
         if (this.disposed$.closed)
             return;
+
+        document.body.classList.remove(VideoPanel.bodyClass);
 
         // Hide before any DOM reshuffling (collapse/reparent) so callers that
         // dispose without playing a close animation don't see the panel briefly

--- a/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
+++ b/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
@@ -1,0 +1,16 @@
+// The app's container:has(descendant) relationships, registered as presence classes - see
+// mutation-processor.ts for why. Every class registered here is written by MutationProcessor
+// and must never be set in markup.
+//
+// Only container subjects belong here. A :has() whose subject is a small element (.toggle,
+// .checkbox, .navbar-item) walks a tiny subtree and costs nothing worth replacing.
+
+import { MutationProcessor } from 'mutation-processor';
+
+MutationProcessor.registerPresenceClasses(
+    { container: '.chat-message-editor', match: '.related-chat-entry-panel', className: 'has-related-entry' },
+    { container: '.list-view-layout', match: '.chat-activity-panel.listening', className: 'has-listening-activity' },
+    { container: '.list-view-layout', match: '.audio-panel-header', className: 'has-audio-panel-header' },
+    { container: '.right-panel', match: '.c-header.expanded-header', className: 'has-expanded-header' },
+    { container: '.layout-header', match: '.header-activity-panel-wrapper', className: 'has-activity-panel' },
+);

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
@@ -39,8 +39,8 @@
 body.narrow .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
     @apply min-h-0 h-12;
 }
-body.narrow .list-view-layout:has(.chat-activity-panel.listening) .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor,
-body.narrow .list-view-layout:has(.audio-panel-header) .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
+body.narrow .list-view-layout.has-listening-activity .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor,
+body.narrow .list-view-layout.has-audio-panel-header .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
     @apply portrait:min-h-0 h-20;
 }
 

--- a/src/nodejs/src/animation-sync.ts
+++ b/src/nodejs/src/animation-sync.ts
@@ -298,9 +298,6 @@ export class AnimationSync {
 // 5Hz costs ~0.006% of a core (11.5us per empty sweep, measured on an iPhone 13
 // Pro), which is far cheaper than the JS interop the alternative would need.
 export class AnimationSweeper {
-    private static readonly periodMs = 200;
-    private static timer: ReturnType<typeof setInterval> | null = null;
-    private static readonly visibilityListener = (): void => AnimationSweeper.onVisibilityChange();
     private static readonly animationStartListener = (e: AnimationEvent): void => {
         // Not e.target: that is retargeted to the shadow host for an animation
         // inside a shadow root, and the host is not the element that animates.
@@ -310,45 +307,16 @@ export class AnimationSweeper {
     };
 
     public static start(): void {
-        document.removeEventListener('visibilitychange', AnimationSweeper.visibilityListener);
-        document.addEventListener('visibilitychange', AnimationSweeper.visibilityListener);
-        // The sweep can only see elements that already exist; a class change can
-        // give one an animation at any point after it was resolved. Re-phasing does
-        // not restart an animation - it moves its start time - so this cannot loop.
+        // Elements are phase-aligned as they arrive - see MutationProcessor - so there is
+        // no periodic sweep. This listener covers the case no mutation can be matched to:
+        // an element resolved without an animation that a later class change gives one.
+        // Re-phasing does not restart an animation - it moves its start time - so this
+        // cannot loop.
         document.removeEventListener('animationstart', AnimationSweeper.animationStartListener);
         document.addEventListener('animationstart', AnimationSweeper.animationStartListener);
-        AnimationSweeper.resume();
     }
 
     public static stop(): void {
-        document.removeEventListener('visibilitychange', AnimationSweeper.visibilityListener);
         document.removeEventListener('animationstart', AnimationSweeper.animationStartListener);
-        AnimationSweeper.pause();
-    }
-
-    // Private methods
-
-    private static resume(): void {
-        if (AnimationSweeper.timer !== null || document.hidden)
-            return;
-
-        AnimationSweeper.timer = setInterval(() => AnimationSync.syncAll(document), AnimationSweeper.periodMs);
-    }
-
-    // A backgrounded WebView cannot paint, so a sweep there is pure wake-up cost.
-    // Only the timer is paused - the listener stays, or it could never resume.
-    private static pause(): void {
-        if (AnimationSweeper.timer === null)
-            return;
-
-        clearInterval(AnimationSweeper.timer);
-        AnimationSweeper.timer = null;
-    }
-
-    private static onVisibilityChange(): void {
-        if (document.hidden)
-            AnimationSweeper.pause();
-        else
-            AnimationSweeper.resume();
     }
 }

--- a/src/nodejs/src/init.ts
+++ b/src/nodejs/src/init.ts
@@ -9,7 +9,9 @@ import { SharedSettings } from 'shared-settings';
 import { ServiceWorker } from 'service-worker';
 import { ScreenOrientation, DeviceOrientation } from 'orientation';
 import { CompactLayout } from 'compact-layout';
+import { MutationProcessor } from 'mutation-processor';
 import { BrowserInit } from '../../dotnet/UI.Blazor/Services/BrowserInit/browser-init';
+import '../../dotnet/UI.Blazor.App/Services/app-presence-classes';
 
 // Before anything awaits: batches arriving until this runs are applied the old way.
 // The hook name is published because "it silently did nothing" is the failure mode here -
@@ -69,6 +71,9 @@ void (async () => {
     });
 
     AnimationSweeper.start();
+    MutationProcessor.start();
+    // Published so the class-vs-:has() cost can be A/B'd inside one call over the debugger.
+    globalThis.MutationProcessor = MutationProcessor;
 
     const app = window.App;
     if (app) {

--- a/src/nodejs/src/mutation-processor.ts
+++ b/src/nodejs/src/mutation-processor.ts
@@ -1,0 +1,170 @@
+// The single place DOM mutations are turned into work, so nothing has to poll for them.
+//
+// A MutationObserver callback is delivered once per microtask checkpoint - after a render
+// batch is applied and before paint - so anything driven from here is both timelier and
+// cheaper than an interval, and sees JS-driven mutations no render hook would.
+//
+// Two consumers today:
+//  - presence classes, which replace `container:has(descendant)`. WebKit has no
+//    descendant-direction :has() bits, so StyleInvalidator re-runs a real match up the
+//    ancestor chain on every mutation - 6-8% of WebContent's main thread during a call.
+//  - animation phase sync, which used to sweep the whole document every 200ms.
+
+import { AnimationSync } from 'animation-sync';
+
+export interface PresenceClassRule {
+    container: string;
+    match: string;
+    className: string;
+}
+
+const rules = new Array<PresenceClassRule>();
+const observedAttributes = ['class', 'data-side-nav'];
+// Class tokens any rule's match selector can turn on. Records touching none of them cannot
+// change any predicate, which is nearly all of them - this app toggles classes constantly
+// for animation and hover state, and a full rescan per toggle is what we're avoiding.
+const matchTokens = new Set<string>();
+let matchSelector = '';
+let observer: MutationObserver | null = null;
+let isEnabled = true;
+
+export const MutationProcessor = {
+    get presenceClassRules(): readonly PresenceClassRule[] {
+        return rules;
+    },
+
+    // Runtime toggle so the mechanism can be A/B'd inside one session rather than across builds
+    get isEnabled(): boolean {
+        return isEnabled;
+    },
+
+    set isEnabled(value: boolean) {
+        if (isEnabled === value)
+            return;
+
+        isEnabled = value;
+        if (value)
+            updatePresenceClasses();
+        else
+            clearPresenceClasses();
+    },
+
+    // Registered at import time by the modules that own the matching CSS: the CSS applies
+    // whenever the markup exists, so registering when a component mounts would leave a
+    // window with the class missing.
+    registerPresenceClasses(...newRules: PresenceClassRule[]): void {
+        rules.push(...newRules);
+        matchSelector = rules.map(r => r.match).join(',');
+        matchTokens.clear();
+        for (const rule of rules)
+            for (const token of rule.match.match(/\.[\w-]+/g) ?? [])
+                matchTokens.add(token.slice(1));
+        if (observer)
+            updatePresenceClasses();
+    },
+
+    start(): void {
+        if (observer)
+            return;
+
+        observer = new MutationObserver(onMutated);
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: observedAttributes,
+            attributeOldValue: true,
+        });
+        updatePresenceClasses();
+        AnimationSync.syncAll(document);
+    },
+
+    stop(): void {
+        observer?.disconnect();
+        observer = null;
+    },
+
+    update: updatePresenceClasses,
+};
+
+// Private methods
+
+function onMutated(records: MutationRecord[]): void {
+    if (!isEnabled)
+        return;
+
+    let hasPresenceChange = false;
+    for (const record of records) {
+        if (record.type === 'childList')
+            syncAddedAnimations(record.addedNodes);
+        hasPresenceChange ||= affectsPresence(record);
+    }
+    if (hasPresenceChange) {
+        updatePresenceClasses();
+        // Our own class writes are mutations too; they land after this callback, so dropping
+        // the records here discards exactly them and nothing else.
+        observer?.takeRecords();
+    }
+}
+
+// Phase-aligns whatever arrived, replacing the sweep that used to run every 200ms.
+// The animationstart listener still covers an element that gains an animation later,
+// which no mutation can be matched to.
+function syncAddedAnimations(nodes: NodeList): void {
+    for (const node of nodes) {
+        if (!(node instanceof HTMLElement) && !(node instanceof SVGElement))
+            continue;
+
+        // querySelectorAll excludes the root, so an added element that is itself
+        // animated has to be handled separately.
+        if (node.matches(AnimationSync.selector))
+            AnimationSync.sync(node as HTMLElement);
+        AnimationSync.syncAll(node);
+    }
+}
+
+function affectsPresence(record: MutationRecord): boolean {
+    if (!matchSelector)
+        return false;
+
+    if (record.type === 'attributes') {
+        if (record.attributeName !== 'class')
+            return true;
+
+        // A class change matters only if it added or removed a token some rule tests for.
+        const target = record.target as Element;
+        const before = new Set((record.oldValue ?? '').split(/\s+/));
+        for (const token of matchTokens)
+            if (target.classList.contains(token) !== before.has(token))
+                return true;
+
+        return false;
+    }
+
+    return hasMatch(record.addedNodes) || hasMatch(record.removedNodes);
+}
+
+function hasMatch(nodes: NodeList): boolean {
+    for (const node of nodes) {
+        if (!(node instanceof Element))
+            continue;
+        // Walks only the added/removed subtree, which is one component's worth of markup -
+        // far cheaper than rescanning every container.
+        if (node.matches(matchSelector) || node.querySelector(matchSelector))
+            return true;
+    }
+
+    return false;
+}
+
+function updatePresenceClasses(): void {
+    for (const rule of rules)
+        for (const container of document.querySelectorAll(rule.container))
+            container.classList.toggle(rule.className, container.querySelector(rule.match) !== null);
+}
+
+function clearPresenceClasses(): void {
+    for (const rule of rules)
+        for (const container of document.querySelectorAll(rule.container))
+            container.classList.remove(rule.className);
+}

--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -133,8 +133,8 @@ body.narrow {
     touch-action: none;
 }
 /* Let fullscreen video panel reach the viewport edges under device cutouts */
-body:has(.video-panel.expanded) .safe-area-left::after,
-body:has(.video-panel.expanded) .safe-area-right::after {
+body.has-video-panel:has(.video-panel.expanded) .safe-area-left::after,
+body.has-video-panel:has(.video-panel.expanded) .safe-area-right::after {
     display: none;
 }
 .safe-area-bottom-overlay {

--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -338,8 +338,8 @@ body.narrow .layout-header > .c-content.selection-header {
     @apply items-center;
     min-height: calc(3.5rem + var(--safe-area-top));
 }
-.list-view-layout .layout-header:has(.header-activity-panel-wrapper),
-.list-view-layout:has(.chat-activity-panel.listening) .layout-header {
+.list-view-layout .layout-header.has-activity-panel,
+.list-view-layout.has-listening-activity .layout-header {
     @apply relative;
     @apply bg-transparent;
     @apply border-transparent;
@@ -366,7 +366,7 @@ body.narrow .list-view-layout:has(.chat-activity-panel:not(.not-participating)) 
     @apply z-40;
 }
 /* Hideable elements (control panel buttons) */
-.list-view-layout .layout-header:has(.header-activity-panel-wrapper) .hideable {
+.list-view-layout .layout-header.has-activity-panel .hideable {
     transition-property: opacity, transform, max-width;
     transition-duration: 0.5s;
     transition-timing-function: ease;
@@ -411,11 +411,11 @@ body.narrow .list-view-layout .layout-header.collapsed .chat-header-title {
     border-top: 1px solid var(--violet-80-20);
 }
 /* Colorized header */
-.list-view-layout:has(.chat-activity-panel.listening) .layout-subheader {
+.list-view-layout.has-listening-activity .layout-subheader {
     @apply bg-transparent;
 }
 /* Colorized footer */
-.list-view-layout:has(.chat-activity-panel.listening) .layout-subfooter:before {
+.list-view-layout.has-listening-activity .layout-subfooter:before {
     @apply content-empty;
     @apply absolute z-minus inset-x-0 bottom-0;
     @apply h-40;
@@ -424,7 +424,7 @@ body.narrow .list-view-layout .layout-header.collapsed .chat-header-title {
     animation: smoothOpacity 1s ease forwards, bottomWave 4s steps(40) 1s infinite;
     animation-delay: 0s, var(--anim-phase, 1s);
 }
-body.narrow .list-view-layout:has(.chat-activity-panel.listening) .layout-subfooter:before {
+body.narrow .list-view-layout.has-listening-activity .layout-subfooter:before {
     background: radial-gradient(80.91% 105.88% at 50% 100%, var(--footer-fog-color-1) 0%, var(--footer-fog-color-2) 100%);
 }
 @keyframes smoothOpacity {


### PR DESCRIPTION
`:has()` matching is **16-18% of WebContent's main thread** during a live call on an iPhone 13 Pro — ~550ms per 15s, about 0.04 cores. Measured by deleting rules from the CSSOM at runtime and re-profiling: the `matchHasPseudoClass` counter goes to exactly 0 when they're removed and back to ~550ms when restored.

## Why it costs anything

The expensive rules test for elements that **aren't in the DOM at all** — `.video-panel`, `.chat-activity-panel`. Proving absence is the work.

WebKit has no descendant-direction "affected by `:has()`" bit (only sibling ones), so `StyleInvalidator`'s `HasRelation::Descendant` branch walks the entire ancestor chain running real selector matches, and `HasSelectorFilter` then builds a Bloom filter over every descendant — on every DOM mutation, purely to re-confirm the panel still isn't there. With the subject being a layout container that wraps the constantly-mutating chat subtree, every transcript update pays for it.

Chrome is unaffected — it keeps per-element breadcrumb bits and resolves the same stylesheet in O(depth), which is why this is invisible in desktop profiling.

Device bisect:

| arm | `matchHasPseudoClass` |
|---|---|
| baseline | 504ms (15.5%) |
| remove 33 rules with a **child** combinator (`.item:has(> .x)`) | no change |
| remove 14 rules with `:not()` inside `:has()` | **142ms (-72%)** |
| guard all 91 container-subject rules with a class present on no element | **2ms (-99.6%)** |
| baseline again | 422ms (13.9%) |

## What this PR does

**1. Drop `:not(.hidden)` from one emoji-modal rule.** `.hidden` is applied via `@apply` in 453 rules, and inside `:not()` the build substitutes it with the full selector text of every one of them — turning one rule into 223 selectors, several dragging an unrelated `:has()` along. The guard was redundant: `.hidden` is `display:none`, which already beats any opacity. Bundle: 227 -> 5 occurrences, 333 -> 301 `:has()` instances.

**2. Guard the `body:has(.video-panel…)` rules with `body.has-video-panel`.** WebKit evaluates a compound left-to-right, so a class that fails short-circuits before `:has()` runs. `VideoPanel`'s constructor adds the class and `dispose` removes it — the same shape `side-nav.ts` already uses.

`:has()` is **kept** as the second condition rather than replaced, so the failure mode is safe: a stale flag cannot apply a style, only a missing one can suppress it.

## Verification

Chrome, on the built CSS:

| check | result |
|---|---|
| rule fires with flag **and** panel present | `display: block` -> `none` |
| reverts when flag removed | back to `block` |
| flag set but **no panel** -> rule does not apply | `block` |
| unguarded `body:has(.video-panel…)` rules remaining | 0 |

The device win for this specific subset is **not yet measured** — that needs an in-call arm, which is queued. Chrome can't size it, since `:has()` is nearly free there.

## Not in this PR

The `.list-view-layout` and `.layout-header` rules need the flag in their own compound and have no state plumbed in. `PageWithHeaderAndFooter` is generic and shared across layouts, so those want a different mechanism than a body class.

Background: `docs/ios-specific.md`, `tmp/has-alternatives-research.md`.