### PR TITLE
fix(location): make the Android location-sharing notification useful #4165

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
@@ -136,7 +136,9 @@ public class AndroidActivitiesBackend : ActivitiesBackend
             intent.PutExtra(IntentExtras.ExtraChatCount, audio.Chat.ExtraChatCount);
             break;
         case LocationActivity location:
-            intent.PutExtra(IntentExtras.LocationShareCount, location.ShareCount);
+            intent.PutExtra(IntentExtras.ChatId, location.Chat.Id.Value);
+            intent.PutExtra(IntentExtras.ChatTitle, location.Chat.Title);
+            intent.PutExtra(IntentExtras.ExtraChatCount, location.Chat.ExtraChatCount);
             break;
         case UploadActivity upload:
             PutUploadExtras(intent, upload);

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
@@ -34,7 +34,6 @@ public class AndroidActivitiesForegroundService : Service
         public const string ExtraChatCount = nameof(ExtraChatCount);
         public const string IsPaused = nameof(IsPaused);
         public const string CanPause = nameof(CanPause);
-        public const string LocationShareCount = nameof(LocationShareCount);
         public const string UploadFileCount = nameof(UploadFileCount);
         public const string UploadBytesUploaded = nameof(UploadBytesUploaded);
         public const string UploadTotalBytes = nameof(UploadTotalBytes);
@@ -300,8 +299,10 @@ public class AndroidActivitiesForegroundService : Service
         // Location only ever becomes primary when no audio activity is - the media session has
         // nothing left to serve.
         ReleaseMediaSession();
-        var shareCount = intent.Extras!.GetInt(IntentExtras.LocationShareCount, 1);
-        var notification = BuildLocationNotification(shareCount);
+        var chatSid = intent.Extras!.GetString(IntentExtras.ChatId) ?? "";
+        var chatTitle = intent.Extras.GetString(IntentExtras.ChatTitle) ?? "";
+        var extraChatCount = intent.Extras.GetInt(IntentExtras.ExtraChatCount);
+        var notification = BuildLocationNotification(chatSid, chatTitle, extraChatCount);
         StartForeground1(notification, ActivityKind.SharingLocation, requested);
         return StartCommandResult.NotSticky;
     }
@@ -486,24 +487,30 @@ public class AndroidActivitiesForegroundService : Service
         return builder.Build()!;
     }
 
-    private Android.App.Notification BuildLocationNotification(int shareCount)
+    private Android.App.Notification BuildLocationNotification(string chatSid, string chatTitle, int extraChatCount)
     {
         var stopIntent = new Intent(this, typeof(AndroidActivitiesForegroundService));
         stopIntent.SetAction(ActionStop);
         var stopPending = PendingIntent.GetService(this, 4, stopIntent, PendingIntentFlags.Immutable);
 
-        var viewIntent = NotificationHelper.CreateViewIntent(this, Links.Home);
+        // Opening the shared chat beats opening the app, but an unparsable id must still open something.
+        var link = ChatId.TryParse(chatSid, out var chatId) ? Links.Chat(chatId) : Links.Home;
+        var viewIntent = NotificationHelper.CreateViewIntent(this, link);
         var viewPending = viewIntent is null
             ? null
             : PendingIntent.GetActivity(this, 3, viewIntent, PendingIntentFlags.Immutable);
+
+        var text = chatTitle;
+        if (!text.IsNullOrEmpty() && extraChatCount > 0)
+            text += extraChatCount == 1 ? " (+ 1 chat)" : $" (+ {extraChatCount} chats)";
 
         var builder = new NotificationCompat.Builder(this, LocationChannelId)
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentTitle("Sharing live location")!
             .SetOngoing(true)!
             .AddAction(Android.Resource.Drawable.IcMenuCloseClearCancel, "Stop", stopPending)!;
-        if (shareCount > 1)
-            _ = builder.SetContentText($"{shareCount} chats");
+        if (!text.IsNullOrEmpty())
+            _ = builder.SetContentText(text);
         if (viewPending is not null)
             _ = builder.SetContentIntent(viewPending);
         return builder.Build()!;

--- a/src/dotnet/App.Maui/Platforms/iOS/Activities/IosActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Activities/IosActivitiesBackend.cs
@@ -85,7 +85,7 @@ public sealed class IosActivitiesBackend : ActivitiesBackend
             AudioActivity audio => (audio.Chat.Title, KindLabel(audio.Kind), -1.0),
             LocationActivity location => (
                 "Sharing live location",
-                location.ShareCount > 1 ? $"{location.ShareCount} chats" : "",
+                location.Chat.ExtraChatCount > 0 ? $"{location.Chat.ExtraChatCount + 1} chats" : location.Chat.Title,
                 -1.0),
             UploadActivity upload => (
                 upload.FileCount == 1 ? "Uploading 1 file" : $"Uploading {upload.FileCount} files",

--- a/src/dotnet/UI.Blazor.App/Services/Activities/LocationActivitySource.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/LocationActivitySource.cs
@@ -15,6 +15,10 @@ public class LocationActivitySource(AppUIHub hub) : IActivitySource, IHasDispose
         if (chatIds.IsEmpty)
             return null;
 
-        return new LocationActivity(chatIds[0], chatIds.Length);
+        var chatId = chatIds[0];
+        var chat = await hub.Chats.Get(hub.Session, chatId, cancellationToken).ConfigureAwait(false);
+        // The picture stays empty: the location notification names its chat but shows no avatar.
+        var chatInfo = new ActivityChatInfo(chatId, chat?.Title ?? "", "", chatIds.Length - 1);
+        return new LocationActivity(chatInfo);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Location/LocationUI.cs
@@ -254,6 +254,7 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
         if (!await LocationPermission.CheckOrRequest(Hub.StopToken).ConfigureAwait(true))
             return;
 
+        await RequestNotificationsPermission().ConfigureAwait(true);
         StartSharing(chatId, duration);
     }
 
@@ -349,6 +350,21 @@ public class LocationUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComputeSe
     }
 
     // Private methods
+
+    private async Task RequestNotificationsPermission()
+    {
+        // Android drops the sharing notification when this permission is missing, leaving the share
+        // with nothing to see, tap or stop - and granting it later doesn't re-post that notification,
+        // so it has to be asked for before the share raises it.
+        if (HostInfo.AppKind != AppKind.Android)
+            return;
+
+        var notificationsPermission = Services.GetRequiredService<INotificationsPermission>();
+        if (await notificationsPermission.IsGranted(Hub.StopToken).ConfigureAwait(true) == true)
+            return;
+
+        await notificationsPermission.Request(Hub.StopToken).ConfigureAwait(true);
+    }
 
     private MapMarker ToMapMarker(SharedLocation location, Author author)
         // A place isn't where its author is, so it must not wear their avatar.

--- a/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
+++ b/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
@@ -27,8 +27,7 @@ public sealed record AudioActivity(
     bool CanPause = true
 ) : ActivityInfo(Kind);
 
-// FirstChatId is reserved for single-share title rendering by platform renderers; unused for now
-public sealed record LocationActivity(ChatId FirstChatId, int ShareCount)
+public sealed record LocationActivity(ActivityChatInfo Chat)
     : ActivityInfo(ActivityKind.SharingLocation);
 
 public sealed record UploadActivity(


### PR DESCRIPTION
Closes #4165.

The Android "Sharing live location" notification named no chat and its tap opened the app's home screen. It now names the chat being shared with and opens that chat.

## Changes

**Name the chat, and open it** (`f6447b559f`)

`LocationActivity` carried `(ChatId FirstChatId, int ShareCount)`, with `FirstChatId` marked *"reserved for single-share title rendering by platform renderers; unused for now"*. It now carries the same `ActivityChatInfo` the audio activities already use, so the renderers get the first chat's id and title along with the extra-chat count:

- the Android notification sets its content text to the chat title (`"Talk"`, `"Talk (+ 1 chat)"`), matching how the audio notification renders multiple chats;
- its content intent resolves to `Links.Chat(chatId)` instead of `Links.Home`, falling back to home when there's no parsable id;
- `LocationActivitySource` resolves the title via `Chats.Get`, so it's a compute method and a renamed chat re-renders;
- `ShareCount` goes away — `ExtraChatCount` says the same thing in the shape the rest of the activity set speaks. The iOS live-activity renderer is updated for the new shape.

**Ask for POST_NOTIFICATIONS before sharing** (`2f43505c4a`)

Separate bug found while testing #4165: with that permission denied, Android drops the foreground service's notification outright, so a share runs with nothing to see, tap or stop — the service still reports location, it's just invisible. Nothing in the sharing flow ever requested it; only the push-notification settings did. On the test device the permission flags showed no `USER_SET` bit, meaning the runtime prompt had never even been shown.

Starting a live share now requests it right after the location permission, so the service starts with the permission in hand — granting it later does *not* re-post the notification.

## Verification

On device (Xiaomi, Android 16):

| Check | Result |
|---|---|
| Notification content | `title='Sharing live location'  text='Talk'` |
| Tap | `OnNewIntent → /chat/s-Fl94QMxQAr-2pSHFeMakr` — the shared chat |
| Stop button / stop from chat | service and notification both gone |
| Permission prompt | appears on share start; notification posts once granted |

Android and Mac Catalyst both build clean (the Mac build matters because the iOS renderer reads `LocationActivity`).

## Not included

While testing I hit an intermittent case where a share's expiry never ran in-process and the notification outlived the share until the app was force-stopped — reproduced roughly one time in four, with the app's own logs going silent right after the app was swiped from Recents, which reads as the OEM freezing the process rather than a logic error.

A fix for that (the foreground service scheduling its own `RTC_WAKEUP` alarm for the share deadline) was built and verified against the *previous* architecture, but it doesn't port directly here: this service is now shared with audio and uploads, so it must end the share via `LiveLocationReporter.StopAllSharing` rather than stopping the service. Dev's new Stop action on the notification also gives users an escape hatch that didn't exist before. Left out pending a decision on whether it's worth chasing.