### PR TITLE
fix(android): two crash fixes found by triaging on-device crash reports

### DIFF
--- a/build/Commands/MauiApp.cs
+++ b/build/Commands/MauiApp.cs
@@ -60,9 +60,7 @@ internal static class MauiApp
             args.Add("-p:UseNativeAot=true");
         switch (settings.Platform) {
         case AppPlatform.Android:
-            if (settings.IsDev)
-                args.Add("-p:EmbedAssembliesIntoApk=true");
-            else
+            if (!settings.IsDev)
                 AddAndroidSigning(plan, args);
             break;
         case AppPlatform.Windows:

--- a/src/dotnet/App.Maui/App.Maui.csproj
+++ b/src/dotnet/App.Maui/App.Maui.csproj
@@ -304,9 +304,13 @@
     <AndroidEnvironment Include="android-env.txt" />
   </ItemGroup>
 
-  <!-- Android: Debug configuration -->
+  <!-- Android: Debug configuration.
+       EmbedAssembliesIntoApk must stay True here, even though the SDK defaults it to False for Debug:
+       under CoreCLR that False also turns off the assembly store, leaving Fast Deployment as the only
+       assembly source. We deploy via 'adb install', which never populates the FastDev override dir,
+       so the APK would ship with no managed assemblies and CoreCLR init would fail with 0x80070002. -->
   <PropertyGroup Condition="$(TargetFramework.Contains('-android')) and '$(Configuration)' == 'Debug'">
-    <EmbedAssembliesIntoApk Condition="'$(EmbedAssembliesIntoApk)' == ''">False</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk Condition="'$(EmbedAssembliesIntoApk)' == ''">True</EmbedAssembliesIntoApk>
   </PropertyGroup>
 
   <!-- Our own startup profile - the union of on-device Android and on-desktop Windows

--- a/src/dotnet/Maui/Platforms/Android/Logging/AndroidTaggedLogSink.cs
+++ b/src/dotnet/Maui/Platforms/Android/Logging/AndroidTaggedLogSink.cs
@@ -13,30 +13,37 @@ public class AndroidTaggedLogSink(string tag, ITextFormatter textFormatter) : IL
         if (logEvent == null)
             throw new ArgumentNullException(nameof(logEvent));
 
-        StringWriter output = new StringWriter();
-        textFormatter.Format(logEvent, output);
-        switch (logEvent.Level) {
-        case LogEventLevel.Verbose:
-            Log.Verbose(tag, output.ToString());
-            break;
-        case LogEventLevel.Debug:
-            Log.Debug(tag, output.ToString());
-            break;
-        case LogEventLevel.Information:
-            Log.Info(tag, output.ToString());
-            break;
-        case LogEventLevel.Warning:
-            Log.Warn(tag, output.ToString());
-            break;
-        case LogEventLevel.Error:
-            Log.Error(tag, output.ToString());
-            break;
-        case LogEventLevel.Fatal:
-            Log.Wtf(tag, output.ToString());
-            break;
-        default:
-            Log.WriteLine(LogPriority.Assert, tag, output.ToString());
-            break;
+        // A sink must never throw: every Android.Util.Log call below is a JNI transition that can fail,
+        // and the throw would propagate into the logging pipeline and re-enter it via FirstChanceException.
+        try {
+            var output = new StringWriter();
+            textFormatter.Format(logEvent, output);
+            switch (logEvent.Level) {
+            case LogEventLevel.Verbose:
+                Log.Verbose(tag, output.ToString());
+                break;
+            case LogEventLevel.Debug:
+                Log.Debug(tag, output.ToString());
+                break;
+            case LogEventLevel.Information:
+                Log.Info(tag, output.ToString());
+                break;
+            case LogEventLevel.Warning:
+                Log.Warn(tag, output.ToString());
+                break;
+            case LogEventLevel.Error:
+                Log.Error(tag, output.ToString());
+                break;
+            case LogEventLevel.Fatal:
+                Log.Wtf(tag, output.ToString());
+                break;
+            default:
+                Log.WriteLine(LogPriority.Assert, tag, output.ToString());
+                break;
+            }
+        }
+        catch {
+            // Intentionally ignored
         }
     }
 }

--- a/src/dotnet/Maui/ThreadIdEnricher.cs
+++ b/src/dotnet/Maui/ThreadIdEnricher.cs
@@ -7,12 +7,17 @@ internal class ThreadIdEnricher : ILogEventEnricher
 {
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        var managedThreadId = Environment.CurrentManagedThreadId.ToString("D4");
-        var threadId = managedThreadId;
+        // An enricher must never throw: on Android MyTid() is a JNI call that can fail, and the throw
+        // would propagate into the logging pipeline and re-enter it via FirstChanceException.
+        try {
+            var threadId = Environment.CurrentManagedThreadId.ToString("D4");
 #if ANDROID
-        var myTid = Android.OS.Process.MyTid();
-        threadId = threadId + "-" + myTid;
+            threadId = threadId + "-" + Android.OS.Process.MyTid();
 #endif
-        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ThreadID", threadId));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ThreadID", threadId));
+        }
+        catch {
+            // Intentionally ignored
+        }
     }
 }

--- a/src/dotnet/UI.Blazor.App/FirstChanceExceptionLogger.cs
+++ b/src/dotnet/UI.Blazor.App/FirstChanceExceptionLogger.cs
@@ -7,6 +7,8 @@ namespace ActualChat.UI.Blazor.App;
 public static class FirstChanceExceptionLogger
 {
     private static readonly ILogger Log = StaticLog.Factory.CreateLogger("FCE");
+    [ThreadStatic]
+    private static bool _isInHandler;
 
     public static Func<Exception, bool> ShouldSkip { get; set; } = _ => false;
     public static bool IsActivated { get; private set; }
@@ -18,13 +20,29 @@ public static class FirstChanceExceptionLogger
             LogLevel = logLevel;
         if (IsActivated)
             return;
+
         IsActivated = true;
         AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
     }
 
     private static void OnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
     {
-        var error = e.Exception;
+        // Every throw below - in a ShouldSkip callback, an enricher, or a sink - re-enters this handler.
+        // Without this guard that recursion continues until the thread's stack overflows.
+        if (_isInHandler)
+            return;
+
+        _isInHandler = true;
+        try {
+            LogFirstChanceException(e.Exception);
+        }
+        finally {
+            _isInHandler = false;
+        }
+    }
+
+    private static void LogFirstChanceException(Exception error)
+    {
         if (error is OperationCanceledException or WebSocketException or HttpRequestException or SocketException)
             return; // This one has to be skipped
         if (error is IOException { InnerException: SocketException })


### PR DESCRIPTION
Root-caused from tombstones and crash logs pulled off the attached Android device
(SM-S948U1, Android 16) covering 2026-03-22 -> 2026-08-19. Two of the three crash
signatures found there are fixed here; the third is not our bug (see below).

## 1. `Failed to initialize CoreCLR. Error code: 80070002` — 7 crashes, dev build

`EmbedAssembliesIntoApk` was `False` for Debug+android, a Fast Deployment setting
from the Mono era. Under CoreCLR that also disables the assembly store, and since
we deploy with `adb install` the FastDev override directory is never populated —
so the APK shipped with **no managed assemblies at all** and `coreclr_initialize`
failed with `ERROR_FILE_NOT_FOUND`.

Evidence: the seven tombstones map only `libcoreclr` / `libmonodroid` /
`libxamarin-app` and **no `libassembly-store.so`**, which every healthy tombstone
from the same app does map; each holds an open handle on the empty
`.__override__/arm64-v8a` dir. All seven land in a 5-minute window on 2026-07-30,
hours after `ddc4b9114c` switched MAUI to CoreCLR. Reinstalling did not help — the
codePath hash changes mid-window and it still crashed.

`b app run android` worked around this by passing the property explicitly, but only
for the dev flavor, so **`b app run android --prod` and any Rider/VS deploy through
the SDK `Install` target were still broken**. Fixing the csproj default covers every
path, so the workaround in the `b` tool is removed.

Verified by MSBuild property evaluation:

| Query | Result |
|---|---|
| `Debug` + `net11.0-android` | `True` (was `False` — the bug) |
| `Release` + `net11.0-android` | `true` (unchanged) |
| `Debug` + explicit `-p:EmbedAssembliesIntoApk=false` | `false` (override still honored) |

## 2. `Aborting process.` — 2 crashes, stack overflow

`OnFirstChanceException` had no re-entrancy guard, and neither the Serilog enricher
nor the Android log sink caught anything. Any throw on the logging path re-enters the
handler and throws again, recursing until the stack is gone.

Both tombstones symbolize (via runtime-pack BuildId match + the Microsoft symbol
server) to `EEPolicy::HandleFatalStackOverflow` on the main thread, with SP on the PAL
`sigaltstack` above its guard page and `COR_E_STACKOVERFLOW` on that stack — a real
overflow, not a nearest-symbol artifact. The interrupted frame is a managed → static-int
JNI call, which matches `ThreadIdEnricher`'s `Process.MyTid()` and the sink's
`Android.Util.Log.*`.

The managed trace went to stderr — `/dev/null` on Android — so the exact cycle is not
recoverable from the tombstones. The fix guards the path that is shaped to produce it.
The guard is `[ThreadStatic]` on purpose: the hazard is a thread re-entering itself, and
a shared flag would drop unrelated exceptions logged concurrently on other threads.

## Not fixed here — not our bug

The dominant live signature (5 crashes, both builds, Aug 14–19) is a `SIGABRT` /
Scudo double-free inside `TypeMapper::java_to_managed`, caused by a thread-safety
defect in .NET-for-Android's `FastTiming::start_event`. It only fires when
`debug.mono.log=timing` is set on the device; clearing the property (or rebooting)
stops it with no app change. Being reported upstream to `dotnet/android` separately.

## Test plan

- `dotnet build src/dotnet/Maui/Maui.csproj -f net11.0-android` — 0 errors (7 warnings, all pre-existing, none in touched files)
- `dotnet build build/Build.csproj` — 0 warnings, 0 errors
- MSBuild property evaluation for all three cases in the table above

Not yet exercised on-device: neither signature reproduces on the current install, so
the fixes are verified structurally rather than by reproduction. Worth a `b app run
android --prod` Debug deploy to confirm #1 end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQj9FVKbc1ect6SR3rESiQ
