### PR TITLE
feat(transcription): sweep orphaned Soniox files periodically

### DIFF
--- a/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
+++ b/src/dotnet/Transcription.Service/Module/TranscriptionServiceModule.cs
@@ -31,6 +31,10 @@ public sealed class TranscriptionServiceModule(IServiceProvider moduleServices)
             services.AddSoniox();
             services.AddSingleton<ITranscriber, SonioxTranscriber>();
             services.AddSingleton<IOfflineTranscriber, SonioxOfflineTranscriber>();
+            // Not in AddSoniox: the tests that hand-build a container from it must not start a sweeper.
+            services.AddSingleton(_ => new SonioxSweeper.Options());
+            services.AddSingleton<SonioxSweeper>()
+                .AddHostedService(c => c.GetRequiredService<SonioxSweeper>());
         }
         if (!coreSettings.ElevenLabsKey.IsNullOrEmpty()) {
             services.AddHttpClient(ElevenLabsOfflineTranscriber.HttpClientName);

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
@@ -83,6 +83,23 @@ public sealed class SonioxClient
             .ConfigureAwait(false);
     }
 
+    // Scoped to the key's project, while the stored-file cap Soniox enforces is organization-wide -
+    // so this lists what we can clean, not everything that counts against the cap.
+    public async Task<SonioxFileList> ListFiles(string? cursor, int maxCount, CancellationToken cancellationToken)
+    {
+        using var httpClient = CreateHttpClient();
+        var url = $"{BaseUrl}/files?num_items={maxCount}";
+        if (!cursor.IsNullOrEmpty())
+            url += $"&cursor={Uri.EscapeDataString(cursor)}";
+
+        using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccess(response, "list files", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsync<SonioxFileList>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result ?? throw StandardError.External("Soniox returned no file list.");
+    }
+
     public Task DeleteTranscription(string transcriptionId, CancellationToken cancellationToken)
         => Delete($"transcriptions/{transcriptionId}", cancellationToken);
 

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxModels.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxModels.cs
@@ -48,3 +48,18 @@ public sealed class SonioxStatusResponse
     [JsonPropertyName("status")] public string? Status { get; set; }
     [JsonPropertyName("error_message")] public string? ErrorMessage { get; set; }
 }
+
+public sealed class SonioxFile
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = "";
+    [JsonPropertyName("filename")] public string? Filename { get; set; }
+    [JsonPropertyName("size")] public long Size { get; set; }
+    [JsonPropertyName("created_at")] public DateTimeOffset? CreatedAt { get; set; }
+}
+
+public sealed class SonioxFileList
+{
+    [JsonPropertyName("files")] public SonioxFile[]? Files { get; set; }
+    // Opaque - valid only when passed back verbatim, so it's never parsed or rebuilt.
+    [JsonPropertyName("next_page_cursor")] public string? NextPageCursor { get; set; }
+}

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
@@ -1,0 +1,108 @@
+using ActualLab.Diagnostics;
+
+namespace ActualChat.Transcription;
+
+/// <summary>
+/// Periodically deletes Soniox files that <see cref="SonioxCleaner"/> never got to - its queue
+/// lives in memory, so every id it holds is lost when a host dies mid-transcription, and Soniox
+/// caps stored files per organization.
+/// </summary>
+public sealed class SonioxSweeper : WorkerBase
+{
+    public sealed record Options
+    {
+        // Hosts stagger themselves rather than coordinate: the first sweep lands anywhere in a
+        // period, and each next one jitters, so N hosts don't converge on the same instant.
+        public RandomTimeSpan Period { get; init; } = TimeSpan.FromHours(4).ToRandom(0.25);
+        public RandomTimeSpan FirstDelay { get; init; } = new(TimeSpan.FromHours(2), TimeSpan.FromHours(2));
+        // Must outlive the slowest in-flight offline transcription on any host: a file still being
+        // transcribed elsewhere looks exactly like an orphan from here.
+        public TimeSpan Retention { get; init; } = TimeSpan.FromMinutes(15);
+        public int PageSize { get; init; } = 1000;
+        public int MaxDeletesPerSweep { get; init; } = 5000;
+        public RetryDelaySeq RetryDelays { get; init; }
+            = RetryDelaySeq.Exp(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(30));
+        public LogLevel LogLevel { get; init; } = LogLevel.Information;
+    }
+
+    private Options Settings { get; }
+    private SonioxClient Client { get; }
+    private MomentClock SystemClock { get; }
+    private ILogger Log { get; }
+    private ILogger? DefaultLog => Log.IfEnabled(Settings.LogLevel);
+
+    public SonioxSweeper(Options settings, IServiceProvider services)
+    {
+        Settings = settings;
+        Client = services.GetRequiredService<SonioxClient>();
+        SystemClock = services.Clocks().SystemClock;
+        Log = services.LogFor(GetType());
+    }
+
+    // Protected methods
+
+    protected override Task OnRun(CancellationToken cancellationToken)
+        // PrependDelay wraps the cycling chain, so it staggers the host once rather than every cycle
+        => AsyncChain.From(Cycle)
+            .Log(LogLevel.Debug, Log)
+            .RetryForever(Settings.RetryDelays, SystemClock, Log)
+            .CycleForever()
+            .PrependDelay(Settings.FirstDelay, SystemClock)
+            .Run(cancellationToken);
+
+    // It's internal so tests can run a single pass without the loop's delay
+    internal async Task<int> Sweep(CancellationToken cancellationToken)
+    {
+        var deleted = 0;
+        var kept = 0;
+        var failed = 0;
+        var isTruncated = false;
+        var deleteBefore = SystemClock.Now - Settings.Retention;
+        var cursor = (string?)null;
+        do {
+            var page = await Client
+                .ListFiles(cursor, Settings.PageSize, cancellationToken)
+                .ConfigureAwait(false);
+            cursor = page.NextPageCursor;
+            foreach (var file in page.Files ?? []) {
+                // No timestamp means no way to tell an orphan from a live upload, so it stays.
+                if (file.CreatedAt is not { } createdAt || (Moment)createdAt.UtcDateTime >= deleteBefore) {
+                    kept++;
+                    continue;
+                }
+                if (deleted + failed >= Settings.MaxDeletesPerSweep) {
+                    isTruncated = true;
+                    break;
+                }
+
+                try {
+                    await Client.DeleteFile(file.Id, cancellationToken).ConfigureAwait(false);
+                    deleted++;
+                }
+                catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+                    // One bad id must not cost the rest of the sweep - the next run retries it.
+                    failed++;
+                    Log.LogWarning(e, "Sweep: couldn't delete file {FileId}", file.Id);
+                }
+            }
+        } while (!cursor.IsNullOrEmpty() && !isTruncated && !cancellationToken.IsCancellationRequested);
+
+        if (isTruncated)
+            Log.LogWarning(
+                "Sweep: stopped at {MaxCount} deletes, more remain - the next sweep continues",
+                Settings.MaxDeletesPerSweep);
+        if (deleted > 0 || failed > 0)
+            DefaultLog?.Log(Settings.LogLevel,
+                "Sweep: deleted {DeletedCount} orphaned file(s), kept {KeptCount}, {FailedCount} failed",
+                deleted, kept, failed);
+        return deleted;
+    }
+
+    // Private methods
+
+    private async Task Cycle(CancellationToken cancellationToken)
+    {
+        await Sweep(cancellationToken).ConfigureAwait(false);
+        await SystemClock.Delay(Settings.Period.Next(), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/dotnet/Transcription.Service/Transcription.Service.csproj.DotSettings
+++ b/src/dotnet/Transcription.Service/Transcription.Service.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=transcribers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/Transcription.IntegrationTests/SonioxSweeperTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxSweeperTest.cs
@@ -1,0 +1,99 @@
+using ActualChat.Module;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+
+namespace ActualChat.Transcription.IntegrationTests;
+
+[Collection(nameof(TranscriptionCollection))]
+public class SonioxSweeperTest(ITestOutputHelper @out, ILogger<SonioxSweeperTest> log)
+    : TranscriberTestBase(@out, log)
+{
+    [Fact(Timeout = 60_000)]
+    public async Task SweepDeletesOrphansAndKeepsRecentOnes()
+    {
+        // arrange
+        var services = CreateServices();
+        if (services.GetRequiredService<CoreServerSettings>().SonioxKey.IsNullOrEmpty()) {
+            WriteLine("CoreSettings__SonioxKey is not set - skipping.");
+            return;
+        }
+
+        var client = services.GetRequiredService<SonioxClient>();
+        string orphanId;
+        var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
+        await using (stream.ConfigureAwait(false)) {
+            try {
+                orphanId = await client.UploadFile(stream, "orphan.opus", CancellationToken.None);
+            }
+            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
+                return;
+            }
+        }
+        WriteLine($"Uploaded orphan {orphanId}");
+
+        // act - retention shorter than the upload's age, so the fresh file is the orphan here
+        var sweeper = NewSweeper(services, TimeSpan.Zero);
+        var deleted = await sweeper.Sweep(CancellationToken.None);
+
+        // assert
+        WriteLine($"Swept {deleted} file(s)");
+        deleted.Should().BeGreaterThanOrEqualTo(1);
+        var remaining = await client.ListFiles(null, 1000, CancellationToken.None);
+        (remaining.Files ?? []).Should().NotContain(x => x.Id == orphanId);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task SweepKeepsFilesInsideRetention()
+    {
+        // arrange
+        var services = CreateServices();
+        if (services.GetRequiredService<CoreServerSettings>().SonioxKey.IsNullOrEmpty()) {
+            WriteLine("CoreSettings__SonioxKey is not set - skipping.");
+            return;
+        }
+
+        var client = services.GetRequiredService<SonioxClient>();
+        var cleaner = services.GetRequiredService<SonioxCleaner>();
+        string keptId;
+        var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
+        await using (stream.ConfigureAwait(false)) {
+            try {
+                keptId = await client.UploadFile(stream, "in-flight.opus", CancellationToken.None);
+            }
+            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
+                return;
+            }
+        }
+
+        // act - the default retention must protect an upload a transcription is still using
+        var sweeper = NewSweeper(services, new SonioxSweeper.Options().Retention);
+        var deleted = await sweeper.Sweep(CancellationToken.None);
+
+        // assert
+        deleted.Should().Be(0);
+        var remaining = await client.ListFiles(null, 1000, CancellationToken.None);
+        (remaining.Files ?? []).Should().Contain(x => x.Id == keptId);
+
+        cleaner.Enqueue(null, keptId);
+        await cleaner.Flush().WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    // Private methods
+
+    private static SonioxSweeper NewSweeper(IServiceProvider services, TimeSpan retention)
+        => new(new SonioxSweeper.Options { Retention = retention }, services);
+
+    private IServiceProvider CreateServices()
+    {
+        IConfiguration configuration = new ConfigurationManager {
+            Sources = { new EnvironmentVariablesConfigurationSource() },
+        };
+        return new ServiceCollection()
+            .AddSingleton<IConfiguration>(_ => configuration)
+            .AddSingleton(MomentClockSet.Default)
+            .AddSingleton(_ => configuration.Settings<CoreServerSettings>(nameof(CoreSettings)))
+            .AddSoniox()
+            .AddTestLogging(Out)
+            .BuildServiceProvider();
+    }
+}

--- a/tests/Transcription.UnitTests/SonioxSweeperOptionsTest.cs
+++ b/tests/Transcription.UnitTests/SonioxSweeperOptionsTest.cs
@@ -1,0 +1,42 @@
+namespace ActualChat.Transcription.UnitTests;
+
+public class SonioxSweeperOptionsTest
+{
+    private static readonly SonioxSweeper.Options Settings = new();
+
+    [Fact]
+    public void PeriodIsFourHoursPlusMinusQuarter()
+    {
+        // assert
+        Settings.Period.Origin.Should().Be(TimeSpan.FromHours(4));
+        Settings.Period.Min.Should().Be(TimeSpan.FromHours(3));
+        Settings.Period.Max.Should().Be(TimeSpan.FromHours(5));
+    }
+
+    [Fact]
+    public void FirstDelaySpansTheWholePeriod()
+    {
+        // A host that starts must land anywhere in the period, so N hosts spread out
+        Settings.FirstDelay.Min.Should().Be(TimeSpan.Zero);
+        Settings.FirstDelay.Max.Should().Be(TimeSpan.FromHours(4));
+    }
+
+    [Fact]
+    public void DrawnDelaysStayInRangeAndVary()
+    {
+        // act
+        var firstDelays = Enumerable.Range(0, 200).Select(_ => Settings.FirstDelay.Next()).ToList();
+        var periods = Enumerable.Range(0, 200).Select(_ => Settings.Period.Next()).ToList();
+
+        // assert
+        firstDelays.Should().OnlyContain(x => x >= TimeSpan.Zero && x <= TimeSpan.FromHours(4));
+        periods.Should().OnlyContain(x => x >= TimeSpan.FromHours(3) && x <= TimeSpan.FromHours(5));
+        firstDelays.Distinct().Should().HaveCountGreaterThan(100);
+        periods.Distinct().Should().HaveCountGreaterThan(100);
+    }
+
+    [Fact]
+    public void RetentionOutlivesTheLongestTranscription()
+        // A file still being transcribed on another host is indistinguishable from an orphan
+        => Settings.Retention.Should().BeGreaterThanOrEqualTo(Constants.Audio.MaxStreamDuration);
+}


### PR DESCRIPTION
Follow-up to #4171, which stopped the full Soniox file cap from breaking CI but left the cause in place. This adds the missing backstop.

## Why the cap filled

`SonioxCleaner` deletes only the ids it was handed in-process, and its queue lives in memory. A host killed mid-transcription orphans its upload permanently, and nothing ever swept those up. Its own comment predicted it: *"a dropped id just leaves its artifacts on Soniox until the cap forces a manual sweep."*

The evidence matched exactly — all 1000 orphans I cleared by hand were named `speech.ogg`, the literal filename in `SonioxOfflineTranscriber.UploadAudio`, and the age spread (25 from the last day, 975 from the preceding week) says steady drip rather than one incident. Streaming uploads nothing, which is why `StreamingTranscribeWorks` kept passing throughout.

## What this adds

`SonioxSweeper`, a hosted `WorkerBase` that lists the project's files and deletes what's older than `Retention` (**15 min**).

Retention has to outlive the slowest in-flight offline transcription on *any* host — a file another host is still transcribing looks exactly like an orphan from here. It isn't what decides how fast orphans clear, since the sweep period dominates; it's purely the safety margin. A unit test pins `Retention >= MaxStreamDuration` so it can't later be shrunk below the longest possible transcription.

Hosts stagger themselves rather than coordinate: first sweep anywhere in **0–4h**, each next at **4h ± 25%**. So N hosts don't converge on the same instant, and a missed sweep costs at most one period.

**Placement:** `Transcription.Service`, not the streaming service — `Streaming.Service` references `Transcription.Contracts` only, so `SonioxClient` isn't reachable from there, and this belongs next to the cleaner it backs. It still runs on the backend host, since `TranscriptionServiceModule` is gated to `HostRole.OneBackendServer`. Registered alongside the other Soniox services rather than in `AddSoniox()`, which the tests hand-build a container from and must not start a sweeper.

## Known limit

`GET /v1/files` is project-scoped while the cap is organization-wide, so this cleans what we own rather than everything counting against the cap. For the observed failure that's the same set — all 1000 orphans were production's — but another key's project would need its own sweeper.

The fix that removes the problem class entirely is `audio_url` on `POST /v1/transcriptions`: Soniox fetches the audio itself and stores nothing. We already persist audio blobs to GCS. Worth doing next; the sweeper then becomes belt-and-braces.

## Testing

- 4 unit tests pinning the timing contract: period 3h–5h, first delay 0–4h, drawn values in range and varied, and the retention floor
- 2 integration tests against the live API: an orphan is swept, and a file inside retention is kept
- `Transcription.UnitTests` 90 ✅, `Transcription.IntegrationTests` 9 passed / 13 skipped / 0 failed, solution builds clean
- Verified the account is left at 0 files after the suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYDtmCXM5f34yHdHLTh57Q