### PR TITLE
fix(location): keep the old-client maps link out of notifications and quotes #4167

### DIFF
--- a/src/dotnet/Api.Contracts/Chat/ChatMarkupHubExt.cs
+++ b/src/dotnet/Api.Contracts/Chat/ChatMarkupHubExt.cs
@@ -27,6 +27,11 @@ public static class ChatMarkupHubExt
             // HasAudio covers all audio/media entries now
             markup = new PlayableTextMarkup(translation?.Content ?? entry.Content, entry.Audio?.TimeMap ?? default);
             break;
+        case { HasLocation: true }:
+            // TODO: 2026-07, remove when all clients support location entries.
+            // Their Content is a maps-link fallback baked in for old clients - no other consumer must show it.
+            markup = GetEmptyMarkupReplacement(entry, consumer);
+            break;
         default:
             markup = markupHub.Parser.Parse(translation?.Content ?? entry.Content);
             if (ReferenceEquals(markup, MarkupParser.EmptyResult))
@@ -49,6 +54,11 @@ public static class ChatMarkupHubExt
         case { HasAudio: true }:
             // HasAudio covers all audio/media entries now
             markup = new PlayableTextMarkup(entry.Content, entry.Audio?.TimeMap ?? default);
+            break;
+        case { HasLocation: true }:
+            // TODO: 2026-07, remove when all clients support location entries.
+            // Their Content is a maps-link fallback baked in for old clients - no other consumer must show it.
+            markup = GetEmptyMarkupReplacement(entry, consumer);
             break;
         default:
             markup = markupHub.Parser.Parse(entry.Content);

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -649,7 +649,9 @@ public class NotificationsBackend(IServiceProvider services)
         var (text, _) = await NotificationHelper
             .GetText(entry, MarkupConsumer.ReactionNotification, ChatMarkupHubFactory, cancellationToken)
             .ConfigureAwait(false);
-        if (!entry.Content.IsNullOrEmpty())
+        // TODO: 2026-07, drop !entry.HasLocation when the old client fallback Content goes away.
+        // Location Content is a maps-link fallback rather than user text, so it must not be quoted.
+        if (!entry.Content.IsNullOrEmpty() && !entry.HasLocation)
             text = $"\"{text}\"";
         text = $"{reaction.Emoji} to {text}";
         var userIds = new[] { author.UserId };

--- a/tests/Chat.UI.Blazor.UnitTests/ChatMarkupHubExtTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatMarkupHubExtTest.cs
@@ -82,6 +82,33 @@ public class ChatMarkupHubExtTest
         rawMarkup.Should().Be(expectedMarkupText);
     }
 
+    [Theory]
+    [InlineData(MarkupConsumer.Notification, "Sent a location")]
+    [InlineData(MarkupConsumer.ChatListItemText, "Sent a location")]
+    [InlineData(MarkupConsumer.QuoteView, "Sent a location")]
+    [InlineData(MarkupConsumer.ReactionNotification, "your location")]
+    public void ShouldGetLocationMarkupInsteadOfOldClientFallbackContent(
+        MarkupConsumer consumer, string expectedMarkupText)
+    {
+        // arrange
+        using var services = new ServiceCollection().AddTransient<IMarkupParser, MarkupParser>().BuildServiceProvider();
+        var chatId = GroupChatId.New();
+        var markupHub = new ChatMarkupHub(services, chatId);
+        var chatEntryId = ChatEntryId.New(chatId, 1);
+        var chatEntry = new TextEntry {
+            Id = chatEntryId,
+            LocationId = SharedLocationId.New(),
+            Content = "\U0001F4CD Location: https://www.openstreetmap.org/?mlat=1.5&mlon=2.5\n\nUpdate Voxt to the latest version to see it on the map.",
+        };
+
+        // act
+        var markup = markupHub.GetMarkup(chatEntry, consumer);
+        var rawMarkup = MarkupFormatter.Default.Format(markup);
+
+        // assert
+        rawMarkup.Should().Be(expectedMarkupText);
+    }
+
     [Fact]
     public void ShouldGetNotifyMembersMarkupWithoutTargetAuthorId()
     {


### PR DESCRIPTION
Fixes #4167.

Location entries carry a maps-link fallback in their `Content` so old clients still see something. Every other consumer picked that `Content` up too, so a push notification about a shared location was a bare OpenStreetMap URL plus "Update Voxt to the latest version to see it on the map", and chat list previews and quotes showed the same.

## What changed

- `ChatMarkupHubExt.GetMarkup` (both overloads) routes location entries through `GetEmptyMarkupReplacement`, so they read "Sent a location" — or "your location" in a reaction notification — exactly like attachment-only entries do. Location entries never carry a user caption (both call sites build `Chats_UpsertEntry` with no text), so nothing real is suppressed.
- `NotificationsBackend.OnReactionChangedEvent` stops wrapping that text in quotes: it isn't something the author typed. A reaction now reads `❤️ to your location`, matching `❤️ to your image` for attachments.

Both are temporary and marked with `TODO: 2026-07` — once every client renders location entries, the fallback `Content` goes away and all of this comes out together.

## Tests

`ChatMarkupHubExtTest` gains a theory covering `Notification`, `ChatListItemText`, `QuoteView` and `ReactionNotification` for a location entry whose `Content` is the old-client fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)