### PR TITLE
fix(flows): stop an immediate resume claiming a scheduled resume's slot

### DIFF
--- a/src/dotnet/Core.Server/Flows/Infrastructure/FlowResumeEvent.cs
+++ b/src/dotnet/Core.Server/Flows/Infrastructure/FlowResumeEvent.cs
@@ -123,12 +123,17 @@ public sealed partial class FlowResumeEvent :
         // Compute delay quanta
         var hub = _hub ?? services?.FlowHub();
         var delayQuanta = DelayQuanta ?? AutoDelayQuanta.For(DelayUntil - hub.Require().SystemNow);
+        var delay = (DelayUntil - hub.Require().SystemNow).Positive();
 
-        // Produce operation event
+        // Produce operation event.
+        // Quantizing an immediate resume would give every immediate resume of this flow one shared
+        // Uuid - a constant "-at-0" when DelayUntil was never set - which FlushEvents skips and the
+        // queue dedups by. Only a resume scheduled ahead has a slot to coalesce into.
         operationEvent = new OperationEvent("", this);
-        if (delayQuanta > TimeSpan.Zero) {
+        if (delayQuanta > TimeSpan.Zero && delay > TimeSpan.Zero) {
             var uuidPrefix = $"{nameof(FlowResumeEvent)}({FlowId.Value})";
             operationEvent.SetDelayUntil(DelayUntil, delayQuanta, uuidPrefix);
+            DelayUntil = operationEvent.DelayUntil; // The slot is the schedule - keep the two in sync
         }
         else {
             operationEvent.Uuid = $"{nameof(FlowResumeEvent)}-{UuidGenerator.Next()}";

--- a/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
+++ b/src/dotnet/Streaming.Service/Backend/LiveSessionsBackend.cs
@@ -54,16 +54,6 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
     private ICommander Commander => field ??= Services.Commander();
     private FlowHub FlowHub => field ??= Services.FlowHub();
 
-    // Wake the summary flow so it runs its final pass at once instead of on its next throttled resume -
-    // that's what makes a closing block finalize (and dissolve) promptly. By FlowId string name so the
-    // streaming backend needn't reference the Chat.Service flow type. WithDelay(0, 0) is immediate AND
-    // un-quantized - without the zero quantum the resume inherits the flow's 15s DelayQuanta and rounds
-    // up to the next 15s boundary, coalescing with the throttle (defeating the whole point).
-    private Task WakeSummaryFlow(ChatId chatId)
-        => FlowHub.NewResumeEvent(new FlowId(LiveFlows.SummaryFlowName, chatId.Value))
-            .WithDelay(TimeSpan.Zero, TimeSpan.Zero)
-            .Schedule(CancellationToken.None);
-
     public LiveSessionsBackend(IServiceProvider services)
         : base(services, ShardScheme.LiveBackend)
     {
@@ -789,6 +779,16 @@ public partial class LiveSessionsBackend : ShardComputeService, ILiveSessionsBac
     }
 
     // Private methods
+
+    private Task WakeSummaryFlow(ChatId chatId)
+        // Runs the flow's final pass at once rather than on its next throttled resume, which is what
+        // makes a closing block finalize promptly. The zero quantum keeps the Uuid unquantized: under
+        // the flow's own 15s DelayQuanta this wake would share a Uuid with that slot's throttled
+        // resume and be dropped as a duplicate - not delayed to it, dropped. FlowId is built by name
+        // so the streaming backend needn't reference the Chat.Service flow type.
+        => FlowHub.NewResumeEvent(new FlowId(LiveFlows.SummaryFlowName, chatId.Value))
+            .WithDelay(TimeSpan.Zero, TimeSpan.Zero)
+            .Schedule(CancellationToken.None);
 
     private async Task ReassignHost(ChatId chatId, LiveSessionState state, CancellationToken cancellationToken)
     {

--- a/tests/Core.Server.IntegrationTests/Flows/FlowResumeEventUuidTest.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/FlowResumeEventUuidTest.cs
@@ -1,0 +1,87 @@
+using ActualChat.Flows;
+using ActualChat.Flows.Infrastructure;
+using ActualChat.Testing.Host;
+using ActualLab.CommandR.Operations;
+
+namespace ActualChat.Core.Server.IntegrationTests.Flows;
+
+// A quantized Uuid is how resumes landing in the same slot get coalesced - by FlushEvents' Skip on
+// the DbEvents path, and by the queue's dedup MsgId. Applying it to an immediate resume gives every
+// immediate resume of a flow one shared Uuid, so the second one is dropped rather than run.
+
+[Trait("Category", "Slow")]
+public sealed class FlowResumeEventUuidTest(ITestOutputHelper @out)
+    : AppHostTestBase($"x-{nameof(FlowResumeEventUuidTest)}", TestAppHostOptions.Default with {
+        ConfigureServices = (_, services) => services.AddFlows(useMasterFlows: false).Add<QuantaFlow>(),
+    }, @out)
+{
+    private static readonly TimeSpan Quanta = TimeSpan.FromSeconds(30);
+
+    [Fact(Timeout = 120_000)]
+    public async Task ImmediateResumesGetDistinctUuids()
+    {
+        // arrange
+        await using var h = await NewAppHost();
+        var flowHub = h.Services.FlowHub();
+        var flowId = flowHub.NewId<QuantaFlow>("uuids,1");
+
+        // act
+        var first = Uuid(flowHub.NewResumeEvent(flowId), h);
+        var second = Uuid(flowHub.NewResumeEvent(flowId), h);
+
+        // assert
+        WriteLine($"first={first}, second={second}");
+        first.Should().NotEndWith("-at-0", because: "an unset DelayUntil must not quantize to a constant");
+        second.Should().NotBe(first, because: "two immediate resumes are two wake-ups, not one slot");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task AZeroDelayResumeIsNotQuantizedAndKeepsItsDelayUntil()
+    {
+        // arrange
+        await using var h = await NewAppHost();
+        var flowHub = h.Services.FlowHub();
+        var flowId = flowHub.NewId<QuantaFlow>("uuids,2");
+        var resumeEvent = flowHub.NewResumeEvent(flowId).WithDelay(TimeSpan.Zero);
+        var requestedAt = resumeEvent.DelayUntil;
+
+        // act
+        var uuid = Uuid(resumeEvent, h);
+
+        // assert
+        WriteLine($"uuid={uuid}, delayUntil={resumeEvent.DelayUntil:O}");
+        uuid.Should().StartWith($"{nameof(FlowResumeEvent)}-",
+            because: "an immediate resume has no slot to coalesce into");
+        resumeEvent.DelayUntil.Should().Be(requestedAt,
+            because: "rounding it up would make ShardQueueProcessor postpone an immediate resume");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ScheduledResumesInOneSlotShareAUuidAndItsDelayUntil()
+    {
+        // arrange
+        await using var h = await NewAppHost();
+        var flowHub = h.Services.FlowHub();
+        var flowId = flowHub.NewId<QuantaFlow>("uuids,3");
+        var slotStart = (flowHub.SystemNow + TimeSpan.FromMinutes(1)).Ceiling(Quanta);
+        var earlier = flowHub.NewResumeEvent(flowId).WithDelay(slotStart - Quanta + TimeSpan.FromSeconds(1), Quanta);
+        var later = flowHub.NewResumeEvent(flowId).WithDelay(slotStart - TimeSpan.FromSeconds(1), Quanta);
+
+        // act
+        var earlierUuid = Uuid(earlier, h);
+        var laterUuid = Uuid(later, h);
+
+        // assert
+        WriteLine($"earlier={earlierUuid} @ {earlier.DelayUntil:O}");
+        WriteLine($"later  ={laterUuid} @ {later.DelayUntil:O}");
+        laterUuid.Should().Be(earlierUuid, because: "resumes in one slot must still coalesce");
+        earlierUuid.Should().EndWith($"-at-{slotStart.EpochOffsetTicks:x}");
+        earlier.DelayUntil.Should().Be(slotStart, because: "the slot is the schedule");
+        later.DelayUntil.Should().Be(slotStart, because: "the slot is the schedule");
+    }
+
+    // Private methods
+
+    private static string Uuid(FlowResumeEvent resumeEvent, TestAppHost h)
+        => ((IOperationEventSource)resumeEvent).ToOperationEvent(h.Services).Uuid;
+}

--- a/tests/Core.Server.IntegrationTests/Flows/QuantaFlow.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/QuantaFlow.cs
@@ -1,0 +1,17 @@
+using ActualChat.Flows;
+
+namespace ActualChat.Core.Server.IntegrationTests.Flows;
+
+// Carries a DelayQuanta so its resume events reach the quantized-Uuid branch of
+// FlowResumeEvent.ToOperationEvent - TimerFlow declares none and never gets there.
+
+[Flow(ResumeTimeout = 60, DelayQuanta = 30)]
+[DataContract, MessagePackObject(true)]
+public sealed partial class QuantaFlow : Flow<Unit>
+{
+    protected override ValueTask Resume(CancellationToken cancellationToken)
+    {
+        SetResult(default);
+        return default;
+    }
+}


### PR DESCRIPTION
## The bug

A quantized `Uuid` is how two resumes that would land in the same slot get coalesced into one — `FlushEvents` skips the second against the first's row on the DbEvents path, and the queue drops it as a duplicate `MsgId`. That only makes sense for a resume **scheduled ahead**.

Applied to an *immediate* resume it produced a Uuid shared by every immediate resume of that flow — literally the constant `FlowResumeEvent(<flowId>)-at-0` when `DelayUntil` had never been set, because the Uuid encodes `DelayUntil`'s epoch ticks and an unset one encodes the `0` sentinel.

So the second immediate resume of a quantized flow was **not delayed, it was dropped**: for up to an hour on the DbEvents path (`DbEventLogTrimmer` keeps a spent row that long), and for the queue's dedup window otherwise. Live in dev right now:

```
FlowResumeEvent(StreamingEntryFixupFlow:)-at-0          | state=1 | 2026-08-19 10:35:32
FlowResumeEvent(ChatMediaIndexingFlow:6yQiOIhr5a)-at-0  | state=1 | 2026-08-19 10:36:00
```

## The fix

Quantize only when the resume is actually scheduled ahead — the same test `FlowHub.Schedule` uses to choose the DbEvents path, so the two now agree — and when quantizing, assign the slot back to `DelayUntil`.

Leaving `DelayUntil` unquantized made the stored command disagree with its own row (`value_json` said `10:35:34`, `delay_until` said `10:36:00`), and `ShardQueueProcessor` postpones by that property. `Moment.Ceiling` is idempotent, so the Uuid is unchanged if it's re-derived.

The two halves must land together: the sync-back alone would postpone immediate queue-path resumes by up to a full quantum.

## Call-site audit

Affected — immediate resumes of flows that declare a `DelayQuanta`. Every one was losing resumes:

| site | flow / quanta |
|---|---|
| `FlowBackend.OnStore` | the kick every newly created flow gets |
| `MasterFlowStarter.StartMasterFlow` | every master flow on shard acquisition — two restarts inside the dedup window could drop the second |
| `ChatContentIndexingMasterFlow` | `ChatEntryContentIndexingFlow`, `ChatMediaIndexingFlow` (30s) |
| `IndexingMasterFlow` | the non-reset path (`WithReset` already forces a zero quantum) |
| `NotificationsBackend` | `MentionReminderFlow` (60s) |
| `MigrationFlow` | quanta 1 |

Unaffected — flows with no `DelayQuanta` (`AutoDelayQuanta.For` returns `Zero` below 5s, so an immediate resume already took the unique-Uuid branch): `ConversationSplitFlow`, `UploadProcessingFlow`, `UserSignInFlow`/`AccountsBackend` (quanta 0). Sites passing a future delay keep coalescing exactly as before: the `ChatsBackend` kicks, `TranslationsBackend`, `SearchBackend`.

Three sites had already worked around this by hand — `LiveSessionsBackend.WakeSummaryFlow` (`WithDelay(0, 0)`), `AccountMigrationFlow` (`WithDelayQuanta(Zero)`, commented *"otherwise tests may fail due to cross-test NATS dedup"*), and `IndexingMasterFlow` via `MustReset`. All still work; the first two are now redundant.

## Also

`WakeSummaryFlow`'s comment was wrong about the mechanism — it claimed the wake "rounds up to the next 15s boundary", but `SetDelayUntil` quantizes the `OperationEvent`, not the command, and the postpone check reads the command. The wake was never delayed to that slot, it was dropped. Corrected, and the method moved into the private-methods section.

## Tests

`FlowResumeEventUuidTest` — distinct Uuids for immediate resumes; a zero-delay resume stays unquantized **and keeps its `DelayUntil`** (guards the postpone regression); two resumes in one slot still share a Uuid *and* that slot as their `DelayUntil`.

They need a flow that declares a `DelayQuanta` — `TimerFlow` declares none and never reaches the quantized branch — hence `QuantaFlow`. **All three fail without the fix**, the first with the literal `FlowResumeEvent(QuantaFlow:uuids,1)-at-0` for both resumes.

Green: `ActualChat.CI.slnf` builds clean; all 51 `Core.Server.IntegrationTests` flow tests; 29 chat-side flow/indexing/streaming-fixup tests.

## Context

Found while investigating why `ChatEntryFixupFlow` starved for days. This is **not** that root cause — that remains open — but it is a real, live, independently-verified defect found on the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126pFHqZXLgdg6TGsyp4DAr
