### PR TITLE
fix(download): download image saves the file instead of opening a new tab #4148

### DIFF
--- a/src/dotnet/App.Server/Module/AppServerModule.cs
+++ b/src/dotnet/App.Server/Module/AppServerModule.cs
@@ -293,6 +293,10 @@ public sealed class AppServerModule(IServiceProvider moduleServices)
         else
             origins.AddRange(Constants.Hosts.AllProd.Select(host => $"https://{host}"));
 
+        // The app's own origin isn't necessarily among the ones above: worktrees are served
+        // from <worktree>.local.voxt.ai, which can't be listed upfront.
+        origins.Add(HostInfo.BaseUrl.ToUri().GetLeftPart(UriPartial.Authority));
+
         services.AddCors(options => {
             options.AddPolicy("Default", builder => {
                 builder.WithOrigins(origins.ToArray())
@@ -305,7 +309,7 @@ public sealed class AppServerModule(IServiceProvider moduleServices)
                     .WithOrigins(origins.ToArray())
                     .WithMethods("GET")
                     .AllowAnyHeader()
-                    .WithExposedHeaders("Content-Encoding","Content-Length","Content-Range", "Content-Type", "Content-Disposition");
+                    .WithExposedHeaders("Content-Encoding", "Content-Length", "Content-Range", "Content-Type", "Content-Disposition");
             });
         });
         // services.Configure<HstsOptions>(options => {

--- a/src/dotnet/Core.Server/AspNetCore/CacheControlImmutable.cs
+++ b/src/dotnet/Core.Server/AspNetCore/CacheControlImmutable.cs
@@ -12,6 +12,8 @@ public sealed class CacheControlImmutableAttribute : ResultFilterAttribute
 
     public string[]? VaryByQueryKeys { get; set; }
 
+    public string? Vary { get; set; }
+
     public override void OnResultExecuting(ResultExecutingContext context)
     {
         var headers = context.HttpContext.Response.Headers;
@@ -26,6 +28,9 @@ public sealed class CacheControlImmutableAttribute : ResultFilterAttribute
             if (feature != null)
                 feature.VaryByQueryKeys = VaryByQueryKeys;
         }
+
+        if (!Vary.IsNullOrEmpty())
+            headers[HeaderNames.Vary] = Vary;
 
         var location = IsPrivate
             ? "private"

--- a/src/dotnet/Media.Service/Controllers/ContentController.cs
+++ b/src/dotnet/Media.Service/Controllers/ContentController.cs
@@ -45,9 +45,11 @@ public sealed class ContentController(IBlobStorages blobStorages, IMediaBackend 
             "video/x-matroska",
         };
 
+    // The response cache keys by path only, hence VaryByQueryKeys - w/o it "?download=1" gets
+    // the cached inline response, i.e. no Content-Disposition. And w/o Vary, a response cached
+    // for an origin-less request (tab navigation, <img>) breaks the CORS fetch reusing it.
     [HttpGet("{**blobId}")]
-    // Will NOT be cached in memory by response cache middleware
-    [CacheControlImmutable(Duration = 2592000 /*30 days*/)]
+    [CacheControlImmutable(Duration = 2592000 /*30 days*/, VaryByQueryKeys = ["download"], Vary = "Origin")]
     [EnableCors("CDN")]
     public async Task<ActionResult> Download(
         string blobId,

--- a/tests/Media.IntegrationTests/ContentControllerTest.cs
+++ b/tests/Media.IntegrationTests/ContentControllerTest.cs
@@ -62,6 +62,20 @@ public class ContentControllerTest(AppHostFixture fixture, ITestOutputHelper @ou
     }
 
     [Fact]
+    public async Task SendsVaryOriginHeader()
+    {
+        // arrange
+        var blobId = await CreateMedia(TestImages.CreatePng(10, 10), "image/png", "image.png");
+        using var httpClient = AppHost.NewHttpClient();
+
+        // act
+        using var response = await httpClient.GetAsync($"api/content/{blobId}");
+
+        // assert
+        response.Headers.Vary.Should().Contain("Origin");
+    }
+
+    [Fact]
     public async Task ServesStoredImageInline()
     {
         // arrange
@@ -115,6 +129,47 @@ public class ContentControllerTest(AppHostFixture fixture, ITestOutputHelper @ou
         response.Content.Headers.ContentType!.MediaType.Should().Be("image/png");
         response.Content.Headers.ContentDisposition!.DispositionType.Should().Be("attachment");
         response.Content.Headers.ContentDisposition.FileName.Should().Contain("image.bin");
+    }
+
+    [Fact]
+    public async Task ServesAttachmentWhenDownloadRequestedAfterInlineOne()
+    {
+        // arrange
+        var blobId = await CreateMedia(
+            TestImages.CreatePng(10, 10),
+            "application/octet-stream",
+            "image.bin");
+        using var httpClient = AppHost.NewHttpClient();
+        using var inlineResponse = await httpClient.GetAsync($"api/content/{blobId}");
+        inlineResponse.Content.Headers.ContentDisposition.Should().BeNull();
+
+        // act
+        using var response = await httpClient.GetAsync($"api/content/{blobId}?download=1");
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentDisposition!.DispositionType.Should().Be("attachment");
+        response.Content.Headers.ContentDisposition.FileName.Should().Contain("image.bin");
+    }
+
+    [Fact]
+    public async Task ServesInlineAfterDownloadRequest()
+    {
+        // arrange
+        var blobId = await CreateMedia(
+            TestImages.CreatePng(10, 10),
+            "application/octet-stream",
+            "image.bin");
+        using var httpClient = AppHost.NewHttpClient();
+        using var downloadResponse = await httpClient.GetAsync($"api/content/{blobId}?download=1");
+        downloadResponse.Content.Headers.ContentDisposition!.DispositionType.Should().Be("attachment");
+
+        // act
+        using var response = await httpClient.GetAsync($"api/content/{blobId}");
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentDisposition.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #4148 — clicking Download on an image opened it in a new tab and saved nothing.

## Root causes

**1. The response cache ignored the query string.** ASP.NET Core's response-caching middleware keys entries by method + path; the query string is part of the key only for the keys named in `VaryByQueryKeys`, and `ContentController` named none. So `<blob>` and `<blob>?download=1` shared one entry and whichever was requested first won for 30 days. The image is always rendered before it can be downloaded, so the download URL was served the cached inline response — **no `Content-Disposition`** — and the browser displayed the image instead of saving it. The collision ran the other way too: request the download URL first and the inline URL started serving an attachment.

This affects every environment, and it also means the native savers on Android/iOS (which read the file name off `Content-Disposition`) fall back to `download.<ext>`.

**2. CORS rejected the app's own origin in a worktree.** `downloadFile` fetches the URL and saves the blob via `<a download>`, falling back to `window.open` when the fetch fails. Only the hosts in `Hosts.AllLocal` were allowed, not `<worktree>.local.voxt.ai` — so in a worktree that fetch could never succeed, and the fallback opened the tab.

**3. Browser/CDN cache poisoning.** A response cached for an origin-less request (a tab navigation, an `<img>` load) carries no CORS header, and without `Vary: Origin` that entry is reused for the cross-origin fetch — which then fails and falls back to `window.open`, caching another one. `immutable` + 30 days made it stick; my browser kept failing after fix 2 until I cleared its cache.

## Changes

- `ContentController` — `VaryByQueryKeys = ["download"], Vary = "Origin"`. Not `["*"]` as on the avatar endpoints: these are public CDN URLs, so an unbounded key would let any `?v=<random>` allocate a cache entry.
- `CacheControlImmutableAttribute` — new opt-in `Vary` property; the filter clears `Vary`, so the endpoint couldn't set it itself.
- `AppServerModule` — the CORS origin list now includes `HostInfo.BaseUrl`'s origin, i.e. whatever `HostSettings__BaseUri` is set to. This is narrower than a `*.local.voxt.ai` wildcard (another worktree's origin stays rejected) and needs no Development gate.

## Testing

3 regression tests added to `ContentControllerTest`; all 3 fail on the pre-fix controller and pass with it (12/12 green).

Verified end to end against a local worktree server with a cleared browser cache: posted an image, opened the viewer, clicked Download via a synthesized mouse click — `window.open` never fires, no new tab, and `<a download="test-4148.jpg">` saves the file (byte count matches the source). Header checks on the running server confirm the inline URL stays inline, the download URL always carries `Content-Disposition`, both cache independently, and an unrelated origin gets no `Access-Control-Allow-Origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
