### PR TITLE
perf(ui): replace the chat-view and video-panel :has() rules with presence classes

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
@@ -190,10 +190,10 @@ body.narrow .layout-header:has(.video-streaming) {
 .chat-activity-panel.watching .c-film-strip {
     @apply hidden;
 }
-.layout-header.collapsed:not(:has(.video-panel:not(.collapsed):not(.panel-hidden))) .c-film-strip {
+.layout-header.collapsed:not(.has-visible-video-panel) .c-film-strip {
     @apply opacity-0;
 }
-.layout-header.collapsed:not(:has(.video-panel:not(.collapsed):not(.panel-hidden))) .c-film-strip::after {
+.layout-header.collapsed:not(.has-visible-video-panel) .c-film-strip::after {
     animation-play-state: paused;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
@@ -980,11 +980,11 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .volume-settings
 
 /* Video call open: pause the decorative recorder animations — see the
    matching block in chat-activity-panel.css for why. */
-body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .listen-only-btn.btn::before,
-body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on::before,
-body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
-body.has-video-panel:has(.video-panel:not(.panel-hidden)) .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
-body.has-video-panel:has(.video-panel:not(.panel-hidden)) .recorder-btn-skeleton {
+body.video-panel-shown .chat-audio-panel .listen-only-btn.btn::before,
+body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-on::before,
+body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
+body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
+body.video-panel-shown .recorder-btn-skeleton {
     animation-play-state: paused;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/found-result.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/found-result.css
@@ -42,10 +42,10 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item .c-container .c-description .c-second-line.bio {
     @apply text-01;
 }
-.found-result.navbar-item .c-container .c-description:has(.c-third-line) .c-second-line {
+.found-result.navbar-item .c-container .c-description.has-third-line .c-second-line {
     @apply line-clamp-1;
 }
-.found-result.navbar-item .c-container .c-description:has(.c-second-line) .c-third-line {
+.found-result.navbar-item .c-container .c-description.has-second-line .c-third-line {
     @apply line-clamp-1;
 }
 .found-result.navbar-item .c-container .c-description .c-second-line .c-place-title {
@@ -71,14 +71,14 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item .c-last-message .avatar-name {
     @apply text-01;
 }
-.found-result.navbar-item .c-description .c-name:has(.non-shrinkable) {
+.found-result.navbar-item .c-description .c-name.has-non-shrinkable {
     @apply flex-none inline whitespace-normal;
 }
-.found-result.navbar-item .c-description:has(.c-name .non-shrinkable) .c-entry {
+.found-result.navbar-item .c-description.has-non-shrinkable-name .c-entry {
     @apply inline whitespace-normal;
     @apply ml-0.5;
 }
-.found-result.navbar-item .c-description .c-name:has(.shrinkable) {
+.found-result.navbar-item .c-description .c-name.has-shrinkable {
     @apply min-w-16;
 }
 .found-result.navbar-item .c-description .c-text {
@@ -95,10 +95,10 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item.message .c-container .c-description .c-third-line.place-chat {
     @apply line-clamp-2;
 }
-.found-result.navbar-item.message .c-container .c-description:has(.c-second-line) .c-third-line.place-chat {
+.found-result.navbar-item.message .c-container .c-description.has-second-line .c-third-line.place-chat {
     @apply flex-x gap-x-0.5;
     -webkit-line-clamp: none;
 }
-.found-result.navbar-item.message .c-container .c-description:has(.c-second-line) .c-third-line.place-chat .c-entry {
+.found-result.navbar-item.message .c-container .c-description.has-second-line .c-third-line.place-chat .c-entry {
     @apply truncate;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
@@ -228,10 +228,10 @@ body.hoverable .navbar-item:hover .navbar-item-content > .c-container > .c-descr
 .chat-list .navbar-item-content .c-last-message .c-name .avatar-name {
     @apply text-caption-4;
 }
-.chat-list .navbar-item-content .c-last-message .c-name:has(.non-shrinkable) {
+.chat-list .navbar-item-content .c-last-message .c-name.has-non-shrinkable {
     @apply flex-none;
 }
-.chat-list .navbar-item-content .c-last-message .c-name:has(.shrinkable) {
+.chat-list .navbar-item-content .c-last-message .c-name.has-shrinkable {
     @apply min-w-16;
 }
 .chat-list .navbar-item-content .c-last-message .c-colon {
@@ -243,7 +243,7 @@ body.hoverable .navbar-item:hover .navbar-item-content > .c-container > .c-descr
     @apply truncate;
     @apply pointer-events-none;
 }
-.chat-list .navbar-item-content .c-last-message:has(.c-text.two-line) {
+.chat-list .navbar-item-content .c-last-message.has-two-line-text {
     @apply h-auto;
 }
 .chat-list .navbar-item-content .c-last-message .c-text.two-line {
@@ -275,8 +275,8 @@ body.hoverable .chat-list .navbar-item:hover .recording-in-chat.on {
 }
 /* Timer ring around the listen button would be clipped by the ending's
    overflow-hidden — open it up only for rows that actually show the controls. */
-.chat-list .navbar-item .navbar-item-ending:has(.chat-audio-controls),
-.chat-list .navbar-item .navbar-item-ending:has(.chat-audio-controls) .slot,
+.chat-list .navbar-item .navbar-item-ending.has-audio-controls,
+.chat-list .navbar-item .navbar-item-ending.has-audio-controls .slot,
 .chat-list .navbar-item .chat-audio-controls,
 .chat-list .navbar-item .chat-audio-controls .c-listening-timer {
     @apply overflow-visible;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageSendingStatus/chat-message-sending-status.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageSendingStatus/chat-message-sending-status.css
@@ -38,11 +38,11 @@ body.hoverable .navbar-item:hover .chat-message-sending-status {
 
 /*Sending status in attachments and with code markup*/
 .message-attachments .chat-message-sending-status,
-.chat-message-markup:has(.code-block-markup) .chat-message-sending-status {
+.chat-message-markup.has-code-block .chat-message-sending-status {
     @apply -right-1 bottom-0.5;
 }
 
 .message-attachments .chat-message-sending-status.sending,
-.chat-message-markup:has(.code-block-markup) .chat-message-sending-status.sending {
+.chat-message-markup.has-code-block .chat-message-sending-status.sending {
     @apply bottom-1.5;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -11,13 +11,13 @@
 }
 /* The gap goes on the data-key item, the only box the list measures, and as padding, which
    getBoundingClientRect counts - a margin here escapes that box and drifts the list's geometry. */
-.virtual-list .c-virtual-container .item:has(> .conversation-message) {
+.virtual-list .c-virtual-container .item.has-conversation-message {
     @apply pt-4;
 }
 /* ...but inside a block (one carrying the split-out live header) the card follows the header flush -
    no gap between the header and the description. Covers both the joined block and the frozen/unjoined
    (left-the-call) block. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .conversation-message.live) {
+.virtual-list .c-virtual-container .group.has-live-block .item.has-live-card {
     @apply pt-0;
 }
 /* Standalone preview card (not inside a block - never joined, no overlay) keeps its own box. */
@@ -29,7 +29,7 @@
    rounding, so a card box here would draw a second box inside the block with the title detached.
    No rounded corners left to clip, so overflow goes visible too - lets the "Show more" pill straddle
    below the card's bottom edge instead of being cut off by the base .conversation-message rule. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .conversation-message.live {
+.virtual-list .c-virtual-container .group.has-live-block .conversation-message.live {
     @apply border-none rounded-none;
     background: none;
     overflow: visible;
@@ -41,22 +41,22 @@
 }
 /* The split header carries the title, so the description card drops its own top padding and butts
    right up under the header - one continuous surface, no gap. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .c-live-card {
+.virtual-list .c-virtual-container .group.has-live-block .c-live-card {
     @apply pt-0;
 }
 /* The unjoined card ends with the faded preview; drop its bottom padding so the preview sits flush
    above the footer (mirrors the pt-0 that butts the card under the header) - no gap after the last row. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) .c-live-card {
+.virtual-list .c-virtual-container .group.has-live-block-join .c-live-card {
     @apply pb-0;
 }
 /* When expanded, the split header carries the title so the card renders empty (no .c-live-card child).
    The item's default min-h-6 would then leave a gap between the header and the first message - collapse
    the empty card and its item to zero. The :not(:has(.c-live-card)) guard leaves the collapsed card
    (which still has content) untouched. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .conversation-message.live:empty) {
+.virtual-list .c-virtual-container .group.has-live-block .item.has-empty-live-card {
     @apply min-h-0;
 }
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .conversation-message.live:empty {
+.virtual-list .c-virtual-container .group.has-live-block .conversation-message.live:empty {
     @apply min-h-0 mb-0;
 }
 .c-live-card .c-lc-title {
@@ -349,8 +349,8 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    footer as one box. The tint is the block's own background (no overflow:hidden needed - which is what
    lets position:sticky author badges and the sticky header work). The outline is a border-box layer,
    not border-image, which would drop the rounded corners; the opaque bg-01 base carries the tint. */
-.virtual-list .c-virtual-container .group:has(> .item > .conversation-message.live.joined),
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) {
+.virtual-list .c-virtual-container .group.has-joined-live-card,
+.virtual-list .c-virtual-container .group.has-live-block {
     isolation: isolate;
     /* mx-1 matches the 4px horizontal padding on regular conversation .item wrappers, so the live
        block's box lines up with regular conversations and the message hover highlight (same width). */
@@ -362,7 +362,7 @@ body.hoverable .conversation-attachments .image-attachment:hover {
         linear-gradient(to bottom,
             var(--violet-60) 0%, var(--violet-60) 50%, var(--c-live-tint, rgba(166, 53, 255, 0.1)) 100%) border-box;
 }
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) {
+.virtual-list .c-virtual-container .group.has-live-block {
     @apply px-0;
     @apply overflow-hidden;
 }
@@ -374,7 +374,7 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    so this wins whenever it matches. Its match set is a strict subset of the base shell rule's
    expanded arm, so mx-1 and the transparent border cascade in from there - only the tint is overridden
    here. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) {
+.virtual-list .c-virtual-container .group.has-live-block-join {
     isolation: isolate;
     @apply rounded-2xl;
     background:
@@ -382,11 +382,11 @@ body.hoverable .conversation-attachments .image-attachment:hover {
         linear-gradient(var(--background-01), var(--background-01)) padding-box;
 }
 
-/* Mirrors virtual-list.css's .item:has(.conversation-header) rule - that one only matches the literal
+/* Mirrors virtual-list.css's .item.has-conversation-header rule - that one only matches the literal
    conversation-header class, not this component's own live-conversation-header. Wide screens only:
    this header is much taller than a regular conversation header, so pinning it on a narrow screen
    eats too much of the viewport. It scrolls away there; regular headers stay sticky everywhere. */
-body.wide .virtual-list .c-virtual-container .item:has(.live-conversation-header) {
+body.wide .virtual-list .c-virtual-container .item.has-live-header {
     @apply sticky -top-px z-20;
 }
 
@@ -442,24 +442,24 @@ body.hoverable .virtual-list .c-virtual-container .live-conversation-header .c-l
 }
 /* The footer band is 0.75rem; without this its item keeps the default min-h-6, leaving ~12px of dead
    space between the last message and the rounded bottom. Collapse the item so the footer sits flush. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header) .item:has(> .live-conversation-footer) {
+.virtual-list .c-virtual-container .group.has-live-block .item.has-live-footer {
     @apply min-h-0;
 }
 /* The unjoined block is a compact preview card that the group's own rounding already closes, so its
    footer band would just add empty space below the last preview row - collapse it to nothing. */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header .c-lc-join) .live-conversation-footer {
+.virtual-list .c-virtual-container .group.has-live-block-join .live-conversation-footer {
     @apply h-0;
 }
 
 /* Tier-1 dissolve: a too-short session leaves no card, so its block fades + collapses its chrome
    (border, tint, header, card, footer) out while the entries stay put, then it's removed and they
    drop to plain messages. Duration is kept in sync with LiveBlockUI.DissolveDuration (300ms). */
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header.dissolving) {
+.virtual-list .c-virtual-container .group.has-live-block-dissolving {
     animation: lc-dissolve-frame 300ms ease forwards;
 }
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header.dissolving) > .item.expanded,
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header.dissolving) > .item:has(> .conversation-message.live),
-.virtual-list .c-virtual-container .group:has(> .item.expanded > .live-conversation-header.dissolving) > .item:has(> .live-conversation-footer) {
+.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.expanded,
+.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.has-live-card,
+.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.has-live-footer {
     overflow: hidden;
     animation: lc-dissolve-chrome 300ms ease forwards;
 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -170,7 +170,7 @@ body.wide .video-panel.expanded > .c-container {
     @apply rounded-lg;
     @apply overflow-hidden;
 }
-body.wide .video-panel.expanded:has(.video-panel-chat) > .c-container {
+body.wide .video-panel.expanded.has-video-panel-chat > .c-container {
     @apply justify-start;
 }
 .video-panel .video-panel-content {
@@ -331,7 +331,7 @@ body.device-mobile.narrow .video-panel.expanded .video-panel-content.video-panel
     }
 }
 
-.video-panel.expanded:has(.video-panel-chat:not(.chat-hidden)) .video-panel-toolbar {
+.video-panel.expanded.has-video-panel-chat-shown .video-panel-toolbar {
     right: calc(var(--video-panel-chat-width) + 0.5rem);
 }
 .btn-video-panel.btn,
@@ -753,17 +753,17 @@ body.narrow .video-panel-content .video-track-player.pip-overlay .video-particip
 
 /* ── Embedded chat panel (expanded video, wide only) ── */
 
-.video-panel:has(.video-panel-chat) {
+.video-panel.has-video-panel-chat {
     --video-panel-chat-width: 20rem;
 }
 @media (min-width: 1024px) {
-    .video-panel:has(.video-panel-chat) { --video-panel-chat-width: 28rem; }
+    .video-panel.has-video-panel-chat { --video-panel-chat-width: 28rem; }
 }
 @media (min-width: 1280px) {
-    .video-panel:has(.video-panel-chat) { --video-panel-chat-width: 32rem; }
+    .video-panel.has-video-panel-chat { --video-panel-chat-width: 32rem; }
 }
 @media (min-width: 1536px) {
-    .video-panel:has(.video-panel-chat) { --video-panel-chat-width: 40rem; }
+    .video-panel.has-video-panel-chat { --video-panel-chat-width: 40rem; }
 }
 .video-panel-chat {
     @apply absolute z-tooltip right-0 top-0 bottom-0;
@@ -844,7 +844,7 @@ body.narrow .video-panel-content .video-track-player.pip-overlay .video-particip
 .video-panel.expanded .video-panel-content.video-panel-layout__sidebar {
     @apply gap-2 p-4 pb-20;
 }
-.video-panel.expanded:has(.video-panel-chat) .video-panel-content {
+.video-panel.expanded.has-video-panel-chat .video-panel-content {
     width: calc(100% - var(--video-panel-chat-width) - 0.5rem);
 }
 
@@ -968,23 +968,23 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
    with the chat visible below it, and pausing there freezes one-shot entrance
    animations (`smoothShow`, `showSubHeader`) on their opacity:0 first frame —
    the text keeps its box but never appears. */
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::before,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-body *::after,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::before,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .side-nav *::after,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::before,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .layout-subfooter::after {
+body.narrow.video-panel-expanded .layout-body *,
+body.narrow.video-panel-expanded .layout-body *::before,
+body.narrow.video-panel-expanded .layout-body *::after,
+body.narrow.video-panel-expanded .side-nav *,
+body.narrow.video-panel-expanded .side-nav *::before,
+body.narrow.video-panel-expanded .side-nav *::after,
+body.narrow.video-panel-expanded .layout-subfooter,
+body.narrow.video-panel-expanded .layout-subfooter::before,
+body.narrow.video-panel-expanded .layout-subfooter::after {
     /* !important: `animation` shorthands re-declare play-state `running`;
        deep multi-class ones can out-rank this gate's specificity. */
     animation-play-state: paused !important;
 }
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::before,
-body.narrow.has-video-panel:has(.video-panel.expanded:not(.panel-hidden)) .video-panel *::after {
+body.narrow.video-panel-expanded .video-panel,
+body.narrow.video-panel-expanded .video-panel *,
+body.narrow.video-panel-expanded .video-panel *::before,
+body.narrow.video-panel-expanded .video-panel *::after {
     /* Both gates are !important and tie on specificity — this one wins by
        source order, so it MUST stay below the paused block. */
     animation-play-state: running !important;

--- a/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
+++ b/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
@@ -7,10 +7,56 @@
 
 import { MutationProcessor } from 'mutation-processor';
 
+const virtualListGroup = '.virtual-list .c-virtual-container .group';
+const virtualListItem = '.virtual-list .c-virtual-container .item';
+
 MutationProcessor.registerPresenceClasses(
     { container: '.chat-message-editor', match: '.related-chat-entry-panel', className: 'has-related-entry' },
     { container: '.list-view-layout', match: '.chat-activity-panel.listening', className: 'has-listening-activity' },
     { container: '.list-view-layout', match: '.audio-panel-header', className: 'has-audio-panel-header' },
     { container: '.right-panel', match: '.c-header.expanded-header', className: 'has-expanded-header' },
     { container: '.layout-header', match: '.header-activity-panel-wrapper', className: 'has-activity-panel' },
+
+    // The chat view's live-conversation block. Measured on an iPhone 13 Pro during a
+    // fullscreen video call: 69 `.group` and 44 `.item` subjects, every predicate false,
+    // and `matchHasPseudoClass` 20% of attributable main-thread time - the whole cost was
+    // proving absence over and over.
+    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header', className: 'has-live-block' },
+    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header .c-lc-join', className: 'has-live-block-join' },
+    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header.dissolving', className: 'has-live-block-dissolving' },
+    { container: virtualListGroup, match: ':scope > .item > .conversation-message.live.joined', className: 'has-joined-live-card' },
+    { container: virtualListItem, match: ':scope > .conversation-message', className: 'has-conversation-message' },
+    { container: virtualListItem, match: ':scope > .conversation-message.live', className: 'has-live-card' },
+    { container: virtualListItem, match: ':scope > .conversation-message.live:empty', className: 'has-empty-live-card' },
+    { container: virtualListItem, match: ':scope > .live-conversation-footer', className: 'has-live-footer' },
+    { container: virtualListItem, match: '.live-conversation-header', className: 'has-live-header' },
+    { container: virtualListItem, match: '.show-author', className: 'has-show-author' },
+    { container: virtualListItem, match: '.conversation-header', className: 'has-conversation-header' },
+
+    // The video panel's state, mirrored onto body. `body` is an ancestor of every mutation,
+    // so a `body:has()` is re-proven on all of them - and the `.has-video-panel` compound
+    // that guards these short-circuits everywhere EXCEPT during a call, which is the one
+    // time it matters.
+    { container: 'body', match: '.video-panel:not(.panel-hidden)', className: 'video-panel-shown' },
+    { container: 'body', match: '.video-panel.expanded:not(.panel-hidden)', className: 'video-panel-expanded' },
+    { container: 'body', match: '.video-panel.expanded', className: 'video-panel-expanded-any' },
+    { container: '.layout-header', match: '.video-panel:not(.collapsed)', className: 'has-open-video-panel' },
+    { container: '.layout-header', match: '.video-panel:not(.collapsed):not(.panel-hidden)', className: 'has-visible-video-panel' },
+    { container: '.list-view-layout', match: '.video-panel:not(.collapsed)', className: 'has-open-video-panel' },
+    // Shares a declaration block with the video-panel rules above, so it has to move with
+    // them - left as :has() it would keep the specificity those rules just gave up.
+    { container: '.list-view-layout', match: '.map-panel', className: 'has-map-panel' },
+    { container: '.list-view-layout .layout-header', match: '.map-panel', className: 'has-map-panel' },
+    { container: '.video-panel', match: '.video-panel-chat', className: 'has-video-panel-chat' },
+    { container: '.video-panel', match: '.video-panel-chat:not(.chat-hidden)', className: 'has-video-panel-chat-shown' },
+
+    { container: '.tab-panel-tabs .tab-btn .btn-content', match: '.c-badge', className: 'has-badge' },
+    { container: '.chat-message-markup', match: '.code-block-markup', className: 'has-code-block' },
+    { container: '.chat-list .navbar-item .navbar-item-ending', match: '.chat-audio-controls', className: 'has-audio-controls' },
+    { container: '.chat-list .navbar-item-content .c-last-message', match: '.c-text.two-line', className: 'has-two-line-text' },
+    { container: '.chat-list .navbar-item-content .c-last-message .c-name', match: '.non-shrinkable', className: 'has-non-shrinkable' },
+    { container: '.chat-list .navbar-item-content .c-last-message .c-name', match: '.shrinkable', className: 'has-shrinkable' },
+    { container: '.found-result.navbar-item .c-description', match: '.c-second-line', className: 'has-second-line' },
+    { container: '.found-result.navbar-item .c-description', match: '.c-third-line', className: 'has-third-line' },
+    { container: '.found-result.navbar-item .c-description', match: '.c-name .non-shrinkable', className: 'has-non-shrinkable-name' },
 );

--- a/src/dotnet/UI.Blazor/Components/TabPanel/tab-panel.css
+++ b/src/dotnet/UI.Blazor/Components/TabPanel/tab-panel.css
@@ -98,7 +98,7 @@ body.hoverable .tab-panel-tabs .tab-btn.on:hover .btn-content {
     @apply py-1.5 px-2;
     @apply rounded-xl;
 }
-.tab-panel-tabs .tab-btn .btn-content:has(.c-badge) {
+.tab-panel-tabs .tab-btn .btn-content.has-badge {
     @apply pr-1.5;
 }
 .tab-panel-tabs .tab-btn .btn-content .message-counter-badge {

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
@@ -137,7 +137,7 @@ body.narrow .list-view-layout.has-audio-panel-header .virtual-list > .c-wrapper 
 .virtual-list > .c-wrapper > ul.c-virtual-container .item:empty {
     @apply min-h-0;
 }
-.virtual-list > .c-wrapper > ul.c-virtual-container .item:has(.show-author) {
+.virtual-list > .c-wrapper > ul.c-virtual-container .item.has-show-author {
     @apply min-h-14;
 }
 
@@ -146,7 +146,7 @@ body.narrow .list-view-layout.has-audio-panel-header .virtual-list > .c-wrapper 
     overflow-anchor: none;
 }
 
-.virtual-list > .c-wrapper > ul.c-virtual-container .item:has(.conversation-header) {
+.virtual-list > .c-wrapper > ul.c-virtual-container .item.has-conversation-header {
     @apply sticky -top-px z-20;
 }
 

--- a/src/nodejs/src/mutation-processor.ts
+++ b/src/nodejs/src/mutation-processor.ts
@@ -54,11 +54,20 @@ export const MutationProcessor = {
     // window with the class missing.
     registerPresenceClasses(...newRules: PresenceClassRule[]): void {
         rules.push(...newRules);
-        matchSelector = rules.map(r => r.match).join(',');
+        // The pre-filter tests added/removed nodes directly, where a leading `:scope >` would
+        // scope the selector to the node itself and so never match. Dropping it widens the
+        // check, which is the safe direction for a filter that only decides whether to work.
+        matchSelector = rules.map(r => r.match.replace(/^:scope\s*>\s*/, '')).join(',');
         matchTokens.clear();
-        for (const rule of rules)
+        for (const rule of rules) {
             for (const token of rule.match.match(/\.[\w-]+/g) ?? [])
                 matchTokens.add(token.slice(1));
+            // A Blazor re-render that rewrites `class` drops whatever we wrote there, and
+            // nothing else would tell us: the tokens the rule matches on didn't move. Watching
+            // our own class makes that a change we see. Our writes land after this callback
+            // and takeRecords() discards them, so this cannot feed back on itself.
+            matchTokens.add(rule.className);
+        }
         if (observer)
             updatePresenceClasses();
     },
@@ -93,18 +102,55 @@ function onMutated(records: MutationRecord[]): void {
     if (!isEnabled)
         return;
 
-    let hasPresenceChange = false;
+    const dirty = new Set<Element>();
     for (const record of records) {
         if (record.type === 'childList')
             syncAddedAnimations(record.addedNodes);
-        hasPresenceChange ||= affectsPresence(record);
+        if (affectsPresence(record))
+            collectContainers(record, dirty);
     }
-    if (hasPresenceChange) {
-        updatePresenceClasses();
+    if (dirty.size !== 0) {
+        updateContainers(dirty);
         // Our own class writes are mutations too; they land after this callback, so dropping
         // the records here discards exactly them and nothing else.
         observer?.takeRecords();
     }
+}
+
+// Only containers on the mutated node's ancestor chain can have flipped, so a mutation
+// costs O(rules) rather than O(rules x containers) - the difference between a handful of
+// container subjects and every `.item` in the chat view.
+function collectContainers(record: MutationRecord, dirty: Set<Element>): void {
+    const target = record.target instanceof Element ? record.target : record.target.parentElement;
+    if (target !== null)
+        for (const rule of rules) {
+            const container = target.closest(rule.container);
+            if (container !== null)
+                dirty.add(container);
+        }
+    if (record.type !== 'childList')
+        return;
+
+    // An added subtree can bring its own containers with it, and those are not on the
+    // ancestor chain of anything.
+    for (const node of record.addedNodes) {
+        if (!(node instanceof Element))
+            continue;
+
+        for (const rule of rules) {
+            if (node.matches(rule.container))
+                dirty.add(node);
+            for (const container of node.querySelectorAll(rule.container))
+                dirty.add(container);
+        }
+    }
+}
+
+function updateContainers(containers: Set<Element>): void {
+    for (const container of containers)
+        for (const rule of rules)
+            if (container.matches(rule.container))
+                container.classList.toggle(rule.className, container.querySelector(rule.match) !== null);
 }
 
 // Phase-aligns whatever arrived, replacing the sweep that used to run every 200ms.

--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -133,8 +133,8 @@ body.narrow {
     touch-action: none;
 }
 /* Let fullscreen video panel reach the viewport edges under device cutouts */
-body.has-video-panel:has(.video-panel.expanded) .safe-area-left::after,
-body.has-video-panel:has(.video-panel.expanded) .safe-area-right::after {
+body.video-panel-expanded-any .safe-area-left::after,
+body.video-panel-expanded-any .safe-area-right::after {
     display: none;
 }
 .safe-area-bottom-overlay {
@@ -355,14 +355,14 @@ body.narrow .list-view-layout:has(.chat-activity-panel:not(.not-participating)) 
         var(--transparent) 100%);
 }
 /* Video panel styling — no max-height, just visual treatment */
-.list-view-layout .layout-header:has(.video-panel:not(.collapsed)),
-.list-view-layout .layout-header:has(.map-panel) {
+.list-view-layout .layout-header.has-open-video-panel,
+.list-view-layout .layout-header.has-map-panel {
     border: none;
 }
 /* Collapsed video panel island uses fixed positioning — no header overflow needed.
    The map panel counts too: its Call/Map switch overhangs the header into the subheader area. */
-.list-view-layout:has(.video-panel:not(.collapsed)) .layout-subheader,
-.list-view-layout:has(.map-panel) .layout-subheader {
+.list-view-layout.has-open-video-panel .layout-subheader,
+.list-view-layout.has-map-panel .layout-subheader {
     @apply z-40;
 }
 /* Hideable elements (control panel buttons) */


### PR DESCRIPTION
## Why

Measured on an iPhone 13 Pro during a fullscreen video call (3 × 30s captures, `xctrace`, symbolicated locally with `atos`):

| bucket | cores | % of attributable main thread |
|---|---|---|
| `Document::updateLayout` | 0.128 | 61.9% |
| `Style::TreeResolver` | 0.065 | 31.3% |
| — `SelectorChecker` | 0.047 | 22.8% |
| — — **`matchHasPseudoClass`** | **0.042** | **20.2%** |
| `RenderLayerCompositor` | 0.047 | 22.9% |
| **`performLayout`** (real layout) | **0.009** | **4.4%** |

`:has()` is **86% of all selector matching** and larger than layout, paint and the compositing update put together. Every migrated predicate matched **zero** elements — the entire cost was proving absence, again, on every DOM mutation.

Two independent groups dominate:

- **The chat view** — 69 `.group` and 44 `.item` subjects, each carrying several `:has()` rules, all still walked while a fullscreen call covers them.
- **The body-subject rules** — `body` is an ancestor of every mutation. The `.has-video-panel` compound added in #4162 to guard them short-circuits everywhere *except* during a call, which is the one time it matters.

## What

Migrated to the existing `MutationProcessor` presence-class mechanism. Bundle `:has()` occurrences: **238 → 158**.

| subjects × rules | family |
|---|---|
| 69 × 4 | `.group:has(> .item.expanded > .live-conversation-header…)` |
| 44 × 7 | `.item:has(…)` — conversation message / live card / footer / header / show-author |
| body × 3 | `body:has(.video-panel…)`, 58 occurrences |
| 33 / 30 / 14×3 / 14 / 14 / 8×2 | `.btn-content`, `.chat-message-markup`, `.c-description`, `.c-last-message`, `.navbar-item-ending`, `.c-name` |

Two supporting changes that this scale required:

- `MutationProcessor` updates only the containers on the mutated node's **ancestor chain** instead of rescanning every container. Without it, 113 container subjects would trade style cost for JS cost.
- Presence class names join the token pre-filter. A Blazor re-render that rewrites `class` drops the class we wrote, and no other signal reports it — that would surface as intermittent styling bugs, not as an obvious failure.

## Cascade safety

`:has()` contributes the specificity of its most specific argument, so the class form is usually **less** specific. Checked by diffing the built bundles before/after and looking for rules that declare an overlapping property on the same subject with a specificity in the newly-exposed band.

Six landed in that band. Two were fixed by migrating `:has(.map-panel)` so it moves together with the comma-separated video-panel rule it shares a declaration block with. The remaining four are benign:

- `.item.has-empty-live-card` vs `.item.has-live-footer` — both declare an identical `min-h-0`, and an item cannot hold both.
- `.group.has-live-block` / `.has-joined-live-card` vs `.has-live-block-join` — the join rule used to win by specificity and now wins by source order, which is the outcome its own comment asks for.

## Test plan

- [x] `npm run build:Verify` — `tsc --noEmit`, eslint, bundle
- [x] Cascade diff of built bundles (script in the job scratch dir)
- [ ] On-device verification that the presence classes are applied in their true states, and a re-capture to quantify the win

⚠️ Not yet verified on device — the phone currently carries a diagnostics build for a separate `.nettrace` investigation into interpreted managed code (44% of the `ActualChat` process, 0.22 cores). Happy to hold this until the device pass is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMeEZiEK8LHQ7VgT44VwAL