### PR TITLE
fix(audio): keep iPhone audio on the speaker, and let a headset take it

### DIFF
--- a/docs/ios-specific.md
+++ b/docs/ios-specific.md
@@ -828,6 +828,37 @@ To prove where a cost lives: kill the app (does it vanish?), fresh-launch withou
 the feature (is it absent?), then exercise it. That three-point chain localises an owner far
 faster than reasoning about the code.
 
+### A configuration change stops the engine, and `start()` does not repair it
+
+Anything that changes the hardware format or the route under a running `AVAudioEngine` - a
+session category switch, disabling voice processing, AirPods flipping between HFP and A2DP -
+makes AVFoundation log `iounit configuration changed > stopping the engine` and post
+`AVAudioEngineConfigurationChange`. Note **`stop`**, not `pause`: the graph comes down with it.
+
+Restarting the engine is not enough. Measured on device, stopping a recording while a message
+was playing:
+
+| attempted repair | result |
+|---|---|
+| `engine.Start()` alone | engine runs, renders silence |
+| reading `MainMixerNode` | no effect - it does **not** rebuild the connection |
+| `player.Play()` again | no effect; `Playing` still reports `true`, so it isn't even a signal |
+| **`engine.Connect(player, MainMixerNode, format)`** | **sound returns** |
+
+So the repair is the one a freshly built player node performs anyway - which is why the symptom
+was "silence until the next message", the next message being the thing that ran `ConnectToMainMixer`.
+`AudioEngine.Reconnect()` does this for every live player node, then restates `Play()` on each.
+
+### An interruption that never ends wedges all audio
+
+`AVAudioSessionInterruptionType.Began` is not guaranteed a matching `Ended` - a Bluetooth device
+connecting produced a `Began` with nothing after it, for the life of the process. Treating the
+flag as a latch meant every mode change was deferred forever: no playback, and a microphone whose
+`InstallTapOnBus` failed with `IsFormatSampleRateAndChannelCountValid(format)` on every retry,
+because the session had never been activated and the input node reported 0 Hz. Only killing the
+app cleared it. The flag now expires (see `InterruptionEndTimeout`) rather than waiting for a
+notification that may not come.
+
 ## WebKit rendering cost during a call
 
 WebContent is **~94% main thread** - there is no large hidden worker bucket. Inclusive

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using ActualChat.App.Maui.Services.Recording;
 using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.Services;
 using AVFoundation;
 
 namespace ActualChat.App.Maui.Audio;
@@ -38,7 +39,7 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
     public ResamplerFactory ResamplerFactory => field ??= hub.Services.GetRequiredService<ResamplerFactory>();
 
     private AudioEngines AudioEngines => field ??= hub.Services.GetRequiredService<AudioEngines>();
-    private AudioSession AudioSession => field ??= hub.Services.GetRequiredService<AudioSession>();
+    private AudioFocusUI AudioFocusUI => field ??= hub.AudioFocusUI;
     private ILogger Log => field ??= hub.Services.LogFor(GetType());
 
     public Task<IAsyncEnumerable<IMemoryOwner<float>>?> Capture(CancellationToken cancellationToken)
@@ -113,7 +114,7 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
             using var _2 = engine.Input.Tap(HandleSamples);
             engine.EnsureRunning();
             // Voice processing activation can route audio to the earpiece — fix it
-            await AudioSession.EnsureCorrectOutputRoute().ConfigureAwait(false);
+            await AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
 
             var frameLen = Constants.Audio.OpusFrameLength;
             while (!cancellationToken.IsCancellationRequested) {

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -9,6 +9,9 @@ namespace ActualChat.App.Maui.Audio;
 public sealed class AppleAudioFocusUI : AudioFocusUI
 {
     private static readonly RetryDelaySeq RetryDelays = RetryDelaySeq.Exp(0.2, 3);
+    // iOS may never post the interruption end - a Bluetooth device connecting can leave a Began
+    // with nothing after it - so the latch expires rather than waiting for a notification.
+    private static readonly TimeSpan InterruptionEndTimeout = TimeSpan.FromSeconds(10);
 
     private readonly AsyncLock _lock = new(LockReentryMode.CheckedFail);
     private readonly ActiveScopes _activeScopes;
@@ -17,11 +20,12 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     private readonly Disposable<NSObject> _mediaServicesResetSubscription;
     private readonly Disposable<NSObject> _routeChangeSubscription;
     private readonly TaskSerializer _interruptionQueue = new();
-    private bool _isInterrupted;
+    private long _interruptedAt;
     private bool _isSuspended;
     private bool _isSessionConfigured;
     private bool _isSessionActivated;
 
+    private bool IsInterrupted => Volatile.Read(ref _interruptedAt) != 0;
     private AppUIHub Hub { get; }
     private AudioSession AudioSession => field ??= Hub.Services.GetRequiredService<AudioSession>();
     private AudioEngines AudioEngines => field ??= Hub.Services.GetRequiredService<AudioEngines>();
@@ -106,11 +110,21 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
             .ConfigureAwait(false);
     }
 
+    public override async Task EnsureOutputRoute(CancellationToken cancellationToken = default)
+    {
+        using var cts = cancellationToken.LinkWith(StopToken);
+        using var _1 = await _lock.Lock(cts.Token).ConfigureAwait(false);
+        if (_activeScopes.IsEmpty)
+            return;
+
+        await AudioSession.ApplyOutputRoute(_activeScopes.GetMode()).ConfigureAwait(false);
+    }
+
     public override AudioFocusDiagnostics GetDiagnostics()
         => new (
             IsSupported: true,
             ActiveMode: _activeScopes.GetMode(),
-            IsInterrupted: Volatile.Read(ref _isInterrupted),
+            IsInterrupted: IsInterrupted,
             IsSuspended: _isSuspended,
             IsSessionConfigured: _isSessionConfigured,
             Scopes: _activeScopes.GetScopeInfos(),
@@ -143,11 +157,23 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     private async Task SetModeUnsafe(AudioFocusMode mode)
     {
         Log.LogInformation("SetMode: {Mode}", mode);
-        if (Volatile.Read(ref _isInterrupted)) {
-            // iOS rejects SetActive(true) while an interruption is in progress; RecoverInternal
-            // reactivates in the latest mode once the interruption ends.
-            Log.LogInformation("SetMode: {Mode} deferred - interruption in progress", mode);
-            return;
+        // One read: a Began landing between a flag test and a timestamp read would make a fresh
+        // interruption look like an expired one.
+        var interruptedAt = Volatile.Read(ref _interruptedAt);
+        if (interruptedAt != 0) {
+            if (new CpuTimestamp(interruptedAt).Elapsed < InterruptionEndTimeout) {
+                // iOS rejects SetActive(true) while an interruption is in progress; RecoverInternal
+                // reactivates in the latest mode once the interruption ends.
+                Log.LogInformation("SetMode: {Mode} deferred - interruption in progress", mode);
+                return;
+            }
+
+            // An end that never came would otherwise defer every mode change for the rest of the
+            // process: no playback, and a mic whose InstallTapOnBus fails on a 0 Hz input format
+            // because the session was never activated.
+            Log.LogWarning("SetMode: {Mode} - no interruption end in {Timeout}, proceeding anyway",
+                mode, InterruptionEndTimeout);
+            Volatile.Write(ref _interruptedAt, 0);
         }
 
         // GetMode() reports Tune both for a live tune scope and for no scopes at all, so the
@@ -165,7 +191,18 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         if (mustBounceEngines)
             AudioEngines.Pause();
 
-        var setup = await AudioSession.Reconfigure(mode).ConfigureAwait(false);
+        AudioSessionSetup setup;
+        try {
+            setup = await AudioSession.Reconfigure(mode).ConfigureAwait(false);
+        }
+        catch (Exception) {
+            // Nothing else resumes the engines, so a session call that fails - which is what a
+            // real interruption still in progress looks like - would leave them paused for good.
+            if (mustBounceEngines)
+                AudioEngines.Resume(mode);
+            throw;
+        }
+
         // setup.IsActivated covers an owner flip between the snapshot above and ReconfigureUnsafe
         // running: the session went through a deactivate/activate pair with the engines never paused.
         if (mustBounceEngines || setup.IsActivated)
@@ -233,7 +270,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         _ = BackgroundTask.Run(async () => {
             using var _1 = await _lock.Lock(StopToken).ConfigureAwait(false);
             if (!_activeScopes.IsEmpty && !_isSuspended)
-                AudioEngines.Resume(_activeScopes.GetMode());
+                AudioEngines.Reconnect(_activeScopes.GetMode());
         }, Log, "Failed to handle configuration change", StopToken);
     }
 
@@ -243,7 +280,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         // observes this, so without a full rebuild audio stays dead while the UI still
         // thinks it's listening (headphones button stays on).
         Log.LogWarning("Media services were reset - rebuilding audio session");
-        Volatile.Write(ref _isInterrupted, false);
+        Volatile.Write(ref _interruptedAt, 0);
         _ = _interruptionQueue.Enqueue(_ => RebuildAfterMediaServicesReset());
     }
 
@@ -281,14 +318,25 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     private void OnRouteChange(object? sender, AVAudioSessionRouteChangeEventArgs e)
     {
         var reason = e.Reason;
-        _ = _interruptionQueue.Enqueue(_ => MaybeRecoverOnRouteChange(reason));
+        _ = _interruptionQueue.Enqueue(_ => HandleRouteChange(reason));
     }
 
-    private async Task MaybeRecoverOnRouteChange(AVAudioSessionRouteChangeReason reason)
+    private async Task HandleRouteChange(AVAudioSessionRouteChangeReason reason)
     {
         bool shouldRecover;
-        using (await _lock.Lock(StopToken).ConfigureAwait(false))
-            shouldRecover = _isSuspended && !Volatile.Read(ref _isInterrupted) && !_activeScopes.IsEmpty;
+        using (await _lock.Lock(StopToken).ConfigureAwait(false)) {
+            if (_activeScopes.IsEmpty)
+                return;
+
+            shouldRecover = _isSuspended && !IsInterrupted;
+            if (!shouldRecover) {
+                // A headset that just arrived or left changes which port the session should be
+                // on, and the speaker override that outlived it has to be restated or dropped.
+                Log.LogInformation("Route change ({Reason}) - re-applying the output route", reason);
+                await AudioSession.ApplyOutputRoute(_activeScopes.GetMode()).ConfigureAwait(false);
+            }
+        }
+
         if (!shouldRecover)
             return;
 
@@ -309,12 +357,12 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
             switch (type) {
             case AVAudioSessionInterruptionType.Began:
                 using (await _lock.Lock(StopToken).ConfigureAwait(false)) {
-                    Volatile.Write(ref _isInterrupted, true);
+                    Volatile.Write(ref _interruptedAt, CpuTimestamp.Now.Value);
                     InvokeLostFocusUnsafe(true, false);
                 }
                 break;
             case AVAudioSessionInterruptionType.Ended:
-                Volatile.Write(ref _isInterrupted, false);
+                Volatile.Write(ref _interruptedAt, 0);
                 // ShouldResume is unreliable for phone calls, so always recover.
                 await TryRecover().ConfigureAwait(false);
                 break;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
@@ -41,9 +41,12 @@ public class AppleAudioPlaybackEngine(
         _decodeFeedTask = null;
     }
 
-    public Task Play(CancellationToken cancellationToken)
+    public async Task Play(CancellationToken cancellationToken)
     {
         DebugLog?.LogInformation("#{PlayerId}.Play", playerId);
+        // Focus is taken seconds before the first frames arrive, and a route the session picked
+        // back then may no longer be the one this track should come out of.
+        await hub.AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
         _frames.SetTargetDuration(GetEncodedBufferDuration(info.TargetBufferSize));
 
         _voicePlayer = new VoicePlayer(playerId, hub);
@@ -55,7 +58,6 @@ public class AppleAudioPlaybackEngine(
             "Failed to decode/feed iOS audio",
             _decodeFeedCts.Token);
         _voicePlayer.Play();
-        return Task.CompletedTask;
     }
 
     public Task Pause(CancellationToken cancellationToken)

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
@@ -62,6 +62,18 @@ public class AudioEngines : ProcessorBase
             Recording.Resume();
     }
 
+    public void Reconnect(AudioFocusMode mode)
+    {
+        // Same gating as Resume: this replaces it on the configuration-change path, where an
+        // engine that stopped itself also needs its output graph and player nodes restored.
+        if (mode >= AudioFocusMode.Tune)
+            Tunes.Reconnect();
+        if (mode >= AudioFocusMode.Playback)
+            Playback.Reconnect();
+        if (mode >= AudioFocusMode.Recording)
+            Recording.Reconnect();
+    }
+
     private void OnConfigurationChange(object? sender, NSNotificationEventArgs e)
         => Log.LogInformation("Audio engine configuration change");
 }

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -61,8 +61,8 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
     public Task<AudioSessionSetup> Reactivate(AudioFocusMode mode)
         => DispatchToMainThread(() => ReactivateUnsafe(mode));
 
-    public Task EnsureCorrectOutputRoute()
-        => DispatchToMainThread(EnsureCorrectOutputRouteUnsafe);
+    public Task ApplyOutputRoute(AudioFocusMode mode)
+        => DispatchToMainThread(() => ApplyOutputRouteUnsafe(mode));
 
     public AppleAudioSessionDiagnostics? GetDiagnostics()
     {
@@ -209,6 +209,7 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
             error.Assert("Failed to re-activate audio session after retry");
         }
 
+        ApplyOutputRouteUnsafe(mode);
         return new AudioSessionSetup(isConfigured, true);
     }
 
@@ -226,6 +227,7 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
                 // The framework's session is already active, and SetCategory on an active session
                 // is what lets an in-app recording get PlayAndRecord during a live wake playback.
                 ConfigureUnsafe(session, minMode);
+                ApplyOutputRouteUnsafe(minMode);
             }
 
             return new AudioSessionSetup(isConfigured, false);
@@ -237,6 +239,7 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
         session.SetActive(false, deactivateOptions).Assert("Failed to deactivate session");
         ConfigureUnsafe(session, minMode);
         session.SetActive(true).Assert("Failed to activate session");
+        ApplyOutputRouteUnsafe(minMode);
         return new AudioSessionSetup(true, true);
     }
 
@@ -254,31 +257,43 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
             Log.LogWarning("Failed to deactivate audio session: {Error}", error.LocalizedDescription);
     }
 
-    private void EnsureCorrectOutputRouteUnsafe()
+    private void ApplyOutputRouteUnsafe(AudioFocusMode mode)
     {
+        if (!AudioSessionOwnership.MayConfigure(Owner, mode))
+            return;
+        // PlayAndRecord is the only category with a route to pick: Playback and Ambient always
+        // reach the speaker, and an override on either is rejected. See ConfigureUnsafe.
+        if (mode is not AudioFocusMode.Recording)
+            return;
+
         var session = AVAudioSession.SharedInstance();
         var outputs = session.CurrentRoute.Outputs;
         if (outputs.Length == 0) {
-            Log.LogWarning("EnsureCorrectOutputRoute: no output ports found");
+            Log.LogWarning("ApplyOutputRoute: no output ports found");
             return;
         }
 
-        // If any output is an external device, don't override — let iOS route to it
-        foreach (var output in outputs) {
-            if (IsExternalPort(output.PortType)) {
-                Log.LogInformation("EnsureCorrectOutputRoute: external device ({PortType}), skipping", output.PortType);
-                return;
-            }
-        }
+        if (GetPortOverride(outputs) is not { } portOverride)
+            return;
 
-        // If output is the receiver (earpiece), override to speaker
-        foreach (var output in outputs) {
-            if (output.PortType == AVAudioSession.PortBuiltInReceiver) {
-                Log.LogInformation("EnsureCorrectOutputRoute: receiver detected, overriding to speaker");
-                if (!session.OverrideOutputAudioPort(AVAudioSessionPortOverride.Speaker, out var error))
-                    Log.LogWarning("EnsureCorrectOutputRoute: override failed: {Error}", error.LocalizedDescription);
-                return;
-            }
+        Log.LogInformation("ApplyOutputRoute: mode={Mode}, outputs={Outputs} -> {Override}",
+            mode, string.Join(", ", outputs.Select(x => x.PortType)), portOverride);
+        if (!session.OverrideOutputAudioPort(portOverride, out var error))
+            Log.LogWarning("ApplyOutputRoute: override failed: {Error}", error.LocalizedDescription);
+        return;
+
+        // Null means the route is already where it should be - which also covers Macs, where
+        // there's no receiver to be pushed off.
+        static AVAudioSessionPortOverride? GetPortOverride(AVAudioSessionPortDescription[] outputs) {
+            // An external device is the user's own choice of where to listen, so it outranks the
+            // speaker default - and clearing the override is also what hands the route back to a
+            // headset plugged in while the speaker was forced.
+            if (outputs.Any(x => IsExternalPort(x.PortType)))
+                return AVAudioSessionPortOverride.None;
+
+            return outputs.Any(x => x.PortType == AVAudioSession.PortBuiltInReceiver)
+                ? AVAudioSessionPortOverride.Speaker
+                : null;
         }
     }
 

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -22,9 +22,9 @@ public class AudioEngine : IDisposable
     private readonly Lock _lock = new ();
     private readonly ComputedState<bool> _isRunning;
     private readonly Debouncer<Unit> _idleReleaseDebouncer;
+    private readonly List<PlayerNode> _playerNodes = new();
     private AVAudioEngine? _engine;
     private InputNode? _inputNode;
-    private int _playerNodeCount;
     private bool _isStarted;
     private bool _isDisposed;
     private AudioFocusMode Mode { get; }
@@ -105,6 +105,41 @@ public class AudioEngine : IDisposable
         _isRunning.Invalidate();
     }
 
+    public void Reconnect()
+    {
+        // A configuration change stops the engine itself and drops its connections to the I/O
+        // nodes; start() restores neither those nor the player nodes it stopped on the way down.
+        if (!_isStarted)
+            return;
+
+        PlayerNode[] playerNodes;
+        lock (_lock) {
+            if (!_isStarted)
+                return;
+
+            playerNodes = [.. _playerNodes];
+            var engine = EngineUnsafe;
+            if (!engine.Running) {
+                // Rebuilding player -> main mixer is what a freshly built player node does, and
+                // that's the only thing observed to bring the sound back after a change.
+                foreach (var playerNode in playerNodes)
+                    engine.Connect(playerNode.Node, engine.MainMixerNode, playerNode.Format);
+            }
+            if (!TryEnsureEngineRunningUnsafe()) {
+                Log.LogWarning("{Mode}.Reconnect: Engine failed, attempting reset", Mode);
+                ResetEngineUnsafe();
+                EnsureEngineRunningUnsafe();
+            }
+        }
+        // Outside the lock: a node takes its own lock and then this one when it's disposed.
+        var requestedCount = playerNodes.Count(x => x.IsPlayRequested);
+        var restartedCount = playerNodes.Count(x => x.RestorePlayState());
+        Log.LogInformation(
+            "{Mode}.Reconnect: restarted {RestartedCount} of {Count} player node(s), {RequestedCount} want to play",
+            Mode, restartedCount, playerNodes.Length, requestedCount);
+        _isRunning.Invalidate();
+    }
+
     // Tears the AVAudioEngine down rather than stopping it - see the note on this type. Safe to
     // call more than once, and it must never be reached through Input, which would rebuild the
     // very engine being released.
@@ -160,7 +195,7 @@ public class AudioEngine : IDisposable
     {
         var node = new PlayerNode(new AVAudioPlayerNode(), format, DisposePlayerNode, Hub);
         lock (_lock)
-            _playerNodeCount++;
+            _playerNodes.Add(node);
         AttachNode(node.Node);
         if (connectToMainOutput)
             ConnectToMainMixer(node, format);
@@ -174,7 +209,8 @@ public class AudioEngine : IDisposable
         bool isIdle;
         lock (_lock) {
             DisposeNodeUnsafe(node);
-            isIdle = --_playerNodeCount == 0;
+            _playerNodes.RemoveAll(x => ReferenceEquals(x.Node, node));
+            isIdle = _playerNodes.Count == 0;
         }
         if (isIdle)
             _idleReleaseDebouncer.Debounce(default);
@@ -185,7 +221,7 @@ public class AudioEngine : IDisposable
         lock (_lock) {
             // Re-checked here rather than by cancelling the debounce, so a player created while
             // the release was pending keeps the engine alive without any ordering assumptions.
-            if (_isDisposed || _engine is null || _playerNodeCount != 0)
+            if (_isDisposed || _engine is null || _playerNodes.Count != 0)
                 return Task.CompletedTask;
 
             Log.LogInformation("{Mode}.ReleaseIfIdle: no players left, releasing the engine", Mode);

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/PlayerNode.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/PlayerNode.cs
@@ -7,8 +7,15 @@ public class PlayerNode : AudioNode, IDisposable
 {
     public AVAudioFormat Format { get; }
     private readonly ComputedState<bool> _isPlaying;
+    private bool _isPlayRequested;
 
     public IState<bool> IsPlaying => _isPlaying;
+    public bool IsPlayRequested {
+        get {
+            lock (Lock)
+                return _isPlayRequested;
+        }
+    }
     public new AVAudioPlayerNode Node => (AVAudioPlayerNode)base.Node;
 
     public PlayerNode(AVAudioPlayerNode node, AVAudioFormat format, Action<AVAudioNode> disposer, AppUIHub hub) : base(node, disposer, hub)
@@ -26,18 +33,40 @@ public class PlayerNode : AudioNode, IDisposable
 
     public void Play()
     {
-        lock (Lock)
+        lock (Lock) {
+            _isPlayRequested = true;
             if (!Node.Playing)
                 Node.Play();
+        }
         _isPlaying.Invalidate();
     }
 
     public void Pause()
     {
-        lock (Lock)
+        lock (Lock) {
+            _isPlayRequested = false;
             if (Node.Playing)
                 Node.Pause();
+        }
         _isPlaying.Invalidate();
+    }
+
+    public bool RestorePlayState()
+    {
+        // AVAudioEngine.Stop() stops its player nodes, and on a configuration change the engine
+        // stops itself, so the intent to play has to be restated once it's running again. Playing
+        // can keep reporting true across that, so it only decides what to report, not whether to
+        // act - Play() on a node that really is live is a no-op.
+        bool wasPlaying;
+        lock (Lock) {
+            if (!_isPlayRequested)
+                return false;
+
+            wasPlaying = Node.Playing;
+            Node.Play();
+        }
+        _isPlaying.Invalidate();
+        return !wasPlaying;
     }
 
     public void ScheduleBuffer(AVAudioPcmBuffer pcm, Action<AVAudioPlayerNodeCompletionCallbackType> callback)
@@ -62,8 +91,10 @@ public class PlayerNode : AudioNode, IDisposable
 
     public void Stop()
     {
-        lock (Lock)
+        lock (Lock) {
+            _isPlayRequested = false;
             Node.Stop();
+        }
         _isPlaying.Invalidate();
     }
 

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
@@ -103,13 +103,13 @@ public class AndroidAudioFocusHelper : IDisposable
             _log.LogInformation("WarmUpAudioMode: keeping InCommunication (real focus acquired)");
     }
 
-    public Task EnsureCommunicationRoute()
+    public Task EnsureCommunicationRoute(CancellationToken cancellationToken)
         // Deliberately not driven off the device-changed callback: Android re-clears the route
         // every ~6s for as long as a focus holder stays idle, and answering each one turned into a
         // permanent re-assert loop (13 in 100s, measured). Asserting only when audio is about to
         // play fixes the route where it matters and leaves an idle armed session alone.
         => _hasFocus
-            ? _deviceRouter.SetCommunicationDeviceAsync(CancellationToken.None)
+            ? _deviceRouter.SetCommunicationDeviceAsync(cancellationToken)
             : Task.FromResult(false);
 
     public void AbandonFocus()

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusUI.cs
@@ -33,11 +33,11 @@ public class AndroidAudioFocusUI : MauiAudioFocusUI
         return Task.CompletedTask;
     }
 
-    public override async Task EnsureOutputRoute()
+    public override async Task EnsureOutputRoute(CancellationToken cancellationToken = default)
     {
-        using var releaser = await OperationLock.Lock(CancellationToken.None).ConfigureAwait(false);
+        using var releaser = await OperationLock.Lock(cancellationToken).ConfigureAwait(false);
         releaser.MarkLockedLocally();
-        await _focusHelper.EnsureCommunicationRoute().ConfigureAwait(false);
+        await _focusHelper.EnsureCommunicationRoute(cancellationToken).ConfigureAwait(false);
     }
 
     public override async Task WarmUp()

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
@@ -51,7 +51,7 @@ internal sealed class AndroidAudioPlaybackEngine(
         // Before the track exists, not after: Android hands the communication route back to the
         // earpiece once it decides the focus holder is idle, and a wake takes focus seconds before
         // its first frames arrive - a track built then stays on the earpiece for its whole life.
-        await AudioFocusUI.EnsureOutputRoute().ConfigureAwait(false);
+        await AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
 
         var audioSource = (AudioSource)source;
         _remainingPreSkip = audioSource.Format.PreSkip;

--- a/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
@@ -45,7 +45,7 @@ public class AudioFocusUI : ProcessorBase
     public virtual Task TryRecover(CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 
-    public virtual Task EnsureOutputRoute()
+    public virtual Task EnsureOutputRoute(CancellationToken cancellationToken = default)
         // Called right before audio is produced. Android hands the communication route back to its
         // earpiece default once it decides a focus holder has gone idle, which a wake always hits:
         // focus is taken seconds before the first frames arrive.


### PR DESCRIPTION
Closes #4189.

Audio comes out of the loudspeaker — for tunes, playback and recording alike — and moves to a headset whenever one is connected. That is the whole policy; there is no earpiece switching.

## What was wrong

The output route was decided once, at capture start, and only for the case it was written for: `EnsureCorrectOutputRoute` pushed the session off the earpiece after voice processing had grabbed it. Nothing else that moves a route was answered — an interruption ending, a media-services reset, a headset arriving or leaving, or playback starting at all, which never asked.

A speaker override also outlives the route it was set against. Plugging in a headset mid-recording left the forced speaker in place, because the old code returned early the moment it saw an external port without clearing what it had set itself.

## What it does now

`ApplyOutputRoute` is the single decision:

| Condition | Route |
|---|---|
| External output (BT HFP/A2DP/LE, wired, USB, CarPlay, HDMI, AirPlay) | override cleared — iOS routes to it |
| On the built-in receiver | overridden to the speaker |
| Already on the speaker | left alone |

Leaving an already-correct route alone is also what keeps Mac Catalyst from issuing an override for a receiver it doesn't have. The whole thing is gated on `AudioSessionOwnership.MayConfigure`, so it stays out of the PushToTalk framework's session, and returns early for the `Playback` and `Ambient` categories, where the speaker is the only output and an override is rejected anyway.

It runs from every point that can move the route:

- `Reconfigure` — focus/mode change, and app start via the first acquire
- `Reactivate` — interruption ended
- `Rebuild` — media services reset
- the route-change notification — headset plug/unplug
- each track start, and capture start

`OnRouteChange` previously decided only whether to recover a suspended session and ignored the route that had just moved under it.

Capture now reaches `AudioFocusUI.EnsureOutputRoute` instead of `AudioSession` directly, so both platforms enter through the same door, and iOS playback calls it at track start the way Android already did.

## Cancellation

`EnsureOutputRoute` takes a `CancellationToken`. Both implementations block on a lock, and on Android the wait underneath is real — the API 28–30 router waits up to two seconds for a Bluetooth SCO connect. `IAudioDeviceRouter` has always taken a token and threaded it into that wait; `EnsureCommunicationRoute` was passing `CancellationToken.None` and severing it one frame short.

Still severed, deliberately: `RequestFocusAsync` also calls `SetCommunicationDeviceAsync(CancellationToken.None)`. Fixing that means adding a token to `AudioFocusUI.TryAcquire` on the shared base and its five call sites, including the recorder — a separate change.

## Testing

Builds clean on iOS, Mac Catalyst and Android; unit tests pass. **Not verified on device** — the case whose behavior actually changed is a Bluetooth headset connecting and disconnecting mid-recording, and that is worth a pass on a real iPhone before merging.

## Note on scope

An earlier revision of this branch added raise-to-ear detection (proximity + accelerometer, earpiece while the phone is held to an ear). It was dropped on request — speaker-only for now. No sensor code ships here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
