### PR TITLE
feat(ios): apply the Figma design to the share upload progress #4186

### DIFF
--- a/resources/images/converted/error-barrier-image.png
+++ b/resources/images/converted/error-barrier-image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b2b03e451308347203d11a292e4e058613dbe80d76a8ae3727dcb5f3b0475d4
-size 29789
+oid sha256:44789344dbfc9cb759113b7bde35566afa805a9e16caca2afb76182d045f751a
+size 30272

--- a/resources/images/converted/error-barrier-image@2x.png
+++ b/resources/images/converted/error-barrier-image@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4825baf89ae28f0033270a3b545c2bf6039b7eb93dac591e1f368c430e9da1f7
+size 64306

--- a/resources/images/converted/error-barrier-image@3x.png
+++ b/resources/images/converted/error-barrier-image@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d428c937a996f738fc335ed4efaaff67c9d342a1dc9e8a9e88165e6031f700b0
+size 99599

--- a/resources/images/converted/upload-progress-image.png
+++ b/resources/images/converted/upload-progress-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a9e7c99d29356ebd3b4220642541567673cc2644d0bca7351b580d9f8cfffc2
+size 19644

--- a/resources/images/converted/upload-progress-image@2x.png
+++ b/resources/images/converted/upload-progress-image@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83582b2d7570a03e18f02f96b4dab8ebb79cdd1426e7780e68f86c7c4dba87f8
+size 41338

--- a/resources/images/converted/upload-progress-image@3x.png
+++ b/resources/images/converted/upload-progress-image@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84ca609a049931860afd4bc8ed465964b4a4f21e936e851e13008ada7497e27b
+size 66438

--- a/scripts/prepare-images.cmd
+++ b/scripts/prepare-images.cmd
@@ -1,0 +1,56 @@
+:<<BATCH
+    @echo off
+    setlocal enabledelayedexpansion
+
+    where rsvg-convert >nul 2>&1
+    if errorlevel 1 (
+        echo ERROR: rsvg-convert not found in PATH.
+        echo Install with one of:
+        echo   scoop install librsvg
+        echo   choco install rsvg
+        echo   winget install librsvg
+        exit /b 1
+    )
+
+    set inDir=src\nodejs\images
+    set outDir=resources\images\converted
+    if not exist "%outDir%" mkdir "%outDir%"
+
+    for %%N in (error-barrier-image upload-progress-image) do (
+        echo Converting %%N.svg
+        rsvg-convert -o %outDir%\%%N.png %inDir%\%%N.svg || exit /b 1
+        rsvg-convert -z 2 -o %outDir%\%%N@2x.png %inDir%\%%N.svg || exit /b 1
+        rsvg-convert -z 3 -o %outDir%\%%N@3x.png %inDir%\%%N.svg || exit /b 1
+    )
+    exit /b 0
+BATCH
+
+#!/bin/sh
+set -eu
+
+if ! command -v rsvg-convert >/dev/null 2>&1; then
+    cat >&2 <<EOF
+ERROR: rsvg-convert not found in PATH.
+Install with one of:
+  apt install librsvg2-bin       # Debian / Ubuntu
+  dnf install librsvg2-tools     # Fedora
+  brew install librsvg           # macOS
+EOF
+    exit 1
+fi
+
+# Only the SVGs the iOS app extension bundles as PNGs - UIKit can't render SVG, unlike the
+# web, which is served every other file under $inDir as-is. Add a name here when a native
+# view needs one. @2x/@3x come from the SVG's own size, so each image keeps its dimensions.
+names="error-barrier-image upload-progress-image"
+
+inDir="src/nodejs/images"
+outDir="resources/images/converted"
+mkdir -p "$outDir"
+
+for name in $names; do
+    echo "Converting ${name}.svg"
+    rsvg-convert      -o "$outDir/${name}.png"    "$inDir/${name}.svg"
+    rsvg-convert -z 2 -o "$outDir/${name}@2x.png" "$inDir/${name}.svg"
+    rsvg-convert -z 3 -o "$outDir/${name}@3x.png" "$inDir/${name}.svg"
+done

--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -70,7 +70,8 @@
 
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
-    <BundleResource Include="..\..\..\resources\images\converted\error-barrier-image.png" Link="%(Filename)%(Extension)" />
+    <!-- Generated from src\nodejs\images\*.svg by scripts\prepare-images.cmd; the glob picks up @2x/@3x -->
+    <BundleResource Include="..\..\..\resources\images\converted\error-barrier-image*.png" Link="%(Filename)%(Extension)" />
     <BundleResource Include="..\..\..\resources\images\converted\upload-progress-image*.png" Link="%(Filename)%(Extension)" />
   </ItemGroup>
 

--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -71,6 +71,7 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <BundleResource Include="..\..\..\resources\images\converted\error-barrier-image.png" Link="%(Filename)%(Extension)" />
+    <BundleResource Include="..\..\..\resources\images\converted\upload-progress-image*.png" Link="%(Filename)%(Extension)" />
   </ItemGroup>
 
   <!-- TODO: Move GoogleService-Info.plist files to Maui project and define BundleResource there,

--- a/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
@@ -5,6 +5,8 @@ namespace ActualChat.App.Maui.IosShareExt.Components;
 
 public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressView.Model>(hub)
 {
+    private static readonly UIColor AccentColor = UIColor.FromRGB(0x54, 0xA6, 0xFF);
+    private static readonly UIColor ProgressTrackColor = UIColor.FromRGB(0x42, 0x42, 0x4D);
     private UIProgressView _progressBar = null!;
     private ShareUI ShareUI => Hub.ShareUI;
 
@@ -12,43 +14,76 @@ public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressVi
     {
         TranslatesAutoresizingMaskIntoConstraints = false;
 
+        // Image
+        var imageView = new UIImageView(UIImage.FromBundle("upload-progress-image.png")) {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            ContentMode = UIViewContentMode.ScaleAspectFit,
+        };
+        // The stack stretches its rows to full width, so the image keeps its own size inside this container
+        var imageContainer = new UIView {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+        };
+        imageContainer.AddSubview(imageView);
+
+        // Progress bar
+        _progressBar = new UIProgressView(UIProgressViewStyle.Default) {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            ProgressTintColor = AccentColor,
+            TrackTintColor = ProgressTrackColor,
+            ClipsToBounds = true,
+        };
+        _progressBar.Layer.CornerRadius = 2;
+
         // Label
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
             Text = "Uploading...",
-            Font = UIFont.SystemFontOfSize(24),
+            Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium)!,
+            TextColor = UIColor.White,
         };
-
-        // Progress bar
-        _progressBar = new UIProgressView(UIProgressViewStyle.Default) {
-            TranslatesAutoresizingMaskIntoConstraints = false,
-        };
-
-        // Cancel button
-        var cancelButton = UIButton.FromType(UIButtonType.System);
-        cancelButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        cancelButton.SetTitle("Cancel", UIControlState.Normal);
-        cancelButton.TitleLabel.Font = UIFont.SystemFontOfSize(20, UIFontWeight.Semibold);
-        cancelButton.TouchUpInside += Safe(ShareUI.CancelUploading);
 
         // Vertical stack view
-        var stackView = new UIStackView([label, _progressBar, cancelButton]) {
+        var stackView = new UIStackView([imageContainer, _progressBar, label]) {
             TranslatesAutoresizingMaskIntoConstraints = false,
             Axis = UILayoutConstraintAxis.Vertical,
             Alignment = UIStackViewAlignment.Fill,
             Distribution = UIStackViewDistribution.Fill,
-            Spacing = 20,
+            Spacing = 28,
         };
+        stackView.SetCustomSpacing(17, _progressBar);
         AddSubview(stackView);
+
+        // Cancel button
+        var cancelConfiguration = UIButtonConfiguration.PlainButtonConfiguration;
+        cancelConfiguration.ContentInsets = new NSDirectionalEdgeInsets(10, 24, 10, 24);
+        cancelConfiguration.BaseForegroundColor = AccentColor;
+        cancelConfiguration.AttributedTitle = new NSAttributedString("Cancel",
+            new UIStringAttributes { Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium) });
+        var cancelButton = new UIButton {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            Configuration = cancelConfiguration,
+        };
+        cancelButton.TouchUpInside += Safe(ShareUI.CancelUploading);
+        AddSubview(cancelButton);
 
         // Layout constraints
         NSLayoutConstraint.ActivateConstraints([
-            stackView.CenterYAnchor.ConstraintEqualTo(CenterYAnchor, -25),
-            stackView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, 24),
-            stackView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -24),
+            stackView.CenterYAnchor.ConstraintEqualTo(CenterYAnchor, -49),
+            stackView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, 31),
+            stackView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -31),
 
-            _progressBar.HeightAnchor.ConstraintEqualTo(8),
+            imageContainer.HeightAnchor.ConstraintEqualTo(200),
+            imageView.WidthAnchor.ConstraintEqualTo(210),
+            imageView.HeightAnchor.ConstraintEqualTo(200),
+            imageView.CenterXAnchor.ConstraintEqualTo(imageContainer.CenterXAnchor),
+            imageView.CenterYAnchor.ConstraintEqualTo(imageContainer.CenterYAnchor),
+
+            _progressBar.HeightAnchor.ConstraintEqualTo(4),
+
+            cancelButton.TrailingAnchor.ConstraintEqualTo(TrailingAnchor, -16),
+            cancelButton.BottomAnchor.ConstraintEqualTo(SafeAreaLayoutGuide.BottomAnchor, -16),
+            cancelButton.HeightAnchor.ConstraintEqualTo(40),
         ]);
 
         OnStateChanged(model);

--- a/src/nodejs/images/upload-progress-image.svg
+++ b/src/nodejs/images/upload-progress-image.svg
@@ -1,0 +1,108 @@
+<svg width="210" height="200" viewBox="0 0 210 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Share files">
+<g id="Share cat 2" clip-path="url(#clip0_10192_157657)">
+<g id="Group 1106">
+<ellipse id="Ellipse 781" cx="105.71" cy="82.2322" rx="105.71" ry="82.2322" transform="matrix(-0.953202 0.302335 0.299782 0.954008 181.111 -10.4102)" fill="url(#paint0_linear_10192_157657)"/>
+<g id="Group 968">
+<g id="Group 921">
+<path id="Rectangle 458" d="M136.963 123.872L191.767 123.872C196.185 123.872 199.767 120.29 199.767 115.872L199.767 74.6166C199.767 70.1984 196.185 66.6166 191.767 66.6166L161.727 66.6166" stroke="#858599" stroke-width="3"/>
+</g>
+<g id="Group 967">
+<path id="Ellipse 771" d="M168.365 94.2983C171.385 94.2983 174.047 95.0503 175.905 96.187C177.788 97.3393 178.635 98.7304 178.635 99.9995C178.635 101.269 177.789 102.661 175.905 103.813C174.047 104.95 171.385 105.702 168.365 105.702C165.345 105.702 162.683 104.95 160.825 103.813C158.941 102.661 158.094 101.269 158.094 99.9995C158.095 98.7304 158.942 97.3393 160.825 96.187C162.683 95.0503 165.345 94.2983 168.365 94.2983Z" fill="#B6B6CC" stroke="#B6B6CC" stroke-width="3"/>
+<path id="Vector 182" d="M185.469 86.2045C185.469 86.2045 191.861 82.8036 191.861 69.1744C191.861 55.5452 182.609 52.7717 178.541 52.3047V99.0328" stroke="#B6B6CC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+<g id="Group 921_2">
+<rect id="Rectangle 457" x="69.4402" y="149.087" width="62.8041" height="57.2552" rx="8" transform="rotate(-180 69.4402 149.087)" fill="url(#paint1_linear_10192_157657)"/>
+</g>
+<g id="Group 942">
+<g id="Group 970">
+<g id="Group 933">
+<g id="Group 966">
+<path id="Vector 169" d="M145.952 13.3201C137.841 9.76734 122.806 23.5307 120.778 31.2268C140.109 38.6243 147.416 49.5553 148.486 54.7611C156.429 43.9076 151.022 15.5406 145.952 13.3201Z" fill="url(#paint2_linear_10192_157657)"/>
+<path id="Vector" d="M105.823 111.84C74.8382 114.35 50.8501 92.2585 50.8501 73.8225C50.8501 48.4394 74.226 27.9912 102.824 27.9912C131.423 27.9912 154.799 48.603 154.799 73.8225C154.799 86.7355 148.302 97.7815 131.31 106.819" fill="url(#paint3_linear_10192_157657)"/>
+<path id="Vector 168" d="M58.8041 12.366C66.9155 8.81324 81.9502 22.5766 83.9787 30.2727C64.6477 37.6702 57.3404 48.6012 56.2699 53.807C48.3277 42.9535 53.7346 14.5865 58.8041 12.366Z" fill="url(#paint4_linear_10192_157657)"/>
+</g>
+<g id="Group 885">
+<path id="Vector 143" d="M100.662 20.1714L100.662 28.2048" stroke="#858599" stroke-width="3"/>
+<g id="Group 886">
+<path id="Ellipse 36" d="M101.2 7.61719C104.524 7.61719 107.159 10.1233 107.159 13.1426C107.159 16.1617 104.524 18.667 101.2 18.667C97.8763 18.6668 95.2421 16.1616 95.2419 13.1426C95.2419 10.1234 97.8761 7.61736 101.2 7.61719Z" fill="white" stroke="#42424D"/>
+<path id="Vector_2" d="M100.662 20.1715C104.526 20.1715 107.658 17.2492 107.658 13.6443C107.658 10.0395 104.526 7.11719 100.662 7.11719C96.7977 7.11719 93.6653 10.0395 93.6653 13.6443C93.6653 17.2492 96.7977 20.1715 100.662 20.1715Z" fill="#858599" stroke="#42424D" stroke-width="3" stroke-miterlimit="10"/>
+<ellipse id="Ellipse 763" cx="99.1626" cy="13.6443" rx="4.49778" ry="4.51879" fill="#B6B6CC"/>
+<ellipse id="Ellipse 34" cx="2.47142" cy="2.77663" rx="2.47142" ry="2.77663" transform="matrix(0.659124 0.752034 -0.795089 0.606492 98.0806 7.11719)" fill="white"/>
+</g>
+</g>
+<g id="Group 884">
+<path id="Vector_3" d="M101.458 98.4973C122.323 98.4973 139.237 88.1568 139.237 75.4012C139.237 62.6456 122.323 52.3052 101.458 52.3052C80.5938 52.3052 63.6797 62.6456 63.6797 75.4012C63.6797 88.1568 80.5938 98.4973 101.458 98.4973Z" fill="#42424D"/>
+<path id="Ellipse 782" d="M113.823 75.4011C113.823 82.2301 108.287 87.7661 101.458 87.7661C94.6293 87.7661 89.0933 82.2301 89.0933 75.4011C89.0933 68.5721 94.6293 63.0361 101.458 63.0361" stroke="url(#paint5_linear_10192_157657)" stroke-width="4" stroke-linecap="round"/>
+</g>
+<path id="Vector_4" d="M104.66 112.054C73.6751 114.564 49.687 92.4724 49.687 74.0364C49.687 48.6533 73.0629 28.2051 101.661 28.2051C130.26 28.2051 153.636 48.8169 153.636 74.0364C153.636 83.2924 150.298 91.5892 142.149 98.8746" stroke="#42424D" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="Group 972">
+<path id="Vector_5" d="M70.5802 36.583C70.5802 25.3865 65.8713 16.6346 57.1599 13.0859" stroke="#42424D" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector 164" d="M83.2942 30.1958C81.96 20.1032 65.164 9.34133 57.1605 12.7338C52.1583 14.8541 46.8234 41.9411 54.66 52.3048" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+</g>
+<path id="Vector 165" d="M120.305 31.13C121.925 21.3135 138.159 9.34146 146.162 12.7339C151.164 14.8542 156.499 41.9412 148.663 52.3049" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector_6" d="M132.527 36.6392C132.527 25.4427 137.235 16.6907 145.947 13.1421" stroke="#42424D" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+<g id="Group 975">
+<g id="Group 931">
+<path id="Rectangle 458_2" d="M29.8965 91.248L14.6356 91.248C10.2173 91.248 6.6356 94.8297 6.6356 99.248L6.63559 140.503C6.63559 144.922 10.2173 148.503 14.6356 148.503L61.4399 148.503C65.8582 148.503 69.4399 144.922 69.4399 140.503L69.4399 112.865" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 177" d="M17.103 136.819H39.2009" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 178" d="M17.103 128.639H39.2009" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 179" d="M17.103 120.46H58.9726" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 180" d="M17.103 112.281H58.9726" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 181" d="M17.103 104.102H41.5269" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+</g>
+</g>
+<g id="Group 930">
+<rect id="Rectangle 456" x="109.996" y="175.703" width="65.9527" height="48.325" rx="8" transform="rotate(-180 109.996 175.703)" fill="#42424D"/>
+<path id="Vector 176" d="M68.6899 160.443V142.638C68.6899 141.1 70.352 140.138 71.6853 140.903L87.2007 149.806C88.5402 150.574 88.5402 152.507 87.2007 153.275L71.6853 162.178C70.352 162.943 68.6899 161.98 68.6899 160.443Z" fill="#B6B6CC"/>
+</g>
+<g id="Group 921_3">
+<rect id="Rectangle 457_2" x="164.81" y="163.098" width="62.8043" height="57.2554" rx="8" transform="rotate(-180 164.81 163.098)" fill="url(#paint6_linear_10192_157657)"/>
+<path id="Vector 174" d="M124.125 136.322L105.494 159.593L107.82 161.93H136.315V144.231C136.315 143.215 135.929 142.237 135.234 141.496L130.167 136.087C128.502 134.309 125.648 134.42 124.125 136.322Z" fill="#B6B6CC"/>
+<path id="Vector 177_2" d="M105.494 159.593L124.125 136.322C125.648 134.42 128.502 134.309 130.167 136.087L136.315 142.65" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Vector 175" d="M147.215 130.305L120.614 161.93H159.576L163.647 157.84V142.777C163.647 141.754 163.255 140.769 162.551 140.026L153.18 130.13C151.538 128.395 148.752 128.477 147.215 130.305Z" fill="#B6B6CC"/>
+<path id="Vector 176_2" d="M126.263 158.942L147.257 130.697C148.739 128.703 151.663 128.529 153.372 130.333L163.645 141.183" stroke="#42424D" stroke-width="3" stroke-linecap="round"/>
+<path id="Ellipse 771_2" d="M120.032 117.859C122.73 117.859 124.93 120.059 124.93 122.786C124.93 125.514 122.73 127.713 120.032 127.713C117.335 127.713 115.136 125.513 115.136 122.786C115.136 120.059 117.335 117.86 120.032 117.859Z" fill="#B6B6CC" stroke="#42424D" stroke-width="3"/>
+<rect id="Rectangle 458_3" x="164.81" y="163.098" width="62.8043" height="57.2554" rx="8" transform="rotate(-180 164.81 163.098)" stroke="#42424D" stroke-width="3"/>
+</g>
+</g>
+</g>
+</g>
+</g>
+<defs>
+<linearGradient id="paint0_linear_10192_157657" x1="125.021" y1="1.80027" x2="173.97" y2="156.256" gradientUnits="userSpaceOnUse">
+<stop stop-color="#303038"/>
+<stop offset="1" stop-color="#6D6D80"/>
+</linearGradient>
+<linearGradient id="paint1_linear_10192_157657" x1="72.9706" y1="205.254" x2="111.035" y2="166.265" gradientUnits="userSpaceOnUse">
+<stop stop-color="#858599" stop-opacity="0"/>
+<stop offset="1" stop-color="#858599"/>
+</linearGradient>
+<linearGradient id="paint2_linear_10192_157657" x1="136.646" y1="12.7451" x2="136.646" y2="54.7611" gradientUnits="userSpaceOnUse">
+<stop stop-color="#676778"/>
+<stop offset="1" stop-color="#CFCFE5"/>
+</linearGradient>
+<linearGradient id="paint3_linear_10192_157657" x1="102.824" y1="33.7676" x2="102.824" y2="134.742" gradientUnits="userSpaceOnUse">
+<stop stop-color="#606071"/>
+<stop offset="1" stop-color="#CFCFE5"/>
+</linearGradient>
+<linearGradient id="paint4_linear_10192_157657" x1="68.1108" y1="11.791" x2="68.1108" y2="53.807" gradientUnits="userSpaceOnUse">
+<stop stop-color="#606071"/>
+<stop offset="1" stop-color="#CFCFE5"/>
+</linearGradient>
+<linearGradient id="paint5_linear_10192_157657" x1="113.823" y1="75.4011" x2="101.458" y2="57.0384" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B6B6CC"/>
+<stop offset="1" stop-color="#42424D"/>
+</linearGradient>
+<linearGradient id="paint6_linear_10192_157657" x1="196.212" y1="220.354" x2="196.212" y2="163.098" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CFCFE5"/>
+<stop offset="1" stop-color="#666677"/>
+</linearGradient>
+<clipPath id="clip0_10192_157657">
+<rect width="210" height="200" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Applies the [Figma design](https://www.figma.com/design/EJxXOzem02zhRvuqsJIool/Actual-chat-Desktop?node-id=28590-816770&m=dev)
to the upload-progress screen of the iOS share extension, and scripts the SVG→PNG
conversion the extension's images depend on.

## Upload progress (`73fa347` → `e9761ff`)

Reordered to image / progress bar / caption, with Cancel moved out of the stack
into the bottom-right corner. Every coordinate is taken from the design's 360×800
frame and lands within ~1pt:

| | Figma | Implemented |
|---|---|---|
| Illustration | x 75, y 217.24, 210×200 | 210×200 leaf centered in a full-width row |
| Progress bar | y 447.59, w 298.03, 4pt round caps | h 4, radius 2, insets 31 |
| Caption | y 467.01, 16/18, centered | 16pt Medium, white, **below** the bar |
| Cancel | 246,744.24 · 98×40, text inset 24/10 | trailing −16, bottom −16, `ContentInsets(10,24,10,24)` |

Colors come from the design tokens: `blue/70 #54A6FF` (bar fill + Cancel) on an
`ash/30 #42424D` track. The bar was previously an 8pt default-gray `UIProgressView`
and the caption sat *above* it at 24pt.

The illustration is the design's own vector. It lives in `src/nodejs/images/`
beside `error-barrier-image.svg`, so the web is served it from `/dist/images/`
(verified — it publishes with no build change), and is rasterized into
`resources/images/converted/` at 1x/2x/3x for UIKit, which can't render SVG.

## Image tooling (`fb6939b` → `341480a`)

The PNGs the extension bundles were rasterized by hand and committed with nothing
recording how. `scripts/prepare-images.cmd` does it the way
`prepare-system-icons.cmd` already does — `rsvg-convert`, polyglot batch/sh — over
an explicit list of names, since only the few SVGs a native view needs have to
become PNGs. `-z` keeps each image at its own size, so a new name needs no
per-image configuration.

Regenerating `error-barrier-image.png` from its SVG reproduces the committed one
exactly (same 241×169, same 15676/40729 transparent pixels) — that's what confirms
the list and the tool are the ones that originally produced it.

**It gains `@2x`/`@3x` in passing.** `ErrorContentView` draws a 169px asset at
164pt, so the error screen has been soft on every retina device. The `Include` is
now a glob so they get bundled. This touches a screen unrelated to #4186, which is
why it's a separate commit — drop the name from `names` and revert the glob if
you'd rather ship that asset byte-identical.

## Deliberate deviations

Both are extension-wide decisions I kept out of a single-screen change:

- **Font** — the design specifies TT Commons Pro Medium 16/18. The repo has the
  face, but the appex bundles no fonts and every sibling screen uses
  `SystemFontOfSize`. Matched the size and weight only; bundling the real face
  should cover all five screens at once (TTF + `UIAppFonts` in the appex plist).
- **Background** — the design frame is `ash/14 #1F1F24`; `ShareView` paints
  `#1C1C1F` for all steps. Setting it on `UploadProgressView` alone would leave a
  seam during the scale/fade transition from the contact picker, so the fix belongs
  in `ShareView`.

## Testing

Built and run on device (iPhone 15 Pro Max, iOS 26.6). Verified all six PNGs reach
the `.appex`, and that the shipped bytes decode as genuinely transparent
(`sips -g hasAlpha` is not sufficient — it reports the channel exists, not that any
pixel is transparent; an earlier fully-opaque export passed that check).

## Note for anyone running this on a device

`scripts/run-ios.sh` doesn't pass a team id, so `build.sh` produces an **unsigned**
Live Activities widget and iOS refuses to launch the whole bundle with "invalid code
signature, inadequate entitlements". Pre-existing since df4ff8703b, unrelated to this
PR. Workaround:

```
dotnet build src/dotnet/App.Maui/ -f net11.0-ios -p:RuntimeIdentifier=ios-arm64 \
  -p:VoxtActivitiesTeamId=M287G8G83F
```

Probably wants fixing by defaulting `CodesignTeamId` for device builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
