### PR TITLE
perf(startup): defer composition layers, blur and skeleton pulse past first paint

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -320,7 +320,10 @@ public partial class MainActivity : MauiAppCompatActivity
     [SupportedOSPlatform("android31.0")]
     private sealed class SplashExitAnimator : JObject, Android.Window.ISplashScreenOnExitAnimationListener
     {
-        private static readonly TimeSpan FadeDuration = TimeSpan.FromMilliseconds(300);
+        // Runs entirely after the first frame, so every ms of it is added latency. It is also a
+        // main-thread animation, so a long WebView raster frame starves it: at 300ms the splash
+        // routinely outlived the first frame by ~330ms rather than by its nominal duration.
+        private static readonly TimeSpan FadeDuration = TimeSpan.FromMilliseconds(150);
 
         public void OnSplashScreenExit(Android.Window.SplashScreenView splashScreenView)
         {

--- a/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
@@ -12,6 +12,32 @@ public class MainApplication : MauiApplication
         : base(handle, ownership)
         => Android.Util.Log.Info(MauiDiagnostics.LogTag, "---- Started ----");
 
+    public override void OnCreate()
+    {
+        WarmUpWebView();
+        base.OnCreate();
+    }
+
     protected override MauiApp CreateMauiApp()
         => MauiProgram.CreateMauiApp();
+
+    // Private methods
+
+    private static void WarmUpWebView()
+    {
+        // Without this the WebView provider is loaded on the UI thread inside MainActivity's
+        // performStart, right before BlazorAndroidWebView is constructed. GetDefaultUserAgent
+        // forces the same load and is safe off the UI thread, moving ~10ms off the critical path.
+        // Nothing waits on this: Chromium's own provider lock already makes WebView construction
+        // block until the load finishes, and it posts its native init back to the UI thread - so
+        // blocking the UI thread on this task instead would deadlock.
+        _ = Task.Run(() => {
+            try {
+                _ = Android.Webkit.WebSettings.GetDefaultUserAgent(Android.App.Application.Context);
+            }
+            catch (Exception e) {
+                Android.Util.Log.Warn(MauiDiagnostics.LogTag, $"WebView warm-up failed: {e.Message}");
+            }
+        });
+    }
 }

--- a/src/dotnet/App.Maui/wwwroot/index.htm
+++ b/src/dotnet/App.Maui/wwwroot/index.htm
@@ -51,19 +51,9 @@
     <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-DemiBold.woff2" as="font" crossorigin />
     <link rel="preload" href="/dist/assets/woff2/forkawesome-webfont.woff2" as="font" crossorigin />
     <link rel="prefetch" href="/dist/assets/woff2/TT-Commons-Pro-Light.woff2" as="font" crossorigin />
-    <link rel="prefetch" href="/dist/onDeviceAwakeWorker.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="worker" crossorigin />
-    <link rel="prefetch" href="/dist/opusDecoderWorker.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="worker" crossorigin />
-    <link rel="prefetch" href="/dist/opusEncoderWorker.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="worker" crossorigin />
-    <link rel="prefetch" href="/dist/warmUpWorklet.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="audioworklet" crossorigin />
-    <link rel="prefetch" href="/dist/vadWorker.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="worker" crossorigin />
-    <link rel="prefetch" href="/dist/feederWorklet.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="audioworklet" crossorigin />
-    <link rel="prefetch" href="/dist/opusEncoderWorklet.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="audioworklet" crossorigin />
-    <link rel="prefetch" href="/dist/vadWorklet.js?v=1.4.101-alpha-g0c6da31447-7C64C707" as="audioworklet" crossorigin />
-    <!--
-    <link rel="prefetch" href="/dist/assets/wasm/codec.wasm?v=1.4.101-alpha-g0c6da31447-7C64C707" as="fetch" crossorigin />
-    <link rel="prefetch" href="/dist/assets/wasm/webrtc-vad.wasm?v=1.4.101-alpha-g0c6da31447-7C64C707" as="fetch" crossorigin />
-    <link rel="prefetch" href="/dist/assets/onnx/vad.onnx" as="fetch" crossorigin />
-    -->
+    <!-- Nothing else is prefetched here on purpose: workers, worklets and wasm are all served
+         from the APK, so there is no network latency to hide (~15ms each), and they only
+         competed with the first paint. -->
     <link href="/dist/bundle.css" rel="stylesheet" />
     <script src="_startup.js"></script>
 </head>

--- a/src/dotnet/UI.Blazor/Components/Pic/pic.css
+++ b/src/dotnet/UI.Blazor/Components/Pic/pic.css
@@ -18,9 +18,13 @@
     @apply opacity-70;
     @apply absolute right-0 top-0 left-0 bottom-0;
     @apply overflow-hidden;
+}
+/* Deferred until app-ready: a 40px blur across a full-width cover is the most expensive thing
+   the compositor is asked for during the first paint, and the cover is usually off-screen then. */
+body.app-ready .pic-blurred {
     filter: blur(40px);
 }
-body.device-ios .pic-blurred {
+body.app-ready.device-ios .pic-blurred {
     /* Addresses blur performance issue on WebKit */
     will-change: transform;
     transform: translateZ(0);

--- a/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
+++ b/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
@@ -13,6 +13,10 @@
     @apply md:left-0 md:right-auto md:w-full; /* Must go 2nd */
     transform: none;
     touch-action: manipulation;
+}
+/* Deferred until app-ready: both side navs are promoted before the first paint, and each costs
+   the compositor a full-screen raster - including the right one, which sits fully off-screen. */
+body.app-ready .side-nav {
     will-change: transform; /* Ensures its own composition layer */
 }
 

--- a/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
@@ -555,6 +555,21 @@ voxt-skeleton {
     animation: pulse 2s steps(10) infinite;
 }
 
+/* Skeletons still show before app-ready, they just hold still. The pulse ticks for the whole
+   loading window, and on mobile WebView every animation tick redraws the entire screen (see the
+   note in chat-audio-panel.css) - which lands on the compositor exactly while it is the startup
+   bottleneck. Suppressing the animation is one rule here; gating it on body.app-ready like the
+   layer hints would mean splitting all nine rules below. */
+body:not(.app-ready) .animated-skeleton,
+body:not(.app-ready) .string-skeleton,
+body:not(.app-ready) voxt-skeleton,
+body:not(.app-ready) image-skeleton.show-image-skeleton,
+body:not(.app-ready) thin-left-panel-skeleton .button,
+body:not(.app-ready) chat-view-footer-skeleton .footer-button,
+body:not(.app-ready) tab-skeleton .c-line {
+    animation: none;
+}
+
 @keyframes pulse {
     0%, 100% {
         opacity: 1;

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
@@ -5,10 +5,14 @@
     scrollbar-gutter: stable;
     -ms-overflow-style: none;
     overflow-anchor: none;
+    contain: strict;
+}
+/* Deferred until app-ready - see side-nav.css. The transform here is the identity, so gating it
+   changes layout in no way; it exists only to force a composition layer. */
+body.app-ready .virtual-list {
     will-change: transform;
     transform: translate3d(0, 0, 0);
     backface-visibility: hidden;
-    contain: strict;
 }
 
 .virtual-list > .data.render-index {
@@ -47,11 +51,13 @@ body.narrow .list-view-layout.has-audio-panel-header .virtual-list > .c-wrapper 
 .virtual-list > .c-wrapper > ul.c-virtual-container {
     @apply absolute w-full;
     @apply flex flex-nowrap flex-col items-stretch content-start justify-start;
+    list-style-type: none;
+    overflow-anchor: none;
+}
+body.app-ready .virtual-list > .c-wrapper > ul.c-virtual-container {
     will-change: transform;
     transform: translate3d(0, 0, 0);
     backface-visibility: hidden;
-    list-style-type: none;
-    overflow-anchor: none;
 }
 
 /* FiniteList keeps the container in flow: its spacers cover the unloaded ranges exactly, so the

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
@@ -15,6 +15,7 @@ import { initAppConstants, AppConstants } from 'app-constants';
 
 const { debugLog, infoLog, warnLog, errorLog } = getLogs('BrowserInit');
 const IsAnalyticsEnabledSetting = 'isAnalyticsEnabled';
+const AppReadyDelayMs = 350;
 
 const sessionStorage = globalThis?.sessionStorage;
 
@@ -32,6 +33,7 @@ export class BrowserInit {
     public static readonly reconnectedEvents = new EventHandlerSet<void>();
     public static connectionState = '';
     public static reconnectingPromise: Promise<void> = null!;
+    private static isAppReady = false;
 
     public static init(
         hostKind: HostKind,
@@ -214,19 +216,25 @@ export class BrowserInit {
     public static removeWebSplash(instantly = false) {
         document.body.style.backgroundColor = '';
         const splash = document.getElementById('web-splash');
-        if (!splash)
+        if (!splash) {
+            this.scheduleAppReady();
             return;
+        }
 
         if (instantly) {
             splash.remove();
             void BrowserInfo.onWebSplashRemoved();
+            this.scheduleAppReady();
         }
         else {
             splash.classList.add('removing');
             // Total transition duration: 350ms, see web-splash.css
-            setTimeout(function () {
+            setTimeout(() => {
                 void BrowserInfo.onWebSplashRemoved();
-                setTimeout(function () { splash.remove(); }, 150);
+                setTimeout(() => {
+                    splash.remove();
+                    this.scheduleAppReady();
+                }, 150);
             }, 200);
         }
     }
@@ -277,6 +285,18 @@ export class BrowserInit {
     }
 
     // Private methods
+
+    // body.app-ready gates the composition-layer hints, the blurred-cover filter and the skeleton
+    // pulse. Each layer costs the compositor a full-screen raster and each animation tick redraws
+    // the whole screen on Android WebView, so before this class lands all of that would pile onto
+    // the compositor exactly while it is the startup bottleneck.
+    private static scheduleAppReady(): void {
+        if (this.isAppReady)
+            return;
+
+        this.isAppReady = true;
+        setTimeout(() => document.body.classList.add('app-ready'), AppReadyDelayMs);
+    }
 
     private static initWindowId(): void {
         // Set App.windowId


### PR DESCRIPTION
## What

The longest single frame of an Android cold start is `WebViewFunctor::drawVk` with Chromium's GPU thread saturated. Profiling showed **25 composited layers created and rasterized before the first paint** — two of them full-screen side navs, one translated entirely off-screen — alongside a `blur(40px)` over a full-width cover and nine skeleton pulse animations, each tick of which redraws the whole screen (the WebView functor has no partial damage).

`body.app-ready`, applied 350ms after the web splash is removed, now gates the composition-layer hints, the blurred cover and the skeleton pulse, so that work lands *after* the compositor has finished the initial view instead of inside it.

## Measurements

SM-S948U1, 6 cold starts per build, using the pre-Main phases (libmonodroid load, runtime init, `MainApplication` ctor) as a drift control — those are upstream of every change here, so they detect device drift between sessions.

| | baseline | this branch |
|---|---|---|
| `Displayed` | 830 ms | **804 ms** |
| `MarkRendered` | 730 ms | 700 ms |
| `MarkChatListLoaded` | 603 ms | 575 ms |
| worst `drawVk` frame | 273 ms | **170 ms** |
| `Chrome_InProcGp` in that frame | 244 ms | 168 ms |
| `kswapd0` + `zram_comp` | 117 ms | **40 ms** |

The memory-reclaim drop is the layer textures no longer forcing the kernel to reclaim during startup.

## Also here

- **WebView provider warm-up.** Chromium's provider load was otherwise paid on the main thread inside `performStart` (~10 ms). Nothing waits on the warm-up: Chromium's own lock already orders `WebView` construction behind it, and it posts native init *back* to the UI thread — so blocking on it would deadlock rather than wait.
- **Dropped the worker/worklet prefetches from `index.htm`.** They are served from the APK at ~15 ms each, so there is no network latency to hide, and their `?v=` was stale (`1.4.101` against a 2.16 app) so the responses were never reused.
- **Native splash fade 300 ms → 150 ms.** This does not move the splash tail on its own — the ~330 ms there is the main thread being too busy to acknowledge the `SplashScreenView` handoff, which happens *before* the fade starts — but it stops being dead weight once that stall shrinks.

## Risk / what to watch

- Side-nav slide and virtual-list scrolling run unpromoted for the first ~350 ms after the splash clears. Worth a look if the very first swipe feels rougher.
- `app-ready` is applied from all `removeWebSplash` paths including the no-splash early return, and `init.ts` already calls `startWebSplashRemoval(5_000)` as a backstop, so the class cannot be skipped.
- Verified on device that `will-change: transform` and `blur(40px)` return to their normal computed values once `app-ready` lands — nothing is permanently degraded.

## Not addressed

37-38 Vulkan shader pipelines (~85 ms) are recompiled on **every** cold start — nothing persists the pipeline cache. That is independent of layer count and looks like a platform issue worth confirming separately.

`npm run build:Verify` passes (tsc + eslint + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
