### PR TITLE
build(ios): fold a live-video-call recording into ios-interactive.mibc

### DIFF
--- a/src/dotnet/App.Maui/_Profiling/ios-interactive.mibc
+++ b/src/dotnet/App.Maui/_Profiling/ios-interactive.mibc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:caf4e5762d2dfb10d6cbd2a4c31db6e463e09fff58369ad5f46712b8df74f8d8
-size 50898
+oid sha256:90f5911a4b9bb9abbec7262142ad59082c213752ac2b9ad33a94692575b3f3cb
+size 50319


### PR DESCRIPTION
## Why

There is no JIT on iOS, so **any method missing from the R2R image is interpreted for the life of the process**. `ios-interactive.mibc` is a session recording that predates the virtual-list refactorings, so it names instantiations that no longer exist and misses the ones that replaced them.

A fresh 3-minute recording (cold launch + live 2-party video call, per `docs/ios-specific.md` → *Measuring what runs interpreted*) found **357 methods running interpreted**, of which **196 were named by neither `ios-interactive.mibc` nor `aothelper.mibc`**.

The new ones are the live-call surface:

| hits | path |
|---|---|
| 7 | `ChatUI.Get`, `.LeaseReadPositionState` |
| 7 | `VirtualList.SetParametersAsync`, `.OnAfterRenderAsync` |
| 7 | `ChatView` → `IVirtualListDataSource` |
| 6 | `LiveSessionUI.Get` / `.GetConversation` / `.GetBlockSnapshot` / `.GetMutedRecordingChat` |
| 6 | `ChatUI.GetChatItemsInternal` / `.GetPreview` / `.GetState` |
| 6 | `ChatAudioUI.TryAcquireAudioFocus` / `.GetRecordingState` / `RecordChat` |
| 6, 5 | `ChatVideoUI.CompleteRecording`, `.RunRecorderLifecycle` |
| 6 | `VirtualList.ComputeState`, `ChatPinnedBar.ComputeState`, `AsyncMemoizer.OnRun` |

plus 25 methods of `ComputedState<Nullable<Moment>>` / `ComputedStateComponentState<>` machinery, `UserSettingsAccessor<VoiceMode>` / `<ContinuedListening>`, and `BoxMessagePackFormatter<Moment>`.

## Verification

- **Merge is a true superset**: 4155 + 357 with 161 overlapping = **4351** methods, nothing dropped from either input.
- **crossgen2 compiles the additions**: `ActualChat.r2r.map.csv` now contains `ComputedStateComponentState_1<Nullable_1<Moment>>`, absent from the previous image.
- LFS pointer oid/size verified against the file on both the build machine and here.

## What this does NOT show

**No measured CPU win.** On device the interpreter's share of the managed process is unchanged: **44.0% / 44.8% → 42.6% / 43.9%**. The absolute interpreter time fell, but `ActualChat` as a whole fell by the same proportion (and GC with it), and compilation cannot reduce the *compiled* portion — so that drop is a workload difference between captures, not this change.

So the interpreted time lives elsewhere, including **161 methods that were already named by a shipped profile and ran interpreted anyway** — which no amount of re-recording will fix. That's a separate thread.

Taken anyway because the costs are asymmetric: a stale entry costs a little image size, a missing one costs interpretation forever.

## Note for the future

Expect to **re-record rather than keep merging** — a merged file accumulates dead entries as the code moves, and another refactoring is already in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMeEZiEK8LHQ7VgT44VwAL