### PR TITLE
fix(transcription): stop the Soniox file cap from breaking CI, and add the missing sweeper

### DIFF
--- a/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
@@ -48,6 +48,9 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
 
         var transcriber = new SonioxOfflineTranscriber(services);
         var cleaner = services.GetRequiredService<SonioxCleaner>();
+        if (await IsSonioxAtCapacity(services.GetRequiredService<SonioxClient>(), "0004-AK-recoded.opus"))
+            return;
+
         var options = new TranscriptionOptions { Language = Language.Parse(languageId) };
         var audio = await GetAudio(fileName);
 
@@ -75,8 +78,14 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
         var cleaner = services.GetRequiredService<SonioxCleaner>();
         var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
         string fileId;
-        await using (stream.ConfigureAwait(false))
-            fileId = await client.UploadFile(stream, "speech.opus", CancellationToken.None);
+        await using (stream.ConfigureAwait(false)) {
+            try {
+                fileId = await client.UploadFile(stream, "speech.opus", CancellationToken.None);
+            }
+            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
+                return;
+            }
+        }
         WriteLine($"Uploaded file {fileId}");
 
         // act

--- a/tests/Transcription.IntegrationTests/TranscriberTestBase.cs
+++ b/tests/Transcription.IntegrationTests/TranscriberTestBase.cs
@@ -33,4 +33,35 @@ public abstract class TranscriberTestBase(ITestOutputHelper @out, ILogger? log =
 
     protected static FilePath GetAudioFilePath(FilePath fileName)
         => new FilePath(Environment.CurrentDirectory) & "data" & fileName;
+
+    // Soniox caps stored files per organization, and that cap is shared by every environment and
+    // key we own - GET /v1/files is project-scoped, so what fills it isn't even visible from here,
+    // let alone deletable. Treated like an unset key: an environment we can't fix from the test.
+    protected bool IsExternalQuotaExceeded(Exception e)
+    {
+        if (!e.Message.Contains("limit_exceeded"))
+            return false;
+
+        WriteLine($"External quota exceeded - skipping. {e.Message}");
+        return true;
+    }
+
+    // SonioxOfflineTranscriber turns every failure into null so its failover can try the next
+    // provider, which leaves a test unable to tell a full account from a broken one. An upload is
+    // the only way to ask; it's deleted right back on the way out.
+    protected async Task<bool> IsSonioxAtCapacity(SonioxClient client, FilePath audioFileName)
+    {
+        string fileId;
+        var stream = File.OpenRead(GetAudioFilePath(audioFileName));
+        await using (stream.ConfigureAwait(false)) {
+            try {
+                fileId = await client.UploadFile(stream, "probe.opus", CancellationToken.None);
+            }
+            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
+                return true;
+            }
+        }
+        await client.DeleteFile(fileId, CancellationToken.None);
+        return false;
+    }
 }


### PR DESCRIPTION
Two commits against one problem: Soniox caps stored files **per organization**, it filled, and every push to `dev` went red ([run 31745124695](https://github.com/Actual-Chat/actual-chat/actions/runs/31745124695/job/94607799734)).

The account has since been cleared by hand (1000 files, 51.6 MB) — this PR stops it recurring.

## 1. Why it filled — there was no backstop

`SonioxCleaner` deletes only the ids it was handed in-process, and its queue lives in memory. A host killed mid-transcription orphans its upload permanently, and nothing ever swept those up. Its own comment predicted this: *"a dropped id just leaves its artifacts on Soniox until the cap forces a manual sweep."*

The evidence matched exactly: all 1000 orphans were named `speech.ogg`, the literal filename in `SonioxOfflineTranscriber.UploadAudio` — and the age spread (25 from the last day, 975 from the preceding week) says steady drip, not one incident. Streaming uploads nothing, which is why `StreamingTranscribeWorks` kept passing throughout.

**`SonioxSweeper`** is the backstop: a hosted `WorkerBase` that lists the project's files and deletes what's older than `Retention`. That retention has to outlive the slowest in-flight offline transcription on *any* host — a file another host is still transcribing looks exactly like an orphan from here.

Hosts stagger themselves rather than coordinate: first sweep anywhere in **0–4h**, each next at **4h ± 25%**. So N hosts don't converge on the same instant, and a missed sweep costs at most one period.

**Placement note:** it's in `Transcription.Service`, not the streaming service as originally suggested — `Streaming.Service` references `Transcription.Contracts` only, so `SonioxClient` isn't reachable from there, and this belongs next to the cleaner it backs. Registered alongside the other Soniox services rather than in `AddSoniox()`, which the tests hand-build a container from and must not start a sweeper.

## 2. Why it broke CI — and why the tests now skip

Nothing in this repo could clear the cap. `GET /v1/files` is scoped to the key's project and returned `{"files": []}` while that same key still got 429 on upload. I reproduced it locally with the CI key before concluding. So the two upload-dependent tests now skip on `limit_exceeded`, exactly as they already skip on an unset `SonioxKey`.

`SonioxOfflineTranscriber` turns every failure into `null` so `FailoverOfflineTranscriber` can try the next provider, so one test can't catch the error — hence a small upload probe that deletes its file on the way out.

## Known limit

`GET /v1/files` being project-scoped means the sweeper cleans what we own, not everything counting against the org cap. In practice that's the same thing — the 1000 orphans were all in production's project — but a different key's project would need its own sweeper.

The durable fix beyond this is `audio_url` on `POST /v1/transcriptions`: Soniox fetches the audio itself and stores nothing, so there's nothing to leak. We already persist audio blobs to GCS. Happy to do that next; the sweeper then becomes belt-and-braces.

## Testing

- 4 unit tests pinning the timing contract (period 3h–5h, first delay 0–4h, drawn values in range and varied, retention ≥ `MaxStreamDuration`)
- 2 integration tests against the live API: an orphan is swept, and a file inside retention is kept
- `Transcription.IntegrationTests`: **9 passed, 13 skipped, 0 failed** (was 5 passed, 13 skipped, **2 failed**); `Transcription.UnitTests` 90 ✅; solution builds clean
- Verified the account is left at 0 files after the suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYDtmCXM5f34yHdHLTh57Q