### PR TITLE
fix: Detect lost render batches, recover the WebView app, and stop rendering while backgrounded

### DIFF
--- a/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
@@ -47,7 +47,7 @@ public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub, IPost
     private RenderGate RenderGate => field ??= Services.GetRequiredService<RenderGate>();
 
     protected override bool ShouldRender()
-        => base.ShouldRender() && !RenderGate.TryPostpone(this);
+        => !RenderGate.TryPostpone(this);
 
     void IPostponableRenderer.ResumeRender()
         => _ = InvokeAsync(() => {

--- a/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
@@ -6,7 +6,7 @@ namespace ActualChat.UI.Blazor;
 /// <summary>
 /// Base class for Blazor components with typed <see cref="UIHub"/> access and service shortcuts.
 /// </summary>
-public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub
+public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub, IPostponableRenderer
     where THub : UIHub
 {
     [Inject] protected THub Hub { get; init; } = null!;
@@ -43,6 +43,21 @@ public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub
     // Shortcuts
     protected bool IsPrerendering => Hub.IsPrerendering;
     protected bool IsInteractive => Hub.IsInteractive;
+
+    private RenderGate RenderGate => field ??= Services.GetRequiredService<RenderGate>();
+
+    protected override bool ShouldRender()
+        => base.ShouldRender() && !RenderGate.TryPostpone(this);
+
+    void IPostponableRenderer.ResumeRender()
+        => _ = InvokeAsync(() => {
+            try {
+                StateHasChanged();
+            }
+            catch {
+                // An earlier replay in the same pass may already have removed this component
+            }
+        });
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
@@ -6,7 +6,7 @@ namespace ActualChat.UI.Blazor;
 /// <summary>
 /// Base class for Blazor components with typed <see cref="UIHub"/> access and service shortcuts.
 /// </summary>
-public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub, IPostponableRenderer
+public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub
     where THub : UIHub
 {
     [Inject] protected THub Hub { get; init; } = null!;
@@ -48,9 +48,6 @@ public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub, IPost
 
     protected override bool ShouldRender()
         => !RenderGate.TryPostpone(this);
-
-    void IPostponableRenderer.ResumeRender()
-        => this.NotifyStateHasChanged();
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComponentBase.cs
@@ -50,14 +50,7 @@ public abstract class ComponentBase<THub> : ComponentBase, IHasCircuitHub, IPost
         => !RenderGate.TryPostpone(this);
 
     void IPostponableRenderer.ResumeRender()
-        => _ = InvokeAsync(() => {
-            try {
-                StateHasChanged();
-            }
-            catch {
-                // An earlier replay in the same pass may already have removed this component
-            }
-        });
+        => this.NotifyStateHasChanged();
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
@@ -6,7 +6,7 @@ namespace ActualChat.UI.Blazor;
 /// <summary>
 /// Base class for Blazor components with computed state and typed <see cref="UIHub"/> access.
 /// </summary>
-public abstract class ComputedStateComponent<THub, TState> : ComputedStateComponent<TState>, IPostponableRenderer
+public abstract class ComputedStateComponent<THub, TState> : ComputedStateComponent<TState>
     where THub : UIHub
 {
     private THub? _hub;
@@ -52,7 +52,4 @@ public abstract class ComputedStateComponent<THub, TState> : ComputedStateCompon
 
     protected override bool ShouldRender()
         => base.ShouldRender() && !RenderGate.TryPostpone(this);
-
-    void IPostponableRenderer.ResumeRender()
-        => this.NotifyStateHasChanged();
 }

--- a/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
@@ -54,12 +54,5 @@ public abstract class ComputedStateComponent<THub, TState> : ComputedStateCompon
         => base.ShouldRender() && !RenderGate.TryPostpone(this);
 
     void IPostponableRenderer.ResumeRender()
-        => _ = InvokeAsync(() => {
-            try {
-                StateHasChanged();
-            }
-            catch {
-                // An earlier replay in the same pass may already have removed this component
-            }
-        });
+        => this.NotifyStateHasChanged();
 }

--- a/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/ComputedStateComponent.cs
@@ -6,7 +6,7 @@ namespace ActualChat.UI.Blazor;
 /// <summary>
 /// Base class for Blazor components with computed state and typed <see cref="UIHub"/> access.
 /// </summary>
-public abstract class ComputedStateComponent<THub, TState> : ComputedStateComponent<TState>
+public abstract class ComputedStateComponent<THub, TState> : ComputedStateComponent<TState>, IPostponableRenderer
     where THub : UIHub
 {
     private THub? _hub;
@@ -47,4 +47,19 @@ public abstract class ComputedStateComponent<THub, TState> : ComputedStateCompon
         _hub ??= (THub)CircuitHub;
         return base.SetParametersAsync(parameters);
     }
+
+    private RenderGate RenderGate => field ??= Hub.Services.GetRequiredService<RenderGate>();
+
+    protected override bool ShouldRender()
+        => base.ShouldRender() && !RenderGate.TryPostpone(this);
+
+    void IPostponableRenderer.ResumeRender()
+        => _ = InvokeAsync(() => {
+            try {
+                StateHasChanged();
+            }
+            catch {
+                // An earlier replay in the same pass may already have removed this component
+            }
+        });
 }

--- a/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
@@ -3,7 +3,7 @@ using ActualChat.UI.Blazor.Services;
 
 namespace ActualChat.UI.Blazor;
 
-public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircuitHub, IPostponableRenderer
+public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircuitHub
     where THub : UIHub
 {
     [Inject] protected THub Hub { get; init; } = null!;
@@ -46,9 +46,6 @@ public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircu
 
     protected override bool ShouldRender()
         => !RenderGate.TryPostpone(this);
-
-    void IPostponableRenderer.ResumeRender()
-        => this.NotifyStateHasChanged();
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
@@ -3,7 +3,7 @@ using ActualChat.UI.Blazor.Services;
 
 namespace ActualChat.UI.Blazor;
 
-public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircuitHub
+public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircuitHub, IPostponableRenderer
     where THub : UIHub
 {
     [Inject] protected THub Hub { get; init; } = null!;
@@ -41,6 +41,21 @@ public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircu
     protected bool IsPrerendering => Hub.IsPrerendering;
     protected bool IsInteractive => Hub.IsInteractive;
     protected bool ShouldAutoFocusField => Hub.BrowserInfo.ShouldAutoFocusField;
+
+    private RenderGate RenderGate => field ??= Services.GetRequiredService<RenderGate>();
+
+    protected override bool ShouldRender()
+        => base.ShouldRender() && !RenderGate.TryPostpone(this);
+
+    void IPostponableRenderer.ResumeRender()
+        => _ = InvokeAsync(() => {
+            try {
+                StateHasChanged();
+            }
+            catch {
+                // An earlier replay in the same pass may already have removed this component
+            }
+        });
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
@@ -45,7 +45,7 @@ public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircu
     private RenderGate RenderGate => field ??= Services.GetRequiredService<RenderGate>();
 
     protected override bool ShouldRender()
-        => base.ShouldRender() && !RenderGate.TryPostpone(this);
+        => !RenderGate.TryPostpone(this);
 
     void IPostponableRenderer.ResumeRender()
         => _ = InvokeAsync(() => {

--- a/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/FusionComponentBase.cs
@@ -48,14 +48,7 @@ public abstract class FusionComponentBase<THub> : FusionComponentBase, IHasCircu
         => !RenderGate.TryPostpone(this);
 
     void IPostponableRenderer.ResumeRender()
-        => _ = InvokeAsync(() => {
-            try {
-                StateHasChanged();
-            }
-            catch {
-                // An earlier replay in the same pass may already have removed this component
-            }
-        });
+        => this.NotifyStateHasChanged();
 
     // Explicit IHasFusionHub & IHasServices implementation
     CircuitHub IHasCircuitHub.CircuitHub => Hub;

--- a/src/dotnet/UI.Blazor/BaseTypes/IPostponableRenderer.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/IPostponableRenderer.cs
@@ -1,0 +1,9 @@
+namespace ActualChat.UI.Blazor;
+
+/// <summary>
+/// A component whose render <see cref="RenderGate"/> may hold back and replay later.
+/// </summary>
+public interface IPostponableRenderer
+{
+    void ResumeRender();
+}

--- a/src/dotnet/UI.Blazor/BaseTypes/IPostponableRenderer.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/IPostponableRenderer.cs
@@ -1,9 +1,0 @@
-namespace ActualChat.UI.Blazor;
-
-/// <summary>
-/// A component whose render <see cref="RenderGate"/> may hold back and replay later.
-/// </summary>
-public interface IPostponableRenderer
-{
-    void ResumeRender();
-}

--- a/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
@@ -1,0 +1,81 @@
+namespace ActualChat.UI.Blazor;
+
+// A backgrounded WebView stops acknowledging Blazor's render batches while .NET keeps producing
+// them, and every batch produced in that window is one the host can drop - which desyncs the
+// renderer permanently. Holding renders back until the app is visible keeps that window empty.
+public sealed class RenderGate : WorkerBase
+{
+    // Elsewhere the render batch transport is in-process, so nothing can be lost and postponing
+    // would only add latency.
+    public const bool IsEnabledOnMauiApp = true;
+
+    private readonly BackgroundStateTracker? _backgroundStateTracker;
+    private readonly HashSet<IPostponableRenderer> _postponed = new();
+    private readonly Lock _lock = new();
+
+    private ILogger Log { get; }
+    public bool IsEnabled => _backgroundStateTracker != null;
+
+    public RenderGate(IServiceProvider services)
+    {
+        Log = services.LogFor(GetType());
+        _backgroundStateTracker = IsEnabledOnMauiApp && services.HostInfo().HostKind.IsMauiApp()
+            ? services.GetService<BackgroundStateTracker>()
+            : null;
+        if (IsEnabled)
+            this.Start();
+    }
+
+    // Runs inside ShouldRender for every component on every render, so it must never throw:
+    // one exception here would stop the whole app rendering rather than one component.
+    public bool TryPostpone(IPostponableRenderer renderer)
+    {
+        if (_backgroundStateTracker is not { } backgroundStateTracker)
+            return false;
+
+        var computed = backgroundStateTracker.IsBackground.Computed;
+        if (computed.HasError || !computed.Value)
+            return false;
+
+        lock (_lock)
+            _postponed.Add(renderer);
+        return true;
+    }
+
+    // Protected methods
+
+    protected override async Task OnRun(CancellationToken cancellationToken)
+    {
+        var isBackgroundState = _backgroundStateTracker!.IsBackground;
+        var cIsBackground = await Computed
+            .Capture(() => isBackgroundState.Use(cancellationToken), cancellationToken)
+            .ConfigureAwait(false);
+        var wasBackground = cIsBackground.Value;
+        await foreach (var c in cIsBackground.Changes(cancellationToken).ConfigureAwait(false)) {
+            if (c.HasError)
+                continue;
+
+            var isBackground = c.Value;
+            if (wasBackground && !isBackground)
+                Resume();
+            wasBackground = isBackground;
+        }
+    }
+
+    // Private methods
+
+    private void Resume()
+    {
+        IPostponableRenderer[] postponed;
+        lock (_lock) {
+            if (_postponed.Count == 0)
+                return;
+
+            postponed = _postponed.ToArray();
+            _postponed.Clear();
+        }
+        Log.LogInformation("Resuming {Count} postponed render(s)", postponed.Length);
+        foreach (var renderer in postponed)
+            renderer.ResumeRender();
+    }
+}

--- a/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
@@ -10,7 +10,7 @@ public sealed class RenderGate : WorkerBase
     public const bool IsEnabledOnMauiApp = true;
 
     private readonly BackgroundStateTracker? _backgroundStateTracker;
-    private readonly HashSet<IPostponableRenderer> _postponed = new();
+    private readonly HashSet<ComponentBase> _postponed = new();
     private readonly Lock _lock = new();
 
     private ILogger Log { get; }
@@ -28,7 +28,7 @@ public sealed class RenderGate : WorkerBase
 
     // Runs inside ShouldRender for every component on every render, so it must never throw:
     // one exception here would stop the whole app rendering rather than one component.
-    public bool TryPostpone(IPostponableRenderer renderer)
+    public bool TryPostpone(ComponentBase renderer)
     {
         if (_backgroundStateTracker is not { } backgroundStateTracker)
             return false;
@@ -66,7 +66,7 @@ public sealed class RenderGate : WorkerBase
 
     private void Resume()
     {
-        IPostponableRenderer[] postponed;
+        ComponentBase[] postponed;
         lock (_lock) {
             if (_postponed.Count == 0)
                 return;
@@ -76,6 +76,6 @@ public sealed class RenderGate : WorkerBase
         }
         Log.LogInformation("Resuming {Count} postponed render(s)", postponed.Length);
         foreach (var renderer in postponed)
-            renderer.ResumeRender();
+            renderer.NotifyStateHasChanged();
     }
 }

--- a/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
+++ b/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
@@ -107,6 +107,7 @@ public sealed class BlazorUICoreModule(IServiceProvider moduleServices)
             services.AddScoped<AudioFocusUI>(_ => new AudioFocusUI());
             services.AddScoped<TuneUI>(c => new WebTuneUI(c.UIHub()));
         }
+        services.AddScoped(c => new RenderGate(c));
         services.AddScoped(c => new ClipboardUI(c.UIHub()));
         services.AddScoped(c => new ExternalUrlOpener(c.UIHub()));
         services.AddScoped(c => new ExternalMapOpener(c.UIHub()));

--- a/src/dotnet/UI.Blazor/Services/AppRecovery/app-recovery.ts
+++ b/src/dotnet/UI.Blazor/Services/AppRecovery/app-recovery.ts
@@ -1,0 +1,212 @@
+import { ConnectivityUI } from '../ConnectivityUI/connectivity-ui';
+import { EventHandlerSet } from 'event-handling';
+import { PromiseSource } from 'actuallab-core';
+import { getLogs } from 'logging';
+import { RenderSync } from 'render-sync';
+
+const { infoLog, warnLog, errorLog } = getLogs('AppRecovery');
+
+// Blazor's WebView IPC wire format is `__bwv:["RenderBatch",<id>,"<base64>"]`. Matching the prefix and
+// slicing the id out beats JSON.parse, which would decode the whole batch payload on every render.
+const RenderBatchPrefix = '__bwv:["RenderBatch",';
+
+interface OpusMediaRecorderHost {
+    opusMediaRecorder?: { stop: () => Promise<void> };
+}
+
+// Everything that gets the app out of a state it can't leave on its own: Blazor's reconnect and
+// fatal-error overlays, and - on MAUI - a gap in the render batch sequence. All three end in
+// startReloading(), which is idempotent: the first caller wins and the rest are no-ops.
+export class AppRecovery {
+    public static readonly whenReloading = new PromiseSource<void>();
+    public static readonly reconnectedEvents = new EventHandlerSet<void>();
+    public static connectionState = '';
+    public static reconnectingPromise: Promise<void> | null = null;
+    private static lastRenderBatchId = 0;
+
+    public static start(): void {
+        if (document.readyState === 'loading')
+            document.addEventListener('DOMContentLoaded', () => this.startOverlayWatchers());
+        else
+            this.startOverlayWatchers();
+    }
+
+    // Registered right after RenderSync.init(), which already owns the host message seam, so the
+    // very first batch is seen. MAUI-only: a WebView whose renderer stops consuming messages while
+    // .NET keeps producing them is a mobile-app failure mode - a browser tab's Blazor IPC is
+    // in-process, and WASM applies its batches synchronously.
+    public static startRenderBatchWatch(): void {
+        if (!ConnectivityUI.isMauiApp)
+            return;
+
+        RenderSync.observer = message => this.onIpcMessage(message);
+    }
+
+    public static resetAppConnectionState(): void {
+        if (this.connectionState === '')
+            return; // Already reset
+
+        this.setAppConnectionState();
+        this.reconnectedEvents.triggerSilently();
+    }
+
+    public static startReconnecting(mustReconnectBlazor: boolean): void {
+        this.setAppConnectionState('Reconnecting...');
+        if (!mustReconnectBlazor)
+            return;
+
+        this.reconnectingPromise ??= (async (): Promise<void> => {
+            try {
+                const blazor = window['Blazor'] as { reconnect?: () => Promise<boolean> } | undefined;
+                if (!blazor?.reconnect) {
+                    // No Blazor reconnect = it's WASM & something is severely wrong,
+                    // so the best we can do is to reload the page.
+                    void this.startReloading();
+                    return;
+                }
+
+                await ConnectivityUI.whenReadyToReload('reconnecting');
+                if (this.whenReloading.isCompleted)
+                    return; // Already reloading
+
+                warnLog?.log('startReconnecting: reconnecting...');
+                try {
+                    if (await blazor.reconnect())
+                        return;
+                }
+                catch {
+                    // We assume it may fail
+                }
+
+                errorLog?.log('startReconnecting: failed to reconnect, will reload...');
+                void this.startReloading();
+            }
+            finally {
+                this.reconnectingPromise = null;
+            }
+        })();
+    }
+
+    public static async startReloading(): Promise<void> {
+        if (this.whenReloading.isCompleted)
+            return; // Already reloading
+
+        if (!ConnectivityUI.isMauiApp) // No "Reloading..." on MAUI app
+            this.setAppConnectionState('Reloading...');
+
+        warnLog?.log('startReloading: reloading...');
+        this.whenReloading.resolve(undefined);
+
+        const opusMediaRecorder = (window as unknown as OpusMediaRecorderHost).opusMediaRecorder;
+        await opusMediaRecorder?.stop();
+
+        await ConnectivityUI.whenReadyToReload('reloading');
+        window.location.reload();
+    }
+
+    // Private methods
+
+    private static startOverlayWatchers(): void {
+        const errors: string[] = [];
+        const reconnectDiv = document.getElementById('components-reconnect-modal');
+        if (reconnectDiv) {
+            const checkReconnectDiv = () => {
+                if (this.whenReloading.isCompleted)
+                    return;
+
+                const classList = reconnectDiv.classList;
+                if (classList.length == 0 || classList.contains('components-reconnect-hide'))
+                    this.resetAppConnectionState();
+                else if (classList.contains('components-reconnect-rejected')) {
+                    warnLog?.log(
+                        'startReloading: triggered by #components-reconnect-modal',
+                        { classes: reconnectDiv.className, text: reconnectDiv.innerText.trim().slice(0, 300) });
+                    void this.startReloading();
+                }
+                else if (classList.contains('components-reconnect-failed'))
+                    this.startReconnecting(true);
+                else if (classList.contains('components-reconnect-show'))
+                    this.startReconnecting(false);
+            };
+            const observer = new MutationObserver(() => checkReconnectDiv());
+            observer.observe(reconnectDiv, { attributes: true });
+            checkReconnectDiv();
+        }
+        else
+            errors.push('no reconnectDiv');
+
+        const errorDiv = document.getElementById('blazor-error-ui');
+        if (errorDiv) {
+            const checkErrorDiv = () => {
+                if (errorDiv.style.display === 'block') {
+                    warnLog?.log(
+                        'startReloading: triggered by #blazor-error-ui',
+                        { text: errorDiv.innerText.trim().slice(0, 300) });
+                    void this.startReloading();
+                }
+            };
+            const observer = new MutationObserver(() => checkErrorDiv());
+            observer.observe(errorDiv, { attributes: true });
+            checkErrorDiv();
+        }
+        else
+            errors.push('no errorDiv');
+
+        if (errors.length === 0)
+            infoLog?.log('startOverlayWatchers: completed');
+        else
+            errorLog?.log('startOverlayWatchers: errors:', errors);
+    }
+
+    private static onIpcMessage(data: string): void {
+        if (this.whenReloading.isCompleted || !data.startsWith(RenderBatchPrefix))
+            return;
+
+        const idEnd = data.indexOf(',', RenderBatchPrefix.length);
+        const batchId = idEnd < 0 ? NaN : Number(data.slice(RenderBatchPrefix.length, idEnd));
+        if (!Number.isFinite(batchId))
+            return;
+
+        const lastBatchId = this.lastRenderBatchId;
+        this.lastRenderBatchId = batchId;
+        // A backwards id means .NET built a new page context against this same document, which restarts
+        // the sequence - not a loss. Only the first id after attaching is 0, and that has no predecessor.
+        if (lastBatchId === 0 || batchId <= lastBatchId + 1)
+            return;
+
+        warnLog?.log(
+            'startReloading: triggered by a render batch gap',
+            { lost: batchId - lastBatchId - 1, expected: lastBatchId + 1, received: batchId });
+        void this.startReloading();
+    }
+
+    private static setAppConnectionState(state = ''): void {
+        if (this.connectionState === state)
+            return;
+
+        this.connectionState = state;
+        if (this.whenReloading.isCompleted)
+            return;
+
+        const appConnectionStateDiv = document.getElementById('app-connection-state');
+        if (!appConnectionStateDiv)
+            return;
+
+        if (state) {
+            appConnectionStateDiv.innerHTML = `
+                <div class="c-bg"></div>
+                <div class="c-circle-blur"></div>
+                <div class="c-circle">
+                    <!-- Must have open and close tags, otherwise doesn't work! -->
+                    <loading-cat-svg></loading-cat-svg>
+                    <span class="c-text">${state}</span>
+                </div>
+            `;
+            appConnectionStateDiv.style.display = '';
+        }
+        else {
+            appConnectionStateDiv.innerHTML = '';
+            appConnectionStateDiv.style.display = 'none';
+        }
+    }
+}

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
@@ -1,8 +1,8 @@
 // TODO: fix eslint errors
 /* eslint-disable @typescript-eslint/no-unnecessary-condition,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-argument */
 import { Api, streamingApi, uploadsApi } from 'api';
+import { AppRecovery } from '../AppRecovery/app-recovery';
 import { ConnectivityUI } from '../ConnectivityUI/connectivity-ui';
-import { EventHandlerSet } from 'event-handling';
 import { delayAsync, PromiseSource } from 'actuallab-core';
 import { AppKind, BrowserInfo, HostKind } from '../BrowserInfo/browser-info';
 import { getLogs } from 'logging';
@@ -29,10 +29,6 @@ export class BrowserInit {
     public static firebasePublicKey?: string;
     public static readonly isMauiApp = ConnectivityUI.isMauiApp;
     public static readonly whenInitialized = new PromiseSource<void>();
-    public static readonly whenReloading = new PromiseSource<void>();
-    public static readonly reconnectedEvents = new EventHandlerSet<void>();
-    public static connectionState = '';
-    public static reconnectingPromise: Promise<void> = null!;
     private static isAppReady = false;
 
     public static init(
@@ -74,7 +70,7 @@ export class BrowserInit {
             errorLog?.log('init: error:', e);
             this.whenInitialized.reject(e);
             // We can't do much in this case, so...
-            void this.startReloading();
+            void AppRecovery.startReloading();
         }
         finally {
             this.whenInitialized.resolve(undefined);
@@ -89,128 +85,6 @@ export class BrowserInit {
     public static getUrl(url: string) : string {
         const baseUri = BrowserInit.baseUri;
         return baseUri ? new URL(url, baseUri).toString() : url;
-    }
-
-    public static resetAppConnectionState(): void {
-        if (this.connectionState === '')
-            return; // Already reset
-
-        this.setAppConnectionState();
-        this.reconnectedEvents.triggerSilently();
-    }
-
-    public static startReconnecting(mustReconnectBlazor : boolean): void {
-        this.setAppConnectionState('Reconnecting...');
-        if (!mustReconnectBlazor)
-            return;
-
-        this.reconnectingPromise ??= (async (): Promise<void> => {
-            try {
-                const blazor = window['Blazor'] as { reconnect: () => Promise<boolean> };
-                if (!blazor?.reconnect) {
-                    // No Blazor reconnect = it's WASM & something is severely wrong,
-                    // so the best we can do is to reload the page.
-                    void this.startReloading();
-                    return;
-                }
-
-                await ConnectivityUI.whenReadyToReload('reconnecting');
-                if (this.whenReloading.isCompleted)
-                    return; // Already reloading
-
-                warnLog?.log('startReconnecting: reconnecting...');
-                try {
-                    if (await blazor.reconnect())
-                        return;
-                }
-                catch {
-                    // We assume it may fail
-                }
-
-                errorLog?.log('startReconnecting: failed to reconnect, will reload...');
-                void this.startReloading();
-            }
-            finally {
-                this.reconnectingPromise = null!;
-            }
-        })();
-    }
-
-    public static async startReloading(): Promise<void> {
-        if (this.whenReloading.isCompleted)
-            return; // Already reloading
-
-        if (!this.isMauiApp) // No "Reloading..." on MAUI app
-            this.setAppConnectionState('Reloading...');
-
-        warnLog?.log('startReloading: reloading...');
-        this.whenReloading.resolve(undefined);
-
-        // @ts-expect-error because of the `window.opusMediaRecorder`
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        await window?.opusMediaRecorder?.stop();
-
-        await ConnectivityUI.whenReadyToReload('reloading');
-        window.location.reload();
-    }
-
-    public static startReloadWatchers() {
-        const attachWatchers = () => {
-            const errors: string[] = [];
-            const reconnectDiv = document.getElementById('components-reconnect-modal');
-            if (reconnectDiv) {
-                const checkReconnectDiv = () => {
-                    if (this.whenReloading.isCompleted)
-                        return;
-
-                    const classList = reconnectDiv.classList;
-                    if (classList.length == 0 || classList.contains('components-reconnect-hide'))
-                        this.resetAppConnectionState();
-                    else if (classList.contains('components-reconnect-rejected')) {
-                        warnLog?.log(
-                            'startReloading: triggered by #components-reconnect-modal',
-                            { classes: reconnectDiv.className, text: reconnectDiv.innerText?.trim().slice(0, 300) });
-                        void this.startReloading();
-                    }
-                    else if (classList.contains('components-reconnect-failed'))
-                        this.startReconnecting(true);
-                    else if (classList.contains('components-reconnect-show'))
-                        this.startReconnecting(false);
-                }
-                const observer = new MutationObserver(() => checkReconnectDiv());
-                observer.observe(reconnectDiv, { attributes: true });
-                checkReconnectDiv();
-            }
-            else
-                errors.push('no reconnectDiv');
-
-            const errorDiv = document.getElementById('blazor-error-ui');
-            if (errorDiv) {
-                const checkErrorDiv = () => {
-                    if (errorDiv.style.display === 'block') {
-                        warnLog?.log(
-                            'startReloading: triggered by #blazor-error-ui',
-                            { text: errorDiv.innerText?.trim().slice(0, 300) });
-                        void this.startReloading();
-                    }
-                }
-                const observer = new MutationObserver(() => checkErrorDiv());
-                observer.observe(errorDiv, { attributes: true });
-                checkErrorDiv();
-            }
-            else
-                errors.push('no errorDiv');
-
-            if (errors.length === 0)
-                infoLog?.log(`startReloadWatchers: completed`);
-            else
-                errorLog?.log(`startReloadWatchers: errors:`, errors);
-        }
-
-        if (document.readyState === 'loading')
-            document.addEventListener('DOMContentLoaded', () => attachWatchers());
-        else
-            attachWatchers();
     }
 
     public static removeWebSplash(instantly = false) {
@@ -399,36 +273,6 @@ export class BrowserInit {
         }
 
         void keepWebLock();
-    }
-
-    private static setAppConnectionState(state = ''): void {
-        if (this.connectionState === state)
-            return;
-
-        this.connectionState = state;
-        if (this.whenReloading.isCompleted)
-            return;
-
-        const appConnectionStateDiv = document.getElementById('app-connection-state');
-        if (!appConnectionStateDiv)
-            return;
-
-        if (state) {
-            appConnectionStateDiv.innerHTML = `
-                <div class="c-bg"></div>
-                <div class="c-circle-blur"></div>
-                <div class="c-circle">
-                    <!-- Must have open and close tags, otherwise doesn't work! -->
-                    <loading-cat-svg></loading-cat-svg>
-                    <span class="c-text">${state}</span>
-                </div>
-            `;
-            appConnectionStateDiv.style.display = '';
-        }
-        else {
-            appConnectionStateDiv.innerHTML = '';
-            appConnectionStateDiv.style.display = 'none';
-        }
     }
 
     private static isProdBaseUri(baseUri: string): boolean {

--- a/src/dotnet/UI.Blazor/exports.ts
+++ b/src/dotnet/UI.Blazor/exports.ts
@@ -3,6 +3,7 @@ export * from './Services/BrowserInit/browser-init';
 
 // Please sort the imports alphabetically!
 export * from './Services/AccountUI/web-auth';
+export * from './Services/AppRecovery/app-recovery';
 export * from 'animation-sync';
 export * from './Services/BrowserInfo/browser-info';
 export * from './Services/Caching/remote-computed-cache';

--- a/src/nodejs/src/init.ts
+++ b/src/nodejs/src/init.ts
@@ -10,6 +10,7 @@ import { ServiceWorker } from 'service-worker';
 import { ScreenOrientation, DeviceOrientation } from 'orientation';
 import { CompactLayout } from 'compact-layout';
 import { MutationProcessor } from 'mutation-processor';
+import { AppRecovery } from '../../dotnet/UI.Blazor/Services/AppRecovery/app-recovery';
 import { BrowserInit } from '../../dotnet/UI.Blazor/Services/BrowserInit/browser-init';
 import '../../dotnet/UI.Blazor.App/Services/app-presence-classes';
 import '../../dotnet/UI.Blazor.App/Services/conversation-collapse';
@@ -20,6 +21,7 @@ import '../../dotnet/UI.Blazor.App/Services/conversation-collapse';
 // RenderSync itself is published so deferral can be switched on mid-call over the debugger,
 // which is the only way to A/B it against the same call rather than a different one.
 globalThis.renderSyncHook = RenderSync.init();
+AppRecovery.startRenderBatchWatch();
 globalThis.RenderSync = RenderSync;
 
 globalThis.ServerClock = ServerClock;
@@ -79,7 +81,7 @@ void (async () => {
     const app = window.App;
     if (app) {
         await app.whenBlazorReady;
-        BrowserInit.startReloadWatchers();
+        AppRecovery.start();
         void BrowserInit.startWebSplashRemoval(5_000);
     }
 })();

--- a/src/nodejs/src/logging.ts
+++ b/src/nodejs/src/logging.ts
@@ -33,6 +33,7 @@ export type { LogRef, LogScopeFns } from './actuallab-core/index.js';
 export type LogScope =
     | 'default'
     // Library
+    | 'AppRecovery'
     | 'Api'
     | 'AsyncProcessor'
     | 'AsyncVideoEncoder'
@@ -147,6 +148,7 @@ export type LogScope =
 const defaults: Record<LogScope, LogLevel> = {
     default: LogLevel.Warn,
     // Library
+    AppRecovery: LogLevel.Warn,
     Api: LogLevel.Warn,
     AsyncProcessor: LogLevel.Warn,
     AsyncVideoEncoder: LogLevel.Warn,

--- a/src/nodejs/src/render-sync.ts
+++ b/src/nodejs/src/render-sync.ts
@@ -30,6 +30,9 @@ const maxPendingCount = 32;
 // replacing it is the seam. Wrapping `receiveMessage` itself would be tidier but is
 // unreachable: it has already been called by the time any bundle code runs.
 const handlerGlobals = ['__dispatchMessageCallback', '__receiveMessageCallback'];
+// Android is the odd one out: its handler hangs off window.external rather than the global
+// scope, so the same seam needs a second lookup with a different root.
+const externalHandlerName = '__callback';
 
 type MessageHandler = (message: string) => void;
 
@@ -50,6 +53,8 @@ function flush(): void {
 }
 
 function onMessage(message: string, handler: MessageHandler): void {
+    // Ahead of the deferral so observers see arrival order, which is what a lost message shows up in.
+    RenderSync.observer?.(message);
     if (!isEnabled || !message.startsWith(renderBatchPrefix)) {
         // Interop must stay ordered against the DOM it reads: an ElementReference is
         // resolved by querySelector when the call runs, so it would silently miss an
@@ -72,6 +77,8 @@ function onMessage(message: string, handler: MessageHandler): void {
 }
 
 export class RenderSync {
+    public static observer: MessageHandler | null = null;
+
     public static get isEnabled(): boolean {
         return isEnabled;
     }
@@ -88,20 +95,27 @@ export class RenderSync {
     // No-op on every host that isn't a MAUI WebView - including WASM, where a render
     // batch must be applied synchronously because it holds a Mono heap pointer.
     //
-    // The global is normally still absent here: blazor.webview.js registers its handler
-    // from Blazor.start(), which runs after this deferred bundle. So the usual path is the
+    // The handler is normally still absent here: blazor.webview.js registers it from
+    // Blazor.start(), which runs after this deferred bundle. So the usual path is the
     // accessor below, which wraps whatever gets assigned, whenever that happens.
     public static init(): string | null {
-        const target = globalThis as unknown as Record<string, unknown>;
+        const globals = globalThis as unknown as Record<string, unknown>;
+        const external = (globalThis as unknown as { external?: Record<string, unknown> }).external;
         for (const name of handlerGlobals) {
-            const handler = target[name];
-            if (typeof handler === 'function') {
-                target[name] = RenderSync.wrap(handler as MessageHandler);
+            if (typeof globals[name] === 'function') {
+                globals[name] = RenderSync.wrap(globals[name] as MessageHandler);
                 return name;
             }
         }
+        if (external && typeof external[externalHandlerName] === 'function') {
+            external[externalHandlerName] = RenderSync.wrap(external[externalHandlerName] as MessageHandler);
+            return externalHandlerName;
+        }
+
         for (const name of handlerGlobals)
-            RenderSync.hookOnAssign(target, name);
+            RenderSync.hookOnAssign(globals, name);
+        if (external)
+            RenderSync.hookOnAssign(external, externalHandlerName);
         return null;
     }
 
@@ -119,8 +133,9 @@ export class RenderSync {
             set: (handler: MessageHandler) => {
                 wrapped = RenderSync.wrap(handler);
                 // Published only once it actually fires: "installed but never triggered"
-                // is the failure this whole indirection exists to make visible.
-                target['renderSyncHook'] = name;
+                // is the failure this whole indirection exists to make visible. Always on the
+                // global scope, even when the seam that fired was window.external's.
+                (globalThis as unknown as Record<string, unknown>)['renderSyncHook'] = name;
             },
         });
     }


### PR DESCRIPTION
Two commits, reviewable independently.

## Why

Blazor's `WebViewRenderer` requires render batch acknowledgements to arrive **in order**. Backgrounding the app on Android stops the WebView renderer consuming messages while .NET keeps rendering into it, so batches are lost. The first acknowledgement after the gap makes `NotifyRenderCompleted` throw — and it never resyncs, because it dequeues before validating:

```csharp
var nextUnacknowledgedBatch = _unacknowledgedRenderBatches.Dequeue();   // dequeued before validation
if (nextUnacknowledgedBatch.BatchId != batchId)
    throw new InvalidOperationException(...);
```

After that every later acknowledgement burns one more queued batch and throws again, and each stranded `TaskCompletionSource` means `OnAfterRenderAsync` never fires for those components. Components that create their JS objects there — `VirtualList` among them — are never initialized, which is what a chat view stuck on skeletons actually is.

Observed on a Samsung SM-S948U1 / Android 16, three times in one 90-minute capture:

```
InvalidOperationException: Received unexpected acknowledgement for render batch 375 (next batch should be 169)
```

The gap scales with time spent hidden — 10 batches over ~100s, 207 over 39 minutes.

Both upstream halves are filed separately with the .NET team (the dequeue-before-validate bug, and the missing backpressure that lets hundreds of batches queue).

## Commit 1 — detect and recover

**`AppRecovery`** — recovery logic moves out of `BrowserInit` into its own class: the reconnect overlay watcher, the fatal-error overlay watcher, `startReconnecting`, `startReloading` and the connection-state banner. No behaviour change in the move itself.

**Render batch gap detection (MAUI only)** — a discontinuity in the batch id is a direct signal that messages were lost, seen as it arrives instead of several hops later via `#blazor-error-ui` — an element this app deliberately styles to zero size and watches for `display: block`. The gap size is logged, which is what separates *a reload that was missed* from *a reload that never triggered*. The overlay watcher stays as the backstop.

**`RenderSync` Android seam** — `RenderSync` already owned the host message seam, so the detector observes it rather than hooking it a second time. Its handler list only covered iOS and Tizen (`__dispatchMessageCallback`); Android keeps its handler on `window.external.__callback`, so the seam had never installed on Android and `renderSyncHook` was `null` there. That also means `RenderSync`'s batch deferral could never have worked on Android — it's off by default, so nothing regressed, but it was never exercised either.

## Commit 2 — stop producing batches nobody is consuming

`ShouldRender` is the only lever an app has: `ComponentBase` consults it *before* enqueueing the component, so returning `false` means no batch is produced at all. `RenderGate` holds those components and replays them on resume — Blazor discards a suppressed render request rather than deferring it, so without the replay a component whose state changed while backgrounded would stay stale.

MAUI-only, via `IsEnabledOnMauiApp` plus a `HostKind` check.

**This is mitigation, not a guarantee.** Coverage is the three `UI.Blazor` base types — most of the app, but 17 of the 18 components that override `ShouldRender` themselves don't call `base`, so they keep rendering while backgrounded. One batch is enough to open a gap, which is why commit 1 stays.

## Risk

- The gap detector triggers the same `startReloading()` the overlay watcher already triggers, gated on `ConnectivityUI.isMauiApp`. Web and WASM unaffected.
- `RenderGate.TryPostpone` runs inside `ShouldRender` for every component on every render, so it is written to never throw — one exception there would stop the whole app rendering. Worth checking that reasoning holds.
- The `RenderSync` change now installs an accessor on `window.external` as well as `globalThis`.

## Verification

`tsc --noEmit` and `eslint` clean on the touched files; `npm run build:Debug` succeeds; `UI.Blazor` and `UI.Blazor.App` build clean.

**Not yet exercised on a device.** The failure needs a real backgrounded Android WebView, and commit 2 changes render behaviour for most components in the app — it deserves a device run before merge.

(Note: `ActualChat.CI.slnf` is stale on `dev` — it references `tests/Core.Benchmarks` which isn't in the solution — so a full filter build fails independently of this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQFFwGWZqoCEXWzupaHTsh
