### PR TITLE
fix(cache): give the client computed cache one folder per session + related changes

### DIFF
--- a/src/dotnet/App.Maui.IosShareExt/Services/SessionInitializer.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Services/SessionInitializer.cs
@@ -1,13 +1,22 @@
 using ActualChat.Maui;
 using ActualChat.Security;
+using ActualChat.UI.Caching;
 using ActualLab.Interception;
 
 namespace ActualChat.App.Maui.IosShareExt.Services;
 
-public class SessionInitializer(TrueSessionResolver trueSessionResolver, ILogger<SessionInitializer> log)
+public class SessionInitializer(
+    TrueSessionResolver trueSessionResolver,
+    KvasarRemoteComputedCache remoteComputedCache,
+    IServiceProvider services)
     : WorkerBase, IComputeService, INotifyInitialized
 {
     private const string SessionStorageKey = "Fusion.SessionId";
+
+    private IServiceProvider Services { get; } = services;
+    private TrueSessionResolver TrueSessionResolver { get; } = trueSessionResolver;
+    private KvasarRemoteComputedCache RemoteComputedCache { get; } = remoteComputedCache;
+    private ILogger Log => field ??= Services.LogFor(GetType());
 
     void INotifyInitialized.Initialized()
         => this.Start();
@@ -18,14 +27,14 @@ public class SessionInitializer(TrueSessionResolver trueSessionResolver, ILogger
             await SetSession(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
-            log.LogError(e, "Failed to refresh the session");
+            Log.LogError(e, "Failed to refresh the session");
         }
     }
 
     protected override Task OnRun(CancellationToken cancellationToken)
         => AsyncChain.From(SetSession)
-            .Log(LogLevel.Debug, log)
-            .RetryForever(RetryDelaySeq.Fixed(1), log)
+            .Log(LogLevel.Debug, Log)
+            .RetryForever(RetryDelaySeq.Fixed(1), Log)
             .RunIsolated(cancellationToken);
 
     // Private methods
@@ -36,24 +45,27 @@ public class SessionInitializer(TrueSessionResolver trueSessionResolver, ILogger
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
         if (sessionId.IsNullOrEmpty()) {
-            log.LogWarning("No session id found");
+            Log.LogWarning("No session id found");
             return;
         }
 
         var session = new Session(sessionId);
-        var oldSession = trueSessionResolver.HasSession ? trueSessionResolver.Session : null;
+        var oldSession = TrueSessionResolver.HasSession ? TrueSessionResolver.Session : null;
         if (oldSession == session)
             return;
 
         // Replace rather than the Session setter: the setter throws AlreadyInitialized once the
         // main app rotates the stored id, and this process outlives many shares.
-        trueSessionResolver.Replace(session);
+        TrueSessionResolver.Replace(session);
+        // The extension has its own data container - no App Group, only a shared keychain group -
+        // so this cache is private to it and can't contend with the main app's.
+        await RemoteComputedCache.Activate(session).ConfigureAwait(false);
         if (oldSession is null)
             return;
 
         // Everything computed for the previous session - the own account above all - survives the
         // reconnect Replace triggers, so without this the sheet keeps showing the previous user.
-        log.LogInformation("Session changed - invalidating everything");
+        Log.LogInformation("Session changed - invalidating everything");
         ComputedRegistry.InvalidateEverything();
     }
 }

--- a/src/dotnet/App.Maui/Services/MauiReloadUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiReloadUI.cs
@@ -15,9 +15,7 @@ public class MauiReloadUI(IServiceProvider services) : ReloadUI(services)
             Log.LogInformation("Reloading...");
             try {
                 await Clear(clearCaches, clearLocalSettings).ConfigureAwait(true);
-                // Our own sign-out deactivates the session; it can also be killed elsewhere or expire.
-                // Revalidate mints a fresh one and re-binds the RPC connection, so the WebView recreated
-                // next binds every Session.Default-keyed computed to the new session, not the dead id.
+                // Sign-out deactivates the session - mint a replacement before the new WebView binds it.
                 await Services.GetRequiredService<MauiSession>().Revalidate().ConfigureAwait(true);
                 MainPage.Current.RecreateWebView();
             }

--- a/src/dotnet/App.Maui/Services/MauiSession.cs
+++ b/src/dotnet/App.Maui/Services/MauiSession.cs
@@ -1,5 +1,6 @@
 using ActualChat.Security;
 using ActualChat.UI.Blazor.Services;
+using ActualChat.UI.Caching;
 using ActualLab.Rpc;
 
 namespace ActualChat.App.Maui.Services;
@@ -17,6 +18,8 @@ public sealed class MauiSession(IServiceProvider services)
     private IServiceProvider Services { get; } = services;
     private TrueSessionResolver TrueSessionResolver { get; } = services.GetRequiredService<TrueSessionResolver>();
     private IMobileSessions MobileSessions => field ??= Services.GetRequiredService<IMobileSessions>();
+    private KvasarRemoteComputedCache RemoteComputedCache
+        => field ??= Services.GetRequiredService<KvasarRemoteComputedCache>();
 
     private static ISecureStorage Storage
 #if IOS || MACCATALYST
@@ -45,23 +48,30 @@ public sealed class MauiSession(IServiceProvider services)
             var session = await ReadStored().ConfigureAwait(false);
             if (session == null) {
                 // No session -> create one
-                session = await MobileSessions.CreateSession(MauiSettings.AppUserAgent, CancellationToken.None).ConfigureAwait(false);
+                session = await MobileSessions
+                    .CreateSession(MauiSettings.AppUserAgent, CancellationToken.None)
+                    .ConfigureAwait(false);
                 TrueSessionResolver.Session = session;
+                // No InvalidateEverything here or below: Acquire returns early once a session is set,
+                // so nothing session-scoped has been computed yet - only the cache needs pointing.
+                await RemoteComputedCache.Activate(session).ConfigureAwait(false);
                 _ = Task.Run(() => Store(session));
                 return;
             }
 
             // Session is there -> validate it
             TrueSessionResolver.Session = session;
-            var validSession =
-                await MobileSessions.ValidateSession(session, MauiSettings.AppUserAgent, CancellationToken.None).ConfigureAwait(false);
+            await RemoteComputedCache.Activate(session).ConfigureAwait(false);
+            var validSession = await MobileSessions
+                .ValidateSession(session, MauiSettings.AppUserAgent, CancellationToken.None)
+                .ConfigureAwait(false);
             if (session == validSession)
                 return;
 
             // Session is invalid -> update it to valid + reload MAUI App
             Log.LogWarning("Stored session is invalid - will reload");
-            await Store(validSession).ConfigureAwait(false);
             await SwitchTo(validSession).ConfigureAwait(false);
+            await Store(validSession).ConfigureAwait(false);
             // Reloading mid-startup recreates the WebView while the first Blazor scope is
             // still initializing, leaving a half-disposed scope with a disconnected JS runtime
             // (=> endless JSDisconnectedException in the post-reload sign-in UI). Wait until the
@@ -77,9 +87,9 @@ public sealed class MauiSession(IServiceProvider services)
         });
     }
 
-    // Never throws: MauiReloadUI calls it on the reload path, where a failure would terminate the app
     public async Task Revalidate()
     {
+        // Never throws: MauiReloadUI's reload path terminates the app on failure
         using var _ = Tracer.MethodRegion();
         if (!TrueSessionResolver.HasSession)
             return;
@@ -93,8 +103,10 @@ public sealed class MauiSession(IServiceProvider services)
             if (session == validSession)
                 return;
 
-            await Store(validSession).ConfigureAwait(false);
+            // Switch first: it drops the cache, so a crash before Store leaves the old id with a
+            // cold cache. The other order can persist the new id over the old session's entries.
             await SwitchTo(validSession).ConfigureAwait(false);
+            await Store(validSession).ConfigureAwait(false);
             Log.LogInformation("Replaced an invalid Session");
         }
         catch (Exception e) {
@@ -133,10 +145,17 @@ public sealed class MauiSession(IServiceProvider services)
         catch (Exception e) {
             Log.LogWarning(e, "Failed to await the RPC disconnect after a Session switch");
         }
+        await OnSessionChanged(session).ConfigureAwait(false);
+    }
+
+    private async Task OnSessionChanged(Session session)
+    {
         // Every client call passes Session.Default, so the session id is never part of a computed's
-        // key - the server resolves it per connection. A swap thus changes no key and triggers no
+        // key - the server resolves it per connection. A change thus changes no key and triggers no
         // invalidation, and the reconnect only resets cached values when the server peer itself
-        // changed. Without this the UI keeps serving the replaced session's account until a restart.
+        // changed. So both caches have to be re-pointed by hand: the persistent one at the folder
+        // belonging to this session, the in-memory one by dropping every value it holds.
+        await RemoteComputedCache.Activate(session).ConfigureAwait(false);
         ComputedRegistry.InvalidateEverything();
     }
 
@@ -150,6 +169,7 @@ public sealed class MauiSession(IServiceProvider services)
                 Log.LogInformation("Successfully read stored Session");
                 return new Session(sessionId).RequireValid();
             }
+
             Log.LogInformation("No stored Session");
         }
         catch (Exception e) {

--- a/src/dotnet/Core/Kvas/KvasarKvas.cs
+++ b/src/dotnet/Core/Kvas/KvasarKvas.cs
@@ -28,7 +28,9 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
     private readonly Lock _lock = new();
     private Task<KvasarStore?> _storeTask;
     private string? _activeKey;
+    private long _generation;
     private bool _isSuspended;
+    private bool _isDetached;
 
     private ILogger Log { get; }
 
@@ -156,8 +158,9 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         Task<KvasarStore?> oldStoreTask;
         string? oldKey;
         Task<KvasarStore?> newStoreTask;
+        long generation;
         lock (_lock) {
-            if (IsDisposed)
+            if (IsDisposed || _isDetached)
                 return Task.CompletedTask;
             if (_activeKey == key)
                 return _storeTask;
@@ -165,12 +168,13 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             oldStoreTask = _storeTask;
             oldKey = _activeKey;
             _activeKey = key;
+            generation = ++_generation;
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
             newStoreTask = _isSuspended ? NoStoreTask : Open(key);
             Volatile.Write(ref _storeTask, newStoreTask);
         }
 
-        _ = SwitchAway(oldStoreTask, oldKey, key);
+        _ = SwitchAway(oldStoreTask, oldKey, generation);
         return newStoreTask;
     }
 
@@ -209,7 +213,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
     public void Resume()
     {
         lock (_lock) {
-            if (!_isSuspended || IsDisposed)
+            if (!_isSuspended || IsDisposed || _isDetached)
                 return;
 
             _isSuspended = false;
@@ -274,10 +278,10 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
                 & (Settings.BasePath.FileName + "-" + key)
                 & Settings.BasePath.FileName;
 
-    private async Task SwitchAway(Task<KvasarStore?> oldStoreTask, string? oldKey, string newKey)
+    private async Task SwitchAway(Task<KvasarStore?> oldStoreTask, string? oldKey, long generation)
     {
         await CloseAndDelete(oldStoreTask, oldKey).ConfigureAwait(false);
-        SweepKeyFolders(newKey);
+        SweepKeyFolders(generation);
     }
 
     private async Task CloseAndDelete(Task<KvasarStore?> storeTask, string? keyToDelete)
@@ -290,6 +294,12 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
 
     private void DeleteKeyFolder(string key)
     {
+        lock (_lock) {
+            // Activate may have switched back to this key while we were closing its old store
+            if (_activeKey == key)
+                return;
+        }
+
         var folder = GetBasePath(key).DirectoryPath;
         try {
             if (Directory.Exists(folder))
@@ -300,19 +310,24 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         }
     }
 
-    private void SweepKeyFolders(string keyToKeep)
+    private void SweepKeyFolders(long generation)
     {
         var root = Settings.BasePath.DirectoryPath;
         var prefix = Settings.BasePath.FileName + "-";
-        var folderToKeep = prefix + keyToKeep;
         try {
             if (!Directory.Exists(root))
                 return;
 
             foreach (var folder in Directory.EnumerateDirectories(root, prefix + "*")) {
                 var folderName = ((FilePath)folder).FileName;
-                if (folderName == folderToKeep)
-                    continue;
+                lock (_lock) {
+                    // Re-read per folder: a later Activate owns the sweep and its key is the live
+                    // one, so a superseded sweep must not delete the folder that replaced it.
+                    if (_generation != generation || _activeKey == null)
+                        return;
+                    if (folderName == prefix + _activeKey)
+                        continue;
+                }
 
                 try {
                     Directory.Delete(folder, true);
@@ -332,6 +347,9 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
     {
         lock (_lock) {
             var storeTask = _storeTask;
+            // IsDisposed only flips once DisposeAsync(bool) has returned, i.e. after this runs -
+            // without a flag of our own a concurrent Activate would open a store nothing closes.
+            _isDetached = true;
             _activeKey = null;
             Volatile.Write(ref _storeTask, NoStoreTask);
             return storeTask;

--- a/src/dotnet/Core/Kvas/KvasarKvas.cs
+++ b/src/dotnet/Core/Kvas/KvasarKvas.cs
@@ -27,6 +27,8 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
 
     private readonly Lock _lock = new();
     private Task<KvasarStore?> _storeTask;
+    // Closes and deletes, serialized: an open must wait for them, or it hits the store's own lock
+    private Task _maintenanceTask = Task.CompletedTask;
     private string? _activeKey;
     private long _generation;
     private bool _isSuspended;
@@ -43,7 +45,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         Settings = settings;
         Services = services;
         Log = services.LogFor(GetType());
-        _storeTask = settings.RequiresActivation ? NoStoreTask : Open(null);
+        _storeTask = settings.RequiresActivation ? NoStoreTask : Open(null, null);
         WhenInitialized = _storeTask;
     }
 
@@ -169,45 +171,44 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             oldKey = _activeKey;
             _activeKey = key;
             generation = ++_generation;
+            var pending = _maintenanceTask;
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
-            newStoreTask = _isSuspended ? NoStoreTask : Open(key);
+            newStoreTask = _isSuspended ? NoStoreTask : Open(key, pending);
             Volatile.Write(ref _storeTask, newStoreTask);
+            _maintenanceTask = SwitchAway(pending, oldStoreTask, oldKey, generation);
         }
 
-        _ = SwitchAway(oldStoreTask, oldKey, generation);
         return newStoreTask;
     }
 
     public Task Deactivate(bool clear)
     {
-        Task<KvasarStore?> oldStoreTask;
-        string? oldKey;
         lock (_lock) {
-            oldStoreTask = _storeTask;
-            oldKey = _activeKey;
+            var oldStoreTask = _storeTask;
+            var oldKey = _activeKey;
             _activeKey = null;
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
             Volatile.Write(ref _storeTask, NoStoreTask);
+            _maintenanceTask = CloseAndDelete(_maintenanceTask, oldStoreTask, clear ? oldKey : null);
+            return _maintenanceTask;
         }
-
-        return CloseAndDelete(oldStoreTask, clear ? oldKey : null);
     }
 
     public Task Suspend()
     {
         // Closes the store so no file handle or advisory lock survives into suspension - iOS kills an
         // app that holds one (0xdead10cc). Reads miss and writes are dropped until Resume reopens it.
-        Task<KvasarStore?> storeTask;
         lock (_lock) {
             if (_isSuspended)
                 return Task.CompletedTask;
 
             _isSuspended = true;
-            storeTask = _storeTask;
+            var storeTask = _storeTask;
             Volatile.Write(ref _storeTask, NoStoreTask);
+            // Chained so Resume's reopen waits for this close - the store's lock is exclusive
+            _maintenanceTask = CloseAndDelete(_maintenanceTask, storeTask, null);
+            return _maintenanceTask;
         }
-
-        return CloseStore(storeTask);
     }
 
     public void Resume()
@@ -221,7 +222,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
                 return;
 
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
-            Volatile.Write(ref _storeTask, Open(_activeKey));
+            Volatile.Write(ref _storeTask, Open(_activeKey, _maintenanceTask));
         }
     }
 
@@ -231,10 +232,17 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         // Volatile.Read pairs with the publication in Resume.
         => Volatile.Read(ref _storeTask);
 
-    private Task<KvasarStore?> Open(string? key)
+    private Task<KvasarStore?> Open(string? key, Task? after)
         // Deferred to the pool: callers hold _lock, and both the directory creation and Kvasar's own
         // open path are synchronous file I/O - Activate is on the session switch path.
-        => Task.Run(() => OpenStore(key));
+        => Task.Run(async () => {
+            // A pending close still holds this key's lock file, and Kvasar opens it exclusively -
+            // reopening a key we just switched away from would otherwise degrade to a no-op store.
+            if (after != null)
+                await after.SilentAwait(false);
+
+            return await OpenStore(key).ConfigureAwait(false);
+        });
 
     private async Task<KvasarStore?> OpenStore(string? key)
     {
@@ -278,14 +286,16 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
                 & (Settings.BasePath.FileName + "-" + key)
                 & Settings.BasePath.FileName;
 
-    private async Task SwitchAway(Task<KvasarStore?> oldStoreTask, string? oldKey, long generation)
+    private async Task SwitchAway(Task pending, Task<KvasarStore?> oldStoreTask, string? oldKey, long generation)
     {
-        await CloseAndDelete(oldStoreTask, oldKey).ConfigureAwait(false);
+        await CloseAndDelete(pending, oldStoreTask, oldKey).ConfigureAwait(false);
         SweepKeyFolders(generation);
     }
 
-    private async Task CloseAndDelete(Task<KvasarStore?> storeTask, string? keyToDelete)
+    private async Task CloseAndDelete(Task pending, Task<KvasarStore?> storeTask, string? keyToDelete)
     {
+        await pending.SilentAwait(false);
+
         // The store holds an advisory lock file, so it has to be closed before its folder can go.
         await CloseStore(storeTask).ConfigureAwait(false);
         if (keyToDelete != null)

--- a/src/dotnet/Core/Kvas/KvasarKvas.cs
+++ b/src/dotnet/Core/Kvas/KvasarKvas.cs
@@ -175,7 +175,10 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
             newStoreTask = _isSuspended ? NoStoreTask : Open(key, pending);
             Volatile.Write(ref _storeTask, newStoreTask);
-            _maintenanceTask = SwitchAway(pending, oldStoreTask, oldKey, generation);
+            _maintenanceTask = CloseAndDelete(pending, oldStoreTask, oldKey);
+            // Reclaiming disk is not something an open or a suspend should ever wait behind, so the
+            // sweep trails the chain instead of joining it.
+            _ = SweepAfter(_maintenanceTask, generation);
         }
 
         return newStoreTask;
@@ -286,9 +289,10 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
                 & (Settings.BasePath.FileName + "-" + key)
                 & Settings.BasePath.FileName;
 
-    private async Task SwitchAway(Task pending, Task<KvasarStore?> oldStoreTask, string? oldKey, long generation)
+    private async Task SweepAfter(Task pending, long generation)
     {
-        await CloseAndDelete(pending, oldStoreTask, oldKey).ConfigureAwait(false);
+        await pending.SilentAwait(false);
+
         SweepKeyFolders(generation);
     }
 

--- a/src/dotnet/Core/Kvas/KvasarKvas.cs
+++ b/src/dotnet/Core/Kvas/KvasarKvas.cs
@@ -9,7 +9,7 @@ namespace ActualChat.Kvas;
 /// </summary>
 public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
 {
-    public record Options
+    public sealed record Options
     {
         public required FilePath BasePath { get; init; }
         public required byte[] EncryptionKey { get; init; }
@@ -18,12 +18,16 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         public long PageCacheBytes { get; init; } = 16 * 1024 * 1024;
         public TimeSpan FlushDelay { get; init; } = TimeSpan.FromSeconds(0.5);
         public KvasarDurability Durability { get; init; } = KvasarDurability.Buffered;
+
+        // Keyed stores live in "<BasePath>-<key>" folders and no-op until Activate picks the key
+        public bool RequiresActivation { get; init; }
     }
 
     private static readonly Task<KvasarStore?> NoStoreTask = Task.FromResult<KvasarStore?>(null);
 
     private readonly Lock _lock = new();
     private Task<KvasarStore?> _storeTask;
+    private string? _activeKey;
     private bool _isSuspended;
 
     private ILogger Log { get; }
@@ -37,7 +41,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         Settings = settings;
         Services = services;
         Log = services.LogFor(GetType());
-        _storeTask = Open();
+        _storeTask = settings.RequiresActivation ? NoStoreTask : Open(null);
         WhenInitialized = _storeTask;
     }
 
@@ -88,6 +92,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             var (key, value) = items[i];
             updates[i] = (key, ToValue(value));
         }
+
         try {
             await store.SetMany(updates, cancellationToken).ConfigureAwait(false);
         }
@@ -110,6 +115,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
             Log.LogWarning(e, "ListAllEntries failed after {Count} entries", result.Count);
         }
+
         return result.ToArray();
     }
 
@@ -141,10 +147,52 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         }
     }
 
-    // Closes the store so no file handle or advisory lock survives into suspension - iOS kills an app
-    // that holds one (0xdead10cc). Reads miss and writes are dropped until Resume reopens it.
+    public Task Activate(string key)
+    {
+        // Points a keyed store at "<BasePath>-<key>", so what one key wrote can't be read back under
+        // another - whether or not switching away manages to delete the old folder.
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        Task<KvasarStore?> oldStoreTask;
+        string? oldKey;
+        Task<KvasarStore?> newStoreTask;
+        lock (_lock) {
+            if (IsDisposed)
+                return Task.CompletedTask;
+            if (_activeKey == key)
+                return _storeTask;
+
+            oldStoreTask = _storeTask;
+            oldKey = _activeKey;
+            _activeKey = key;
+            // Publication: readers pick the new task up with a Volatile.Read in GetStore.
+            newStoreTask = _isSuspended ? NoStoreTask : Open(key);
+            Volatile.Write(ref _storeTask, newStoreTask);
+        }
+
+        _ = SwitchAway(oldStoreTask, oldKey, key);
+        return newStoreTask;
+    }
+
+    public Task Deactivate(bool clear)
+    {
+        Task<KvasarStore?> oldStoreTask;
+        string? oldKey;
+        lock (_lock) {
+            oldStoreTask = _storeTask;
+            oldKey = _activeKey;
+            _activeKey = null;
+            // Publication: readers pick the new task up with a Volatile.Read in GetStore.
+            Volatile.Write(ref _storeTask, NoStoreTask);
+        }
+
+        return CloseAndDelete(oldStoreTask, clear ? oldKey : null);
+    }
+
     public Task Suspend()
     {
+        // Closes the store so no file handle or advisory lock survives into suspension - iOS kills an
+        // app that holds one (0xdead10cc). Reads miss and writes are dropped until Resume reopens it.
         Task<KvasarStore?> storeTask;
         lock (_lock) {
             if (_isSuspended)
@@ -154,6 +202,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             storeTask = _storeTask;
             Volatile.Write(ref _storeTask, NoStoreTask);
         }
+
         return CloseStore(storeTask);
     }
 
@@ -164,8 +213,11 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
                 return;
 
             _isSuspended = false;
+            if (Settings.RequiresActivation && _activeKey == null)
+                return;
+
             // Publication: readers pick the new task up with a Volatile.Read in GetStore.
-            Volatile.Write(ref _storeTask, Open());
+            Volatile.Write(ref _storeTask, Open(_activeKey));
         }
     }
 
@@ -175,10 +227,16 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         // Volatile.Read pairs with the publication in Resume.
         => Volatile.Read(ref _storeTask);
 
-    private async Task<KvasarStore?> Open()
+    private Task<KvasarStore?> Open(string? key)
+        // Deferred to the pool: callers hold _lock, and both the directory creation and Kvasar's own
+        // open path are synchronous file I/O - Activate is on the session switch path.
+        => Task.Run(() => OpenStore(key));
+
+    private async Task<KvasarStore?> OpenStore(string? key)
     {
-        var options = new KvasarOptions() {
-            BasePath = Settings.BasePath,
+        var basePath = GetBasePath(key);
+        var options = new KvasarOptions {
+            BasePath = basePath,
             EncryptionKey = Settings.EncryptionKey,
             Version = Settings.Version,
             PageSize = Settings.PageSize,
@@ -187,23 +245,86 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
             Durability = Settings.Durability,
         };
         try {
+            Directory.CreateDirectory(basePath.DirectoryPath);
             return await KvasarStore.Open(options).ConfigureAwait(false);
         }
         catch (KvasarLockException e) {
             // Deleting the files wouldn't help: someone else is using them.
-            Log.LogError(e, "Store '{BasePath}' is already open, it will be a no-op", Settings.BasePath);
+            Log.LogError(e, "Store '{BasePath}' is already open, it will be a no-op", basePath);
             return null;
         }
         catch (Exception e) {
-            Log.LogWarning(e, "Failed to open store '{BasePath}', deleting and retrying", Settings.BasePath);
+            Log.LogWarning(e, "Failed to open store '{BasePath}', deleting and retrying", basePath);
             try {
-                DeleteStoreFiles(Settings.BasePath);
+                DeleteStoreFiles(basePath);
+                Directory.CreateDirectory(basePath.DirectoryPath);
                 return await KvasarStore.Open(options).ConfigureAwait(false);
             }
             catch (Exception e2) {
-                Log.LogError(e2, "Failed to open store '{BasePath}' after retry", Settings.BasePath);
+                Log.LogError(e2, "Failed to open store '{BasePath}' after retry", basePath);
                 return null;
             }
+        }
+    }
+
+    private FilePath GetBasePath(string? key)
+        => key == null
+            ? Settings.BasePath
+            : Settings.BasePath.DirectoryPath
+                & (Settings.BasePath.FileName + "-" + key)
+                & Settings.BasePath.FileName;
+
+    private async Task SwitchAway(Task<KvasarStore?> oldStoreTask, string? oldKey, string newKey)
+    {
+        await CloseAndDelete(oldStoreTask, oldKey).ConfigureAwait(false);
+        SweepKeyFolders(newKey);
+    }
+
+    private async Task CloseAndDelete(Task<KvasarStore?> storeTask, string? keyToDelete)
+    {
+        // The store holds an advisory lock file, so it has to be closed before its folder can go.
+        await CloseStore(storeTask).ConfigureAwait(false);
+        if (keyToDelete != null)
+            DeleteKeyFolder(keyToDelete);
+    }
+
+    private void DeleteKeyFolder(string key)
+    {
+        var folder = GetBasePath(key).DirectoryPath;
+        try {
+            if (Directory.Exists(folder))
+                Directory.Delete(folder, true);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to delete store folder '{Folder}'", folder);
+        }
+    }
+
+    private void SweepKeyFolders(string keyToKeep)
+    {
+        var root = Settings.BasePath.DirectoryPath;
+        var prefix = Settings.BasePath.FileName + "-";
+        var folderToKeep = prefix + keyToKeep;
+        try {
+            if (!Directory.Exists(root))
+                return;
+
+            foreach (var folder in Directory.EnumerateDirectories(root, prefix + "*")) {
+                var folderName = ((FilePath)folder).FileName;
+                if (folderName == folderToKeep)
+                    continue;
+
+                try {
+                    Directory.Delete(folder, true);
+                    Log.LogInformation("Swept stale store folder '{Folder}'", folder);
+                }
+                catch (Exception e) {
+                    Log.LogWarning(e, "Failed to sweep store folder '{Folder}'", folder);
+                }
+            }
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to sweep stale store folders in '{Root}'", root);
         }
     }
 
@@ -211,6 +332,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
     {
         lock (_lock) {
             var storeTask = _storeTask;
+            _activeKey = null;
             Volatile.Write(ref _storeTask, NoStoreTask);
             return storeTask;
         }
@@ -228,6 +350,7 @@ public sealed class KvasarKvas : SafeAsyncDisposableBase, IKvasStore
         catch (Exception e) {
             Log.LogWarning(e, "Flush failed while closing the store");
         }
+
         try {
             await store.DisposeAsync().ConfigureAwait(false);
         }

--- a/src/dotnet/Maui/Module/MauiModule.cs
+++ b/src/dotnet/Maui/Module/MauiModule.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Storage;
 
 namespace ActualChat.Maui.Module;
 
-public class MauiModule(IServiceProvider moduleServices)
+public sealed class MauiModule(IServiceProvider moduleServices)
     : HostModule(moduleServices), IAppModule
 {
     protected override void InjectServices(IServiceCollection services)
@@ -20,18 +20,21 @@ public class MauiModule(IServiceProvider moduleServices)
         KvasarStoreSupport.DeleteLegacyDbFiles(ModuleServices,
             appCacheDir & "CCC.db3",
             appDataDir & "LocalSettings.db3");
+        // The pre-session-scoped cache wrote these next to the per-session folders that replaced it
+        KvasarStoreSupport.DeleteLegacyStoreFiles(ModuleServices, appCacheDir & "CCC");
 
         // RemoteComputedCache
         services.AddSingleton(_ => new KvasarRemoteComputedCache.Options() {
-            BasePath = appCacheDir & "CCC",
+            BasePath = appCacheDir & "ccc",
             EncryptionKey = MauiPreferences.DbEncryptionKey,
         });
-        services.AddSingleton<IRemoteComputedCache>(c => {
+        services.AddSingleton(c => {
             var options = c.GetRequiredService<KvasarRemoteComputedCache.Options>();
             var cache = new KvasarRemoteComputedCache(options, c);
             cache.Kvas.WithSuspendHandler(c);
             return cache;
         });
+        services.AddSingleton<IRemoteComputedCache>(c => c.GetRequiredService<KvasarRemoteComputedCache>());
 
         // LocalSettings backend override
         services.AddSingleton(_ => new LocalSettings.Options() {

--- a/src/dotnet/Maui/Services/KvasarStoreSupport.cs
+++ b/src/dotnet/Maui/Services/KvasarStoreSupport.cs
@@ -48,4 +48,21 @@ public static class KvasarStoreSupport
                 }
             }
     }
+
+    public static void DeleteLegacyStoreFiles(IServiceProvider services, FilePath basePath)
+    {
+        var log = services.LogFor(typeof(KvasarStoreSupport));
+        var directory = basePath.DirectoryPath;
+        if (!Directory.Exists(directory))
+            return;
+
+        foreach (var file in Directory.EnumerateFiles(directory, basePath.FileName + ".*"))
+            try {
+                File.Delete(file);
+                log.LogInformation("Deleted legacy Kvasar file: {File}", file);
+            }
+            catch (Exception e) {
+                log.LogWarning(e, "Failed to delete legacy Kvasar file: {File}", file);
+            }
+    }
 }

--- a/src/dotnet/UI.Blazor/Pages/SystemTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/SystemTestPage.razor
@@ -41,6 +41,13 @@
     [Inject] private IServiceProvider Services { get; init; } = null!;
 
     private Task OnInvalidateEverythingLocallyClick() {
+        // Under the Server render mode "locally" is the whole server process: one static registry
+        // shared by every circuit and every server-side compute service.
+        if (HostInfo.HostKind.IsServer()) {
+            UICommander.ShowError("Not available on a server - use \"On this front-end\" instead");
+            return Task.CompletedTask;
+        }
+
         ComputedRegistry.InvalidateEverything();
         return Task.CompletedTask;
     }

--- a/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
+++ b/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
@@ -27,7 +27,7 @@ public sealed class KvasarRemoteComputedCache : AppRemoteComputedCache
         : base(settings, services)
     {
         Settings = settings;
-        Kvas = new KvasarKvas(new KvasarKvas.Options() {
+        Kvas = new KvasarKvas(new KvasarKvas.Options {
             BasePath = settings.BasePath,
             EncryptionKey = settings.EncryptionKey,
             Version = settings.Version,
@@ -36,8 +36,17 @@ public sealed class KvasarRemoteComputedCache : AppRemoteComputedCache
             FlushDelay = settings.FlushDelay,
             // The whole cache is regenerable, so a power loss costs an upstream lookup, not correctness.
             Durability = KvasarDurability.Buffered,
+            // Cache keys carry Session.Default rather than the real id, so entries are only
+            // distinguishable by the folder they live in - one per session, picked by Activate.
+            RequiresActivation = true,
         }, services);
         Store = Kvas;
         WhenInitialized = Kvas.WhenInitialized;
     }
+
+    public Task Activate(Session session)
+        => Kvas.Activate(session.Hash);
+
+    public Task Deactivate(bool clear)
+        => Kvas.Deactivate(clear);
 }

--- a/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
+++ b/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
@@ -156,9 +156,115 @@ public class KvasarKvasTest(ITestOutputHelper @out) : TestBase(@out), IAsyncLife
         await kvas2.Set("b", "b"); // Must not throw
     }
 
+    [Fact]
+    public async Task KeyedStoreIsInertBeforeActivateTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+
+        // act
+        await kvas.Set("a", "a");
+
+        // assert
+        (await kvas.Get<string>("a")).Should().BeNull();
+        Directory.EnumerateFileSystemEntries(_basePath.DirectoryPath).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ActivateIsolatesEntriesByKeyTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Activate("aaaa1111");
+        await kvas.Set("a", "a");
+
+        // act
+        await kvas.Activate("bbbb2222");
+
+        // assert
+        (await kvas.Get<string>("a")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReactivatingSameKeyKeepsEntriesTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Activate("aaaa1111");
+        await kvas.Set("a", "a");
+        await kvas.Flush();
+
+        // act
+        await kvas.Deactivate(false);
+        await kvas.Activate("aaaa1111");
+
+        // assert
+        (await kvas.Get<string>("a")).Should().Be("a");
+    }
+
+    [Fact]
+    public async Task DeactivateWithClearDropsEntriesTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Activate("aaaa1111");
+        await kvas.Set("a", "a");
+        await kvas.Flush();
+
+        // act
+        await kvas.Deactivate(true);
+        await kvas.Activate("aaaa1111");
+
+        // assert
+        (await kvas.Get<string>("a")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ActivateSweepsStaleKeyFoldersTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Activate("aaaa1111");
+        await kvas.Set("a", "a");
+        await kvas.Flush();
+
+        // act
+        await kvas.Activate("bbbb2222");
+
+        // assert
+        await WhenFolderNamesAre(["Store-bbbb2222"]);
+    }
+
     // Private methods
 
-    private KvasarKvas CreateKvas(IServiceProvider services, string version = "1.0")
+    private async Task WhenFolderNamesAre(string[] expected)
+    {
+        // The sweep runs in the background so switching away stays off the session-switch path
+        var endsAt = CpuTimestamp.Now + TimeSpan.FromSeconds(5);
+        while (true) {
+            var names = Directory.EnumerateDirectories(_basePath.DirectoryPath)
+                .Select(x => ((FilePath)x).FileName.Value)
+                .ToArray();
+            if (names.OrderBy(x => x).SequenceEqual(expected.OrderBy(x => x)))
+                return;
+            if (endsAt.Elapsed >= TimeSpan.Zero) {
+                names.Should().BeEquivalentTo(expected);
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+    }
+
+    private KvasarKvas CreateKvas(
+        IServiceProvider services,
+        string version = "1.0",
+        bool requiresActivation = false)
         => new(new KvasarKvas.Options() {
             BasePath = _basePath,
             EncryptionKey = Key,
@@ -166,6 +272,7 @@ public class KvasarKvasTest(ITestOutputHelper @out) : TestBase(@out), IAsyncLife
             PageSize = 4 * 1024,
             PageCacheBytes = 1024 * 1024,
             FlushDelay = TimeSpan.FromMilliseconds(10),
+            RequiresActivation = requiresActivation,
         }, services);
 
     private IServiceProvider CreateServices()

--- a/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
+++ b/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
@@ -260,6 +260,24 @@ public class KvasarKvasTest(ITestOutputHelper @out) : TestBase(@out), IAsyncLife
     }
 
     [Fact]
+    public async Task ReactivatingAKeyBeingClosedStillOpensTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Activate("aaaa1111");
+
+        // act
+        await kvas.Activate("bbbb2222"); // Starts closing + deleting aaaa1111 in the background
+        await kvas.Activate("aaaa1111"); // Must wait for that close: the store lock is exclusive
+        await kvas.Set("a", "a");
+
+        // assert
+        (await kvas.Get<string>("a")).Should().Be("a");
+        await WhenFolderNamesAre(["Store-aaaa1111"]);
+    }
+
+    [Fact]
     public async Task ActivateSweepsStaleKeyFoldersTest()
     {
         // arrange

--- a/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
+++ b/tests/Core.UnitTests/Kvas/KvasarKvasTest.cs
@@ -224,6 +224,42 @@ public class KvasarKvasTest(ITestOutputHelper @out) : TestBase(@out), IAsyncLife
     }
 
     [Fact]
+    public async Task ActivateWhileSuspendedDefersToResumeTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+        await kvas.Suspend();
+
+        // act
+        await kvas.Activate("aaaa1111");
+        var whenSuspended = await kvas.Get<string>("a");
+        kvas.Resume();
+        await kvas.Set("a", "a");
+
+        // assert
+        whenSuspended.Should().BeNull();
+        (await kvas.Get<string>("a")).Should().Be("a");
+    }
+
+    [Fact]
+    public async Task SupersededSweepKeepsTheLiveFolderTest()
+    {
+        // arrange
+        var services = CreateServices();
+        await using var kvas = CreateKvas(services, requiresActivation: true);
+
+        // act
+        await kvas.Activate("aaaa1111");
+        await kvas.Activate("bbbb2222");
+        await kvas.Set("b", "b");
+
+        // assert
+        await WhenFolderNamesAre(["Store-bbbb2222"]);
+        (await kvas.Get<string>("b")).Should().Be("b");
+    }
+
+    [Fact]
     public async Task ActivateSweepsStaleKeyFoldersTest()
     {
         // arrange


### PR DESCRIPTION
Follow-up to #4208.

## Problem

Every client call passes `Session.Default`, so the real session id never reaches an `RpcCacheKey` — the persistent computed cache cannot tell one session's entries from another's, and it outlives the process. #4208 handled the in-memory side (`ComputedRegistry.InvalidateEverything()` on a swap); the on-disk side still relied on `ReloadUI.Reload(true, true)` happening to pass `clearCaches: true`.

Two ways that leaked the previous account's cached data to the next session:

1. **The clear silently no-ops.** `AppRemoteComputedCache.Clear` returns early when `!WhenInitialized.IsCompleted`; `KvasarKvas.Clear` no-ops while the store is suspended (iOS backgrounding) or if it failed to open. All three report success.
2. **`Acquire`'s create-session branch never cleared at all** — reachable whenever `SecureStorage` throws and `Read` returns `null`, which the surrounding code already documents as a real MAUI failure mode.

`Reload()` also revalidates the session on *every* call while defaulting to `clearCaches: false`, so `MauiBlazorApp`, `NavbarLogoMenu`, `SystemTestPage` and `UnknownGuideContent` could rotate the session and then serve the previous one's cached values to it.

## Approach

**Key the storage instead of clearing it.** A keyed `KvasarKvas` lives in `<BasePath>-<key>` and stays a no-op until `Activate` picks the key, so `ccc-<sessionHash>` separates sessions by path. What one session wrote is unreachable from another whether or not any deletion succeeds — deleting the old folder becomes disk reclamation, and failing at it costs space rather than privacy. Both failure modes above stop being correctness bugs.

This is what the web has done all along: `WebKvasBackend` stamps `SessionHash` into its version key and wipes on mismatch. Same idea, per-session folders instead of a wipe — so switching back to a session that still has its folder keeps its cache.

Notes on the implementation:

- `Activate`/`Deactivate` reuse the close-and-reopen machinery `Suspend`/`Resume` already had, so the `KvasarKvas` instance stays put. `MauiBackgroundState.RegisterStateHandler` is add-only, so a per-session instance would leak a suspend handler on every rotation.
- Neither blocks the caller: `Activate` returns once the new store is open, while closing the old store, deleting its folder and sweeping folders left by earlier crashes all run in the background.
- `MauiSession` activates on every path that establishes or changes the session, and switches before storing the new id, so a crash in between leaves the old id with a cold cache rather than the new id sitting on the old session's entries.
- The registry drop stays where a session actually *changes*: `Acquire` returns early once a session is set, so nothing session-scoped exists to invalidate there.

## Three races found in review, fixed here

Each is cache loss rather than a cross-session read — a store object only ever touches its own key's path — but each is silent.

- **A superseded sweep could delete the live folder.** `SweepKeyFolders` captured the key-to-keep when `Activate` scheduled it and never re-checked, so with two `Activate`s in flight the first one's sweep could delete the second's folder. Reachable on the real startup path, where the first sweep has an RPC round trip and a disconnect to fall behind in. Fixed with a generation stamp re-read under the lock per folder; `DeleteKeyFolder` got the same guard for `Activate(a) → Activate(b) → Activate(a)`.
- **An open could race the close of the key it reopens.** Switching away closes the old store in the background and Kvasar opens its lock file `FileShare.None`, so `Activate(a) → Activate(b) → Activate(a)` could hit `KvasarLockException`, which `Open` reads as "already open in another process" and degrades to a null store — the cache then does nothing for the rest of the run. `Suspend` → `Resume` had the same shape and predates this PR. Fixed by serialising closes and deletes through one maintenance chain that every open awaits.
- **A dispose/activate race leaked an open store.** `IsDisposed` is `SafeAsyncDisposableBase`'s `_disposeTask`, published only *after* `DisposeAsync(bool)` returns — so `Detach()` runs while it's still false and a concurrent `Activate` could open a store nothing would close. `Detach` now sets its own flag under the lock.

The sweep is deliberately **not** in that chain: it's a recursive directory delete, and neither an open nor iOS suspension (which blocks the main thread on a 3s budget) should ever wait behind disk reclamation.

## Second commit, unrelated and independently revertable

`SystemTestPage`'s "Locally" button calls `ComputedRegistry.InvalidateEverything()`, which under the Server render mode runs in the server process and drops every computed the host holds, across every circuit and every server-side compute service. Admin-gated, so a foot-gun rather than an exposure; "On this front-end" already scopes it by `HostId`.

## Verification

- `KvasarKvasTest`: **15/15 pass, 8 new** — inert-before-activate, isolation across keys, reuse of the same key, `Deactivate(clear)`, activate-while-suspended, the stale-folder sweep, a superseded sweep keeping the live folder, and reopening a key mid-close.
- Builds clean: `App.Maui` (net11.0-android), `App.Server` (incl. WASM), `App.Maui.IosShareExt`.
- **Not exercised on a device** — worth a sign-out → sign-in pass on Android and iOS before merge.

One caveat: `ReactivatingAKeyBeingClosedStillOpens` and `SupersededSweepKeepsTheLiveFolder` pin the intended outcome but are timing-dependent, so they wouldn't reliably catch a regression. Both guards are correct by inspection.

## Known / deliberate

- **`Session.Hash` is a 32-bit non-crypto hash** (`((uint)Id.GetXxHash3()).ToString("x8")`) — 8 lowercase hex chars. A collision would reuse another session's folder, at roughly 1 in 4 billion per rotation. It's the same value the web already stamps; moving to a truncated `Sha256Hash` is a one-liner.
- **`LocalSettings` is still not session-scoped** on MAUI, though the web treats its store as session-dependent. Sign-out clears it via `clearLocalSettings`, but a bare `Reload()` that rotates the session does not.
- **The iOS share extension keeps its cache.** Making the store keyed left it inert, since it loads `MauiModule` but had nothing calling `Activate`. Activating it is safe: the entitlements grant a shared *keychain* group but no App Group, so the extension gets its own data container and its cache can neither see nor contend with the main app's. (An earlier revision of this PR left it inert on the theory that the main app's sweep could delete its folders — that turned out to be impossible for the same reason.)

## Follow-ups

#4218 is stacked on this branch and addresses the rest of the #4208 review: the `ValidateSession` timeout that stranded the app on a deactivated session, rotation not being single-flight, `Revalidate`'s `Tracer.MethodRegion()` sitting outside its `try`, and the main-thread `clearCaches` work — which it removes outright, since this PR makes it redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfod9zd7A9oVjDaNPHF736
