### PR TITLE
fix(translation): stop the translation queue jamming, and stop a lost stream lying

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -39,6 +39,16 @@ edited. The reason can be as short as whose decision it was.
   — type not sealed — required: Fusion generates a proxy over the `[ComputeMethod]`
   members, so they must stay `virtual`, and a sealed type can't declare one (CS0549)
 
+## src/dotnet/UI.Blazor.App/Services/TranslationUI/ThrottledTranslations.cs
+
+- L5 `public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IAsyncDisposable`
+  — type not sealed — required: Fusion generates a proxy over the `[ComputeMethod]`
+  members, so they must stay `virtual`, and a sealed type can't declare one (CS0549)
+- L17 `public ThrottledTranslations(AppUIHub hub) : base(hub)`
+  — explicit constructor instead of a primary one — required: both fields are built
+  from the instance methods `WhenTranslated` / `WhenLanguageDetected`, which a field
+  initializer can't reference (CS0236)
+
 ## src/nodejs/src/scroll-controller.ts
 
 - L452 `switch (this.phase) {`

--- a/src/dotnet/Chat.Service/TranslationsBackend.cs
+++ b/src/dotnet/Chat.Service/TranslationsBackend.cs
@@ -417,9 +417,10 @@ public class TranslationsBackend(IServiceProvider services) : DbServiceBase<Chat
         var stopTokenSource = HostLifetime.CreateStopTokenSource();
  #pragma warning restore CA2016
         var stopToken = stopTokenSource.Token;
-        var transcriptStream = transcript
-            .SuppressExceptions(e => e is RpcReconnectFailedException, stopToken)
-            .Memoize(stopToken);
+        // A lost source stream must stay an error: suppressing it here made a truncated transcript
+        // look like a finished one, so TranslateTranscriptStream persisted a mid-sentence
+        // translation as final and ended the client's stream normally, with nothing logged.
+        var transcriptStream = transcript.Memoize(stopToken);
 
         var worker = _activePublishers.GetOrAdd(translatedStreamId,
             static (_, state) => {

--- a/src/dotnet/Core/Concurrency/ConcurrentProcessor.cs
+++ b/src/dotnet/Core/Concurrency/ConcurrentProcessor.cs
@@ -11,26 +11,31 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
     private readonly ConcurrentDictionary<TKey, Item> _queue;
     private readonly Channel<Item> _channel;
     private readonly ChannelWriter<Item> _writer;
-    private volatile int _enqueueCount;
-    private volatile int _processedCount;
+    private int _enqueueCount;
+    private int _processedCount;
 
     private ILogger? Log { get; }
     private ILogger? DebugLog => Log.IfEnabled(LogLevel.Debug, CoreConstants.DebugMode.ConcurrentProcessor);
 
-    public int EnqueueCount => _enqueueCount;
-    public int ProcessedCount => _processedCount; // Processed or removed
+    public int EnqueueCount => Volatile.Read(ref _enqueueCount);
+    public int ProcessedCount => Volatile.Read(ref _processedCount); // Processed or removed
     public int QueueSize => _queue.Count;
     public IEnumerable<Item> Queue => _queue.Values;
+    public TimeSpan ProcessCallTimeout { get; }
 
+    // processCallTimeout is a constructor parameter rather than an init-only property because
+    // .ctor may start the processor, i.e. an initializer would set it after the first item runs.
     public ConcurrentProcessor(
         int concurrencyLevel,
         Func<TKey, CancellationToken, Task<TResult>> processor,
+        TimeSpan processCallTimeout = default,
         IEqualityComparer<TKey>? keyComparer = null,
         ILogger? log = null,
         bool mustStart = true)
     {
         Log = log;
         _processor = processor;
+        ProcessCallTimeout = processCallTimeout;
         _concurrencyGate = new SemaphoreSlim(concurrencyLevel);
         _queue = new ConcurrentDictionary<TKey, Item>(keyComparer);
         _channel = Channel.CreateUnbounded<Item>(ChannelExt.UnboundedFanInOptions);
@@ -71,38 +76,32 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
         }
     }
 
-    public bool Remove(Item item, bool cancelRunning)
+    public bool Remove(TKey key, bool mustCancelRunning)
+        => _queue.TryGetValue(key, out var item) && Remove(item, mustCancelRunning);
+
+    public bool Remove(Item item, bool mustCancelRunning)
     {
-        if (!_queue.TryRemove(item.Key, item))
+        // An uncancelled running item holds its slot till it completes, so Process dequeues that one
+        var isRemoved = item.Remove(mustCancelRunning);
+        if (!isRemoved && !mustCancelRunning)
             return false;
 
-        // Remove wasn't called for this item yet
-        Interlocked.Increment(ref _processedCount);
-        item.Remove(cancelRunning);
+        if (_queue.TryRemove(item.Key, item))
+            Interlocked.Increment(ref _processedCount);
+
         return true;
     }
 
-    public bool Remove(TKey key, bool cancelRunning)
-    {
-        if (!_queue.TryRemove(key, out var item))
-            return false;
-
-        // Remove wasn't called for this item yet
-        Interlocked.Increment(ref _processedCount);
-        item.Remove(cancelRunning);
-        return true;
-    }
-
-    public void RemoveMany(bool cancelRunning, params ReadOnlySpan<TKey> keys)
+    public void RemoveMany(bool mustCancelRunning, params ReadOnlySpan<TKey> keys)
     {
         foreach (var key in keys)
-            Remove(key, cancelRunning);
+            Remove(key, mustCancelRunning);
     }
 
-    public void RemoveMany(bool cancelRunning, params ReadOnlySpan<Item> items)
+    public void RemoveMany(bool mustCancelRunning, params ReadOnlySpan<Item> items)
     {
         foreach (var item in items)
-            Remove(item, cancelRunning);
+            Remove(item, mustCancelRunning);
     }
 
     // Protected methods
@@ -139,12 +138,12 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
             StopToken = _stopTokenSource.Token;
         }
 
-        internal bool Remove(bool cancelRunning)
+        internal bool Remove(bool mustCancelRunning)
         {
             var debugLog = Owner.DebugLog;
             lock (Lock) {
                 if (ProcessTask != null) {
-                    if (cancelRunning) {
+                    if (mustCancelRunning) {
                         _stopTokenSource.CancelAndDisposeSilently();
                         debugLog?.LogDebug("Cancelled already running item #{Key}", Key);
                     }
@@ -168,7 +167,7 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
             var key = Key;
             var concurrencyGate = Owner._concurrencyGate;
             var debugLog = Owner.DebugLog;
-            var alreadyRemoved = false;
+            var isAlreadyRemoved = false;
 
             try {
                 await concurrencyGate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -180,15 +179,23 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
 
             try {
                 var startedAt = CpuTimestamp.Now;
+                Task<TResult> processTask;
                 lock (Lock) {
-                    alreadyRemoved = ProcessTask != null;
-                    if (alreadyRemoved)
+                    isAlreadyRemoved = ProcessTask != null;
+                    if (isAlreadyRemoved)
                         return;
 
                     debugLog?.LogDebug("Processing item #{Key}", key);
-                    ProcessTask ??= Task.Run(() => Owner._processor.Invoke(key, cancellationToken), cancellationToken);
+                    processTask = ProcessTask =
+                        Task.Run(() => Owner._processor.Invoke(key, cancellationToken), cancellationToken);
                 }
-                var result = await ProcessTask.ConfigureAwait(false);
+
+                // The timeout covers processing only - the wait for a slot is unbounded by design.
+                // Timing out faults the item, and the finally below cancels what it was running.
+                var timeout = Owner.ProcessCallTimeout;
+                var result = timeout > TimeSpan.Zero
+                    ? await processTask.WaitAsync(timeout, cancellationToken).ConfigureAwait(false)
+                    : await processTask.ConfigureAwait(false);
                 _resultSource.TrySetResult(result);
                 debugLog?.LogDebug("Processed item #{Key} in {Elapsed}", key, startedAt.Elapsed.ToShortString());
             }
@@ -203,7 +210,7 @@ public sealed class ConcurrentProcessor<TKey, TResult> : WorkerBase
                 }
             }
             finally {
-                if (alreadyRemoved)
+                if (isAlreadyRemoved)
                     debugLog?.LogDebug("Skipping already removed item #{Key}", key);
                 else if (Owner._queue.TryRemove(key, this))
                     Interlocked.Increment(ref Owner._processedCount);

--- a/src/dotnet/UI.Blazor.App/Services/TranslationUI/ThrottledTranslations.cs
+++ b/src/dotnet/UI.Blazor.App/Services/TranslationUI/ThrottledTranslations.cs
@@ -5,6 +5,8 @@ namespace ActualChat.UI.Blazor.App.Services;
 public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IAsyncDisposable
 {
     public const int ConcurrencyLevel = 10;
+    // Bounds a WhenNotNull wait the server may never end, so a slot can't be held for the session
+    private static readonly TimeSpan ProcessCallTimeout = TimeSpan.FromSeconds(60);
     private readonly ConcurrentProcessor<TranslationId, Translation> _translations;
     private readonly ConcurrentProcessor<ChatEntryId, ChatEntryLanguage> _languageDetections;
 
@@ -14,8 +16,12 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
 
     public ThrottledTranslations(AppUIHub hub) : base(hub)
     {
-        _translations = new (ConcurrencyLevel, WhenTranslated, log: hub.LogFor<ConcurrentProcessor<TranslationId, Translation>>());
-        _languageDetections = new (ConcurrencyLevel, WhenLanguageDetected, log: hub.LogFor<ConcurrentProcessor<ChatEntryId, ChatEntryLanguage>>());
+        _translations = new(
+            ConcurrencyLevel, WhenTranslated, ProcessCallTimeout,
+            log: hub.LogFor<ConcurrentProcessor<TranslationId, Translation>>());
+        _languageDetections = new(
+            ConcurrencyLevel, WhenLanguageDetected, ProcessCallTimeout,
+            log: hub.LogFor<ConcurrentProcessor<ChatEntryId, ChatEntryLanguage>>());
     }
 
     public async ValueTask DisposeAsync()
@@ -42,14 +48,13 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
     public Task<Translation?> GetExisting(TranslationId id, CancellationToken cancellationToken)
         => Translations.Get(Session, id, false, cancellationToken);
 
-    public async Task<Translation?> Get(
-        TranslationId id,
-        CancellationToken cancellationToken)
+    public async Task<Translation?> Get(TranslationId id, CancellationToken cancellationToken)
     {
         var session = Session;
         var existingTranslation = await Translations.Get(session, id, false, cancellationToken).ConfigureAwait(false);
         if (existingTranslation is null)
             _translations.Enqueue(id);
+
         return existingTranslation;
     }
 
@@ -62,9 +67,10 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
         return existing;
     }
 
-    // Internal methods (used in tests)
+    // Protected/internal methods
 
 #pragma warning disable RCS1210
+    // These three are internal to be accessible from tests
     internal Task<Translation>? GetWorkItem(TranslationId id)
         => _translations.Get(id)?.ResultTask;
 #pragma warning restore RCS1210
@@ -74,8 +80,6 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
 
     internal IReadOnlyList<(TranslationId Id, Task<Translation> Task)> ListQueued()
         => _translations.Queue.Where(x => !x.IsStarted).Select(x => (x.Key, x.ResultTask)).ToList();
-
-    // Protected methods
 
     [ComputeMethod]
     protected virtual async Task<State?> GetTranslationVisibilityState(CancellationToken cancellationToken)
@@ -88,11 +92,13 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
         var targetLanguage = await TranslationUI
             .GetTranslationLanguage(itemVisibility.ChatId, cancellationToken)
             .ConfigureAwait(false);
+
         return new(itemVisibility, targetLanguage);
     }
 
     [ComputeMethod]
-    protected virtual Task<ChatEntryLanguage?> GetLanguageInternal(ChatEntryId entryId, CancellationToken cancellationToken)
+    protected virtual Task<ChatEntryLanguage?> GetLanguageInternal(
+        ChatEntryId entryId, CancellationToken cancellationToken)
         => Translations.GetLanguage(Session, entryId, cancellationToken);
 
     protected override Task OnRun(CancellationToken cancellationToken)
@@ -106,6 +112,8 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
             .RunIsolated(cancellationToken);
     }
 
+    // Private methods
+
     private async Task SyncRunningTranslations(CancellationToken cancellationToken)
     {
         var cState0 = await Computed
@@ -113,32 +121,63 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
             .ConfigureAwait(false);
         State? last = null;
         await foreach (var (state, _) in cState0.Changes(cancellationToken).ConfigureAwait(false)) {
-            // TODO(FC): dequeue for thread entries - use ChatUI.GetThreadPreviewEntries
-            _translations.RemoveMany(false, GetDisappearedTranslationIds(state).ToArray());
-            _languageDetections.RemoveMany(false, GetDisappearedEntryIds(state).ToArray());
+            var keys = GetDisappearedKeys(state).ToList();
+            var threadEntryIds = await ListThreadPreviewEntryIds(keys).ConfigureAwait(false);
+            _translations.RemoveMany(false, GetDisappearedTranslationIds(keys, threadEntryIds).ToArray());
+            _languageDetections.RemoveMany(false, GetDisappearedEntryIds(state).Concat(threadEntryIds).ToArray());
             last = state;
         }
         return;
 
-        IEnumerable<TranslationId> GetDisappearedTranslationIds(State? state)
-        {
+        IEnumerable<ChatMessageKey> GetDisappearedKeys(State? state) {
             if (last is null)
                 return [];
 
-            var keys = state is not null
+            return state is not null
                 ? last.ItemVisibility.VisibleKeys.Except(state.ItemVisibility.VisibleKeys)
                 : last.ItemVisibility.VisibleKeys;
-            return ToPossibleTranslationIds(keys, last.ItemVisibility.ChatId, last.TargetLanguage);
         }
 
-        IEnumerable<ChatEntryId> GetDisappearedEntryIds(State? state)
-        {
+        IEnumerable<TranslationId> GetDisappearedTranslationIds(
+            IReadOnlyList<ChatMessageKey> keys,
+            IReadOnlyList<ChatEntryId> threadEntryIds) {
+            if (last is null)
+                return [];
+
+            var targetLanguage = last.TargetLanguage;
+            return ToPossibleTranslationIds(keys, last.ItemVisibility.ChatId, targetLanguage)
+                .Concat(threadEntryIds.Select(x => TranslationId.New(x, targetLanguage)));
+        }
+
+        IEnumerable<ChatEntryId> GetDisappearedEntryIds(State? state) {
             if (last is null)
                 return [];
 
             return state is not null
                 ? last.ItemVisibility.VisibleTextEntryIds.Except(state.ItemVisibility.VisibleTextEntryIds)
                 : last.ItemVisibility.VisibleTextEntryIds;
+        }
+
+        // A thread card previews entries of the thread chat, so no visible key of the chat we're
+        // watching maps to them - they have to be resolved the same way the card resolves them.
+        async Task<List<ChatEntryId>> ListThreadPreviewEntryIds(IReadOnlyList<ChatMessageKey> keys) {
+            var result = new List<ChatEntryId>();
+            if (last is null)
+                return result;
+
+            var chatId = last.ItemVisibility.ChatId;
+            foreach (var key in keys) {
+                if (key.Kind != ChatMessageKind.Thread)
+                    continue;
+
+                var threadChatId = chatId.CreateThreadId(key.LocalId);
+                var entries = await ChatUI
+                    .GetThreadPreviewEntries(threadChatId, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+                result.AddRange(entries.Select(x => x.Id));
+            }
+
+            return result;
         }
     }
 
@@ -154,13 +193,20 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
             .Capture(taskFactory, cancellationToken)
             .ConfigureAwait(false);
         var cData = await cData0.When(x => x is not null, cancellationToken).ConfigureAwait(false);
+
         return cData.Value!;
     }
 
-    private static IEnumerable<TranslationId> ToPossibleTranslationIds(IEnumerable<ChatMessageKey> keys, ChatId chatId, Language targetLanguage)
+    private static IEnumerable<TranslationId> ToPossibleTranslationIds(
+        IEnumerable<ChatMessageKey> keys,
+        ChatId chatId,
+        Language targetLanguage)
         => keys.SelectMany(x => ToPossibleTranslationIds(x, chatId, targetLanguage));
 
-    private static IEnumerable<TranslationId> ToPossibleTranslationIds(ChatMessageKey key, ChatId chatId, Language targetLanguage)
+    private static IEnumerable<TranslationId> ToPossibleTranslationIds(
+        ChatMessageKey key,
+        ChatId chatId,
+        Language targetLanguage)
         => key.Kind switch {
             ChatMessageKind.None => [TranslationId.New(ChatEntryId.New(chatId, key.LocalId), targetLanguage)],
             ChatMessageKind.ConversationStart => [
@@ -168,7 +214,8 @@ public class ThrottledTranslations : UIWorkerBase<AppUIHub>, IComputeService, IA
                     targetLanguage),
                 TranslationId.New(TranslationSourceId.New(chatId, TranslationIdKind.ConversationSummary, key.LocalId),
                     targetLanguage),
-                TranslationId.New(TranslationSourceId.New(chatId, TranslationIdKind.ConversationDescription, key.LocalId),
+                TranslationId.New(
+                    TranslationSourceId.New(chatId, TranslationIdKind.ConversationDescription, key.LocalId),
                     targetLanguage),
             ],
             ChatMessageKind.Thread => [

--- a/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
@@ -369,10 +369,64 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
                 queued.Should().AllSatisfy(x => x.Task.IsCompleted.Should().BeTrue());
             },
             TimeSpan.FromSeconds(TestRunnerInfo.IsBuildAgent() ? 20 : 10));
+        // A started translation isn't cancelled on dequeue - it holds its concurrency slot, and so
+        // its queue entry, until it completes, which is why this waits rather than asserting at once
         await TestExt.When(() => {
             ThrottledTranslations.ListQueued().Should().BeEmpty();
             ThrottledTranslations.ListRunning().Should().BeEmpty();
-        }, TimeSpan.FromSeconds(10));
+        }, TimeSpan.FromSeconds(TestRunnerInfo.IsBuildAgent() ? 60 : 30));
+    }
+
+    [Fact]
+    public async Task ShouldDequeueThreadPreviewTranslationsWhenThreadsBecomeInvisible()
+    {
+        // arrange
+        const int threadCount = 8; // x PreviewEntryCount, so the queue holds more than ConcurrencyLevel
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60).Debuggable());
+        var cancellationToken = cts.Token;
+        var chatId = await CreateChat(cancellationToken);
+        await TranslationUI.SetTargetLanguage(chatId, Languages.German, cancellationToken);
+        // Without this GetTranslationVisibilityState stays null and nothing is ever dequeued
+        await TranslationUI.SetIsOn(chatId, true, cancellationToken);
+        await ComputedTest.When(async ct => (await TranslationUI.IsEnabled(chatId, ct)).Should().BeTrue(),
+            TimeSpan.FromSeconds(10).Debuggable());
+
+        var threadStartLids = new List<long>();
+        var previewEntries = new List<ChatEntry>();
+        for (var i = 0; i < threadCount; i++) {
+            var threadStart = (await CreateEntries(chatId, $"Thread start {i}")).Single();
+            var threadChat = await BobTester.Commander.Call(
+                new ChatThreads_Start(BobTester.Session, chatId, $"Thread#{i}", "", [threadStart.Id]),
+                cancellationToken);
+            // Digits only: the server decides these need no translation and keeps returning null, so
+            // an item can only leave the queue by being dequeued - never by completing
+            previewEntries.AddRange(await CreateEntries(threadChat.Id, $"{i}00", $"{i}01"));
+            threadStartLids.Add(threadStart.LocalId);
+        }
+        SetVisibleThreads(chatId, threadStartLids);
+        // Started here, after the cards are visible, so its very first observed state is that one -
+        // the dequeue needs a previous state to diff against. The app starts it from AfterFirstRender,
+        // which BlazorTester never reaches.
+        ThrottledTranslations.Start();
+
+        // act - this is what ThreadMessageView does for the entries its card previews
+        var translations = await GetTranslations(previewEntries, cancellationToken);
+        var queued = ThrottledTranslations.ListQueued();
+
+        // assert
+        translations.Should().AllSatisfy(x => x.Should().BeNull());
+        queued.Should().NotBeEmpty();
+        queued.Should().AllSatisfy(x => x.Id.SourceId.ChatId.IsThread(out _).Should().BeTrue());
+
+        // act
+        ClearVisibleItems(chatId);
+
+        // assert - a thread card's key is the only visible key that maps to these entries
+        await TestExt.When(() => {
+                queued.Should().AllSatisfy(x => ThrottledTranslations.GetWorkItem(x.Id).Should().BeNull());
+                queued.Should().AllSatisfy(x => x.Task.IsCanceled.Should().BeTrue());
+            },
+            TimeSpan.FromSeconds(TestRunnerInfo.IsBuildAgent() ? 20 : 10));
     }
 
     private async Task<ChatId> CreateChat(CancellationToken cancellationToken)
@@ -424,6 +478,11 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
             lids.Select(lid => ChatMessageKey.New(ChatMessageKind.None, lid)).ToHashSet(),
             true));
     }
+
+    private void SetVisibleThreads(ChatId chatId, IEnumerable<long> threadStartLids)
+        => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId,
+            threadStartLids.Select(lid => ChatMessageKey.New(ChatMessageKind.Thread, lid)).ToHashSet(),
+            true));
 
     private void ClearVisibleItems(ChatId chatId)
         => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId, ReadOnlySet<ChatMessageKey>.Empty, true));

--- a/tests/Core.UnitTests/Concurrency/ConcurrentProcessorTest.cs
+++ b/tests/Core.UnitTests/Concurrency/ConcurrentProcessorTest.cs
@@ -34,8 +34,8 @@ public class ConcurrentProcessorTest(ITestOutputHelper @out) : TestBase(@out)
         // act - remove all
         sut.RemoveMany(cancel, ids);
 
-        // assert - queue is always empty after remove (regardless of cancel)
-        sut.QueueSize.Should().Be(0);
+        // assert - a started item we didn't cancel still holds its slot, so it stays queued
+        sut.QueueSize.Should().Be(cancel ? 0 : concurrencyLevel);
 
         // not-started items are always cancelled on remove
         await TestExt.When(() => {
@@ -56,6 +56,7 @@ public class ConcurrentProcessorTest(ITestOutputHelper @out) : TestBase(@out)
             await TestExt.When(() => {
                 items.Take(concurrencyLevel).Should().AllSatisfy(
                     x => x.ResultTask.IsCompletedSuccessfully.Should().BeTrue());
+                sut.QueueSize.Should().Be(0);
             }, TimeSpan.FromSeconds(5));
         }
     }
@@ -205,6 +206,50 @@ public class ConcurrentProcessorTest(ITestOutputHelper @out) : TestBase(@out)
         // assert
         sut.QueueSize.Should().Be(0);
         await TestExt.When(() => item.ResultTask.IsCanceled.Should().BeTrue(), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ShouldKeepUncancelledRunningItemQueued()
+    {
+        // arrange
+        var fetcher = new Fetcher().Register(["a"]);
+        await using var sut = new ConcurrentProcessor<string, string>(
+            1, fetcher.Fetch,
+            log: Out.ToLogger<ConcurrentProcessor<string, string>>());
+
+        var item = sut.Enqueue("a");
+        await TestExt.When(() => item.IsStarted.Should().BeTrue(), TimeSpan.FromSeconds(5));
+
+        // act
+        sut.Remove("a", false);
+
+        // assert - it still holds a slot, so it stays queued and Enqueue must not duplicate it
+        sut.QueueSize.Should().Be(1);
+        ReferenceEquals(sut.Enqueue("a"), item).Should().BeTrue();
+
+        fetcher.SetResult("a");
+        await TestExt.When(() => sut.QueueSize.Should().Be(0), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ShouldTimeOutProcessCall()
+    {
+        // arrange
+        var fetcher = new Fetcher().Register(["a", "b"]);
+        await using var sut = new ConcurrentProcessor<string, string>(
+            1, fetcher.Fetch, TimeSpan.FromMilliseconds(200),
+            log: Out.ToLogger<ConcurrentProcessor<string, string>>());
+
+        // act
+        var item = sut.Enqueue("a");
+        var next = sut.Enqueue("b");
+
+        // assert - the timed out item frees its slot, so the next one gets to start
+        await Assert.ThrowsAsync<TimeoutException>(() => item.ResultTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        await TestExt.When(() => next.IsStarted.Should().BeTrue(), TimeSpan.FromSeconds(5));
+
+        fetcher.SetResult("b");
+        await TestExt.When(() => sut.QueueSize.Should().Be(0), TimeSpan.FromSeconds(5));
     }
 
     [Fact]


### PR DESCRIPTION
Three fixes found while sweeping for issues of the same class as the streaming-transcript ellipsis bug (`adbb8c9f3a`). All three are on the translation path, all three are silent failures, and none of them self-heal.

## 1. A work item could hold a queue slot for the whole session

`ThrottledTranslations` runs translation and language detection through two `ConcurrentProcessor`s, 10 concurrent items each. Two independent defects leaked those slots; once they were gone, nothing translated again for that circuit — every message stuck on the "Translating" mark, nothing in the logs.

**Unbounded wait.** Both processors wait for a compute method to stop returning null, and the server can legitimately decide it has nothing to produce — translation disabled server-side, a removed entry, or a translation still marked `IsStreaming` all make `TranslationsBackend.Get` return null without enqueueing anything. `ConcurrentProcessor` now takes a `ProcessCallTimeout`, applied around the processor call only (never around the wait for a slot); `ThrottledTranslations` sets 60s.

This is deliberately a give-up: the item faults and gets logged, and that entry isn't retried until something invalidates it. That beats ten such waits freezing translation for the session with no signal.

**Removal dropped a running item on the floor.** `Remove()` pulled the item out of `_queue` *before* asking it, and `Item.Remove` then declined to cancel an already-running one. So a running item we chose not to cancel — exactly what the visibility sync asks for — kept its semaphore slot while being invisible to `Queue`/`Get`, and the next `Enqueue` for that key built a second item. `Remove` now asks the item first and leaves an uncancelled running one queued until `Process` is done with it; a cancelled one still leaves at once.

## 2. A thread card's preview translations were never dequeued

`ThreadMessageView` requests translations for entries that live in the **thread** chat, while `SyncRunningTranslations` built its disappeared ids from the **parent** chat plus the visible key's lid — so no key could ever match them. They only ever left the queue by completing. Now a disappeared `Thread` key is resolved through `chatId.CreateThreadId(key.LocalId)` + `ChatUI.GetThreadPreviewEntries`, the same pair the card itself uses. Retires the `TODO(FC)`.

## 3. A lost transcript stream read as a finished one

`StartTranscriptStreamTranslation` wrapped the source transcript in `SuppressExceptions(e => e is RpcReconnectFailedException, …)`, so a mid-flight relay drop looked like a normal end of stream: `error` stayed null, a mid-sentence translation was persisted as final, and the client's stream completed cleanly — with nothing logged. Dropping the suppression puts the failure back on the path built for it (logged, `finalizeRealtime` skipped so nothing truncated is written, re-translation still enqueued, client stream faults so its retry engages).

Consumer chain checked: the memoizer has a single replayer — the one whose `catch` this is; its own rethrow out of `OnRun` is swallowed by `WorkerBase.Run`; `PushTranscript` awaits a `WhenRunning` that never throws.

## Tests

- `ConcurrentProcessorTest.ShouldKeepUncancelledRunningItemQueued` — a running item stays queued and `Enqueue` returns the same item instead of duplicating it.
- `ConcurrentProcessorTest.ShouldTimeOutProcessCall` — a timed-out item frees its slot so the next one starts.
- `TranslationUITest.ShouldDequeueThreadPreviewTranslationsWhenThreadsBecomeInvisible` — 8 thread cards × 2 preview entries, digits-only text so the server keeps returning null and an item can only leave the queue by being dequeued. **Verified non-vacuous**: stub the thread resolution to return empty and it fails; with the fix it passes.
- `ShouldRemove` moves to the new removal contract; the `ListRunning` assertion in `ShouldDequeueTranslationWhenItemBecomesInvisible` now waits instead of expecting a started item to vanish on the spot.

Two things surfaced while writing test 3, both pre-existing and worth knowing:

- `ThrottledTranslations` is started from `AppScopedServiceStarter.AfterFirstRender`, which `BlazorTester` never reaches — so the dequeue worker was **never running** in these tests. `ShouldDequeueTranslationWhenItemBecomesInvisible` passes only because the translations complete; it never covered the dequeue.
- That test also never enables translation, so `GetTranslationVisibilityState` returns null and no dequeue could happen even with the worker up.

The new test starts the worker and enables translation explicitly, and says why in comments.

**No test for #3** — `StartTranscriptStreamTranslation` has no coverage today, and forcing an `RpcReconnectFailedException` mid-stream needs a multi-node harness that doesn't exist here.

## Verification

- `dotnet build ActualChat.CI.slnf` — 0 errors.
- `Core.UnitTests` — 621 passed.
- `TranslationUITest` — 14 passed / 1 pre-existing skip, four consecutive runs.
- Live on `local.voxt.ai`, two signed-in Chrome clients: both render, no stuck ellipsis, translation on → three Russian messages translated to English, `to-translated not-streaming`, zero stuck `translating`. Server DevLog shows `SyncRunningTranslations started` on every circuit with no failures (the new thread resolution doesn't throw live) and no spurious `Item #… failed` timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuJUG1bpTnXmM5BXKp6T6R
