### PR TITLE
fix(auth): rotate the session on MAUI sign-out, then drop the stale cache

### DIFF
--- a/src/dotnet/App.Maui/Services/MauiReloadUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiReloadUI.cs
@@ -15,6 +15,10 @@ public class MauiReloadUI(IServiceProvider services) : ReloadUI(services)
             Log.LogInformation("Reloading...");
             try {
                 await Clear(clearCaches, clearLocalSettings).ConfigureAwait(true);
+                // Our own sign-out deactivates the session; it can also be killed elsewhere or expire.
+                // Revalidate mints a fresh one and re-binds the RPC connection, so the WebView recreated
+                // next binds every Session.Default-keyed computed to the new session, not the dead id.
+                await Services.GetRequiredService<MauiSession>().Revalidate().ConfigureAwait(true);
                 MainPage.Current.RecreateWebView();
             }
             catch (Exception e) {

--- a/src/dotnet/App.Maui/Services/MauiSession.cs
+++ b/src/dotnet/App.Maui/Services/MauiSession.cs
@@ -1,5 +1,6 @@
 using ActualChat.Security;
 using ActualChat.UI.Blazor.Services;
+using ActualLab.Rpc;
 
 namespace ActualChat.App.Maui.Services;
 
@@ -60,7 +61,7 @@ public sealed class MauiSession(IServiceProvider services)
             // Session is invalid -> update it to valid + reload MAUI App
             Log.LogWarning("Stored session is invalid - will reload");
             await Store(validSession).ConfigureAwait(false);
-            TrueSessionResolver.Replace(validSession);
+            await SwitchTo(validSession).ConfigureAwait(false);
             // Reloading mid-startup recreates the WebView while the first Blazor scope is
             // still initializing, leaving a half-disposed scope with a disconnected JS runtime
             // (=> endless JSDisconnectedException in the post-reload sign-in UI). Wait until the
@@ -76,6 +77,31 @@ public sealed class MauiSession(IServiceProvider services)
         });
     }
 
+    // Never throws: MauiReloadUI calls it on the reload path, where a failure would terminate the app
+    public async Task Revalidate()
+    {
+        using var _ = Tracer.MethodRegion();
+        if (!TrueSessionResolver.HasSession)
+            return;
+
+        var session = TrueSessionResolver.Session;
+        try {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var validSession = await MobileSessions
+                .ValidateSession(session, MauiSettings.AppUserAgent, cts.Token)
+                .ConfigureAwait(false);
+            if (session == validSession)
+                return;
+
+            await Store(validSession).ConfigureAwait(false);
+            await SwitchTo(validSession).ConfigureAwait(false);
+            Log.LogInformation("Replaced an invalid Session");
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to validate Session - keeping the current one");
+        }
+    }
+
     public static Task RemoveStored()
     {
         using var _ = Tracer.MethodRegion();
@@ -89,6 +115,29 @@ public sealed class MauiSession(IServiceProvider services)
             // - https://learn.microsoft.com/en-us/answers/questions/1001662/suddenly-getting-securestorage-issues-in-maui
         }
         return Task.CompletedTask;
+    }
+
+    private async Task SwitchTo(Session session)
+    {
+        lock (Lock)
+            _readSessionTask = Task.FromResult<Session?>(session);
+        TrueSessionResolver.Replace(session);
+        // Replace starts the disconnect but doesn't wait for it, and it's the reconnect that carries
+        // the new session id in the connection header. A call that beats it rides the old connection,
+        // so the server resolves Session.Default to the session we just replaced - a deactivated one,
+        // whose guest account never changes again no matter what the app signs in.
+        try {
+            var peer = Services.RpcHub().GetClientPeer(RpcRef.Default);
+            await peer.Disconnect().WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to await the RPC disconnect after a Session switch");
+        }
+        // Every client call passes Session.Default, so the session id is never part of a computed's
+        // key - the server resolves it per connection. A swap thus changes no key and triggers no
+        // invalidation, and the reconnect only resets cached values when the server peer itself
+        // changed. Without this the UI keeps serving the replaced session's account until a restart.
+        ComputedRegistry.InvalidateEverything();
     }
 
     private static async Task<Session?> Read()


### PR DESCRIPTION
Fixes #4207.

## Symptom

On iOS, signing out and then tapping **Sign in with Apple** failed — first with a
visible `This Session is expired.`, then silently: the Apple sheet closed and
nothing happened. A force-quit and relaunch showed the user signed in all along.
Android's native Google sign-in behaves the same way.

## Root cause

Two distinct problems, one stacked on the other.

**1. A deactivated session can't be signed into.** Sign-out ran
`Accounts_SignOut(…, deactivate: true)`, so the next sign-in landed on a dead id.

**2. The client can't see a session change — this is the real one.** Every client
call passes `Session.Default` (`AppNonScopedServiceStarter`: *"All clients use
default session"*); the server resolves it to the connection's session. So the
session id is **never part of a computed's cache key**. Swapping the session
changes no key and fires no invalidation, and the reconnect doesn't help either:
`RpcHandshake.GetPeerChangeKind` compares the **server's** `RemotePeerId`, so a
client-initiated disconnect that lands on the same pod reports `Unchanged` — and
`Reset`, which drops cached values, only runs on `Changed`. Meanwhile
`ClearCaches()` clears only the persistent `IRemoteComputedCache`,
`RecreateWebView()` disposes only the Blazor scope, and `ComputedRegistry` is
static, surviving both.

Measured on device — the sign-in succeeded server-side, and the UI stayed stale
for 105 seconds, recovering only when a pod change happened to force a reset:

```
17:00:1x  sign-in completes server-side
17:01:44  RegisterDeviceTask. Awaiting user is signed in     <- UI still guest
17:01:55  Handshake succeeded, PeerChangeKind=Changed
17:01:55  Reset (Remote peer has been changed.)
17:01:56  Account is changed to: … Alexey Kochetov          <- only now
```

## Fix

Rotate the session on sign-out, then drop the client's stale cache.

- **Deactivation stays** — `AccountUI` is byte-identical to `dev` again, so
  1ba2608156 is untouched and now applies to web *and* mobile alike. The earlier
  revision of this PR added a `MustDeactivateSessionOnSignOut` opt-out; that is
  gone.
- `MauiSession.Revalidate()`, called from `MauiReloadUI.Reload()`, notices the
  dead session, mints a replacement via `ValidateSession`, and stores it.
- `MauiSession.SwitchTo()` awaits the RPC disconnect that
  `TrueSessionResolver.Replace()` fires and discards, so no call rides the old
  connection mid-swap.
- **`ComputedRegistry.InvalidateEverything()`** after that disconnect. This is
  the piece that makes a live session swap actually observable: it drops the
  client's cached values so each re-fetches on the new connection carrying the
  new session. It's client-local (the registry is a static per-process
  dictionary) and the server was never wrong — only the client's cache was.
  Fusion uses the same call server-side in `DbOperationLogReader` when it loses
  invalidation coverage.

## Verification

Android, three consecutive sign-out → sign-in cycles, **every one with
`PeerChangeKind=Unchanged`** — i.e. no server-side reset; the local invalidation
is what refreshed the UI:

| # | sign-out → guest | rotation | handshake | new guest | signed in |
|---|---|---|---|---|---|
| 1 | `~BYTRImU` | `Replaced an invalid Session` | Unchanged | `~1WF5MjW` (+0.2s) | `g8sh0lda` |
| 2 | `~1WF5MjW` | `Replaced an invalid Session` | Unchanged | `~JIQsxmE` (+0.3s) | `9e37vvvg` |
| 3 | `~JIQsxmE` | `Replaced an invalid Session` | Unchanged | `~dL9KSRu` (+1.2s) | `g8sh0lda` |

The post-sign-out guest id changes every cycle — the same evidence 1ba2608156
cited, where it used to stay constant — confirming each sign-out really
deactivates the old session and mints a new one. Two different accounts were
signed into on one device, each landing on a fresh id.

No errors attributable to the invalidation; the warnings in that window
(`Cleaning caches`, a `NotFoundException` for a chat cleared from cache,
`SyncedState Read failed`, `ContactSync TrySync failed`) are ordinary sign-out
teardown, non-fatal and retried. Outbound call tracking went 762 → 887 across
three cycles — no refetch storm.

**Not verified: iOS / native Apple sign-in**, which takes the same `SwitchTo`
path. Since #4207 was originally an Apple bug, it should get a device pass
before merge.

## Note for @alexyakunin

An earlier revision of this PR proposed skipping deactivation on MAUI, on the
grounds that the id lives in the device keychain rather than a shared cookie.
**That is no longer the case here** — your commit stands as written. A security
review of that approach found it re-opened the id-reuse hole for the
shared/handed-over device case (a previous owner's pre-extracted id would be
re-bound to the next user who signs in on the same install), so this PR rotates
instead. The "invalidate every `Session.Default`-keyed computed on a swap" I
flagged as the expensive alternative turned out to be one public Fusion call.

Branch history keeps both steps; worth squashing via `/prepare-merge` before
merging to `dev`.
