### PR TITLE
fix(walkie): make Android push-to-talk survive a real device

### DIFF
--- a/docs/dev-chat-render-delay-findings.md
+++ b/docs/dev-chat-render-delay-findings.md
@@ -1,0 +1,133 @@
+# Dev chat-render delay — measured evidence (2026-08-17)
+
+Handoff notes for whoever picks up the dev chat-render delay. Found while
+debugging Android push-to-talk; **the recorder turned out to be innocent**, so
+this is written up separately rather than fixed in that branch.
+
+## One-line summary
+
+On dev, a chat entry reaches the server within **0.76 s** of the speaker's voice
+being detected, but takes **8.4 s** (Blazor Server) or **up to 60.9 s in one
+batch** (WASM) to appear in another user's browser.
+
+## How it was measured
+
+Three clocks correlated, all UTC:
+
+- **Phone** — `adb logcat -s dev.voxt.ai:V`, using the `VAD: Start` line as
+  "the speaker's voice was detected".
+- **Server** — `gcloud logging read` on `actual-chat-app-dev`, container
+  `actual-chat-app`, using `PushStream: AudioRecord` as "the server has the
+  stream".
+- **Browser** — a `MutationObserver` on the chat-view virtual list
+  (`.virtual-list.chat-view`), recording the wall-clock time each new
+  `[data-key]` element is inserted, plus `document.visibilityState` at that
+  moment and a log of every `visibilitychange`.
+
+The observer matters: an earlier attempt used a 200 ms `setInterval`, and Chrome
+throttles timers in hidden tabs to roughly once a minute — which fabricates
+exactly the batch-arrival pattern being investigated. Every figure below comes
+from the observer, on a tab that logged **no visibility transitions at all**.
+
+## Result 1 — the upload leg is not the problem
+
+Seven consecutive utterances, phone `VAD: Start` → server `PushStream`:
+
+| VAD: Start | PushStream | Lag | server-reported `delta` |
+|---|---|---|---|
+| 17:33:57.691 | 17:33:58.454 | 0.76 s | 236 ms |
+| 17:34:41.042 | 17:34:41.804 | 0.76 s | 236 ms |
+| 17:34:56.004 | 17:34:56.775 | 0.77 s | 245 ms |
+| 17:35:34.303 | 17:35:35.064 | 0.76 s | 233 ms |
+| 17:36:08.136 | 17:36:08.899 | 0.76 s | 234 ms |
+| 17:39:14.158 | 17:39:14.927 | 0.77 s | — |
+| 17:39:28.358 | 17:39:29.124 | 0.77 s | — |
+
+Streams end normally with real frame counts (665, 301, 292, 243 …), and Soniox
+finds speech endpoints inside them. The audio is on the server, promptly, intact.
+
+## Result 2 — WASM: a stall, then a batch flush
+
+Render mode `'w'`. Tab **visible** throughout, zero visibility transitions.
+
+| PushStream | DOM patched | Lag |
+|---|---|---|
+| 17:34:56.775 | 17:37:05.840 | **129 s** |
+| 17:35:35.064 | 17:37:05.840 | **91 s** |
+| 17:36:08.899 | 17:37:05.840 | **57 s** |
+| 17:39:14.927 | 17:40:15.787 | **60.9 s** |
+| 17:39:29.124 | 17:40:15.787 | **46.7 s** |
+
+Two independent observations, both showing the same two properties:
+
+1. **Entries appear simultaneously**, in one batch, however far apart the
+   pushes were (the 17:34–17:36 group spans 72 s of pushes and lands in a single
+   DOM patch).
+2. **The shortest lag in each batch is ~57–61 s.**
+
+A working invalidation would deliver per-entry, staggered like the pushes.
+Batching plus a ~60 s floor is the signature of the view not being invalidated at
+all, and only catching up when a periodic fallback fires. The 60 s dev fallback
+on the invalidation-delivery path is the obvious suspect.
+
+## Result 3 — Blazor Server: slow but not stalled
+
+Render mode `'s'`, same tab, same chat, same session, tab visible throughout.
+
+| PushStream | DOM patched | Lag |
+|---|---|---|
+| 17:46:59.287 | 17:47:08.003 | 8.7 s |
+| 17:47:18.696 | 17:47:27.125 | 8.4 s |
+| 17:47:25.664 | 17:47:34.115 | 8.5 s |
+| 17:47:38.793 | 17:47:47.080 | 8.3 s |
+
+Staggered per entry, consistent ~8.4 s. No batching, no 60 s floor.
+
+**So the batch stall did not reproduce under Server rendering.** That points at
+the WASM client's invalidation delivery rather than at the server's
+invalidation *production* — consistent with Result 4.
+
+Caveat: this is one round of four entries. It shows Server mode did not stall
+here; it does not prove it never does.
+
+## Result 4 — the server is quiet
+
+Across every stall window, filtering the app container for `op-log`,
+`OperationLog`, `Npgsql`, `fallback`, `invalidat`, `UpdateOnlineNodes`,
+`Rerouting`, `watcher` returns **nothing**. No mesh churn, no rerouting, no
+op-log watcher complaints. The server has the data and logs no trouble
+publishing it.
+
+## Reproducing
+
+```js
+// In the receiving browser, on the chat page:
+const list = [...document.querySelectorAll('.virtual-list')]
+  .find(l => l.className.includes('chat-view'));
+window.__log = []; const seen = new Set();
+const note = () => { for (const el of list.querySelectorAll('[data-key]')) {
+  const k = el.getAttribute('data-key'); if (seen.has(k)) continue; seen.add(k);
+  window.__log.push({ key: k, at: new Date().toISOString(), vis: document.visibilityState });
+} };
+note(); window.__log.length = 0;
+new MutationObserver(note).observe(list, { childList: true, subtree: true });
+document.addEventListener('visibilitychange',
+  () => window.__log.push({ vis: document.visibilityState, at: new Date().toISOString() }));
+```
+
+Then speak from another device and compare `window.__log` against:
+
+```bash
+gcloud logging read \
+  'resource.labels.container_name="actual-chat-app"
+   AND timestamp>="<T0>" AND timestamp<="<T1>"
+   AND textPayload:"<chatId>" AND textPayload:"PushStream: AudioRecord"' \
+  --project=actual-chat-app-dev --format='value(timestamp, textPayload)' --order=asc
+```
+
+**Always check `visibilityState`** in the log before trusting any timing.
+
+## What this is not
+
+Not the recorder, and not the network. Same session, same chat, same phone
+produced 0.76 s uploads throughout — including during the 60 s browser stalls.

--- a/docs/live-audio/10-walkie-talkie.md
+++ b/docs/live-audio/10-walkie-talkie.md
@@ -414,7 +414,22 @@ background at that moment — so a service first started by a wake can never
 record, however it is re-typed. That's what `ActivityKind.Armed` is for. While
 any chat is armed, `AudioActivitySource.GetArmedChat` keeps `ActivitiesBackend`'s
 state non-null, so the foreground service runs continuously, started from the
-foreground (with the microphone type) at arming time. The service then latches
+foreground (with the microphone type) at arming time.
+
+`MainActivity.OnCreate` is what raises it at launch, from the persisted
+`MauiPreferences.IsWalkieArmed` — the app doesn't know its own armed set until
+Blazor has rendered and Kvas has loaded, by which time the start no longer counts
+as a foreground one. Three rules follow. `TryStartArmed` marks the service shown
+(`AndroidActivitiesBackend.MarkForegroundServiceShown`), or `HideImpl` — which
+early-returns on that flag — could never take the notification down again. No
+later-arriving scope may hide it: `AndroidActivitiesBackend`'s constructor skips
+its reconcile hide while `IsWalkieArmed`, since a warm start leaves the static
+`_isShown` set from the previous scope and stopping the service there would cost
+the microphone type for the rest of the session. And the mirrored flag is
+latched — `ActivitiesBackend.ShouldPersistArmed` refuses to persist an empty
+armed set until the session has seen a non-empty one, because `GetPttChatIds` is
+legitimately empty during startup and RPC reconnects, and persisting that would
+strand the *next* launch without a foreground-raised, mic-typed service. The service then latches
 the mic type: once granted, every later `startForeground` keeps it, because
 those all run in the background and dropping the type would forfeit the grant
 permanently.
@@ -468,6 +483,27 @@ Only the first down edge acts (`repeatCount != 0` passes through — one press
 delivers both edges plus auto-repeats, and acting twice would open and instantly
 close the mic); a hot reply always maps to `StopReply` regardless of window or
 practice mode, because leaving a live mic open is the unsafe direction.
+`GestureUI` is started from `AppScopedServiceStarter.PrepareFirstRender`, not
+`AfterFirstRender` — nothing in the sensing path needs a rendered WebView, and the
+latter's render gate plus its 1 s delay left a shake doing nothing for the first
+seconds after launch.
+
+Two things condition the raw sensor stream before the detectors see it.
+`MauiSensorFeed` drops samples closer together than
+`Constants.Audio.GestureSampleMinPeriod` (50 ms): `SensorSpeed.UI` is only a hint, and
+any other app pinning the accelerometer at its maximum rate raises the shared HAL rate
+and floods every connection (470 Hz measured against our 15 Hz request). And
+`ProximityGuard` decides what a "near" reading means: under-display sensors emit
+sub-second false positives while the phone lies still, so a cover suppresses the start
+gestures only after it has held for `ProximitySuppressionDelay` (0.5 s), and never
+while the last gravity-dominated reading says the phone is resting screen-up. The
+resting-face-up veto is latched rather than evaluated per sample, because mid-shake the
+accelerometer reads gravity plus hand motion — which is exactly when the veto must hold.
+The flip/shake reset on the suppression edge is driven by that debounced decision, so a
+sensor spike can no longer wipe a gesture in progress. The proximity *level* survives
+`GestureRecognizer`'s sample-gap reset: it is edge-driven, so forgetting it would read as
+"uncovered" until the sensor next changed its mind.
+
 `GestureUI.GetHeadsetButtonState` publishes `IsEnabled` / `HasAnswerWindow` with
 `Volatile` reads/writes, since the native handler calls it off any of our
 threads. `HeadsetButtonPolicy.GetState` deliberately uses `HasAnswerWindow`
@@ -604,6 +640,8 @@ working if the flag is later turned off; only the UI for changing it goes away.
 | `WalkieTalkieIdleTimeout` | 5 min | Background silence after which listening drops from hot to armed |
 | `WalkieTalkieIdleCheckPeriod` | 15 s | Poll period of the idle-drop loop; also the answer-window expiry floor in `GestureUI` |
 | `WalkieTalkieGestureCheckMinPeriod` | 0.25 s | Debounce floor for `GestureUI`'s activation loop |
+| `GestureSampleMinPeriod` | 50 ms | Floor between accelerometer samples handed to the detectors |
+| `ProximitySuppressionDelay` | 0.5 s | How long "near" must hold before it suppresses start gestures |
 | `WalkieTalkieStaleWakeAge` | 60 s | Older wakes skip the from-start catch-up and go straight to live listening |
 | `ListeningCatchUpTolerance` | 2 s | Clock-fuzz allowance between a wake's `startedAt` and the target stream's `BeginsAt` |
 | `WalkieTalkieReplyColdStartTimeout` | 15 s | Cold-start dead-man: no voice within this and the mic closes with the "nothing heard" cue |

--- a/src/dotnet/Api/Constants.Audio.cs
+++ b/src/dotnet/Api/Constants.Audio.cs
@@ -72,6 +72,14 @@ public static partial class Constants
         // Debounces GestureUI's activation loop: its inputs invalidate far more often than the
         // idle-check period, and it runs on battery-sensitive mobile clients.
         public static readonly TimeSpan WalkieTalkieGestureCheckMinPeriod = TimeSpan.FromSeconds(0.25);
+        // Under-display proximity sensors emit sub-second false "near" readings while the phone
+        // lies still (measured 0.2-1s on a OnePlus CPH2747), and each one used to disarm the
+        // start gestures outright, so a cover only counts once it has held this long.
+        public static readonly TimeSpan ProximitySuppressionDelay = TimeSpan.FromSeconds(0.5);
+        // SensorSpeed.UI is a hint, not a contract: another app pinning the accelerometer at its
+        // max rate raises the shared HAL rate and every connection gets the flood - 470Hz measured
+        // against our 15Hz request - so the surplus is dropped at the platform edge.
+        public static readonly TimeSpan GestureSampleMinPeriod = TimeSpan.FromMilliseconds(50);
         // Matches the wake push's FCM TTL; older wakes skip catch-up-from-start and go live.
         public static readonly TimeSpan WalkieTalkieStaleWakeAge = TimeSpan.FromSeconds(60);
         // Clock-fuzz allowance between a wake's startedAt and the target stream's BeginsAt.
@@ -80,6 +88,18 @@ public static partial class Constants
         public static readonly TimeSpan ServerClockWaitTimeout = TimeSpan.FromSeconds(10);
         // Short: a walkie reply that waits longer than this has already lost its answer window.
         public static readonly TimeSpan ConnectivityWaitTimeout = TimeSpan.FromSeconds(3);
+        // How long a stopping recorder may wait for its own pipeline tasks. Start() stops first,
+        // so an unbounded wait here blocks every later recording behind a wedged one. Two drains
+        // must still fit inside AudioRecorder.StopRecordingTimeout.
+        public static readonly TimeSpan RecorderDrainTimeout = TimeSpan.FromSeconds(1);
+        // Startup waits the recorder proceeds without rather than lose the utterance.
+        public static readonly TimeSpan RecorderStartupWaitTimeout = TimeSpan.FromSeconds(3);
+        // A walkie reply's two startup deadlines: how long the recorder may take to report itself
+        // recording, and how long after that the first captured sample may take. Both are shorter
+        // than AudioRecorder.StartRecordingTimeout - a reply that slow has lost its answer window,
+        // and the user needs the failure cue while they're still holding the phone.
+        public static readonly TimeSpan WalkieTalkieReplyMicStartTimeout = TimeSpan.FromSeconds(8);
+        public static readonly TimeSpan WalkieTalkieReplyMicLiveTimeout = TimeSpan.FromSeconds(4);
         public static readonly TimeSpan WalkieTalkieReplyColdStartTimeout = TimeSpan.FromSeconds(15);
         public static readonly TimeSpan WalkieTalkieReplyBackgroundHotWindow = TimeSpan.FromSeconds(15);
         public static readonly TimeSpan WalkieTalkieReplyRecencyWindow = TimeSpan.FromSeconds(150);

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
@@ -26,6 +26,13 @@ public class AndroidActivitiesBackend : ActivitiesBackend
             if (IsStale())
                 return;
 
+            // MainActivity raises the armed service from OnCreate, and it's the only start that
+            // happens with the app reliably visible - the one Android grants the microphone type
+            // on. Hiding it here (a warm start leaves _isShown set from the previous scope) would
+            // stop it, and the re-show would run from the background with the mic type lost.
+            if (MauiPreferences.IsWalkieArmed)
+                return;
+
             HideImpl();
         });
     }
@@ -74,6 +81,8 @@ public class AndroidActivitiesBackend : ActivitiesBackend
     public static void Hide() => HideImpl();
 
     // Protected/internal methods
+
+    protected override bool IsArmedPersisted => MauiPreferences.IsWalkieArmed;
 
     protected override void OnArmedChanged(bool isArmed)
     {

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
@@ -45,6 +45,7 @@ public class AndroidActivitiesForegroundService : Service
     public const string ActionShow = "ACTION_SHOW";
     public const string ActionStop = "ACTION_STOP";
     private const string ChannelId = "audio_widget";
+    private const string RecordingChannelId = "audio_recording";
     private const string LocationChannelId = "location_sharing";
     private const int NotificationId = 3001;
     private static ILogger Log { get; } = StaticLog.For<AndroidActivitiesForegroundService>();
@@ -53,10 +54,14 @@ public class AndroidActivitiesForegroundService : Service
     private static int _lastRequestedTypes;
     private string _requestId = "";
     private MediaSessionCompat? _mediaSession;
+    private string _lastTitle = "";
+    private string _lastLink = "";
+    private Bitmap? _lastAlbumArt;
     private Android.App.Notification? _lastNotification;
     private int _lastKind = -1;
     private bool _hasMicType;
     private Action<bool>? _micCapabilityHandler;
+    private Action? _micBlockedHandler;
     private bool _isStopping;
 
     public static void TryStartArmed(Context context)
@@ -69,7 +74,10 @@ public class AndroidActivitiesForegroundService : Service
         intent.PutExtra(IntentExtras.Kind, (int)ActivityKind.Armed);
         intent.PutExtra(
             IntentExtras.ServiceTypes, (int)(ActivityServiceTypes.Playback | ActivityServiceTypes.Microphone));
-        TryStart(context, intent);
+        // Without this the backend's _isShown stays false while the service is genuinely running,
+        // and HideImpl - which early-returns on it - can never take the armed notification down.
+        if (TryStart(context, intent))
+            AndroidActivitiesBackend.MarkForegroundServiceShown();
     }
 
     public static bool TryStart(Context context, Intent intent)
@@ -106,6 +114,15 @@ public class AndroidActivitiesForegroundService : Service
 
     public static void Stop(Context context)
     {
+        // Never while a chat is armed. This service is what holds the microphone grant, and Android
+        // only hands that to a service started with the app in the foreground - so stopping it from
+        // a background path (a headless session tearing down, a wake failing) costs every later
+        // walkie reply its mic, with no way to earn it back until MainActivity runs again.
+        if (MauiPreferences.IsWalkieArmed) {
+            Log.LogInformation("Stop: keeping the foreground service - walkie-talkie is armed");
+            return;
+        }
+
         // StopService() while a StartForegroundService() request hasn't reached OnStartCommand yet makes
         // Android kill the process with ForegroundServiceDidNotStartInTimeException, even though
         // OnStartCommand does call StartForeground(). Let the service stop itself in that case.
@@ -126,6 +143,8 @@ public class AndroidActivitiesForegroundService : Service
         NotificationHelper.EnsureActivityChannelsExist(this);
         _micCapabilityHandler = OnMicCapabilityRequested;
         WalkieTalkieMicCapability.SetHandler(_micCapabilityHandler);
+        _micBlockedHandler = MicrophoneBlockedNotification.ShowPermissionDenied;
+        WalkieTalkieMicCapability.SetBlockedHandler(_micBlockedHandler);
     }
 
     public override void OnDestroy()
@@ -135,6 +154,10 @@ public class AndroidActivitiesForegroundService : Service
         if (_micCapabilityHandler is { } micCapabilityHandler) {
             WalkieTalkieMicCapability.ResetHandler(micCapabilityHandler);
             _micCapabilityHandler = null;
+        }
+        if (_micBlockedHandler is { } micBlockedHandler) {
+            WalkieTalkieMicCapability.ResetBlockedHandler(micBlockedHandler);
+            _micBlockedHandler = null;
         }
         _requestId = RandomStringGenerator.Default.Next();
         Interlocked.Exchange(ref _pendingStartCount, 0);
@@ -218,13 +241,7 @@ public class AndroidActivitiesForegroundService : Service
             _mediaSession.SetCallback(new Callback());
         }
 
-        var text = kind switch {
-            ActivityKind.Recording => "Recording",
-            ActivityKind.Listening => "Listening",
-            ActivityKind.Replaying => "Replaying",
-            ActivityKind.Armed => "Walkie-talkie is on",
-            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
-        };
+        var text = GetKindText(kind);
         var title = chatTitle;
         if (extraChatCount > 0)
             title += extraChatCount == 1 ? " (+ 1 chat)" : $" (+ {extraChatCount} chats)";
@@ -261,13 +278,13 @@ public class AndroidActivitiesForegroundService : Service
                 if (!Equals(lastRequestId, _requestId))
                     return;
 
-                var metadata = new MediaMetadataCompat.Builder()
-                    .PutString(MediaMetadataCompat.MetadataKeyTitle, title)!
-                    .PutString(MediaMetadataCompat.MetadataKeyArtist, text)!
-                    .PutBitmap(MediaMetadataCompat.MetadataKeyAlbumArt, bitmap)!
-                    .Build();
-                _mediaSession.SetMetadata(metadata);
-                var notification = BuildNotification(_mediaSession, link);
+                // Kept so a microphone-capability change can re-render the same notification with
+                // the new label instead of leaving "Listening" on screen while the mic is open.
+                _lastTitle = title;
+                _lastAlbumArt = bitmap;
+                _lastLink = link;
+                SetMetadata(title, text, bitmap);
+                var notification = BuildNotification(_mediaSession, link, kind);
                 StartForeground1(notification, kind, requested);
             });
 
@@ -332,11 +349,50 @@ public class AndroidActivitiesForegroundService : Service
             if (Volatile.Read(ref _isStopping) || Volatile.Read(ref _lastKind) == (int)kind)
                 return;
 
-            var notification = Volatile.Read(ref _lastNotification) ?? BuildStartingNotification(kind);
+            // Re-labelled, not re-posted as-is: reusing it left "Listening" on screen with the
+            // microphone open.
             var requested = (ActivityServiceTypes)Volatile.Read(ref _lastRequestedTypes);
             if (isMicrophoneNeeded)
                 requested |= ActivityServiceTypes.Microphone;
-            StartForeground1(notification, kind, requested);
+            // Falls back to a freshly built notification rather than the previous one: the armed
+            // idle case has no media session to relabel, and reposting the low-importance armed
+            // notification would leave nothing on the lock screen at the moment the mic opens.
+            StartForeground1(Relabel(kind) ?? BuildStartingNotification(kind), kind, requested);
+        }
+    }
+
+    private static string GetKindText(ActivityKind kind)
+        => kind switch {
+            ActivityKind.Recording => "Recording",
+            ActivityKind.Listening => "Listening",
+            ActivityKind.Replaying => "Replaying",
+            ActivityKind.Armed => "Walkie-talkie is on",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    private void SetMetadata(string title, string text, Bitmap? albumArt)
+        => _mediaSession?.SetMetadata(new MediaMetadataCompat.Builder()
+            .PutString(MediaMetadataCompat.MetadataKeyTitle, title)!
+            .PutString(MediaMetadataCompat.MetadataKeyArtist, text)!
+            .PutBitmap(MediaMetadataCompat.MetadataKeyAlbumArt, albumArt)!
+            .Build());
+
+    private Android.App.Notification? Relabel(ActivityKind kind)
+    {
+        // Null until a real activity has been rendered - the bare armed start carries no chat, so
+        // there's nothing to relabel and the caller keeps whatever is already on screen.
+        if (_mediaSession is null || _lastTitle.IsNullOrEmpty())
+            return null;
+        if (kind is not (ActivityKind.Recording or ActivityKind.Listening or ActivityKind.Replaying))
+            return null;
+
+        try {
+            SetMetadata(_lastTitle, GetKindText(kind), _lastAlbumArt);
+            return BuildNotification(_mediaSession, _lastLink, kind);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Couldn't relabel the notification for {Kind}", kind);
+            return null;
         }
     }
 
@@ -370,6 +426,11 @@ public class AndroidActivitiesForegroundService : Service
             // A mic FGS started over the keyguard can be rejected (SecurityException /
             // ForegroundServiceStartNotAllowedException) on some OEMs — log rather than crash.
             Log.LogError(e, "StartForeground failed (kind={Kind})", kind);
+            // A wake-revived process never was foreground, so it can't earn the while-in-use
+            // microphone and this reply is already lost - tell the user while they're still holding
+            // the phone, rather than leaving them with cues that promised a recording.
+            if (kind is ActivityKind.Recording)
+                MicrophoneBlockedNotification.ShowUnavailable();
         }
     }
 
@@ -427,14 +488,16 @@ public class AndroidActivitiesForegroundService : Service
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentTitle(kind switch {
                 ActivityKind.Armed => "Walkie-talkie is on",
+                ActivityKind.Recording => "Recording",
                 ActivityKind.Uploading => "Uploading",
                 ActivityKind.SharingLocation => "Sharing live location",
                 _ => "Voxt",
             })!
             .SetOngoing(true)!
+            .SetVisibility(NotificationCompat.VisibilityPublic)!
             .Build()!;
 
-    private Android.App.Notification BuildNotification(MediaSessionCompat mediaSession, string link)
+    private Android.App.Notification BuildNotification(MediaSessionCompat mediaSession, string link, ActivityKind kind)
     {
         var viewIntent = NotificationHelper.CreateViewIntent(this, link);
         var viewPending = PendingIntent.GetActivity(this, 3, viewIntent, PendingIntentFlags.Immutable);
@@ -443,10 +506,13 @@ public class AndroidActivitiesForegroundService : Service
         stopIntent.SetAction(ActionStop);
         var stopPending = PendingIntent.GetService(this, 4, stopIntent, PendingIntentFlags.Immutable);
 
-        var builder = new NotificationCompat.Builder(this, ChannelId)
+        var builder = new NotificationCompat.Builder(this, GetChannelId(kind))
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentIntent(viewPending)!
             .SetOngoing(true)!
+            // Public so an open microphone is still legible over the keyguard - that's exactly
+            // when the user needs to see it, and it names only a chat they're already in.
+            .SetVisibility(NotificationCompat.VisibilityPublic)!
             .AddAction(Android.Resource.Drawable.IcMenuCloseClearCancel, "Stop", stopPending)!;
 
         var mediaStyle = new AndroidX.Media.App.NotificationCompat.MediaStyle()
@@ -504,6 +570,14 @@ public class AndroidActivitiesForegroundService : Service
             new NotificationChannel(ChannelId, "Audio Widget", NotificationImportance.Low));
         manager.CreateNotificationChannel(
             new NotificationChannel(LocationChannelId, "Location sharing", NotificationImportance.Low));
+        // High so an open microphone surfaces over the keyguard instead of sitting in the shade,
+        // silent because the walkie's own cues already say it started - this is the visual half.
+        var recordingChannel = new NotificationChannel(
+            RecordingChannelId, "Recording", NotificationImportance.High);
+        recordingChannel.SetSound(null, null);
+        recordingChannel.EnableVibration(false);
+        recordingChannel.LockscreenVisibility = NotificationVisibility.Public;
+        manager.CreateNotificationChannel(recordingChannel);
     }
 
     private static bool TryHandleHeadsetButton(HeadsetKey key, bool isDown, int repeatCount)
@@ -558,6 +632,7 @@ public class AndroidActivitiesForegroundService : Service
         => kind switch {
             ActivityKind.Uploading => NotificationHelper.Constants.ActivityUploadChannelId,
             ActivityKind.SharingLocation => LocationChannelId,
+            ActivityKind.Recording => RecordingChannelId,
             _ => ChannelId,
         };
 

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioCapture.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioCapture.cs
@@ -111,8 +111,13 @@ public class AndroidAudioCapture(ILogger<AndroidAudioCapture> log) : IAudioCaptu
                 catch { /* Ignore */ }
             });
 
+            var isSilent = true;
+            var windowPeak = 0f;
             try {
                 recorder!.StartRecording();
+                // startRecording() can fail without throwing - the mic is then withheld and every
+                // Read returns an error code, which used to end this loop in complete silence.
+                Log.LogInformation("Capture started: recordingState={RecordingState}", recorder.RecordingState);
 
                 while (!cancellationToken.IsCancellationRequested) {
                     int readCount;
@@ -122,16 +127,28 @@ public class AndroidAudioCapture(ILogger<AndroidAudioCapture> log) : IAudioCaptu
                         readCount = recorder.Read(
                             floatReadBuffer.Buffer, 0, frameSamples * 2, 0);
                     }
-                    catch (Exception) {
+                    catch (Exception e) {
+                        Log.LogWarning(e, "AudioRecord.Read threw - ending capture");
                         break;
                     }
 
                     if (readCount <= 0) {
-                        if (readCount < 0)
-                            break; // error
+                        if (readCount < 0) {
+                            Log.LogWarning("AudioRecord.Read returned {ReadCount} - ending capture", readCount);
+                            break;
+                        }
 
                         continue;
                     }
+
+                    // Only while the mic has never produced anything: the peak feeds the
+                    // digital-silence check below, which goes quiet once real audio arrives.
+                    if (isSilent)
+                        for (var i = 0; i < readCount; i++) {
+                            var level = MathF.Abs(floatReadBuffer.Buffer[i]);
+                            if (level > windowPeak)
+                                windowPeak = level;
+                        }
 
                     // Push to ring buffer (fire-and-forget: drop if full)
                     buffer.TryWrite(floatReadBuffer.Buffer.AsSpan(0, readCount));
@@ -155,6 +172,22 @@ public class AndroidAudioCapture(ILogger<AndroidAudioCapture> log) : IAudioCaptu
                             Log.LogWarning(
                                 "audio-capture-cadence: {Gaps} gap(s) >80ms in last second; max gap {MaxMs:F0}ms; gc 0/1/2={Gen0}/{Gen1}/{Gen2}",
                                 readGapsInWindow, readMaxGapMs, gen0, gen1, gen2);
+                        // Only while nothing has ever arrived: all-zero samples are what the OS
+                        // hands a process it has quietly denied the mic to, but VoiceCommunication's
+                        // noise suppressor also gates ordinary pauses to exact zeros, so warning on
+                        // every silent second would cry wolf through every normal recording.
+                        if (isSilent) {
+                            if (windowPeak > 0f) {
+                                isSilent = false;
+                                Log.LogInformation("audio-capture: first audio, peak {Peak:F3}", windowPeak);
+                            }
+                            else {
+                                Log.LogWarning(
+                                    "audio-capture: the microphone has delivered nothing but digital silence");
+                            }
+                        }
+
+                        windowPeak = 0f;
                         readGapsInWindow = 0;
                         readMaxGapMs = 0;
                         readGen0Start += gen0; readGen1Start += gen1; readGen2Start += gen2;
@@ -166,6 +199,10 @@ public class AndroidAudioCapture(ILogger<AndroidAudioCapture> log) : IAudioCaptu
                 Log.LogError(ex, "Error while capturing audio on Android");
             }
             finally {
+                // The consumer parks on the ring buffer with no timeout, so a producer that ends
+                // before cancellation wedges the whole recording silently.
+                if (!cancellationToken.IsCancellationRequested)
+                    Log.LogWarning("Capture producer ended before the recording was stopped");
                 floatReadBuffer.Release();
                 try {
                     if (recorder.RecordingState == RecordState.Recording)

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/WalkieTalkieWakeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/WalkieTalkieWakeHandler.cs
@@ -31,6 +31,15 @@ public static class WalkieTalkieWakeHandler
             // exemption window; the service self-guards the 5s startForeground rule.
             isServiceShown = ShowForegroundService(chatId, InitialTitle);
         }
+        // No activity has run in this process, so nothing can have started the service while the
+        // app was visible - which is the only way Android hands out the while-in-use microphone.
+        // This reply cannot record, and saying so now beats letting the user gesture into silence:
+        // the notification's full-screen intent brings the app up over the keyguard, and that is
+        // what earns the grant back.
+        if (!MainActivity.HasEverRun) {
+            Log.LogWarning("Wake in a process with no activity - the microphone can't be granted yet");
+            MicrophoneBlockedNotification.ShowUnavailable();
+        }
 
         try {
             BlazorWebViewApp.EnsureStarted();

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -55,7 +55,13 @@ public partial class MainActivity : MauiAppCompatActivity
 
     public static MainActivity Current => _current
         ?? throw StandardError.Internal($"{nameof(MainActivity)} isn't created yet.");
+    // Whether an activity has run in THIS process, which is what decides if the foreground service
+    // could ever have earned the microphone: Android grants it only to a service started while the
+    // app is visible, and the grant then outlives the activity. Unlike Current, this never reverts.
+    public static bool HasEverRun { get; private set; }
     public static readonly TimeSpan MaxPermissionRequestDuration = TimeSpan.FromMinutes(1);
+    public static string RequestMicrophonePermissionExtraKey
+        => field ??= Platform.AppContext.PackageName + ".RequestMicrophonePermission";
     private static readonly Tracer Tracer = Tracer.Default[nameof(MainActivity)];
 
     private ActivityResultLauncher _permissionRequestLauncher = null!;
@@ -91,6 +97,7 @@ public partial class MainActivity : MauiAppCompatActivity
         CloseHeadlessScope();
 
         Interlocked.Exchange(ref _current, this);
+        HasEverRun = true;
         // If app is sent to background with back button
         // and user brings it back to foreground by launching app icon or picking app from recents,
         // then warm start happens https://developer.android.com/topic/performance/vitals/launch-time#warm
@@ -152,6 +159,16 @@ public partial class MainActivity : MauiAppCompatActivity
         // https://developer.android.com/develop/ui/views/launch/splash-screen#suspend-drawing
         var contentView = FindViewById(Android.Resource.Id.Content);
         contentView!.ViewTreeObserver!.AddOnPreDrawListener(new SplashDelayer(contentView));
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+        // The one moment the microphone grant can be (re)earned: Android re-evaluates it on every
+        // startForeground and denies it from the background, so a service that lost the type -
+        // killed and revived while backgrounded - can only recover here.
+        if (MauiPreferences.IsWalkieArmed)
+            AndroidActivitiesForegroundService.TryStartArmed(this);
     }
 
     protected override void OnDestroy()
@@ -249,6 +266,19 @@ public partial class MainActivity : MauiAppCompatActivity
         // exactly when the managed runtime is busy collecting - and the JNI-heavy dump below blocks
         // the UI thread long enough to be reported as an ANR.
         _ = Task.Run(DumpMemoryInfo);
+    }
+
+    public void RequestMicrophonePermission()
+    {
+        // Deliberately not routed through MicrophonePermissionHandler: this runs from a notification
+        // tap with no Blazor scope guaranteed, and the OS dialog is all we need.
+        try {
+            RequestPermission(Android.Manifest.Permission.RecordAudio,
+                isGranted => Log.LogInformation("RequestMicrophonePermission: granted={IsGranted}", isGranted));
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "RequestMicrophonePermission failed");
+        }
     }
 
     public void RequestPermission(string permission, Action<bool> onReceiveResult, bool throwIfHavePendingRequest = false)

--- a/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
@@ -1,3 +1,4 @@
+using ActualChat.App.Maui.Activities;
 using Android.App;
 using Android.Runtime;
 
@@ -16,6 +17,12 @@ public class MainApplication : MauiApplication
     {
         WarmUpWebView();
         base.OnCreate();
+        // Any process start, not only a user launch. A message push starts us with no MainActivity
+        // and no Blazor scope, so nothing else raises the armed service - leaving no PTT badge and
+        // no media session for the headset button. Android refuses a background start without an
+        // exemption; TryStart logs that rather than throwing.
+        if (MauiPreferences.IsWalkieArmed)
+            AndroidActivitiesForegroundService.TryStartArmed(this);
     }
 
     protected override MauiApp CreateMauiApp()

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/MicrophoneBlockedNotification.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/MicrophoneBlockedNotification.cs
@@ -1,0 +1,105 @@
+using ActualLab.Diagnostics;
+using Android.App;
+using Android.Content;
+using AndroidX.Core.App;
+using Application = Android.App.Application;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace ActualChat.App.Maui;
+
+/// <summary>
+/// Tells the user a push-to-talk reply couldn't open the microphone, from the lock screen if
+/// that's where they are. A notification can't grant a runtime permission - only a foregrounded
+/// activity can - so this exists to get them there.
+/// </summary>
+public static class MicrophoneBlockedNotification
+{
+    public const string ChannelId = "microphone_blocked";
+    private const string Tag = "microphone-blocked";
+    private static ILogger? _log;
+
+    private static Context Context => Application.Context;
+    private static ILogger Log => _log ??= StaticLog.Factory.CreateLogger(typeof(MicrophoneBlockedNotification));
+
+    public static void ShowPermissionDenied()
+        => Show("Voxt can't use the microphone",
+            "Push-to-talk couldn't record. Tap to allow microphone access.");
+
+    public static void ShowUnavailable()
+        // Opening the app really is the fix: only an activity can re-earn the mic grant.
+        => Show("Voxt can't use the microphone",
+            "Push-to-talk couldn't record. Tap to open Voxt and restore it.");
+
+    private static void Show(string title, string text)
+    {
+        try {
+            EnsureChannelExists();
+            var intent = NotificationHelper.CreateViewIntent(Context, Links.Chats)!;
+            intent.PutExtra(MainActivity.RequestMicrophonePermissionExtraKey, true);
+            var pendingIntent = PendingIntent.GetActivity(Context,
+                NotificationHelper.RequestCodeProvider.IncrementAndGet(),
+                intent, PendingIntentFlags.OneShot | PendingIntentFlags.Immutable);
+
+            var builder = new NotificationCompat.Builder(Context, ChannelId)
+                // ReSharper disable once AccessToStaticMemberViaDerivedType
+                .SetSmallIcon(Microsoft.Maui.Resource.Drawable.notification_app_icon)!
+                .SetContentTitle(title)!
+                .SetContentText(text)!
+                .SetCategory(Android.App.Notification.CategoryError)!
+                .SetPriority((int)NotificationPriority.High)!
+                // Public, or the one place this matters - the lock screen - shows an empty shell.
+                .SetVisibility(NotificationCompat.VisibilityPublic)!
+                .SetAutoCancel(true)!
+                .SetContentIntent(pendingIntent)!;
+            if (CanUseFullScreenIntent())
+                _ = builder.SetFullScreenIntent(pendingIntent, true);
+
+            NotificationManagerCompat.From(Context)!.Notify(Tag, 0, builder.Build());
+        }
+        catch (Exception e) {
+            // Posting needs POST_NOTIFICATIONS on API 33+; a denied permission must not take the
+            // reply path down with it.
+            Log.LogWarning(e, "Couldn't post the microphone-blocked notification");
+        }
+    }
+
+    public static void Dismiss()
+    {
+        try {
+            NotificationManagerCompat.From(Context)!.Cancel(Tag, 0);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Couldn't cancel the microphone-blocked notification");
+        }
+    }
+
+    // Private methods
+
+    private static bool CanUseFullScreenIntent()
+    {
+        // Android 14+ auto-grants USE_FULL_SCREEN_INTENT only to calling and alarm apps, and the
+        // user can revoke it. Without it a full-screen intent is silently ignored, so the
+        // high-importance heads-up above is the whole notification rather than a consolation.
+        if (!OperatingSystem.IsAndroidVersionAtLeast(34))
+            return true;
+
+        var manager = (NotificationManager)Context.GetSystemService(Context.NotificationService)!;
+        var canUse = manager.CanUseFullScreenIntent();
+        if (!canUse)
+            Log.LogInformation("Full-screen intent isn't permitted; falling back to a heads-up notification");
+
+        return canUse;
+    }
+
+    private static void EnsureChannelExists()
+    {
+        var notificationManager = (NotificationManager)Context.GetSystemService(Context.NotificationService)!;
+        if (notificationManager.GetNotificationChannel(ChannelId) != null)
+            return;
+
+        var channel = new NotificationChannel(ChannelId, "Microphone problems", NotificationImportance.High) {
+            LockscreenVisibility = NotificationVisibility.Public,
+        };
+        notificationManager.CreateNotificationChannel(channel);
+    }
+}

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHandler.cs
@@ -14,6 +14,13 @@ public static class NotificationHandler
         if (NotificationHelper.NotificationViewAction != intent.Action)
             return;
 
+        if (intent.GetBooleanExtra(MainActivity.RequestMicrophonePermissionExtraKey, false)) {
+            // Only an activity can show the permission dialog, which is the whole reason the
+            // microphone-blocked notification exists - the reply that hit this had no way there.
+            MicrophoneBlockedNotification.Dismiss();
+            MainActivity.Current.RequestMicrophonePermission();
+        }
+
         if (intent.GetBooleanExtra(IncomingCallNotifications.FullScreenExtraKey, false)) {
             DebugLog?.LogInformation("CALL_TRACE: HandleIntent full-screen intent, isColdStart={IsColdStart}", isColdStart);
             // Over the lock screen we don't navigate to the chat (it opens on go-to-chat). On a cold

--- a/src/dotnet/App.Maui/Services/MauiSensorFeed.cs
+++ b/src/dotnet/App.Maui/Services/MauiSensorFeed.cs
@@ -13,6 +13,7 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
     private readonly Lock _lock = new();
     private bool _isAccelerometerOn;
     private bool _isProximityOn;
+    private Moment _lastSampleAt;
 
     private ILogger Log => field ??= hub.LogFor(GetType());
 
@@ -45,6 +46,8 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
                 return;
 
             _isAccelerometerOn = false;
+            // Or a stale stamp would gate the first sample after the next start.
+            _lastSampleAt = default;
             Accelerometer.Default.ReadingChanged -= OnReadingChanged;
             try {
                 Accelerometer.Default.Stop();
@@ -57,8 +60,17 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
 
     private void OnReadingChanged(object? sender, AccelerometerChangedEventArgs e)
     {
+        // SensorSpeed.UI is only a hint: whenever another app pins the accelerometer at its max
+        // rate the shared HAL rate rises and every connection gets the flood (470Hz measured on a
+        // OnePlus CPH2747 against our 15Hz request), which would run three detectors and two locks
+        // that often on the platform main thread.
+        var now = hub.Clocks.CpuClock.Now;
+        if (now - _lastSampleAt < Constants.Audio.GestureSampleMinPeriod)
+            return;
+
+        _lastSampleAt = now;
         var a = e.Reading.Acceleration;
-        OnSample(new SensorSample(hub.Clocks.CpuClock.Now, a.X, a.Y, a.Z));
+        OnSample(new SensorSample(now, a.X, a.Y, a.Z));
     }
 
 #if ANDROID

--- a/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
+++ b/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
@@ -56,15 +56,8 @@ public class MauiRecorderEngine : IAudioRecorderEngine
         // Stop any existing recording first
         await Stop(cancellationToken).ConfigureAwait(false);
 
-        // Bounded: a scope that never starts ConnectivityUI would wedge the mic here forever.
-        try {
-            await ConnectivityUI.WhenConnected(cancellationToken)
-                .WaitAsync(Constants.Audio.ConnectivityWaitTimeout, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (TimeoutException) {
-            Log.LogWarning("Start: no connectivity signal yet, starting the recorder anyway");
-        }
+        // No connectivity wait here on purpose: opening the mic doesn't need the network, and
+        // CreateAudioStream - which does - still waits.
 
         // Create a new recording context
         var recordingCts = cancellationToken.CreateLinkedTokenSource();
@@ -129,27 +122,36 @@ public class MauiRecorderEngine : IAudioRecorderEngine
                 // Best effort: Stop must proceed to draining the tasks.
             }
 
+        // Both waits are bounded: Start() calls Stop() first, so a pipeline task that never
+        // finishes used to block every later recording until StartRecordingTimeout gave up.
         var processTask = Interlocked.Exchange(ref _processTask, null);
         if (waitForProcessTask && processTask is not null)
             try {
-                await processTask.ConfigureAwait(false);
+                await processTask.WaitAsync(Constants.Audio.RecorderDrainTimeout).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { }
+            catch (TimeoutException) {
+                Log.LogWarning("Stop: the audio processing task didn't finish in time, abandoning it");
+            }
             catch (Exception e) {
                 Log.LogError(e, "Failed to process audio stream");
                 throw;
             }
 
         var sendTask = Interlocked.Exchange(ref _sendTask, null);
-        if (sendTask != null)
+        if (sendTask is not null)
             try {
-                await sendTask.ConfigureAwait(false);
+                await sendTask.WaitAsync(Constants.Audio.RecorderDrainTimeout).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { }
+            catch (TimeoutException) {
+                Log.LogWarning("Stop: the audio send task didn't finish in time, abandoning it");
+            }
             catch (Exception e) {
                 Log.LogError(e, "Failed to send audio stream");
                 throw;
             }
+
         CompleteAudioStream();
         ClearRecordingContext();
 
@@ -494,7 +496,16 @@ public class MauiRecorderEngine : IAudioRecorderEngine
         if (chatId is null)
             return null;
 
-        await ConnectivityUI.WhenConnected(cancellationToken).ConfigureAwait(false);
+        // Bounded like the one in Start: unbounded here means a connectivity signal that never
+        // arrives swallows the whole utterance with nothing logged.
+        try {
+            await ConnectivityUI.WhenConnected(cancellationToken)
+                .WaitAsync(Constants.Audio.ConnectivityWaitTimeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException) {
+            Log.LogWarning("CreateAudioStream: no connectivity signal yet, streaming anyway");
+        }
 
         var stream = Channel.CreateBounded<IMemoryOwner<byte>>(
             new BoundedChannelOptions(Constants.Audio.StreamingChannelCapacity) {
@@ -550,6 +561,7 @@ public class MauiRecorderEngine : IAudioRecorderEngine
             await _vad.EnsureInitialized(cancellationToken).ConfigureAwait(false);
             _vad.Reset();
             var samplesSinceLastReport = samplesPerRecordingInProgressCall;
+            var hasEverHadSignal = false;
             // Cadence on the Process loop body itself: if iterations stall >60ms,
             // the bottleneck is upstream of the encoder (encoder logs already show
             // queue=0, encode-call ≤3ms — so it waits on us). Localizes whether
@@ -578,10 +590,14 @@ public class MauiRecorderEngine : IAudioRecorderEngine
 
                     // Notify that microphone is captured (UI-only, sync — no JSI hop:
                     // the heartbeat lives on the web-only JS AudioRecorderState hub, which MAUI bypasses).
+                    // A withheld microphone still delivers frames, just all-zero ones, so counting
+                    // frames alone would report a healthy signal for one that records silence.
+                    hasEverHadSignal = hasEverHadSignal || HasSignal(memory.Span);
                     samplesSinceLastReport += memory.Length;
                     if (samplesSinceLastReport >= samplesPerRecordingInProgressCall) {
                         samplesSinceLastReport = 0;
-                        engine.MicrophoneIsCaptured();
+                        if (hasEverHadSignal)
+                            engine.MicrophoneIsCaptured();
                     }
 
                     // Process the audio frame (sync — returns Task.CompletedTask)
@@ -681,6 +697,7 @@ public class MauiRecorderEngine : IAudioRecorderEngine
 
         private async Task HandleVadEvent(VoiceActivityChange change, CancellationToken cancellationToken)
         {
+            log.LogInformation("VAD: {Kind}", change.Kind);
             if (change.Kind == VoiceActivityKind.Start) {
                 if (_voiceActive) return;
 
@@ -688,7 +705,10 @@ public class MauiRecorderEngine : IAudioRecorderEngine
                 var firstFrameSourceCapturedAt = TrimPreRollBuffer();
 
                 var stream = await engine.CreateAudioStream(firstFrameSourceCapturedAt, cancellationToken).ConfigureAwait(false);
-                if (stream == null) return;
+                if (stream == null) {
+                    log.LogWarning("VAD: voice started but no audio stream could be created");
+                    return;
+                }
 
                 _encodeSendWorker = FuncWorker.Start(ct => EncodeAndSend(stream, ct), cancellationToken);
                 _voiceActive = true;
@@ -823,6 +843,15 @@ public class MauiRecorderEngine : IAudioRecorderEngine
             finally {
                 engine.CompleteAudioStream();
             }
+        }
+
+        private static bool HasSignal(ReadOnlySpan<float> samples)
+        {
+            foreach (var sample in samples)
+                if (sample != 0f)
+                    return true;
+
+            return false;
         }
     }
     #endregion

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
@@ -63,15 +63,39 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         ChatEntryId? repliedChatEntryId,
         CancellationToken cancellationToken = default)
     {
+        // Both waits are bounded and proceed anyway: neither is worth losing an utterance over,
+        // and unbounded they burn the whole StartRecordingTimeout before the mic is even opened.
         var audioInitializer = Hub.AudioInitializer;
-        await audioInitializer.WhenInitialized.ConfigureAwait(false);
+        try {
+            await audioInitializer.WhenInitialized
+                .WaitAsync(Constants.Audio.RecorderStartupWaitTimeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException) {
+            Log.LogWarning(nameof(StartRecording) + ": audio initialization is still pending, starting anyway");
+        }
 
-        // Ensure server clock is synced before recording — JS needs a valid
-        // offset to report source timestamps on the server-synced clock
-        // (same as VideoRecorder).
+        // The offset stamps frames; it isn't needed to open the microphone. Every device sleep
+        // trips the suspend-drift gate, so awaiting a re-sync here delayed every gesture.
         var serverTimeSync = Hub.Services.GetService<ServerTimeSync>();
-        if (serverTimeSync != null)
-            await serverTimeSync.EnsureSynced(cancellationToken).ConfigureAwait(false);
+        if (serverTimeSync != null) {
+            if (serverTimeSync.SyncCount > 0) {
+                _ = BackgroundTask.Run(
+                    () => serverTimeSync.EnsureSynced(CancellationToken.None),
+                    Log, "Background server clock re-sync failed", CancellationToken.None);
+            }
+            else {
+                // Never synced: there's no offset to stamp with, so this one has to wait.
+                try {
+                    await serverTimeSync.EnsureSynced(cancellationToken)
+                        .WaitAsync(Constants.Audio.RecorderStartupWaitTimeout, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (TimeoutException) {
+                    Log.LogWarning(nameof(StartRecording) + ": the server clock isn't synced yet, starting anyway");
+                }
+            }
+        }
 
         using var releaser = await _stateLock.Lock(cancellationToken).ConfigureAwait(false);
         releaser.MarkLockedLocally();

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/RecordingActivityClient.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/RecordingActivityClient.cs
@@ -15,6 +15,10 @@ public class RecordingActivityClient
     private static readonly string JSSetAudioPowerMethod =
         $"{BlazorUIAppModule.ImportName}.RecordingActivity.setAudioPower";
 
+    private static readonly TimeSpan PushTimeout = TimeSpan.FromSeconds(1);
+
+    private readonly Lock _pushLock = new();
+    private Task _pushChain = Task.CompletedTask;
     private readonly UIHub _hub;
     // Coalesce audio power submissions: the JS bridge can stall under GC /
     // long-task pressure, and power is a continuous visualization signal —
@@ -22,6 +26,7 @@ public class RecordingActivityClient
     private readonly Coalescer<double> _audioPowerCoalescer;
 
     private IJSRuntime JS => _hub.JS;
+    private ILogger Log => field ??= _hub.LogFor(GetType());
 
     public RecordingActivityClient(UIHub hub)
     {
@@ -41,13 +46,31 @@ public class RecordingActivityClient
     private ValueTask SetAudioPowerInternal(double power)
         => Push(JSSetAudioPowerMethod, power);
 
-    private async ValueTask Push(string method, object value)
+    private ValueTask Push(string method, object value)
     {
-        // A headless walkie session has no page to draw on, and this is only a visualization
-        // channel - letting the disconnect escape would abort the recording that feeds it.
+        // Detached, so a JS call that never completes can't hang the recorder start path it sits
+        // on; chained rather than fired loose so the UI still sees the pushes in order.
+        lock (_pushLock)
+            _pushChain = _pushChain.ContinueWith(
+                _ => PushUnsafe(method, value).AsTask(),
+                CancellationToken.None,
+                TaskContinuationOptions.DenyChildAttach,
+                TaskScheduler.Default).Unwrap();
+        return default;
+    }
+
+    private async ValueTask PushUnsafe(string method, object value)
+    {
+        using var cts = new CancellationTokenSource(PushTimeout);
         try {
-            await JS.InvokeVoidAsync(method, value).ConfigureAwait(false);
+            await JS.InvokeVoidAsync(method, cts.Token, value).ConfigureAwait(false);
         }
         catch (JSDisconnectedException) { }
+        catch (OperationCanceledException) {
+            Log.LogWarning("Push: {Method} didn't complete in {Timeout}", method, PushTimeout);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Push: {Method} failed", method);
+        }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/Activities/ActivitiesBackend.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/ActivitiesBackend.cs
@@ -13,6 +13,7 @@ public class ActivitiesBackend : IDisposable
     private readonly ComputedState<ActivitySet?> _state;
     private readonly bool _isAndroidHost;
     private ActivitySet? _lastState;
+    private bool? _hasEverBeenArmed;
 
     private AppUIHub Hub { get; }
     private ChatAudioUI ChatAudioUI => Hub.ChatAudioUI;
@@ -43,6 +44,21 @@ public class ActivitiesBackend : IDisposable
         _state.Updated -= OnStateUpdated;
         _state.Dispose();
     }
+
+    // False on platforms that don't mirror it; Android reads the value MainActivity launches from.
+    protected virtual bool IsArmedPersisted => false;
+
+    public static bool NextHasEverBeenArmed(bool? hasEverBeenArmed, bool isArmedPersisted, bool isArmed)
+        // Seeded from the stored value on the first recompute, not from false: a session that only
+        // ever sees an empty set is exactly what a disarm elsewhere looks like, and seeding false
+        // would make that disarm unwritable - leaving the app armed, notification and all, for good.
+        => (hasEverBeenArmed ?? isArmedPersisted) || isArmed;
+
+    public static bool ShouldPersistArmed(bool isArmed, bool hasEverBeenArmed)
+        // An empty armed set before the first non-empty one is indistinguishable from "the
+        // settings haven't loaded yet", and persisting it costs the next launch the mic-typed
+        // foreground service - which only MainActivity can raise, and only while visible.
+        => isArmed || hasEverBeenArmed;
 
     // Protected methods
 
@@ -100,7 +116,11 @@ public class ActivitiesBackend : IDisposable
         var pttChatIds = _isAndroidHost
             ? await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false)
             : [];
-        OnArmedChanged(pttChatIds.Count > 0);
+        var isArmed = pttChatIds.Count > 0;
+        var hasEverBeenArmed = NextHasEverBeenArmed(_hasEverBeenArmed, IsArmedPersisted, isArmed);
+        _hasEverBeenArmed = hasEverBeenArmed;
+        if (ShouldPersistArmed(isArmed, hasEverBeenArmed))
+            OnArmedChanged(isArmed);
 
         var set = await ActivitiesUI.GetActivitySet(cancellationToken).ConfigureAwait(false);
         return set.IsEmpty ? null : set;

--- a/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
+++ b/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
@@ -73,6 +73,11 @@ public sealed class AppScopedServiceStarter
             // ReSharper disable once ExplicitCallerInfoArgument
             Tracer.Point("BrowserInit completed");
 
+            // Here rather than in AfterFirstRender, whose render gate + 1s delay left gestures dead
+            // for the first seconds after launch - but not before this point: everything below
+            // pushes to JS modules that don't exist until BrowserInit has completed.
+            StartScopedServices(Hub.Services);
+
             // Finishing with AccountUI
             await Hub.AccountUI.WhenReady.ConfigureAwait(false);
             await Hub.ChatUI.RestoreNavbarSelectedGroup().ConfigureAwait(false);
@@ -113,13 +118,15 @@ public sealed class AppScopedServiceStarter
             var hostKind = HostInfo.HostKind;
             var baseDelay = TimeSpan.FromSeconds(hostKind.IsServer() ? 0.25 : 1);
 
+            // Ahead of the delay below: these two drive the OS-level activity UI, and on Android
+            // that includes the armed walkie-talkie notification the user expects at launch.
+            Hub.Services.GetRequiredService<ActivitiesUI>().Start();
+            _ = Hub.ActivitiesBackend; // Touch. Auto-starts on construction; WebView-only - see StartScopedServices
+
             // Starting less important UI services
             await Task.Delay(baseDelay, cancellationToken).ConfigureAwait(false);
             Hub.Services.GetRequiredService<SessionTokens>().Start();
-            Hub.Services.GetRequiredService<ActivitiesUI>().Start();
             Hub.Services.GetRequiredService<ReconnectUI>().Start();
-            StartScopedServices(Hub.Services);
-            _ = Hub.ActivitiesBackend; // Touch. Auto-starts on construction; WebView-only - see StartScopedServices
             _ = Hub.NotificationsPanelUI; // Touch. Auto-starts read-retention tracking on construction.
             _ = Hub.VideoQualityUI; // Touch. Constructor calls Start(); chains gate on first video activity.
             Hub.Services.GetRequiredService<ThrottledTranslations>().Start();
@@ -151,6 +158,9 @@ public sealed class AppScopedServiceStarter
 
     public static void StartScopedServices(IServiceProvider services)
     {
+        // Exactly once per scope: PrepareFirstRender for a WebView scope, HeadlessBlazorScope for
+        // a headless one. AudioFocusUI.WarmUp flips the audio mode for ~300ms, so a second call
+        // would re-prime the HAL for nothing.
         // Runs for any scope, headless or WebView. Everything here must work with a disconnected
         // SafeJSRuntime - see HeadlessBlazorScope. ActivitiesBackend is deliberately absent: the wake
         // handler owns the foreground service, and every widget output parks on DispatchToBlazor.

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/GestureRecognizer.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/GestureRecognizer.cs
@@ -10,7 +10,8 @@ public sealed record GestureOptions(
 /// <summary>
 /// Routes samples to the enabled detectors and emits a single gesture stream.
 /// The stop gesture is evaluated first: on the mic, closing always beats opening.
-/// Start gestures are suppressed while pocketed: proximity-covered or carried upside-down.
+/// Start gestures are suppressed while pocketed: carried upside-down, or proximity-covered
+/// for long enough in an orientation that isn't "resting screen-up on a surface".
 /// </summary>
 public sealed class GestureRecognizer
 {
@@ -28,10 +29,12 @@ public sealed class GestureRecognizer
     private readonly Lock _lock = new();
     private readonly FlipToTalkDetector _flip = new();
     private readonly FaceDownDetector _faceDown = new();
+    private readonly ProximityGuard _proximity = new();
     private readonly ShakeDetector _shake;
     private GestureOptions _options;
     private Moment? _lastSampleAt;
-    private bool _isCovered;
+    private bool _isProximitySuppressed;
+    private bool _wasSuppressed;
     private bool _isUpsideDown;
 
     public GestureOptions Options {
@@ -78,7 +81,7 @@ public sealed class GestureRecognizer
     public string GuardStatus {
         get {
             lock (_lock)
-                return (_isCovered, _isUpsideDown) switch {
+                return (_isProximitySuppressed, _isUpsideDown) switch {
                     (true, true) => "covered+upside-down",
                     (true, false) => "covered",
                     (false, true) => "upside-down",
@@ -96,10 +99,10 @@ public sealed class GestureRecognizer
     public void SetProximityCovered(bool isCovered)
     {
         lock (_lock) {
-            var wasSuppressed = _isCovered || _isUpsideDown;
-            _isCovered = isCovered;
+            // The edge is only recorded here; whether it suppresses anything is decided per
+            // sample, once it has held and against an orientation that can actually be pocketed.
+            _proximity.SetCovered(isCovered, _lastSampleAt ?? default);
             _faceDown.SetProximityCovered(isCovered);
-            ResetStartDetectorsOnSuppressionEdgeUnguarded(wasSuppressed);
         }
     }
 
@@ -113,8 +116,23 @@ public sealed class GestureRecognizer
             UpdateUpsideDownUnguarded(sample);
             if (_options.IsFaceDownEnabled && _faceDown.Process(sample))
                 return new GestureEvent(GestureKind.FaceDown, sample.At);
-            if (_isCovered || _isUpsideDown)
+
+            _isProximitySuppressed = _proximity.IsSuppressing(sample);
+            var isSuppressed = _isProximitySuppressed || _isUpsideDown;
+            if (isSuppressed) {
+                // Reset on the way IN, so no half-built flip/shake state survives pocketing; on
+                // the way out the detectors are already clean - they saw no samples while
+                // suppressed. Driven by the debounced decision, so a sensor spike can't wipe a
+                // shake that's already in progress.
+                if (!_wasSuppressed) {
+                    _flip.Reset();
+                    _shake.Reset();
+                }
+                _wasSuppressed = true;
                 return null;
+            }
+
+            _wasSuppressed = false;
             if (_options.IsFlipToTalkEnabled && _flip.Process(sample))
                 return new GestureEvent(GestureKind.FlipToTalk, sample.At);
             if (_options.IsDoubleShakeEnabled && _shake.Process(sample))
@@ -143,27 +161,18 @@ public sealed class GestureRecognizer
         if (axis == GravityAxis.None)
             return;
 
-        var wasSuppressed = _isCovered || _isUpsideDown;
         // MAUI yields Y ≈ +1 for an UPRIGHT portrait on both platforms (verified on-device
         // 2026-08-11), so top-down pocket carry is the NEGATIVE end of Y.
         _isUpsideDown = axis == GravityAxis.Y && sample.Y <= -UpsideDownMinY;
-        ResetStartDetectorsOnSuppressionEdgeUnguarded(wasSuppressed);
-    }
-
-    private void ResetStartDetectorsOnSuppressionEdgeUnguarded(bool wasSuppressed)
-    {
-        // Reset on the way IN, so no half-built flip/shake state survives pocketing; on the
-        // way out the detectors are already clean - they saw no samples while suppressed.
-        if (wasSuppressed || !(_isCovered || _isUpsideDown))
-            return;
-
-        _flip.Reset();
-        _shake.Reset();
     }
 
     private void ResetUnguarded()
     {
+        // The proximity level is deliberately kept: it's edge-driven, so forgetting it would
+        // leave us reading "uncovered" until the sensor next changes its mind.
         _isUpsideDown = false;
+        _isProximitySuppressed = false;
+        _wasSuppressed = false;
         _flip.Reset();
         _shake.Reset();
         _faceDown.Reset();

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/GestureUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/GestureUI.cs
@@ -13,9 +13,9 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
     private static readonly GestureOptions DisarmedOptions = new(false, false, false, ShakeSensitivity.Medium);
 
     private readonly GestureRecognizer _recognizer = new(DisarmedOptions);
-    // Ring of the last ~5s of samples (at SensorSpeed.UI), logged on FaceDown fire - the only
-    // forensic record of what led to a gesture once it's fired on-device.
-    private readonly SensorSample[] _recentSamples = new SensorSample[80];
+    // Ring of the last ~5s of samples (at Constants.Audio.GestureSampleMinPeriod), logged on
+    // FaceDown fire - the only forensic record of what led to a gesture once it's fired on-device.
+    private readonly SensorSample[] _recentSamples = new SensorSample[100];
     private int _recentSampleIndex;
     private string _lastGuardStatus = "off";
     private volatile bool _isPracticeMode;

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/ProximityGuard.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/ProximityGuard.cs
@@ -1,0 +1,52 @@
+namespace ActualChat.UI.Blazor.App.Services.Gestures;
+
+/// <summary>
+/// Decides whether a proximity reading means "pocketed", i.e. that start gestures must be
+/// suppressed. Raw "near" is untrustworthy: it spikes while the phone lies still, so a cover
+/// counts only once it has held, and never against a phone resting screen-up.
+/// </summary>
+public sealed class ProximityGuard
+{
+    private const float FlatMinZ = 0.7f;
+    private const float MaxGravityDeviation = 0.3f;
+
+    private bool _isCovered;
+    private bool _isRestingFaceUp;
+    private Moment _coveredSince;
+
+    public void SetCovered(bool isCovered, Moment at)
+    {
+        if (isCovered == _isCovered)
+            return;
+
+        _isCovered = isCovered;
+        _coveredSince = at;
+    }
+
+    public bool IsSuppressing(SensorSample sample)
+    {
+        UpdateRestingFaceUp(sample);
+        if (!_isCovered)
+            return false;
+        // The edge can land before the first sample, leaving no timestamp to date it from - and an
+        // unset one reads as covered forever, which skips the dwell the guard exists for.
+        if (_coveredSince == default)
+            _coveredSince = sample.At;
+        if (sample.At - _coveredSince < Constants.Audio.ProximitySuppressionDelay)
+            return false;
+
+        return !_isRestingFaceUp;
+    }
+
+    // Private methods
+
+    private void UpdateRestingFaceUp(SensorSample sample)
+    {
+        // Latched, and only gravity-dominated readings move it: shaking a phone is exactly when
+        // the veto has to hold, and mid-shake the accelerometer reads gravity plus hand motion.
+        if (MathF.Abs(sample.Magnitude - 1f) > MaxGravityDeviation)
+            return;
+
+        _isRestingFaceUp = sample.Z >= FlatMinZ;
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/WalkieTalkieMicCapability.cs
+++ b/src/dotnet/UI.Blazor.App/Services/WalkieTalkieMicCapability.cs
@@ -10,6 +10,7 @@ public static class WalkieTalkieMicCapability
     private static readonly Lock Lock = new();
     private static readonly HashSet<object> Holders = new(ReferenceEqualityComparer.Instance);
     private static Action<bool>? _handler;
+    private static Action? _blockedHandler;
     private static ILogger Log => field ??= StaticLog.For(typeof(WalkieTalkieMicCapability));
 
     public static void SetHandler(Action<bool> handler)
@@ -17,6 +18,27 @@ public static class WalkieTalkieMicCapability
 
     public static void ResetHandler(Action<bool> handler)
         => Interlocked.CompareExchange(ref _handler, null, handler);
+
+    public static void SetBlockedHandler(Action handler)
+        => Volatile.Write(ref _blockedHandler, handler);
+
+    public static void ResetBlockedHandler(Action handler)
+        => Interlocked.CompareExchange(ref _blockedHandler, null, handler);
+
+    public static void ReportBlocked()
+    {
+        // The host's job, not ours: a permission prompt needs a foregrounded activity, and a
+        // headless reply has no way to reach one except through a notification.
+        if (Volatile.Read(ref _blockedHandler) is not { } handler)
+            return;
+
+        try {
+            handler.Invoke();
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Couldn't report the blocked microphone");
+        }
+    }
 
     public static Task HoldWhile(Func<Task> action)
     {

--- a/src/dotnet/UI.Blazor.App/Services/WalkieTalkieReplyUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/WalkieTalkieReplyUI.cs
@@ -29,6 +29,11 @@ public sealed class WalkieTalkieReplyUI(AppUIHub hub) : UIServiceBase<AppUIHub>(
     public static bool ShouldColdClose(bool everVoiced, TimeSpan elapsed, TimeSpan coldTimeout)
         => !everVoiced && elapsed >= coldTimeout;
 
+    public static bool ShouldReportMicFailure(bool hasSignal, TimeSpan elapsed, TimeSpan timeout)
+        // Keyed on captured samples, not on IsRecording: the recorder reports itself started as
+        // soon as AudioRecord initializes, which it does even when the OS then hands it nothing.
+        => !hasSignal && elapsed >= timeout;
+
     public Task<WalkieTalkieReply?> RequestReply(CancellationToken cancellationToken)
         => RequestReply(Constants.Audio.WalkieTalkieReplyRecencyWindow, cancellationToken);
 
@@ -95,6 +100,10 @@ public sealed class WalkieTalkieReplyUI(AppUIHub hub) : UIServiceBase<AppUIHub>(
         }
 
         StartColdStartWatch(chatId);
+        _ = BackgroundTask.Run(
+            () => WatchMicLive(reply),
+            Log, $"{nameof(WatchMicLive)} failed",
+            CancellationToken.None);
         return reply;
     }
 
@@ -176,7 +185,61 @@ public sealed class WalkieTalkieReplyUI(AppUIHub hub) : UIServiceBase<AppUIHub>(
             return await permission.CheckOrRequest(cancellationToken).ConfigureAwait(false);
 
         Log.LogWarning("RequestReply: no microphone permission, and nothing can request it headlessly");
+        WalkieTalkieMicCapability.ReportBlocked();
         return false;
+    }
+
+    private async Task WatchMicLive(WalkieTalkieReply reply)
+    {
+        // SetRecordingChatId only writes the intent, and every way the capture below it can fail
+        // - the mic withheld, a read error, a producer thread that ends - leaves the recorder
+        // reporting success with nothing arriving. The begin tune has already played by then, so
+        // without this the only feedback is the 15s "nothing heard" cue, which claims we listened.
+        // The deadline runs from IsRecording, not from here: StartRecording legitimately takes
+        // seconds, and timing it from the request killed replies that were about to work.
+        var startBudget = Constants.Audio.WalkieTalkieReplyMicStartTimeout;
+        if (!await WaitFor(reply, x => x.IsRecording, startBudget).ConfigureAwait(false)) {
+            await ReportMicFailure(reply, "the recorder never started").ConfigureAwait(false);
+            return;
+        }
+
+        var timeout = Constants.Audio.WalkieTalkieReplyMicLiveTimeout;
+        if (!await WaitFor(reply, x => x.IsSignalDetected, timeout).ConfigureAwait(false))
+            await ReportMicFailure(reply, "no captured audio").ConfigureAwait(false);
+    }
+
+    private async Task<bool> WaitFor(
+        WalkieTalkieReply reply, Func<AudioRecorderState, bool> predicate, TimeSpan budget)
+    {
+        var startedAt = CpuTimestamp.Now;
+        var cState = AudioRecorder.State.Computed;
+        while (true) {
+            var state = cState.Value;
+            if (state.ChatId == reply.ChatId && predicate.Invoke(state))
+                return true;
+            if (ShouldReportMicFailure(false, startedAt.Elapsed, budget))
+                return false;
+
+            using var stepCts = new CancellationTokenSource();
+            var whenChanged = cState.WhenInvalidated(stepCts.Token);
+            var whenTimeout = Clocks.CpuClock.Delay((budget - startedAt.Elapsed).Positive(), stepCts.Token);
+            await Task.WhenAny(whenChanged, whenTimeout).ConfigureAwait(false);
+            stepCts.CancelAndDisposeSilently();
+            cState = await cState.Update(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReportMicFailure(WalkieTalkieReply reply, string reason)
+    {
+        lock (_lock) {
+            if (_reply != reply)
+                return; // Superseded - whatever displaced it owns the mic now
+        }
+
+        Log.LogWarning(
+            nameof(WatchMicLive) + ": chat #{ChatId} - {Reason}, closing the reply", reply.ChatId, reason);
+        await StopReply(reply).ConfigureAwait(false);
+        await PlayFailureCue().ConfigureAwait(false);
     }
 
     private void StartColdStartWatch(ChatId chatId)

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/ConnectivityUI.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/ConnectivityUI.cs
@@ -18,6 +18,8 @@ public abstract class ConnectivityUI : UIWorkerBase<UIHub>
     protected static readonly string JSSetConnectedMethod
         = $"{BlazorUICoreModule.ImportName}.ConnectivityUI.setConnected";
 
+    private static readonly TimeSpan PushToJSTimeout = TimeSpan.FromSeconds(2);
+
     private readonly MutableState<bool> _isConnected;
     private readonly MutableState<RpcConnectionInfo?> _connectionInfo;
     private int _lastConnectionIndex;
@@ -125,10 +127,17 @@ public abstract class ConnectivityUI : UIWorkerBase<UIHub>
         // A headless scope has no page to push to, and this whole chain runs under RetryForever -
         // so letting the disconnect escape would restart it about once a second, forever. The C#
         // state above is what the app consumes; only the DOM mirror is lost.
+        // Bounded, because a call that never completes parks PushIsConnectedToJS before its
+        // ConnectionState loop - freezing IsConnected at its initial false and costing everything
+        // that waits on WhenConnected (the recorder, most visibly) its full timeout.
+        using var cts = new CancellationTokenSource(PushToJSTimeout);
         try {
-            await JS.InvokeVoidAsync(method, CancellationToken.None, value).ConfigureAwait(false);
+            await JS.InvokeVoidAsync(method, cts.Token, value).ConfigureAwait(false);
         }
         catch (JSDisconnectedException) { }
+        catch (OperationCanceledException) {
+            Log.LogWarning("PushToJS: {Method} didn't complete in {Timeout}", method, PushToJSTimeout);
+        }
     }
 
     private async Task ResetReconnectDelaysWhenComeOnline(CancellationToken cancellationToken)

--- a/src/dotnet/UI.Blazor/Services/TuneUI/TuneUI.cs
+++ b/src/dotnet/UI.Blazor/Services/TuneUI/TuneUI.cs
@@ -44,7 +44,9 @@ public abstract class TuneUI : ProcessorBase
         // Walkie-talkie
         [Tune.WalkieReplyEnded] = new ([100, 50, 100]),
         [Tune.WalkieReplyNothingHeard] = new ([80]),
-        [Tune.WalkieGestureDetected] = new ([40]),
+        // Long enough to be felt mid-shake, and a single pulse so it stays distinct from
+        // WalkieReplyFailed's three.
+        [Tune.WalkieGestureDetected] = new ([90]),
         [Tune.WalkieReplyFailed] = new ([150, 100, 150, 100, 150]),
     };
     // Suppress redundant tactile feedback fired as a side-effect of starting

--- a/tests/Chat.UI.Blazor.UnitTests/ArmedFlagLatchTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ArmedFlagLatchTest.cs
@@ -1,0 +1,73 @@
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public sealed class ArmedFlagLatchTest
+{
+    [Fact]
+    public void StartupEmptyIsNotPersisted()
+    {
+        // act
+        var mustPersist = ActivitiesBackend.ShouldPersistArmed(false, hasEverBeenArmed: false);
+
+        // assert
+        mustPersist.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ArmedIsAlwaysPersisted()
+    {
+        // act
+        var fromStartup = ActivitiesBackend.ShouldPersistArmed(true, hasEverBeenArmed: false);
+        var fromSteadyState = ActivitiesBackend.ShouldPersistArmed(true, hasEverBeenArmed: true);
+
+        // assert
+        fromStartup.Should().BeTrue();
+        fromSteadyState.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AStoredArmedFlagSeedsTheLatch()
+    {
+        // act: first recompute of a session that launched armed, but resolves to no armed chats -
+        // which is what a disarm on another device looks like from here.
+        var hasEverBeenArmed = ActivitiesBackend.NextHasEverBeenArmed(null, isArmedPersisted: true, isArmed: false);
+
+        // assert: the disarm must be writable, or the app stays armed for good
+        hasEverBeenArmed.Should().BeTrue();
+        ActivitiesBackend.ShouldPersistArmed(false, hasEverBeenArmed).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnUnarmedStartStillSwallowsTheFirstEmptySet()
+    {
+        // act
+        var hasEverBeenArmed = ActivitiesBackend.NextHasEverBeenArmed(null, isArmedPersisted: false, isArmed: false);
+
+        // assert
+        hasEverBeenArmed.Should().BeFalse();
+        ActivitiesBackend.ShouldPersistArmed(false, hasEverBeenArmed).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheLatchSticksOnceArmedIsSeen()
+    {
+        // act
+        var afterArmed = ActivitiesBackend.NextHasEverBeenArmed(false, isArmedPersisted: false, isArmed: true);
+        var afterEmpty = ActivitiesBackend.NextHasEverBeenArmed(afterArmed, isArmedPersisted: false, isArmed: false);
+
+        // assert
+        afterArmed.Should().BeTrue();
+        afterEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DisarmAfterArmedIsPersisted()
+    {
+        // act
+        var mustPersist = ActivitiesBackend.ShouldPersistArmed(false, hasEverBeenArmed: true);
+
+        // assert
+        mustPersist.Should().BeTrue();
+    }
+}

--- a/tests/Chat.UI.Blazor.UnitTests/GestureDetectorTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/GestureDetectorTest.cs
@@ -487,8 +487,9 @@ public class GestureDetectorTest
         var options = new GestureOptions(false, true, false, ShakeSensitivity.High);
         var r = new GestureRecognizer(options);
         r.SetProximityCovered(true);
-        // act + assert
-        foreach (var sample in Rest(0).Concat(Burst(1.4f, extremes: 5, startMs: 1000, stepMs: 70)))
+        // act + assert: upright, i.e. pocket-like - a phone resting screen-up is covered by
+        // RecognizerCoverDoesNotSuppressWhileRestingScreenUp instead.
+        foreach (var sample in RestUpright(0).Concat(BurstUpright(1.4f, extremes: 5, startMs: 1000, stepMs: 70)))
             r.Process(sample).Should().BeNull("covered carry must suppress shake");
     }
 
@@ -547,7 +548,7 @@ public class GestureDetectorTest
     }
 
     [Fact]
-    public void RecognizerCoverEdgeResetsHalfBuiltFlip()
+    public void RecognizerSustainedCoverResetsHalfBuiltFlip()
     {
         var options = new GestureOptions(true, false, false, ShakeSensitivity.Medium);
         var r = new GestureRecognizer(options);
@@ -555,9 +556,42 @@ public class GestureDetectorTest
         r.Process(Portrait(0)).Should().BeNull();
         r.Process(Landscape(300)).Should().BeNull();
         r.SetProximityCovered(true);
+        // Past ProximitySuppressionDelay and not resting screen-up, so the cover really suppresses
+        r.Process(Portrait(900)).Should().BeNull("a held cover suppresses the flip it would have fired");
+        r.SetProximityCovered(false);
+        r.Process(Landscape(1200)).Should().BeNull();
+        r.Process(Portrait(1500)).Should().BeNull("pocketing must wipe half-built start-gesture state");
+    }
+
+    [Fact]
+    public void RecognizerCoverSpikeKeepsHalfBuiltFlip()
+    {
+        var options = new GestureOptions(true, false, false, ShakeSensitivity.Medium);
+        var r = new GestureRecognizer(options);
+        // act + assert: under-display proximity sensors blip "near" while the phone is still,
+        // and a blip that never reaches the dwell must not wipe a gesture in progress.
+        r.Process(Portrait(0)).Should().BeNull();
+        r.Process(Landscape(300)).Should().BeNull();
+        r.SetProximityCovered(true);
         r.SetProximityCovered(false);
         r.Process(Landscape(600)).Should().BeNull();
-        r.Process(Portrait(900)).Should().BeNull("pocketing must wipe half-built start-gesture state");
+        r.Process(Portrait(900)).Should().NotBeNull("a sub-dwell proximity spike must not disarm gestures");
+    }
+
+    [Fact]
+    public void RecognizerCoverDoesNotSuppressWhileRestingScreenUp()
+    {
+        var options = new GestureOptions(false, true, false, ShakeSensitivity.High);
+        var r = new GestureRecognizer(options);
+        // act: a phone flat on a desk reads "near" on some devices, but it isn't pocketed
+        r.SetProximityCovered(true);
+        r.Process(FaceUp(0)).Should().BeNull();
+        var hasFired = false;
+        foreach (var sample in Burst(1.4f, extremes: 6, startMs: 1000, stepMs: 70))
+            hasFired |= r.Process(sample) is { Kind: GestureKind.DoubleShake };
+
+        // assert
+        hasFired.Should().BeTrue("a flat, screen-up phone must stay shakeable despite a stuck 'near'");
     }
 
     [Fact]
@@ -568,12 +602,13 @@ public class GestureDetectorTest
         r.SetProximityCovered(true);
         // act + assert
         r.Process(UpsideDown(0)).Should().BeNull();
-        // The >2s gap triggers the recognizer reset: _isUpsideDown clears, _isCovered survives.
-        foreach (var sample in Rest(2600).Concat(Burst(1.4f, extremes: 5, startMs: 3600, stepMs: 70)))
+        // The >2s gap triggers the recognizer reset: _isUpsideDown clears, the covered level
+        // survives. Upright throughout, so the resting-screen-up veto can't confound it.
+        foreach (var sample in RestUpright(2600).Concat(BurstUpright(1.4f, extremes: 5, startMs: 3600, stepMs: 70)))
             r.Process(sample).Should().BeNull("covered suppression must survive the gap reset");
         r.SetProximityCovered(false);
         var hasFired = false;
-        foreach (var sample in Rest(4200).Concat(Burst(1.4f, extremes: 6, startMs: 5200, stepMs: 70)))
+        foreach (var sample in RestUpright(4200).Concat(BurstUpright(1.4f, extremes: 6, startMs: 5200, stepMs: 70)))
             hasFired |= r.Process(sample) is { Kind: GestureKind.DoubleShake };
         hasFired.Should().BeTrue("after uncover the latch must not linger - the gap reset cleared it");
     }
@@ -640,6 +675,23 @@ public class GestureDetectorTest
         for (var i = 0; i < extremes; i++) {
             var x = i % 2 == 0 ? amplitude : -amplitude;
             yield return new SensorSample(At(startMs + (i * stepMs)), x, 0f, 1f);
+        }
+    }
+
+    private static IEnumerable<SensorSample> RestUpright(double startMs, double durationMs = 1000, double stepMs = 60)
+    {
+        for (var t = 0d; t < durationMs; t += stepMs)
+            yield return new SensorSample(At(startMs + t), 0f, 1f, 0f);
+    }
+
+    private static IEnumerable<SensorSample> BurstUpright(
+        float amplitude, int extremes, double startMs, double stepMs)
+    {
+        // Gravity on Y, so ProximityGuard's resting-screen-up veto stays out of the way and the
+        // covered level itself is what the test observes.
+        for (var i = 0; i < extremes; i++) {
+            var x = i % 2 == 0 ? amplitude : -amplitude;
+            yield return new SensorSample(At(startMs + (i * stepMs)), x, 1f, 0f);
         }
     }
 }

--- a/tests/Chat.UI.Blazor.UnitTests/ProximityGuardTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ProximityGuardTest.cs
@@ -1,0 +1,104 @@
+using ActualChat.UI.Blazor.App.Services.Gestures;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public sealed class ProximityGuardTest
+{
+    private static readonly Moment T0 = Moment.EpochStart + TimeSpan.FromDays(20_000);
+
+    [Fact]
+    public void ShortSpikeNeverSuppresses()
+    {
+        // arrange: the OnePlus CPH2747 emits 0.2-1s false "near" readings while the phone is still
+        var guard = new ProximityGuard();
+
+        // act
+        guard.SetCovered(true, T0);
+        var duringSpike = guard.IsSuppressing(Upright(T0 + TimeSpan.FromSeconds(0.2)));
+        guard.SetCovered(false, T0 + TimeSpan.FromSeconds(0.36));
+        var afterSpike = guard.IsSuppressing(Upright(T0 + TimeSpan.FromSeconds(0.4)));
+
+        // assert
+        duringSpike.Should().BeFalse();
+        afterSpike.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SustainedCoverSuppressesWhenUpright()
+    {
+        // arrange
+        var guard = new ProximityGuard();
+
+        // act
+        guard.SetCovered(true, T0);
+        var isSuppressing = guard.IsSuppressing(Upright(T0 + TimeSpan.FromSeconds(0.6)));
+
+        // assert
+        isSuppressing.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FlatFaceUpVetoesSuppression()
+    {
+        // arrange
+        var guard = new ProximityGuard();
+
+        // act: a phone resting screen-up on a desk isn't pocketed, however long "near" holds
+        guard.SetCovered(true, T0);
+        var isSuppressing = guard.IsSuppressing(FaceUp(T0 + TimeSpan.FromSeconds(30)));
+
+        // assert
+        isSuppressing.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FaceDownIsStillSuppressed()
+    {
+        // arrange
+        var guard = new ProximityGuard();
+
+        // act
+        guard.SetCovered(true, T0);
+        var isSuppressing = guard.IsSuppressing(FaceDown(T0 + TimeSpan.FromSeconds(30)));
+
+        // assert
+        isSuppressing.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MotionDoesNotVetoSuppression()
+    {
+        // arrange: mid-shake the reading isn't gravity-dominated, so it says nothing about carry
+        var guard = new ProximityGuard();
+
+        // act
+        guard.SetCovered(true, T0);
+        var isSuppressing = guard.IsSuppressing(new SensorSample(T0 + TimeSpan.FromSeconds(5), 0.2f, 0.3f, 1.9f));
+
+        // assert
+        isSuppressing.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UncoverClearsSuppression()
+    {
+        // arrange
+        var guard = new ProximityGuard();
+
+        // act
+        guard.SetCovered(true, T0);
+        var whileCovered = guard.IsSuppressing(Upright(T0 + TimeSpan.FromSeconds(0.6)));
+        guard.SetCovered(false, T0 + TimeSpan.FromSeconds(1));
+        var afterUncover = guard.IsSuppressing(Upright(T0 + TimeSpan.FromSeconds(1.1)));
+
+        // assert
+        whileCovered.Should().BeTrue();
+        afterUncover.Should().BeFalse();
+    }
+
+    // Private methods
+
+    private static SensorSample FaceUp(Moment at) => new(at, -0.01f, 0.02f, 0.99f);
+    private static SensorSample FaceDown(Moment at) => new(at, -0.01f, 0.02f, -0.99f);
+    private static SensorSample Upright(Moment at) => new(at, 0.02f, 0.99f, -0.01f);
+}

--- a/tests/Chat.UI.Blazor.UnitTests/WalkieTalkieTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/WalkieTalkieTest.cs
@@ -93,4 +93,33 @@ public class WalkieTalkieTest
         // act + assert
         WalkieTalkie.MayTransmit(isPracticeMode: false, recordingChatId: null).Should().BeTrue();
     }
+
+    [Fact]
+    public void CapturedAudioIsNeverAMicFailure()
+    {
+        // act + assert
+        WalkieTalkieReplyUI
+            .ShouldReportMicFailure(hasSignal: true, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(4))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void SilenceBeforeTheDeadlineIsNotYetAMicFailure()
+    {
+        // act + assert
+        WalkieTalkieReplyUI
+            .ShouldReportMicFailure(hasSignal: false, TimeSpan.FromSeconds(3.9), TimeSpan.FromSeconds(4))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void SilencePastTheDeadlineIsAMicFailure()
+    {
+        // The recorder reports itself started as soon as AudioRecord initializes, so "no captured
+        // samples" is the only honest signal that the microphone never actually opened.
+        // act + assert
+        WalkieTalkieReplyUI
+            .ShouldReportMicFailure(hasSignal: false, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4))
+            .Should().BeTrue();
+    }
 }


### PR DESCRIPTION
Three reported symptoms on Android push-to-talk, all diagnosed on a real device (OnePlus CPH2747 / Android 16) and verified end to end.

Microphone permission, the foreground-service microphone type and the while-in-use grant were all measured healthy first, so none of this is the known wake-started-FGS problem.

## The reports, and what they turned out to be

**"Armed notification appears late."** Three separate defects. `TryStartArmed` never marked the service shown, so `HideImpl` could never take the notification down again. The backend's constructor hid the service `MainActivity` had just raised (on a warm start `_isShown` survives from the previous scope). And `ActivitiesBackend` persisted an empty armed set from a transient `GetPttChatIds`, stranding the *next* launch.

**"Gestures do nothing, no vibration."** Sensing started **3.69 s** after process start, all of it behind `AfterFirstRender`'s render gate plus a 1 s delay — it now starts from `PrepareFirstRender`. On top of that the proximity sensor reports false "near" for 0.2–7 s at a time with the accelerometer pinned flat on a desk, and each one disarmed flip/shake *and* wiped in-progress detector state. New `ProximityGuard` requires the cover to hold 0.5 s and vetoes it entirely while the phone rests screen-up, latched off gravity-dominated readings so it holds through a shake.

**"Tune plays but nothing records."** The real cause was `RecordingActivityClient` — a *visualization* shim feeding the recording SVG — awaiting `IJSRuntime.InvokeVoidAsync` with no token and no timeout, on `MauiRecorderEngine.Start`'s path. When the WebView didn't answer, the audio pipeline never started: the mic captured into a ring buffer nobody drained while the recorder reported success. The diagnostic tell is a missing `VAD initialized` line. Headless scopes were immune (their JS runtime throws instantly), which is why only foreground scopes were hit.

## Result

Seven consecutive utterances reached the server within **0.76 s** of voice detection, `delta` 233–245 ms, real audio behind every one. The gesture→microphone gap went from **3.25 s to ~380 ms** once the recorder stopped waiting for a server-clock re-sync it didn't need.

## Also fixed

- The armed foreground service is never stopped from a background path — an idle headless teardown used to take it down, and it returned background-started with no microphone grant, killing every later reply.
- A wake landing in a process where no activity has ever run cannot record, by Android's rule. It now says so immediately and the notification's full-screen intent brings the app up over the keyguard, which earns the grant back. **Verified on device: notification at 10:09:12.4, `MainActivity` 701 ms later, recording working by 10:09:27** — with no user tap.
- An open microphone is legible on the lock screen, and the widget says "Recording" instead of "Listening" while the mic is open.

## Commits

1. `fix(audio):` — shared recorder infrastructure. Independently landable: these hang *any* MAUI recording, not just walkie.
2. `feat(walkie):` — the feature.
3. `docs:` — see below.

## Not in scope, documented instead

`docs/dev-chat-render-delay-findings.md` records a receive-side delay found while chasing this: the server has an entry **0.76 s** after voice, but another user's browser shows it **8.4 s** later under Blazor Server, or **46–129 s in a single batch** under WASM with the shortest lag in each batch at ~57–61 s. Server logs are silent throughout. Includes the reproduction and the measurement trap (a `setInterval` poller is throttled to ~1/min in a hidden Chrome tab and fabricates exactly that batch pattern).

Separately worth a look: the walkie wake fan-out excludes *active participants* per **user**, not per device — so being present on your desktop suppresses the wake to the phone in your pocket. That's what made this branch hard to test, and it's a server-side design question left alone here.

## Verification

- CI solution filter builds; 337 + 29 unit tests pass.
- Android head built and installed on-device throughout; the tree is unchanged since the last verified build.
- **Note:** dev has since moved to .NET 11 preview 7 (f37c4b830b). The MAUI workloads for that band would not install in my environment (package downloads failing), so the final Android build could not be re-run locally after the rebase. The only rebase change was a conflict resolution in `AppScopedServiceStarter.cs`, which the CI build covers.

## Not yet exercised on-device

The lock-screen "Recording" peek, and the mic-blocked notification's *permission-denied* variant (the *withheld* variant is verified above).
