### PR TITLE
feat(auth): replace the session when the server says it is unusable

### DIFF
--- a/src/dotnet/App.Maui/Services/MauiAppServerInstanceSelector.cs
+++ b/src/dotnet/App.Maui/Services/MauiAppServerInstanceSelector.cs
@@ -28,7 +28,9 @@ public sealed class MauiAppServerInstanceSelector(UIHub hub) : AppServerInstance
     {
         var hostOverride = instance != Default ? instance : null;
         MauiPreferences.HostOverride = hostOverride?.HostName;
+        // No cache clear: dropping the stored session means the next start mints a new one, and its
+        // folder is a different one - the old server's entries are swept rather than reused.
         _ = MauiSession.RemoveStored().SuppressExceptions();
-        _ = ReloadUI.Clear(true, true);
+        _ = ReloadUI.Clear(clearLocalSettings: true);
     }
 }

--- a/src/dotnet/App.Maui/Services/MauiReloadUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiReloadUI.cs
@@ -6,17 +6,15 @@ namespace ActualChat.App.Maui.Services;
 /// MAUI implementation of <see cref="ReloadUI"/> that recreates the WebView on reload.
 /// </summary>
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(MauiReloadUI))]
-public class MauiReloadUI(IServiceProvider services) : ReloadUI(services)
+public sealed class MauiReloadUI(IServiceProvider services) : ReloadUI(services)
 {
-    public override void Reload(bool clearCaches = false, bool clearLocalSettings = false)
+    public override void Reload(bool clearLocalSettings = false)
     {
         Log.LogInformation("Reload requested");
         _ = DispatchToMainThread(async () => {
             Log.LogInformation("Reloading...");
             try {
-                await Clear(clearCaches, clearLocalSettings).ConfigureAwait(true);
-                // Sign-out deactivates the session - mint a replacement before the new WebView binds it.
-                await Services.GetRequiredService<MauiSession>().Revalidate().ConfigureAwait(true);
+                await Clear(clearLocalSettings).ConfigureAwait(true);
                 MainPage.Current.RecreateWebView();
             }
             catch (Exception e) {
@@ -24,6 +22,14 @@ public class MauiReloadUI(IServiceProvider services) : ReloadUI(services)
                 Quit(); // We can't do much in this case
             }
         }, allowInline: false);
+    }
+
+    public override async Task ReplaceSession(CancellationToken cancellationToken)
+    {
+        // Nothing re-issues a MAUI session for us: it lives in the keychain, so it has to be minted,
+        // switched to and stored before the WebView the reload recreates binds to it.
+        await Services.GetRequiredService<MauiSession>().Replace(cancellationToken).ConfigureAwait(false);
+        Reload(clearLocalSettings: true);
     }
 
     public override void Quit()

--- a/src/dotnet/App.Maui/Services/MauiSession.cs
+++ b/src/dotnet/App.Maui/Services/MauiSession.cs
@@ -13,6 +13,9 @@ public sealed class MauiSession(IServiceProvider services)
     private static ILogger Log => _log ??= StaticLog.Factory.CreateLogger<MauiSession>();
 
     private static readonly Lock Lock = new();
+    // Validate-and-replace can be driven from more than one place, and each call to the server mints
+    // its own session - without this two of them race and the resolver and the storage end up split.
+    private static readonly SemaphoreSlim ReplaceLock = new(1, 1);
     private static Task<Session?>? _readSessionTask;
 
     private IServiceProvider Services { get; } = services;
@@ -45,72 +48,47 @@ public sealed class MauiSession(IServiceProvider services)
         return Task.Run(async () => {
             using var _1 = Tracer.MethodRegion();
 
+            // The stored session is used as-is, without asking the server whether it's still valid:
+            // that call can't be answered offline, and AccountUI replaces the session once the
+            // server does tell us it's unusable. Startup shouldn't wait on either.
             var session = await ReadStored().ConfigureAwait(false);
             if (session == null) {
-                // No session -> create one
                 session = await MobileSessions
                     .CreateSession(MauiSettings.AppUserAgent, CancellationToken.None)
                     .ConfigureAwait(false);
-                TrueSessionResolver.Session = session;
-                // No InvalidateEverything here or below: Acquire returns early once a session is set,
-                // so nothing session-scoped has been computed yet - only the cache needs pointing.
-                await RemoteComputedCache.Activate(session).ConfigureAwait(false);
                 _ = Task.Run(() => Store(session));
-                return;
             }
 
-            // Session is there -> validate it
             TrueSessionResolver.Session = session;
+            // No InvalidateEverything: Acquire returns early once a session is set, so nothing
+            // session-scoped has been computed yet - only the cache needs pointing.
             await RemoteComputedCache.Activate(session).ConfigureAwait(false);
-            var validSession = await MobileSessions
-                .ValidateSession(session, MauiSettings.AppUserAgent, CancellationToken.None)
-                .ConfigureAwait(false);
-            if (session == validSession)
-                return;
-
-            // Session is invalid -> update it to valid + reload MAUI App
-            Log.LogWarning("Stored session is invalid - will reload");
-            await SwitchTo(validSession).ConfigureAwait(false);
-            await Store(validSession).ConfigureAwait(false);
-            // Reloading mid-startup recreates the WebView while the first Blazor scope is
-            // still initializing, leaving a half-disposed scope with a disconnected JS runtime
-            // (=> endless JSDisconnectedException in the post-reload sign-in UI). Wait until the
-            // initial scope is fully rendered so this becomes a clean, single reload instead.
-            try {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                await AppServicesAccessor.WhenBlazorAppServicesReady(true, cts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) {
-                Log.LogWarning("Timed out waiting for the app to render before reload - reloading anyway");
-            }
-            Services.GetRequiredService<ReloadUI>().Reload(true, true);
         });
     }
 
-    public async Task Revalidate()
+    public async Task Replace(CancellationToken cancellationToken)
     {
-        // Never throws: MauiReloadUI's reload path terminates the app on failure
-        using var _ = Tracer.MethodRegion();
         if (!TrueSessionResolver.HasSession)
             return;
 
-        var session = TrueSessionResolver.Session;
+        var invalidSession = TrueSessionResolver.Session;
+        await ReplaceLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var validSession = await MobileSessions
-                .ValidateSession(session, MauiSettings.AppUserAgent, cts.Token)
-                .ConfigureAwait(false);
-            if (session == validSession)
+            // Someone else replaced it while we were waiting for the lock
+            if (TrueSessionResolver.Session != invalidSession)
                 return;
 
-            // Switch first: it drops the cache, so a crash before Store leaves the old id with a
+            var session = await MobileSessions
+                .CreateSession(MauiSettings.AppUserAgent, cancellationToken)
+                .ConfigureAwait(false);
+            // Switch first: it re-points the cache, so a crash before Store leaves the old id with a
             // cold cache. The other order can persist the new id over the old session's entries.
-            await SwitchTo(validSession).ConfigureAwait(false);
-            await Store(validSession).ConfigureAwait(false);
+            await SwitchTo(session).ConfigureAwait(false);
+            await Store(session).ConfigureAwait(false);
             Log.LogInformation("Replaced an invalid Session");
         }
-        catch (Exception e) {
-            Log.LogWarning(e, "Failed to validate Session - keeping the current one");
+        finally {
+            ReplaceLock.Release();
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/ClientUpgradeCover/ClientUpgradeCover.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ClientUpgradeCover/ClientUpgradeCover.razor
@@ -32,7 +32,7 @@
                     Update
                 </Button>
             } else {
-                <Button Class="btn-primary btn-w-full" Click="@(() => ReloadUI.Reload(true, false))">
+                <Button Class="btn-primary btn-w-full" Click="@(() => ReloadUI.Reload())">
                     Update
                 </Button>
             }

--- a/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor/Services/AccountUI/AccountUI.StateSync.cs
@@ -10,6 +10,7 @@ public partial class AccountUI
         var chains = new[] {
             AsyncChain.From(MonitorAccountChange),
             AsyncChain.From(MonitorPendingRegistration),
+            AsyncChain.From(MonitorSessionValidity),
         };
         return Task.WhenAll(chains.Select(c => c
             .Log(LogLevel.Debug, Log)
@@ -82,6 +83,30 @@ public partial class AccountUI
         }
     }
 
+    private async Task MonitorSessionValidity(CancellationToken cancellationToken)
+    {
+        // Nothing validates the session up front - it is used optimistically, and this is what
+        // notices the server rejecting it. Sign-out deactivates it, and it can also be killed from
+        // another device or expire; whichever it is, the session has to be replaced to stay usable.
+        var cSessionInfo0 = await Computed
+            .Capture(() => Accounts.GetSessionInfo(Session, cancellationToken), cancellationToken)
+            .ConfigureAwait(false);
+        var changes = cSessionInfo0.Changes(FixedDelayer.NoneUnsafe, cancellationToken);
+        await foreach (var cSessionInfo in changes.ConfigureAwait(false)) {
+            var (sessionInfo, error) = cSessionInfo;
+            // An error means we couldn't ask, not that the answer is no - offline keeps the session
+            if (error != null || sessionInfo is { IsActive: true })
+                continue;
+
+            Log.LogWarning("Session is no longer valid - replacing it");
+            // Recreating the WebView while the first scope is still initializing leaves a
+            // half-disposed scope with a disconnected JS runtime, so let it finish rendering first.
+            await Hub.WhenInitialized.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await ReloadUI.ReplaceSession(cancellationToken).ConfigureAwait(false);
+            return; // The reload owns everything past this point
+        }
+    }
+
     // Private methods
 
     private void MarkReady()
@@ -107,14 +132,14 @@ public partial class AccountUI
         if (account.IsGuestOrNull()) {
             // We're signed out now
             if (!oldAccount.IsGuestOrNull())
-                ReloadUI.Reload(true, true); // And were signed in -> it's a sign-out
+                ReloadUI.Reload(clearLocalSettings: true); // And were signed in -> it's a sign-out
             return;
         }
 
         // We're signed in now
         if (!oldAccount.IsGuestOrNull()) {
             // And were signed in -> it's an account change
-            ReloadUI.Reload(true, true);
+            ReloadUI.Reload(clearLocalSettings: true);
             return;
         }
 
@@ -137,7 +162,7 @@ public partial class AccountUI
         if (_activeSignInRequest.Value != null)
             return; // No auto-navigation in this case
 
-        if (!History.LocalUrl.IsChatOrChatRoot() && !History.LocalUrl.IsSettings() )
+        if (!History.LocalUrl.IsChatOrChatRoot() && !History.LocalUrl.IsSettings())
             _ = AutoNavigationUI.NavigateTo(Links.Chats, AutoNavigationReason.SignIn);
     }
 
@@ -145,7 +170,7 @@ public partial class AccountUI
     {
         var session = Session;
         var commander = Services.Commander();
-        var confirmed = false;
+        var isConfirmed = false;
 
         var identifier = info.Identifier.NullIfEmpty() ?? "this account";
         var text = $"We didn't find an account for {identifier}. Would you like to register a new one?";
@@ -153,7 +178,7 @@ public partial class AccountUI
             IsDestructive: false,
             Text: text,
             Confirm: () => {
-                confirmed = true;
+                isConfirmed = true;
                 _ = commander.Run(new Accounts_ConfirmRegister(session, info.Token), true, CancellationToken.None);
             }) {
             Title = "Register new account?",
@@ -162,7 +187,7 @@ public partial class AccountUI
         var modalRef = await Hub.ModalUI.Show(model).ConfigureAwait(true);
         await modalRef.WhenClosed.ConfigureAwait(true);
 
-        if (!confirmed && _pendingRegistrationToken == info.Token) {
+        if (!isConfirmed && _pendingRegistrationToken == info.Token) {
             // User dismissed without confirming — clear the prompt and show a sign-in error.
             _ = commander.Run(new Accounts_CancelRegister(session, info.Token), true, CancellationToken.None);
         }

--- a/src/dotnet/UI.Blazor/Services/ReloadUI.cs
+++ b/src/dotnet/UI.Blazor/Services/ReloadUI.cs
@@ -1,20 +1,13 @@
 using ActualChat.Kvas;
-using ActualLab.Fusion.Client.Caching;
 
 namespace ActualChat.UI.Blazor.Services;
 
-public class ReloadUI
+public class ReloadUI(IServiceProvider services)
 {
-    protected IServiceProvider Services { get; }
-    protected ILogger Log { get; }
+    protected IServiceProvider Services { get; } = services;
+    protected ILogger Log => field ??= Services.LogFor(GetType());
 
-    public ReloadUI(IServiceProvider services)
-    {
-        Services = services;
-        Log = services.LogFor(GetType());
-    }
-
-    public virtual void Reload(bool clearCaches = false, bool clearLocalSettings = false)
+    public virtual void Reload(bool clearLocalSettings = false)
     {
         Log.LogInformation("Reload requested");
         var circuitHub = Services.GetRequiredService<CircuitHub>();
@@ -23,7 +16,7 @@ public class ReloadUI
             try {
                 var hostInfo = Services.HostInfo();
                 var nav = Services.GetRequiredService<NavigationManager>();
-                await Clear(clearCaches, clearLocalSettings).ConfigureAwait(true); // Nav requires UI context
+                await Clear(clearLocalSettings).ConfigureAwait(true); // Nav requires UI context
                 if (hostInfo.HostKind.IsApp())
                     AppNavigationQueue.Reset();
                 nav.NavigateTo(Links.Home, true);
@@ -34,31 +27,15 @@ public class ReloadUI
         }), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
     }
 
-    public Task Clear(bool clearCaches, bool clearLocalSettings)
+    public virtual Task ReplaceSession(CancellationToken cancellationToken)
     {
-        if (!(clearCaches || clearLocalSettings))
-            return Task.CompletedTask;
-
-        var clearTasks = new List<Task>();
-        if (clearCaches)
-            clearTasks.Add(ClearCaches());
-        if (clearLocalSettings)
-            clearTasks.Add(ClearLocalSettings());
-        return Task.WhenAll(clearTasks);
+        // AuthHelper drops an invalid cookie session and issues a new one on the next request
+        Reload(clearLocalSettings: true);
+        return Task.CompletedTask;
     }
 
-    public virtual async Task ClearCaches()
-    {
-        Log.LogWarning("Cleaning caches...");
-        try {
-            var remoteComputedCache = Services.GetService<IRemoteComputedCache>();
-            if (remoteComputedCache != null)
-                await remoteComputedCache.Clear(CancellationToken.None).ConfigureAwait(false);
-        }
-        catch (Exception e) {
-            Log.LogError(e, "ClearCaches failed");
-        }
-    }
+    public Task Clear(bool clearLocalSettings)
+        => clearLocalSettings ? ClearLocalSettings() : Task.CompletedTask;
 
     public virtual async Task ClearLocalSettings()
     {


### PR DESCRIPTION
Stacked on #4215 — **base is `feat/session-scoped-client-cache`, not `dev`**, so the diff shows only this change. Retarget to `dev` once #4215 lands.

## Problem

Session validity was checked exactly once, on the reload path: `MauiSession.Revalidate()` asked the server to validate-or-replace the stored session, with a 5s budget.

That has three consequences:

1. **It blocks startup on a round trip** that can't be answered offline. `Acquire` waited for `ValidateSession` before the app could proceed.
2. **A timeout strands the app.** `Revalidate` caught, logged *"keeping the current one"*, and the reload continued onto the session sign-out had just deactivated. Nothing retried — `Acquire` early-returns once `HasSession` is true, and `BlazorViewAppPostBuildRoutine` runs once per process. The next sign-in reached `AccountsBackend.OnSignIn`'s inactive-session check and got **"This Session is expired."** — verbatim #4207, until a restart.
3. **It only ever looked at one moment.** A session killed from another device or expiring mid-run was never noticed.

## Approach

Use the session optimistically and **observe** validity instead of asking up front.

`AccountUI` gains a `MonitorSessionValidity` chain watching `Accounts.GetSessionInfo` — already a `[ComputeMethod]`, already invalidated when the server deactivates a session. Whatever makes a session unusable, the client finds out and replaces it. An **error means we couldn't ask, not that the answer is no**, so going offline keeps the session and recovery is automatic once the connection returns.

Replacement is `ReloadUI.ReplaceSession`, split the way the platforms actually differ:

- **Web** — `AuthHelper` already nulls an invalid cookie session and mints `Session.New()` on the next request, so the base implementation is just the reload.
- **MAUI** — `MauiReloadUI` overrides it, because nothing re-issues a keychain session for us: it has to be minted, switched to, and stored before the recreated WebView binds to it.

Two of the other outstanding review items fall out of this:

- **Rotation is now single-flight.** `MauiSession.Replace` takes a semaphore and re-checks the session it captured, so two of these can't mint two sessions and leave the resolver and secure storage pointing at different ones.
- **`Revalidate` is gone**, and with it the `Tracer.MethodRegion()` that sat outside its `try`. That mattered more than it looked: `MauiDiagnostics` enables the tracer unconditionally in production and writes through Serilog into a Sentry sink, so a throwing sink turned a reload into `Quit()`.

## Also: `clearCaches` is removed

It hangs off the reload path this PR restructures, and nothing needs it anymore:

- **Web** — `WebKvasBackend` stamps `ApiVersion` and `SessionHash` into the store's version key and wipes on mismatch at page load, so a reload with a new session already clears it.
- **MAUI** — the cache is keyed per session (#4215) with the API version in its Kvasar `Version`.

It was also the one part of the reload doing synchronous file I/O inline on the MAUI main thread — `Clear` invokes the tasks before `Task.WhenAll`, so with an idle Kvasar the uncontended write lock completes synchronously and execution chained straight into `WipeFiles()` on the UI thread. `clearLocalSettings` stays, since MAUI local settings aren't session-scoped.

## Verification

Builds clean: `App.Maui` (net11.0-android), `App.Server` (incl. WASM), `App.Maui.IosShareExt`.

**Not exercised on a device.** The paths worth a real pass before merge: sign-out → sign-in on Android and iOS; airplane-mode startup with a stored session (should now start rather than block); and sign-out while offline, then reconnect (the session should be replaced without a restart).

## Worth a reviewer's eye

- **Reload loops.** The monitor now replaces-and-reloads automatically. One cycle is expected when a stored session is dead; a *loop* would need the server to report a freshly minted session as inactive. I deliberately added no rate limit — it would mask that rather than fix it — but it's the failure mode to watch.
- **`GetSessionInfo` returning null** is treated as invalid, matching `IsValidSession`'s own `sessionInfo?.IsActive == true`.
- The monitor awaits `Hub.WhenInitialized` before reloading, preserving the guard the deleted startup code had against recreating the WebView mid-initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfod9zd7A9oVjDaNPHF736
