### PR TITLE
fix: The main-thread stall cascade and the recovery paths it exposed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <ActualLabFusionVersion>14.3.29</ActualLabFusionVersion>
+    <ActualLabFusionVersion>14.3.34</ActualLabFusionVersion>
     <!-- .NET 11 is still in preview: every Microsoft.* package below shares this build number -->
     <DotNetVersion>11.0.0-preview.7.26381.103</DotNetVersion>
     <AspNetCoreVersion>$(DotNetVersion)</AspNetCoreVersion>

--- a/docs/development/ui-components.md
+++ b/docs/development/ui-components.md
@@ -141,6 +141,57 @@ body.hoverable .amazing-panel > button:hover,
 }
 ```
 
+## Lit Components: Blazor owns `class`
+
+A Lit custom element rendered from Razor has **two** potential writers for its host
+attributes — Blazor, which rewrites the element's markup on every re-render, and the
+component itself. Anything both of them write ends up in a permanent tug-of-war,
+because Blazor's render tree never learns what the component changed.
+
+**The rule: a Lit component may *have* a `class`, but must never *write* one.**
+`class` belongs to Blazor. The component owns only attributes Blazor does not render.
+
+Publish component state through a `data-*` attribute and match it from CSS —
+attribute selectors have the same specificity as class selectors, so nothing in the
+cascade changes:
+
+**Wrong** — the component writes `class`, Blazor overwrites it on the next render,
+the component writes it again, forever:
+```typescript
+@property({ reflect: true }) class: string;   // makes every foreign class write re-render
+
+updated(changed: Map<string, unknown>) {
+    if (changed.has('class'))
+        this.classList.add(`show-image-${this._state}`);   // fights Blazor
+}
+```
+```css
+image-skeleton.show-image-original .image { ... }
+```
+
+**Correct** — Blazor owns `class`, the component owns `data-image-state`:
+```typescript
+private applyState(): void {
+    this.setAttribute('data-image-state', this._state);
+}
+```
+```css
+image-skeleton[data-image-state="original"] .image { ... }
+```
+
+Razor keeps writing `class` exactly as it would for any other element:
+```razor
+<image-skeleton class="pic-image @ExtraClass" src="@url" />
+```
+
+If the component needs an **initial** state from Razor, take it as a Lit property
+(`@property({ attribute: 'initial-state' })`) rather than reading it back out of the
+attribute the component itself writes. Razor renders that property as a constant, so
+re-renders write the same value and never conflict.
+
+The same reasoning applies to any attribute Razor emits — `style`, `title`, `id`. If
+Razor renders it, the component must not write it.
+
 ## No Inline Tailwind in Razor
 
 Do NOT write Tailwind utility classes directly in `.razor` markup. Instead, assign a CSS class and use `@apply` in the CSS file.

--- a/docs/live-video/02-sender.md
+++ b/docs/live-video/02-sender.md
@@ -323,7 +323,9 @@ closures, no track references.
 
 | Symptom | Where it's caught | Recovery |
 |---|---|---|
-| Encoder hangs on `output()` | `AsyncVideoEncoder` timeout (3 s first frame, 1 s steady) | Reset, force keyframe, retry bundle |
+| Encoder hangs on `output()` | `encode.ts` bundle watchdog (3 s per bundle; per-item adapter timeouts are disabled) | `handleEncoderHang()` — fail pending recoverably, `reset()` + reconfigure, force keyframe, skip the bundle. Throws after 2 consecutive hangs |
+| Encoder reports a fatal error | WebCodecs `error` callback in `recorder-worker-host.ts` | Fail the in-flight items at once, then `encode.ts` rebuilds any slot left `closed`/`unconfigured` and forces a keyframe |
+| Adapter degraded by a timeout or out-of-order output | `CodecToAsyncAdapter.degradeAndReset` | `maxInflight` drops to 1, restored after `DEGRADE_RECOVERY_OUTPUTS` clean outputs |
 | Frame dims ≠ encoder config | `dim-mismatch-guard.ts` | Drop frame; counter tick |
 | Downscaler hangs (`process()`) | `downscale.ts` 1.5 s watchdog | Close + recreate, force keyframe; bail after 4 consecutive |
 | HW NVENC slot lost | next `acquire()` on pool | Pool recreates encoder, runs through `handleEncoderReset` |

--- a/docs/plans/better-translation.md
+++ b/docs/plans/better-translation.md
@@ -1,0 +1,163 @@
+---
+title: Better translation
+description: Throttle the translation streams — one path is unthrottled per LLM chunk, the other is throttled but tuned for latency rather than cost.
+---
+
+# Better translation
+
+Translation publishes two independent streams. One of them has no rate limit at
+all and emits one wire item per LLM chunk; the other is throttled, but at a
+period chosen for latency rather than for LLM spend. This plan covers both.
+
+Every line reference below was read from source on 2026-08-21.
+
+## Why it matters
+
+Each item a translation stream publishes becomes an RPC message, then a
+`TranscriptStreamReader` state write on every viewing client, then a Fusion
+recompute, then a Blazor render batch. It was one of the producers behind the
+main-thread stall investigated in PR #4220.
+
+The client half of that is already fixed: `ChatEntryMessageInternalView` now
+uses `FixedDelayer.Get(0.2)`, capping rendering at 5/sec regardless of arrival
+rate. So throttling the server no longer changes client *render* cost much —
+what it saves is **wire traffic, RPC serialization, server CPU, and (on the
+realtime path) LLM spend**. The two fixes are complementary, not redundant.
+
+## The two paths
+
+### Path A — realtime translation of live speech
+
+`TranslationsBackend.TranslateTranscriptStream` (`TranslationsBackend.cs:444`),
+using the keyed `RealtimeTranslator` (`:31`,
+`Constants.Translation.RealtimeServiceKey`).
+
+**Already throttled on input** (`:472-476`):
+
+```csharp
+await foreach (var transcriptDiffBatch in originalStream.Replay(cancellationToken)
+                   .Buffer(TranslateThrottleDelay, Clocks.CpuClock, cancellationToken: cancellationToken)
+```
+
+`TranslateThrottleDelay = 500ms` (`:23`, `private static readonly`). Each window
+emits at most two output diffs — the stable diff (`:490`) and the diff-since-stable
+(`:497`) — so roughly 2-4 wire items/sec, not per token.
+
+**The real cost here is LLM calls, not renders.** Every window costs up to two
+`RealtimeTranslator.Translate` round-trips (`:514`), i.e. up to **4 LLM calls per
+second per active realtime translation**. There is an early-exit when the text is
+unchanged (`:507`), so the saving from a larger window is real but not exactly
+linear.
+
+**Proposed work:**
+
+1. Raise `TranslateThrottleDelay`. 1000-1500ms roughly halves-to-thirds the LLM
+   spend. The cost is translated-text lag — but the ASR transcript underneath
+   stays at 200ms (see Path A's source below), so the original text remains
+   responsive and only the translated overlay trails. For live speech, which
+   already lags by a sentence, 1-1.5s is defensible.
+2. Promote it from a hardcoded `private static readonly` to a `ChatSettings`
+   knob, so it can be calibrated against real cost without a deploy.
+
+The number is a product/cost call, not a technical one.
+
+### Path B — whole-message translation streaming
+
+`TranslationsBackend.StreamTranslation` (`:202-211`):
+
+```csharp
+using var stream = Translator
+    .Stream(translationSource.Content, id.Language, context, cancellationToken)
+    .ToTranscriptDiffs()
+    .Memoize(cancellationToken);
+var rpcStream = RpcStream.New(stream.Replay(cancellationToken));
+var publishStreamTask = StreamingBackend.PushTranscript(streamId, rpcStream, cancellationToken);
+```
+
+**No throttle. One wire item per LLM chunk.** This is the path behind the
+`div.chat-message-markup.streaming` churn in the incident log.
+
+Contrast the ASR path, `AudioStreamingBackend.ProcessAudio.cs:540-543`, which
+throttles at `Constants.Transcription.ThrottlePeriod` = 200ms (`Constants.cs:226`).
+
+## The fix for Path B
+
+Three existing operators in `TranscriptDiffStreamExt` compose into exactly the
+coalescing this needs — no new machinery:
+
+```csharp
+using var stream = Translator
+    .Stream(translationSource.Content, id.Language, context, cancellationToken)
+    .ToTranscriptDiffs()                                  // StringDiff -> TranscriptDiff
+    .ToTranscripts()                                      // accumulate: transcript += diff
+    .ThrottleTranscript(throttlePeriod, Clocks.CpuClock, cancellationToken)
+    .ToTranscriptDiffs()                                  // re-diff vs last EMITTED snapshot
+    .Memoize(cancellationToken);
+```
+
+Why each step is safe:
+
+- **Throttling is applicable at all** because `ToTranscripts` (`:39-46`) turns the
+  incremental diffs into cumulative *snapshots*. Dropping a superseded snapshot is
+  lossless; dropping a diff would not be.
+- **The throttle actually engages.** `ToTranscriptDiffs(IAsyncEnumerable<StringDiff>)`
+  (`:31-37`) leaves `IsStable` at its default `false`, and `TranscriptDiff.Apply`
+  (`TranscriptDiff.cs:43`) propagates that to the accumulated transcript. Stable
+  transcripts bypass the throttle (`TranscriptDiffStreamExt.cs:89`); these are not
+  stable, so they are throttled.
+- **First-paint latency is unchanged.** The first transcript passes through
+  immediately — `isFirstTranscript` (`:69`) is only cleared in `ResetPendingState()`
+  (`:121`).
+- **The final translation is never swallowed.** `pendingTranscript` is flushed both
+  on stream end (`:83-85`) and after the loop (`:113-114`).
+- **The dropped text is not lost.** The trailing `ToTranscriptDiffs(IAsyncEnumerable<Transcript>)`
+  (`:8-16`) diffs each transcript against the previously *yielded* one, so every
+  emitted diff is the merge of everything dropped. That is the coalescing.
+
+### Period
+
+Start at 500ms. Translation of an already-complete message does not need the
+200ms smoothness the ASR path targets. Add it as
+`Constants.Translation.StreamThrottlePeriod` rather than reusing
+`Constants.Transcription.ThrottlePeriod`, so the two can diverge —
+`Constants.Translation` (`Constants.cs:438-443`) currently holds only service keys
+and `NoTranslationNeededText`.
+
+## Corrections to earlier analysis
+
+Recorded so they are not repeated:
+
+- **"Translation is an unthrottled producer"** — only half true. Path A has been
+  throttled at 500ms all along; only Path B is unthrottled.
+- **"The `IsStable` bypass makes any throttle a no-op here"** — false. That applies
+  to the *synchronous* `ToTranscriptDiffs(IEnumerable<StringDiff>)` overload
+  (`:28-29`), which sets `IsStable = true`. `Translator.Stream` returns
+  `IAsyncEnumerable<StringDiff>` (`Translator.cs:80`), which binds to the async
+  overload at `:31`, and that one does not set it.
+- **"Fixing it needs a new coalescing helper"** — false. `ToTranscripts` +
+  `ThrottleTranscript` + `ToTranscriptDiffs` already compose into it.
+
+## Dead code found on the way
+
+`ToTranscriptDiffs(IEnumerable<StringDiff>)` (`:28-29`) — the overload that sets
+`IsStable = true` — has **zero call sites**. Only two call sites exist for the
+whole family: `TranslationsBackend.cs:208` and
+`AudioStreamingBackend.ProcessAudio.cs:572`. Worth deleting, and worth noting that
+its `IsStable = true` is what made the analysis above easy to get wrong.
+
+## Risks and open questions
+
+- **Time maps.** The `StringDiff` overload sets `LinearMapDiff.None`, so time maps
+  stay empty through the round-trip. Re-diffing empty maps should be inert, but
+  `Transcript.operator -` (`Transcript.cs:116`) is worth a look to confirm it does
+  not misbehave on an empty `TimeMap`.
+- **Visible UX change.** Translated text arrives in ~500ms steps rather than
+  token-by-token. Probably smoother; still worth eyeballing once.
+- **`Memoize`/`Replay` ordering.** The throttle sits upstream of `Memoize`, so
+  replay consumers get the throttled sequence too. That is intended — the final
+  state is complete — but it does mean a late joiner cannot reconstruct the
+  fine-grained stream.
+- **No test coverage.** Neither translation path is tested, and `ThrottleTranscript`
+  itself appears untested. A test that feeds a known diff sequence through the
+  round-trip and asserts (a) the concatenated output equals the input text and
+  (b) the item count drops, would cover the risky part cheaply.

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -29,6 +29,13 @@ OpenSearch with PostgreSQL full-text search (`tsvector` + GIN) behind
 segmentation) moves to the application level for uniform coverage across the
 top ~50 languages, on a pgvector-ready schema.
 
+### Better translation
+
+[Better translation](./better-translation.md) — throttle both translation
+streams. The whole-message stream publishes one wire item per LLM chunk with no
+rate limit; the realtime stream is throttled at 500ms, tuned for latency rather
+than for the up-to-4-calls/sec of LLM spend it implies.
+
 ### Chat roles — Moderator
 
 [Moderator role](./moderator-role.md) — a third system role between `Anyone` and

--- a/src/dotnet/App.Maui/wwwroot/index.htm
+++ b/src/dotnet/App.Maui/wwwroot/index.htm
@@ -44,12 +44,13 @@
         " />
     <title>Voxt</title>
     <base href="/" />
-    <!-- The version of icon.woff2 must match the version in icons.css! -->
-    <link rel="preload" href="/dist/assets/woff2/icon.woff2?t=1731995804968" as="font" crossorigin />
+    <!-- A preload counts only if its href matches what @font-face requests, query string
+         included. icon.woff2 is absent on purpose: icons.css appends a generated ?t=
+         cache-buster that nothing here can reproduce, so it could never match. -->
     <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-Regular.woff2" as="font" crossorigin />
     <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-Medium.woff2" as="font" crossorigin />
     <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-DemiBold.woff2" as="font" crossorigin />
-    <link rel="preload" href="/dist/assets/woff2/forkawesome-webfont.woff2" as="font" crossorigin />
+    <link rel="preload" href="/dist/assets/woff2/forkawesome-webfont.woff2?v=1.2.0" as="font" crossorigin />
     <link rel="prefetch" href="/dist/assets/woff2/TT-Commons-Pro-Light.woff2" as="font" crossorigin />
     <!-- Nothing else is prefetched here on purpose: workers, worklets and wasm are all served
          from the APK, so there is no network latency to hide (~15ms each), and they only

--- a/src/dotnet/App.Server/Components/Pages/RootServerPage.razor
+++ b/src/dotnet/App.Server/Components/Pages/RootServerPage.razor
@@ -33,7 +33,9 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"/>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no,
+                   viewport-fit=cover, interactive-widget=resizes-content"/>
     <HeadOutlet @rendermode="@(_renderMode.Mode)" />
     <PageTitle>@CoreConstants.AppName</PageTitle>
     <HeadContent>
@@ -48,9 +50,10 @@
     @{
         var title = $"{CoreConstants.AppName}: The New Voice of Everyday Communication";
         var description =
-            "We fuse real-time audio, live transcription, and AI assistance to let you communicate with utmost efficiency. " +
-            "Reply 5x faster, read for quick context, defer without fear of losing clarity, " +
-            "and connect more frequently to deepen ties with those you cherish most — all free from the stress of traditional calls.";
+            "We fuse real-time audio, live transcription, and AI assistance to let you "
+            + "communicate with utmost efficiency. Reply 5x faster, read for quick context, "
+            + "defer without fear of losing clarity, and connect more frequently to deepen "
+            + "ties with those you cherish most — all free from the stress of traditional calls.";
         var siteDescription = title + Environment.NewLine + description;
         var image = "voxt-site-preview.jpg";
         if (_contentLinkInfo is not null) {
@@ -79,12 +82,12 @@
     <meta name="twitter:description" content="@description">
     <meta name="twitter:image" content="@image">
 
-    @* The version of icon.woff2 must match the version in icons.css! *@
-    <link rel="preload" href="/@Assets["dist/assets/woff2/icon.woff2"]" as="font" crossorigin />
-    <link rel="preload" href="/@Assets["dist/assets/woff2/TT-Commons-Pro-Regular.woff2"]" as="font" crossorigin />
-    <link rel="preload" href="/@Assets["dist/assets/woff2/TT-Commons-Pro-Medium.woff2"]" as="font" crossorigin />
-    <link rel="preload" href="/@Assets["dist/assets/woff2/TT-Commons-Pro-DemiBold.woff2"]" as="font" crossorigin />
-    <link rel="prefetch" href="/@Assets["dist/assets/woff2/TT-Commons-Pro-Light.woff2"]" as="font" crossorigin />
+    @* NOT @Assets — a preload counts only if its href matches what @font-face requests, and the
+       bundled CSS keeps the plain path (icon.woff2 also carries a generated ?t=, so it can't match). *@
+    <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-Regular.woff2" as="font" crossorigin />
+    <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-Medium.woff2" as="font" crossorigin />
+    <link rel="preload" href="/dist/assets/woff2/TT-Commons-Pro-DemiBold.woff2" as="font" crossorigin />
+    <link rel="prefetch" href="/dist/assets/woff2/TT-Commons-Pro-Light.woff2" as="font" crossorigin />
     <link rel="prefetch" href="/@Assets["dist/onDeviceAwakeWorker.js"]" as="worker" crossorigin />
     <link rel="prefetch" href="/@Assets["dist/opusDecoderWorker.js"]" as="worker" crossorigin />
     <link rel="prefetch" href="/@Assets["dist/opusEncoderWorker.js"]" as="worker" crossorigin />
@@ -101,7 +104,10 @@
     <link href="/@Assets["dist/bundle.css"]" rel="stylesheet" />
     <ImportMap nonce="@nonce" ImportMapDefinition="importMap"/>
     @if (Captcha.IsAvailable(HostInfo, recaptchaSiteKey)) {
-        <script id="recaptcha-head-script" nonce="@nonce" src="https://www.google.com/recaptcha/enterprise.js?render=@recaptchaSiteKey" async defer></script>
+        <script id="recaptcha-head-script"
+                nonce="@nonce"
+                src="https://www.google.com/recaptcha/enterprise.js?render=@recaptchaSiteKey"
+                async defer></script>
     } else {
         <meta id="recaptcha-fake" content="true" />
     }
@@ -124,9 +130,13 @@
                 await window.App.whenBundleReady;
                 return true;
             },
-            browserInit: async function(hostKind, appKind, apiVersion, baseUri, supportedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef) {
+            browserInit: async function(
+                hostKind, appKind, apiVersion, baseUri, supportedHosts,
+                sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef) {
                 await window.App.whenBundleReady;
-                window.ui.BrowserInit.init(hostKind, appKind, apiVersion, baseUri, supportedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef);
+                window.ui.BrowserInit.init(
+                    hostKind, appKind, apiVersion, baseUri, supportedHosts,
+                    sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef);
             },
         };
         window.App.whenBlazorReady = new Promise((resolve, _) => {
@@ -216,7 +226,8 @@
             @if (closeFlow.RedirectUrl is { } closeFlowRedirectUrl) {
                 @* A custom scheme with no registered handler (e.g. the app isn't installed) aborts
                    the document load, so the hand-off waits for everything above to be parsed. *@
-                @((MarkupString)$"addEventListener('load', function () {{ window.location.href = {JsonSerializer.Serialize(closeFlowRedirectUrl)}; }});")
+                @((MarkupString)("addEventListener('load', function () { window.location.href = "
+                    + JsonSerializer.Serialize(closeFlowRedirectUrl) + "; });"))
             }
             setTimeout(function () {
                 window.open('','_self').close();
@@ -240,8 +251,7 @@
     <script nonce="@nonce">
         if (!window.Blazor) {
             console.error('Blazor is not loaded. Please check the script tag for blazor.web.js.');
-        }
-        else {
+        } else {
             // Suppress stale event handler errors in Blazor Server.
             // When a component re-renders on the server (changing handler IDs) while an event
             // is in-flight over SignalR, the event arrives with a stale handler ID, causing
@@ -288,7 +298,8 @@
                    },
                    */
                     loadBootResource: function(type, name, defaultUri, integrity) {
-                        if (type !== 'dotnetjs' && location.hostname !== 'localhost' && type !== 'configuration' && integrity) {
+                        if (type !== 'dotnetjs' && type !== 'configuration'
+                            && location.hostname !== 'localhost' && integrity) {
                             return (async function() {
                                 const hash = encodeURIComponent(integrity);
                                 const response = await fetch(defaultUri + '?hash=' + hash, { integrity: integrity });
@@ -370,6 +381,7 @@
             HttpContext.Response.Redirect(redirectUrl, false);
             return;
         }
+
         if (!_authState.IsAnyAuthFlow && HttpContext.AcceptsInteractiveRouting()) {
             var forceServerPrerendered = _account.IsGuestOrNull() && (_url.IsHome() || _url.IsDocsOrDocsRoot());
             _renderMode = forceServerPrerendered
@@ -377,5 +389,4 @@
                 : RenderModeEndpoint.GetRenderMode(HttpContext);
         }
     }
-
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/AttachmentItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/AttachmentItem.razor
@@ -27,7 +27,7 @@
                 <i class="icon-close text-lg"></i>
             </ButtonSquare>
             @if (attachment.IsSupportedImage || m.HasCustomPreview || m.HasImagePreview) {
-                <image-skeleton class="show-image-skeleton @plugClass" src="@previewUrl"
+                <image-skeleton initial-state="skeleton" class="@plugClass" src="@previewUrl"
                                 width="@(hasDims ? w : 0)" height="@(hasDims ? h : 0)" style="@ratioStyle"/>
             } else if (attachment.IsSupportedVideo) {
                 <video preload="metadata" class="@plugClass">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/UploadAttachmentItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/UploadAttachmentItem.razor
@@ -26,7 +26,7 @@
             </ButtonSquare>
             @if (previewState is PreviewAccessState.Ok) {
                 @if (attachment.IsSupportedImage || m.HasCustomPreview || m.HasImagePreview) {
-                    <image-skeleton class="show-image-skeleton @plugClass" src="@previewUrl"
+                    <image-skeleton initial-state="skeleton" class="@plugClass" src="@previewUrl"
                                     width="@(hasDims ? w : 0)" height="@(hasDims ? h : 0)" style="@ratioStyle" />
                 } else if (attachment.IsSupportedVideo) {
                     <video preload="metadata" class="@plugClass">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/VisualMediaAttachment.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/VisualMediaAttachment.razor
@@ -36,7 +36,7 @@
             <VideoAttachmentThumbnail Attachment="@attachment"/>
         } else {
             <image-skeleton
-                class="show-image-skeleton"
+                initial-state="skeleton"
                 src="@url"
                 thumbnailSrc="@previewUrl"
                 width="@(hasDims ? mediaW : 0)"

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/attachment.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/attachment.css
@@ -55,11 +55,11 @@ body.hoverable .image-line .image-item:hover {
     @apply flex;
     @apply cursor-pointer;
 }
-.image-attachment image-skeleton.show-image-skeleton {
+.image-attachment image-skeleton[data-image-state="skeleton"] {
     @apply bg-skeleton rounded-md animate-pulse;
     @apply w-full;
 }
-.image-attachment image-skeleton.show-image-original:before {
+.image-attachment image-skeleton[data-image-state="original"]:before {
     @apply content-empty;
     @apply absolute inset-0 z-minus;
     @apply bg-03;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -206,6 +206,10 @@
             IsUnreadByOthers, IsUnreadByOthersBlockStart);
         return new() {
             InitialValue = initialData, // To show the original text immediately
+            // The default delayer collapses to ~32ms whenever UIActionTracker reports
+            // instant updates — ~30 render batches/sec per streaming message, each one a
+            // synchronous DOM patch. 0.2s is the grid the streaming markup already animates on.
+            UpdateDelayer = FixedDelayer.Get(0.2),
             Category = GetStateCategory(GetType()),
         };
     }

--- a/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContentList/VisualMediaList.razor
@@ -34,7 +34,7 @@
                            href="@url" role="button" data-menu="@menuRef"
                            @onclick="@(() => OnMediaClick(item.Key, media))" @onclick:preventDefault="true">
                             @if (thumb.Length > 0) {
-                                <image-skeleton class="show-image-skeleton" src="@thumb"/>
+                                <image-skeleton initial-state="skeleton" src="@thumb"/>
                             }
                             <i class="icon-play-fill c-play-icon"></i>
                             @if (media.DurationMs > 0) {
@@ -50,7 +50,7 @@
                         <a class="image-attachment" @key="@media.Id"
                            href="@url" role="button" data-menu="@menuRef"
                            @onclick="@(() => OnMediaClick(item.Key, media))" @onclick:preventDefault="true">
-                            <image-skeleton class="show-image-skeleton" src="@url" thumbnailSrc="@previewUrl"/>
+                            <image-skeleton initial-state="skeleton" src="@url" thumbnailSrc="@previewUrl"/>
                         </a>
                     }
                 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -250,7 +250,8 @@ export class VideoPlayer {
 
     // PLI: receiver-requested keyframe (kept as a courtesy hook — most of
     // this is now driven by the worker's epoch-reset operator).
-    private lastKeyFrameRequestTime = 0;
+    // Parking expires after the cooldown — an unsettled call (run timeout is unbounded) must not latch it.
+    private keyFrameRequestBlockedSince: number | null = null;
     private readonly keyFrameRequestCooldownMs = 10000;
 
     // Render-quality hint state.
@@ -952,10 +953,10 @@ export class VideoPlayer {
     }
 
     private requestKeyFrame(): void {
-        const now = performance.now();
-        if (now - this.lastKeyFrameRequestTime < this.keyFrameRequestCooldownMs)
+        const sentAt = performance.now();
+        if (this.keyFrameRequestBlockedSince !== null
+            && sentAt - this.keyFrameRequestBlockedSince < this.keyFrameRequestCooldownMs)
             return;
-        this.lastKeyFrameRequestTime = now;
 
         infoLog?.log(`requestKeyFrame: stream=${this.streamId}`);
         // Worker-side hint (the new contract carries this, but the host
@@ -964,8 +965,22 @@ export class VideoPlayer {
         if (this.playerWorker)
             void this.playerWorker.requestKeyframe(this.streamId)
                 .catch(() => { /* worker stub is a no-op; ignore */ });
-        streamingApi.liveVideoStreams.RequestKeyFrame(RPC_SESSION_DEFAULT, this.streamId)
-            .catch((e: unknown) => warnLog?.log('RequestKeyFrame error:', e));
+
+        this.keyFrameRequestBlockedSince = sentAt;
+        // `sentAt` doubles as this request's identity, so a straggler settling after
+        // its parking expired can't disturb whatever request replaced it.
+        void streamingApi.liveVideoStreams.RequestKeyFrame(RPC_SESSION_DEFAULT, this.streamId)
+            .then(
+                () => {
+                    if (this.keyFrameRequestBlockedSince === sentAt)
+                        this.keyFrameRequestBlockedSince = performance.now();
+                },
+                (e: unknown) => {
+                    // Only a request the server actually got starts the cooldown.
+                    warnLog?.log('RequestKeyFrame error:', e);
+                    if (this.keyFrameRequestBlockedSince === sentAt)
+                        this.keyFrameRequestBlockedSince = null;
+                });
     }
 
     public async startPull(streamId: string, skipToMs: number): Promise<void> {

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -34,6 +34,7 @@ import {
     getVideoLayerBitratesKbps,
     kbpsToBitsPerSecond,
 } from 'app-constants';
+import { withTimeout } from 'actuallab-core';
 import { getLogs } from 'logging';
 import { Api, WorkerKind } from 'api';
 import { rpcClientServer, rpcNoWait } from 'rpc';
@@ -113,6 +114,9 @@ const MAX_RECOVERY_ATTEMPTS = 5;
 // on foreground leaves the pipeline silently dead. 3s comfortably clears the
 // ~1s health tick and brief capture gaps without churning a healthy stream.
 const CAPTURE_STALL_RECOVERY_MS = 3000;
+// Ceiling on one recoverNow() pass. 15s clears a slow-but-live restart with room
+// to spare; see scheduleRecovery for why the pass must be bounded at all.
+const RECOVER_NOW_TIMEOUT_MS = 15_000;
 // User-facing message shown when the HW encoder cannot be initialised at all
 // (every codec probe fails) or when recovery has exhausted MAX_RECOVERY_ATTEMPTS.
 // Kept free of codec/encoder/internals — actionable only.
@@ -2301,18 +2305,32 @@ export class VideoRecorder {
             });
             return;
         }
+
         const delayMs = Math.min(3000, 200 * Math.pow(1.7, this.recoveryAttempts - 1));
         warnLog?.log(
             `scheduleRecovery: ${reason}; attempt ${this.recoveryAttempts} in ${delayMs.toFixed(0)}ms`);
+        // The guard stays up for the whole of recoverNow(), not just until the timer
+        // fires: stop() can take seconds on a wedged pipeline, and an error arriving
+        // in that window used to schedule a second recovery whose startWorker() then
+        // rejected with "already running" — feeding itself straight to the attempt cap.
+        // The timeout is what makes holding it safe: recoverNow() awaits a worker that
+        // may be wedged too, and an await that never settles would retire recovery for
+        // the session.
         window.setTimeout(() => {
-            this.recoveryScheduled = false;
-            if (!this.isRecording || this.disposed)
+            if (!this.isRecording || this.disposed) {
+                this.recoveryScheduled = false;
                 return;
+            }
 
-            void this.recoverNow().catch((e: unknown) => {
-                warnLog?.log('scheduleRecovery: recoverNow failed', e);
-                this.scheduleRecovery('recovery attempt failed');
-            });
+            void withTimeout(this.recoverNow(), RECOVER_NOW_TIMEOUT_MS, 'recoverNow').then(
+                () => {
+                    this.recoveryScheduled = false;
+                },
+                (e: unknown) => {
+                    warnLog?.log('scheduleRecovery: recoverNow failed', e);
+                    this.recoveryScheduled = false;
+                    this.scheduleRecovery('recovery attempt failed');
+                });
         }, delayMs);
     }
 
@@ -2532,8 +2550,14 @@ export class VideoRecorder {
             this.worker = null;
         }
         if (this.workerInstance) {
-            try { this.workerInstance.terminate(); } catch { /* ignore */ }
+            const instance = this.workerInstance;
             this.workerInstance = null;
+            // Preview frames the worker already posted are still queued for dispatch;
+            // terminating in this task drops them without releasing them, so give the
+            // drain handler rpcServer.dispose() installed one turn to take them.
+            setTimeout(() => {
+                try { instance.terminate(); } catch { /* ignore */ }
+            }, 0);
         }
         this.tearDownWorkerSource();
     }

--- a/src/dotnet/UI.Blazor.App/Services/Video/adapters.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/adapters.ts
@@ -6,6 +6,12 @@ import { closeEncodedChunk } from './frame-envelopes';
 
 const { warnLog } = getLogs('AsyncVideoEncoder');
 
+// Clean outputs required before a degraded adapter is allowed back to its
+// original queue depth — roughly a second of encoding at 30fps. Doubles on each
+// restore (see noteResolved), capped here at ~2 minutes' worth.
+const DEGRADE_RECOVERY_OUTPUTS = 30;
+const MAX_DEGRADE_RECOVERY_OUTPUTS = 3840;
+
 // ---- Recommended input / output types -------------------------------------
 
 // Frame is owned by the wrapper once submitted; closed on output or failure.
@@ -87,7 +93,10 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
     private readonly timeoutMs: number;
     private readonly firstTimeoutMs: number;
     private maxInflight: number;
+    private readonly initialMaxInflight: number;
     private degraded = false;
+    private consecutiveResolved = 0;
+    private restoreThreshold = DEGRADE_RECOVERY_OUTPUTS;
     private disposed = false;
     private lastResolvedIndex = -1;
     private hasResolvedOutput = false;
@@ -97,6 +106,7 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
         options: CodecToAsyncAdapterOptions = {},
     ) {
         this.maxInflight = options.maxInflight ?? 2;
+        this.initialMaxInflight = this.maxInflight;
         this.timeoutMs = options.timeoutMs ?? 300;
         this.firstTimeoutMs = options.firstTimeoutMs ?? 1_500;
         this.onResetRequested = options.onResetRequested;
@@ -112,14 +122,17 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
             this.closeInput(input);
             return Promise.reject(new ObjectDisposedError(`${this.adapterName} is disposed`));
         }
+
         const readyError = this.getNotReadyError();
         if (readyError) {
             this.closeInput(input);
             return Promise.reject(readyError);
         }
+
         if (this.inflight.length >= this.maxInflight) {
             this.closeInput(input);
-            return Promise.reject(new Error(
+            // Recoverable: a full queue means "skip this item", never "kill the pipeline".
+            return Promise.reject(this.createResetError(
                 `${this.adapterName}: queue full (${this.inflight.length}/${this.maxInflight})`));
         }
 
@@ -134,6 +147,7 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
             pending.source.reject(e);
             return pending.source;
         }
+
         return pending.source;
     }
 
@@ -155,28 +169,35 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
     }
 
     dispose(): void {
-        if (this.disposed) return;
+        if (this.disposed)
+            return;
+
         this.disposed = true;
         this.failAllPending('disposed', false);
         this.closeCodec();
     }
+
+    // Protected/internal methods
 
     protected resolveOutput(output: TCodecOutput): void {
         if (this.disposed) {
             this.closeOutput(output);
             return;
         }
+
         const front = this.inflight.shift();
         if (!front) {
             this.closeOutput(output);
             return;
         }
+
         this.closeInputAfterOutput(front.input);
         if (front.source.isCompleted) {
             this.degradeAndReset(`stale-output (index=${front.index})`);
             this.closeOutput(output);
             return;
         }
+
         if (this.lastResolvedIndex >= 0 && front.index <= this.lastResolvedIndex) {
             this.closeOutput(output);
             front.source.reject(this.createResetError(
@@ -185,11 +206,13 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
                 `out-of-order: index=${front.index} <= last=${this.lastResolvedIndex}`);
             return;
         }
+
         this.lastResolvedIndex = front.index;
         try {
             const result = this.buildOutput(front.input, output);
             this.hasResolvedOutput = true;
             front.source.resolve(result);
+            this.noteResolved();
         } catch (e) {
             this.closeOutput(output);
             front.source.reject(e);
@@ -220,6 +243,12 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
         // Optional subclass hook.
     }
 
+    protected getTimeoutMessage(timeoutMs: number, index: number): string {
+        return `${this.adapterName}: item timeout after ${timeoutMs}ms (index=${index})`;
+    }
+
+    // Private methods
+
     private makePending(input: TIn): PendingCodecItem<TIn, TOut> {
         const source = new PromiseSourceWithTimeout<TOut>();
         // Caller may not attach .catch before sync timeout/queue-full rejection;
@@ -238,15 +267,35 @@ export abstract class CodecToAsyncAdapter<TIn, TOut, TCodecOutput> implements Di
                 this.degradeAndReset(`timeout (index=${pending.index})`);
             });
         }
+
         return pending;
     }
 
-    protected getTimeoutMessage(timeoutMs: number, index: number): string {
-        return `${this.adapterName}: item timeout after ${timeoutMs}ms (index=${index})`;
+    // Lifts the degrade once the codec has proven itself again — staying at
+    // maxInflight=1 for the session caps throughput and keeps `queue full` armed.
+    private noteResolved(): void {
+        if (!this.degraded)
+            return;
+
+        if (++this.consecutiveResolved < this.restoreThreshold)
+            return;
+
+        this.degraded = false;
+        this.consecutiveResolved = 0;
+        this.maxInflight = this.initialMaxInflight;
+        warnLog?.log(
+            `restoring maxInflight to ${this.maxInflight} after ${this.restoreThreshold} clean outputs`);
+        // A machine that is merely over budget re-degrades right after every restore.
+        // Doubling the bar each time lets one transient hiccup recover in a second and
+        // leaves a persistently marginal encoder parked at maxInflight=1.
+        this.restoreThreshold = Math.min(this.restoreThreshold * 2, MAX_DEGRADE_RECOVERY_OUTPUTS);
     }
 
     private degradeAndReset(reason: string): void {
-        if (this.disposed) return;
+        if (this.disposed)
+            return;
+
+        this.consecutiveResolved = 0;
         if (!this.degraded) {
             this.degraded = true;
             this.maxInflight = 1;
@@ -299,6 +348,7 @@ export class AsyncVideoEncoder<
         metadata: EncodedVideoChunkMetadata,
     ) => TOut;
     private lastConfig: VideoEncoderConfig | null = null;
+    private nextEncodeOptions: { keyFrame: boolean } | null = null;
 
     constructor(
         buildOutput: (
@@ -341,10 +391,13 @@ export class AsyncVideoEncoder<
         return input.index;
     }
 
+    // Recoverable on purpose: an unusable encoder means "skip this bundle and rebuild
+    // the slot", not "tear the pipeline down". The encode operator recreates it.
     protected getNotReadyError(): Error | null {
         if (this.encoder.state === 'configured')
             return null;
-        return new Error(`AsyncVideoEncoder: encoder state is '${this.encoder.state}'`);
+
+        return this.createResetError(`AsyncVideoEncoder: encoder state is '${this.encoder.state}'`);
     }
 
     protected buildOutput(input: TIn, output: EncoderOutput): TOut {
@@ -368,11 +421,22 @@ export class AsyncVideoEncoder<
     }
 
     protected resetCodec(): void {
-        if (this.isDisposed || this.encoder.state === 'closed') return;
+        if (this.isDisposed)
+            return;
+
+        // reset() is a no-op on a closed codec — say so instead of reporting success,
+        // because the only way back is a new VideoEncoder.
+        if (this.encoder.state === 'closed') {
+            warnLog?.log(`${this.tag || 'encoder'}: reset requested but the codec is closed`);
+            return;
+        }
+
         try {
             this.encoder.reset();
         } catch { /* ignore */ }
-        if (!this.lastConfig) return;
+        if (!this.lastConfig)
+            return;
+
         try {
             this.encoder.configure(this.lastConfig);
         } catch (e) {
@@ -386,17 +450,6 @@ export class AsyncVideoEncoder<
         }
     }
 
-    private processWithOptions(input: TIn, opts: { keyFrame: boolean }): Promise<TOut> {
-        this.nextEncodeOptions = opts;
-        try {
-            return this.process(input);
-        } finally {
-            this.nextEncodeOptions = null;
-        }
-    }
-
-    private nextEncodeOptions: { keyFrame: boolean } | null = null;
-
     protected submit(input: TIn): void {
         try {
             this.encoder.encode(input.frame, { keyFrame: this.nextEncodeOptions?.keyFrame ?? false });
@@ -409,6 +462,17 @@ export class AsyncVideoEncoder<
             // Chromium's frame pool is ~12-20 and the simulcast pipeline keeps
             // multiple wraps in flight.
             try { input.frame.close(); } catch { /* already closed */ }
+        }
+    }
+
+    // Private methods
+
+    private processWithOptions(input: TIn, opts: { keyFrame: boolean }): Promise<TOut> {
+        this.nextEncodeOptions = opts;
+        try {
+            return this.process(input);
+        } finally {
+            this.nextEncodeOptions = null;
         }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/Video/frame-envelopes.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/frame-envelopes.ts
@@ -346,6 +346,10 @@ export type NormalizedFrame = CapturedFrame;
 // Single-tier (P2P) sources produce a length-1 bundle.
 export interface CapturedBundle {
     layers: CapturedFrame[];
+    // LadderState.version the layer set was built from. The encoder set is
+    // reshaped against it, so a bundle that predates a ladder change must not
+    // be paired with encoders built for the newer one.
+    ladderVersion: number;
     // Bundle-level index (== layers[*].index) for drop-trace gap detection.
     index: number;
     dropTrace: FrameDropStage[];

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/downscale.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/downscale.ts
@@ -111,6 +111,7 @@ export function createDefaultDownscaler(): DownscalerLike {
             warnLog?.log('createDefaultDownscaler: WebGL init failed, using Canvas2D:', e);
         }
     }
+
     return new CanvasDownscaler();
 }
 
@@ -193,7 +194,8 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                 });
 
                 // 2. Tiers from the ceiling, on the selected backend, watchdogged.
-                const layers: LayerSpec[] = opts.controller.current.configs.map(
+                const ladder = opts.controller.current;
+                const layers: LayerSpec[] = ladder.configs.map(
                     c => ({ width: c.width, height: c.height }));
                 slot.downscaler ??= createDownscaler();
                 const downscaler = slot.downscaler;
@@ -202,7 +204,8 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                 // is unavailable / its context was lost.
                 if (!backendLogged) {
                     backendLogged = true;
-                    infoLog?.log(`normalizeDownscale: downscaler backend = ${downscaler.constructor.name} (mode '${mode}')`);
+                    infoLog?.log(
+                        `normalizeDownscale: downscaler backend = ${downscaler.constructor.name} (mode '${mode}')`);
                 }
                 const processPromise = downscaler.process(ceiling, layers);
                 let timerHandle: unknown = null;
@@ -212,6 +215,10 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                 let raced: VideoFrame[] | 'timeout';
                 try {
                     raced = await Promise.race([processPromise, timeoutP]);
+                } catch (e) {
+                    // process() rejects on GPU context loss and closes nothing — the ceiling is still ours.
+                    try { ceiling.close(); } catch { /* ignore */ }
+                    throw e;
                 } finally {
                     if (timerHandle !== null)
                         try { clearTimeoutFn(timerHandle); } catch { /* ignore */ }
@@ -232,6 +239,7 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                             `normalizeDownscale: hang watchdog fired ${consecutiveHangs}x in a row, giving up`);
                     return null;
                 }
+
                 consecutiveHangs = 0;
                 const frames = raced;
                 if (frames.length !== layers.length) {
@@ -241,17 +249,21 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                     throw new Error(
                         `normalizeDownscale: downscaler returned ${frames.length} frames, expected ${layers.length}`);
                 }
+
                 const ms = performance.now() - startedAtMs;
                 const stats = envelope.stats;
                 stats.downscaleTimeMsSum += ms;
                 stats.downscaleTimeMsCount++;
                 if (ms > stats.downscaleTimeMsMax) stats.downscaleTimeMsMax = ms;
-                // After a hang, re-anchor every encoder with a keyframe.
                 const wireRotation = transform.wireRotation;
                 // Preview taps a clone of the ceiling (full-res, never the
                 // shrunk tier). Then close the ceiling iff it is not also a tier
                 // — encode closes the tiers (incl. the ceiling-as-top-tier case).
-                opts.preview?.forward(ceiling, wireRotation);
+                try {
+                    opts.preview?.forward(ceiling, wireRotation);
+                } catch (e) {
+                    warnLog?.log('normalizeDownscale: preview.forward failed:', e);
+                }
                 if (!frames.includes(ceiling))
                     try { ceiling.close(); } catch { /* ignore */ }
                 const layerSource: NormalizedFrame = {
@@ -262,6 +274,7 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
                 forceKeyframeAfterHang = false;
                 return {
                     layers: frames.map(frame => makeLayerEnvelope(layerSource, frame)),
+                    ladderVersion: ladder.version,
                     index: envelope.index,
                     dropTrace: envelope.dropTrace,
                     rotation: wireRotation,
@@ -274,7 +287,8 @@ export function normalizeDownscale(opts: NormalizeDownscaleOptions): PipeOperato
         const op = stage(source);
         return from((async function* (): AsyncIterable<CapturedBundle> {
             for await (const bundle of op)
-                if (bundle !== null) yield bundle;
+                if (bundle !== null)
+                    yield bundle;
         })());
     };
 }
@@ -301,30 +315,33 @@ function produceCeiling(
         && input.codedHeight === target.height) {
         return input;
     }
-    if (cropboxRotation === 0 && input.codedWidth > 0 && input.codedHeight > 0) {
-        const visible = computeCoverVisibleRect(
-            input.codedWidth, input.codedHeight,
-            target.width, target.height);
-        const recropped = new VideoFrame(input, {
-            visibleRect: visible,
-            displayWidth: target.width,
-            displayHeight: target.height,
+
+    // Both remaining paths consume `input`, and allocation or the draw can throw.
+    try {
+        if (cropboxRotation === 0 && input.codedWidth > 0 && input.codedHeight > 0) {
+            const visible = computeCoverVisibleRect(
+                input.codedWidth, input.codedHeight,
+                target.width, target.height);
+            return new VideoFrame(input, {
+                visibleRect: visible,
+                displayWidth: target.width,
+                displayHeight: target.height,
+                timestamp: input.timestamp,
+                duration: input.duration ?? undefined,
+            });
+        }
+
+        const slot = getSlot();
+        prepareSlot(slot, target.width, target.height);
+        drawFrameCover(slot.ctx, input, target.width, target.height, cropboxRotation);
+        return new VideoFrame(slot.canvas, {
             timestamp: input.timestamp,
             duration: input.duration ?? undefined,
+            alpha: 'discard',
         });
+    } finally {
         try { input.close(); } catch { /* already closed */ }
-        return recropped;
     }
-    const slot = getSlot();
-    prepareSlot(slot, target.width, target.height);
-    drawFrameCover(slot.ctx, input, target.width, target.height, cropboxRotation);
-    const out = new VideoFrame(slot.canvas, {
-        timestamp: input.timestamp,
-        duration: input.duration ?? undefined,
-        alpha: 'discard',
-    });
-    try { input.close(); } catch { /* already closed */ }
-    return out;
 }
 
 function closeFrames(frames: readonly VideoFrame[]): void {
@@ -466,6 +483,7 @@ function isFrameTransposed(input: VideoFrame): boolean {
 function signedAngleDeltaDeg(from: number, to: number): number {
     if (!Number.isFinite(from) || !Number.isFinite(to))
         return 0;
+
     return ((((to - from + 180) % 360) + 360) % 360) - 180;
 }
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/encode.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/encode.ts
@@ -138,6 +138,10 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
             // didn't help and we should rebuild the pipeline.
             let bundleHangAttempts = 0;
             const maxBundleHangAttempts = 2;
+            // Every promise settles on this path, so the bundle watchdog never fires —
+            // without a cap, a codec that dies on every encode skips forever.
+            let consecutiveRecoverySkips = 0;
+            const maxRecoverySkips = 30;
 
             // Pipelined submission queue. Steady-state encoding submits
             // multiple bundles before awaiting any one's completion, so the
@@ -165,6 +169,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
             const ensureBundleWatchdog = (): void => {
                 if (bundleWatchdogHandle !== null)
                     return;
+
                 bundleWatchdogHandle = setTimeout(() => {
                     bundleWatchdogHandle = null;
                     bundleWatchdogSignal.notify();
@@ -173,6 +178,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
             const disposeBundleWatchdog = (): void => {
                 if (bundleWatchdogHandle === null)
                     return;
+
                 clearTimeout(bundleWatchdogHandle);
                 bundleWatchdogHandle = null;
             };
@@ -226,6 +232,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                                 settled = res.r;
                                 break;
                             }
+
                             if (performance.now() >= bundleAwaitDeadline)
                                 throw new Error(
                                     `encode: bundle ${p.bundle.index} hung — `
@@ -237,6 +244,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                     recordRestart(p.bundle.stats);
                     if (bundleHangAttempts >= maxBundleHangAttempts)
                         return { kind: 'throw', error: timeoutErr };
+
                     warnLog?.log(
                         `bundle ${p.bundle.index} hung — resetting encoders in place `
                         + `(attempt ${bundleHangAttempts}/${maxBundleHangAttempts}); `
@@ -251,6 +259,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                     forceKeyframeNext = true;
                     return { kind: 'skip' };
                 }
+
                 bundleHangAttempts = 0;
                 let layerSumMs = 0;
                 let layerMaxMs = 0;
@@ -266,9 +275,11 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                 for (const result of settled) {
                     if (result.status === 'fulfilled') {
                         anyEncodedOutput = true;
+                        consecutiveRecoverySkips = 0;
                         break;
                     }
                 }
+
                 if (rejected.length > 0) {
                     for (const result of settled) {
                         if (result.status === 'fulfilled')
@@ -276,8 +287,18 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                     }
                     if (rejected.every(r => isAsyncVideoEncoderResetError(r.reason))) {
                         forceKeyframeNext = true;
-                        return { kind: 'skip' };
+                        if (++consecutiveRecoverySkips < maxRecoverySkips)
+                            return { kind: 'skip' };
+
+                        const skippedCodec = configs[configs.length - 1].codec;
+                        return {
+                            kind: 'throw',
+                            error: new Error(
+                                `${ENCODER_INIT_FAILED_PREFIX} codec=${skippedCodec}: `
+                                + `${consecutiveRecoverySkips} bundles recovered without output`),
+                        };
                     }
+
                     const firstRealReason: unknown = rejected
                         .find(r => !isAsyncVideoEncoderResetError(r.reason))!.reason as unknown;
                     if (!anyEncodedOutput) {
@@ -293,11 +314,14 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                             ),
                         };
                     }
+
                     return { kind: 'throw', error: firstRealReason };
                 }
+
                 const results = settled.map((result): EncodedFrame => {
                     if (result.status !== 'fulfilled')
                         throw new Error('encode: unreachable rejected result after rejection check');
+
                     return result.value;
                 });
                 // Verify keyframe-ness when we asked for one. Pooled
@@ -317,15 +341,18 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                             break;
                         }
                     }
+
                     if (!allKey) {
                         warnLog?.log(
-                            `requested keyframe but encoder produced delta(s) at index=${p.bundle.index}; re-requesting`);
+                            `requested keyframe but encoder produced delta(s) `
+                            + `at index=${p.bundle.index}; re-requesting`);
                         for (const r of results)
                             closeEncodedFrame(r);
                         forceKeyframeNext = true;
                         return { kind: 'skip' };
                     }
                 }
+
                 const out: EncodedFrame[] = [];
                 let mustClose = true;
                 try {
@@ -380,8 +407,10 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                 while (pending.length > 0) {
                     const p = pending.shift()!;
                     const outcome = await awaitPending(p);
-                    if (outcome.kind === 'yield') yield outcome.bundle;
-                    else if (outcome.kind === 'throw') throw outcome.error;
+                    if (outcome.kind === 'yield')
+                        yield outcome.bundle;
+                    else if (outcome.kind === 'throw')
+                        throw outcome.error;
                 }
             }
 
@@ -414,9 +443,27 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                         // in-flight encodes against a different layer set. The
                         // await also lets a just-issued controller reshape land
                         // before we snapshot it below.
-                        for await (const r of drainPending()) yield r;
+                        try {
+                            for await (const r of drainPending())
+                                yield r;
+                        } catch (e) {
+                            closeBundleLayers(bundle);
+                            throw e;
+                        }
+
                         const oldN = encoders.length;
                         const cur = opts.controller.current;
+                        // The bundle's layer set belongs to the ladder version downscale
+                        // stamped on it. Reshaping against a newer one would build encoders
+                        // from one generation's configs and pair them with another's layers
+                        // — cur.configs[i] is not even guaranteed to exist for every i <
+                        // layerCount. Drop the straggler instead; downscale reads the
+                        // controller per frame, so the bundles behind it are already current.
+                        if (bundle.ladderVersion !== cur.version) {
+                            closeBundleLayers(bundle);
+                            continue;
+                        }
+
                         // Reconcile by CANONICAL layer id: a slot's encoder is
                         // reused only when a config with the same canonical id
                         // and dims/codec still exists, wherever it now sits in
@@ -459,6 +506,7 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                                 { cause: e },
                             );
                         }
+
                         // Dispose old encoders that no config reuses.
                         for (let i = 0; i < oldN; i++)
                             if (!reusedOldSlots.has(i))
@@ -473,6 +521,33 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                         if (oldN > 0) forceKeyframeNext = true;
                         configs = cur.configs;
                     }
+                    // A fatal WebCodecs error closes an encoder permanently — reset()
+                    // cannot revive it — so rebuild any slot that is no longer
+                    // configured before it can reject the whole bundle.
+                    const configuredSlots = Math.min(encoders.length, encoderCfgs.length);
+                    for (let i = 0; i < configuredSlots; i++) {
+                        const deadState = encoders[i].state;
+                        if (deadState !== 'closed' && deadState !== 'unconfigured')
+                            continue;
+
+                        const cfg = encoderCfgs[i];
+                        try { encoders[i].dispose(); } catch { /* ignore */ }
+                        try {
+                            encoders[i] = createEncoder(cfg, cfg.layerId ?? i);
+                        } catch (e) {
+                            closeBundleLayers(bundle);
+                            const message = e instanceof Error ? e.message : String(e);
+                            throw new Error(
+                                `${ENCODER_INIT_FAILED_PREFIX} codec=${cfg.codec}: ${message}`,
+                                { cause: e },
+                            );
+                        }
+
+                        recordRestart(bundle.stats);
+                        forceKeyframeNext = true;
+                        warnLog?.log(`encoder ${i} was '${deadState}' — recreated`);
+                    }
+
                     // applyKeyframePolicy promotes forceKeyframe to all-or-none;
                     // use the bundle helper to keep the contract explicit.
                     const keyFrame = isCapturedBundleKeyFrame(bundle)
@@ -483,7 +558,13 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                     // verify the encoder honored the request before pulling
                     // more bundles from source. Delta bundles pipeline freely.
                     if (keyFrame && pending.length > 0) {
-                        for await (const r of drainPending()) yield r;
+                        try {
+                            for await (const r of drainPending())
+                                yield r;
+                        } catch (e) {
+                            closeBundleLayers(bundle);
+                            throw e;
+                        }
                     }
 
                     pending.push(submitBundle(bundle, keyFrame));
@@ -504,12 +585,16 @@ export function encode(opts: EncodeOptions): PipeOperator<CapturedBundle, Encode
                     while (pending.length >= MAX_PIPELINE) {
                         const p = pending.shift()!;
                         const outcome = await awaitPending(p);
-                        if (outcome.kind === 'yield') yield outcome.bundle;
-                        else if (outcome.kind === 'throw') throw outcome.error;
+                        if (outcome.kind === 'yield')
+                            yield outcome.bundle;
+                        else if (outcome.kind === 'throw')
+                            throw outcome.error;
                     }
                 }
+
                 // Source ended — drain anything still in flight.
-                for await (const r of drainPending()) yield r;
+                for await (const r of drainPending())
+                    yield r;
             } finally {
                 disposeBundleWatchdog();
                 for (const enc of encoders) {

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/encoded-buffer.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/encoded-buffer.ts
@@ -34,17 +34,25 @@ export function pacedEncodedBuffer(opts: PacedEncodedBufferOptions): PipeOperato
             const pump: { done: boolean; error: unknown } = { done: false, error: undefined };
             let notify: (() => void) | null = null;
             const wake = (): void => { const n = notify; notify = null; n?.(); };
+            // A returned consumer must stop the producer too — a wedge restart returns it
+            // without raising abortSignal, and upstream keeps delivering regardless.
+            let isStopped = false;
+            let stopProducer: () => void = () => { /* replaced below */ };
+            const stopRace = new Promise<never>((_, reject) => {
+                stopProducer = () => reject(new Error('pacedEncodedBuffer: consumer stopped'));
+            });
+            void stopRace.catch(() => { /* handled by the producer's race while it runs */ });
 
             const produce = async (): Promise<void> => {
                 let pendingNext: Promise<IteratorResult<ArrivedChunk>> | null = null;
                 try {
-                    while (!abortSignal?.aborted) {
+                    while (!isStopped && !abortSignal?.aborted) {
                         pendingNext = iterator.next();
                         let result: IteratorResult<ArrivedChunk>;
                         try {
-                            result = await Promise.race([pendingNext, abortRace]);
+                            result = await Promise.race([pendingNext, abortRace, stopRace]);
                         } catch {
-                            break; // aborted
+                            break;
                         }
                         pendingNext = null;
                         if (result.done)
@@ -100,6 +108,7 @@ export function pacedEncodedBuffer(opts: PacedEncodedBufferOptions): PipeOperato
                     }
                     if (pump.error !== undefined)
                         throw pump.error instanceof Error ? pump.error : new Error('pacedEncodedBuffer: upstream error');
+
                     // Upstream ended: drain is exhausted above, trailing sub-target
                     // frames (if any) are closed by reset() in finally — same as the
                     // legacy single-loop behavior.
@@ -114,6 +123,8 @@ export function pacedEncodedBuffer(opts: PacedEncodedBufferOptions): PipeOperato
                     }
                 }
             } finally {
+                isStopped = true;
+                stopProducer();
                 await producer.catch(() => { /* ignore */ });
                 buffer.reset();
             }

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/keep-alive.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/keep-alive.ts
@@ -99,7 +99,18 @@ export function keepAlive(opts: KeepAliveOptions): PipeOperator<CapturedFrame, C
                         };
                         injectedCount++;
                         retained.stats.keepAliveFramesInjected++;
-                        yield injected;
+                        // The clone is ours until the consumer actually receives it —
+                        // a generator returned at this yield would otherwise strand it.
+                        let isInjectedOwned = true;
+                        try {
+                            yield injected;
+
+                            isInjectedOwned = false;
+                        } finally {
+                            if (isInjectedOwned)
+                                try { injected.frame.close(); } catch { /* ignore */ }
+                        }
+
                         continue;
                     }
                     result = raced;

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/present-mstg.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/present-mstg.ts
@@ -1,9 +1,14 @@
 import { type PipeOperator } from 'ix-ext';
+import { TimeoutError, withTimeout } from 'actuallab-core';
 import { getLogs } from 'logging';
 import { type DecodedFrame, type PlayerStats } from '../frame-envelopes';
 import { presentPacer, type PresentSink } from '../playback/present-pacer';
 
 const { warnLog } = getLogs('VideoPipeline');
+
+// Ceiling on one backpressure wait. Normal pacing resolves within a frame
+// interval; past this the consumer is wedged rather than merely behind.
+const WRITER_READY_TIMEOUT_MS = 1000;
 
 export interface MstgPresentOptions {
     getWriter: () => WritableStreamDefaultWriter<VideoFrame>;
@@ -31,15 +36,21 @@ export function mstgPresent(opts: MstgPresentOptions): PipeOperator<DecodedFrame
             return {
                 async present(frame: VideoFrame): Promise<boolean> {
                     try {
-                        // Backpressure: only block when the generator's queue is
-                        // actually full (desiredSize is synchronous, so steady state
-                        // stays timer-free). When the consumer (<video>/compositor)
-                        // is behind, await ready — this paces us to its drain rate
-                        // and, on a sustained stall, stalls the present loop + the
-                        // upstream decode until it resumes.
+                        // Backpressure: only block when the generator's queue is actually
+                        // full (desiredSize is synchronous, so steady state stays
+                        // timer-free), then pace to the consumer's drain rate — bounded, so
+                        // a wedged consumer costs dropped frames rather than the whole loop.
                         if ((writer.desiredSize ?? 1) <= 0) {
                             if (opts.stats) opts.stats.presentState = 'mstg:awaiting-ready';
-                            await writer.ready;
+                            try {
+                                await withTimeout(writer.ready, WRITER_READY_TIMEOUT_MS, 'mstgPresent: writer.ready');
+                            } catch (e: unknown) {
+                                if (!(e instanceof TimeoutError))
+                                    throw e;
+
+                                if (opts.stats) opts.stats.presentState = 'mstg:ready-timeout';
+                                return false;
+                            }
                         }
                         if (opts.stats) opts.stats.presentState = 'mstg:writing';
                         await writer.write(frame);

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
@@ -293,7 +293,8 @@ export const playerWorkerImpl: PlayerWorker = {
         const player = players.get(streamId);
         if (!player)
             return Promise.resolve(createEmptyPlayerStats());
-        return Promise.resolve({ ...player.stats });
+
+        return Promise.resolve(player.snapshotStats());
     },
 
     async stop(streamId?: string): Promise<void> {

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player.ts
@@ -236,8 +236,18 @@ export class Player {
         return this.abortController !== null;
     }
 
+    // encodedQueueCount is otherwise written only by the latency tap, which rides the
+    // decoded-frame stream — so it freezes at the moment decoding stops, which is
+    // exactly when a wedge report quotes it.
+    snapshotStats(): PlayerStats {
+        this.stats.encodedQueueCount = this.buffer?.count() ?? 0;
+        return { ...this.stats };
+    }
+
     setExpectedPaused(paused: boolean): void {
-        if (paused === this.expectedPaused) return;
+        if (paused === this.expectedPaused)
+            return;
+
         this.expectedPaused = paused;
         if (paused)
             this.stallTimer?.clear();

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-bg.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-bg.ts
@@ -83,7 +83,14 @@ void main() {
 export class WebGlBgRenderer {
     private gl: WebGL2RenderingContext | null = null;
     private readonly perf = new BgBlurPerfTracker('webgl');
-    private disposed = false;
+    private isDisposed = false;
+    // Stored so dispose() can detach it before its own loseContext() — that call
+    // dispatches the same event, and answering it would log an ordinary teardown
+    // as a context loss.
+    private readonly onContextLost = (): void => {
+        warnLog?.log('WebGlBgRenderer: context lost');
+        this.gl = null;
+    };
 
     private copyProgram: WebGLProgram | null = null;
     private blurProgram: WebGLProgram | null = null;
@@ -116,6 +123,10 @@ export class WebGlBgRenderer {
             warnLog?.log('WebGlBgRenderer: webgl2 context unavailable');
             return;
         }
+
+        // Without this the renderer goes silently black on a lost context and the
+        // logs give no way to tell that apart from an ordinary teardown.
+        canvas.addEventListener('webglcontextlost', this.onContextLost);
         try {
             this.gl = gl;
             this.initGl();
@@ -125,13 +136,41 @@ export class WebGlBgRenderer {
         }
     }
 
-    render(frame: VideoFrame): boolean {
-        if (this.disposed) return false;
+    dispose(): void {
+        if (this.isDisposed)
+            return;
+
+        this.isDisposed = true;
+        this.canvas.removeEventListener('webglcontextlost', this.onContextLost);
         const gl = this.gl;
-        if (!gl) return false;
+        if (!gl)
+            return;
+
+        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
+        if (this.pingTexture) gl.deleteTexture(this.pingTexture);
+        if (this.pongTexture) gl.deleteTexture(this.pongTexture);
+        if (this.pingFbo) gl.deleteFramebuffer(this.pingFbo);
+        if (this.pongFbo) gl.deleteFramebuffer(this.pongFbo);
+        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
+        if (this.copyProgram) gl.deleteProgram(this.copyProgram);
+        if (this.blurProgram) gl.deleteProgram(this.blurProgram);
+        gl.getExtension('WEBGL_lose_context')?.loseContext();
+        this.gl = null;
+    }
+
+    render(frame: VideoFrame): boolean {
+        if (this.isDisposed)
+            return false;
+
+        const gl = this.gl;
+        if (!gl)
+            return false;
+
         const fw = frame.displayWidth;
         const fh = frame.displayHeight;
-        if (fw <= 0 || fh <= 0) return false;
+        if (fw <= 0 || fh <= 0)
+            return false;
+
         const targetW = BG_CANVAS_WIDTH;
         const targetH = Math.max(1, Math.round(targetW * fh / fw));
         try {
@@ -212,22 +251,7 @@ export class WebGlBgRenderer {
         }
     }
 
-    dispose(): void {
-        if (this.disposed) return;
-        this.disposed = true;
-        const gl = this.gl;
-        if (!gl) return;
-        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
-        if (this.pingTexture) gl.deleteTexture(this.pingTexture);
-        if (this.pongTexture) gl.deleteTexture(this.pongTexture);
-        if (this.pingFbo) gl.deleteFramebuffer(this.pingFbo);
-        if (this.pongFbo) gl.deleteFramebuffer(this.pongFbo);
-        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
-        if (this.copyProgram) gl.deleteProgram(this.copyProgram);
-        if (this.blurProgram) gl.deleteProgram(this.blurProgram);
-        gl.getExtension('WEBGL_lose_context')?.loseContext();
-        this.gl = null;
-    }
+    // Private methods
 
     private initGl(): void {
         const gl = this.gl!;

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-kawase.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-kawase.ts
@@ -103,7 +103,14 @@ void main() {
 export class WebGlKawaseBgRenderer {
     private gl: WebGL2RenderingContext | null = null;
     private readonly perf = new BgBlurPerfTracker('webgl-kawase');
-    private disposed = false;
+    private isDisposed = false;
+    // Stored so dispose() can detach it before its own loseContext() — that call
+    // dispatches the same event, and answering it would log an ordinary teardown
+    // as a context loss.
+    private readonly onContextLost = (): void => {
+        warnLog?.log('WebGlKawaseBgRenderer: context lost');
+        this.gl = null;
+    };
 
     private downsampleProgram: WebGLProgram | null = null;
     private upsampleProgram: WebGLProgram | null = null;
@@ -135,6 +142,10 @@ export class WebGlKawaseBgRenderer {
             warnLog?.log('WebGlKawaseBgRenderer: webgl2 context unavailable');
             return;
         }
+
+        // Without this the renderer goes silently black on a lost context and the
+        // logs give no way to tell that apart from an ordinary teardown.
+        canvas.addEventListener('webglcontextlost', this.onContextLost);
         try {
             this.gl = gl;
             this.initGl();
@@ -144,13 +155,42 @@ export class WebGlKawaseBgRenderer {
         }
     }
 
-    render(frame: VideoFrame, blurStrength = 20): boolean {
-        if (this.disposed) return false;
+    dispose(): void {
+        if (this.isDisposed)
+            return;
+
+        this.isDisposed = true;
+        this.canvas.removeEventListener('webglcontextlost', this.onContextLost);
         const gl = this.gl;
-        if (!gl) return false;
+        if (!gl)
+            return;
+
+        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
+        for (const t of this.pyramidTex) gl.deleteTexture(t);
+        for (const f of this.pyramidFbo) gl.deleteFramebuffer(f);
+        this.pyramidTex.length = 0;
+        this.pyramidFbo.length = 0;
+        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
+        if (this.downsampleProgram) gl.deleteProgram(this.downsampleProgram);
+        if (this.upsampleProgram) gl.deleteProgram(this.upsampleProgram);
+        if (this.copyProgram) gl.deleteProgram(this.copyProgram);
+        gl.getExtension('WEBGL_lose_context')?.loseContext();
+        this.gl = null;
+    }
+
+    render(frame: VideoFrame, blurStrength = 20): boolean {
+        if (this.isDisposed)
+            return false;
+
+        const gl = this.gl;
+        if (!gl)
+            return false;
+
         const fw = frame.displayWidth;
         const fh = frame.displayHeight;
-        if (fw <= 0 || fh <= 0) return false;
+        if (fw <= 0 || fh <= 0)
+            return false;
+
         const targetW = BG_CANVAS_WIDTH;
         const targetH = Math.max(1, Math.round(targetW * fh / fw));
         try {
@@ -227,23 +267,7 @@ export class WebGlKawaseBgRenderer {
         }
     }
 
-    dispose(): void {
-        if (this.disposed) return;
-        this.disposed = true;
-        const gl = this.gl;
-        if (!gl) return;
-        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
-        for (const t of this.pyramidTex) gl.deleteTexture(t);
-        for (const f of this.pyramidFbo) gl.deleteFramebuffer(f);
-        this.pyramidTex.length = 0;
-        this.pyramidFbo.length = 0;
-        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
-        if (this.downsampleProgram) gl.deleteProgram(this.downsampleProgram);
-        if (this.upsampleProgram) gl.deleteProgram(this.upsampleProgram);
-        if (this.copyProgram) gl.deleteProgram(this.copyProgram);
-        gl.getExtension('WEBGL_lose_context')?.loseContext();
-        this.gl = null;
-    }
+    // Private methods
 
     private initGl(): void {
         const gl = this.gl!;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-host.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-host.ts
@@ -170,6 +170,10 @@ function createEncoder(
         const stack = e instanceof Error ? e.stack : undefined;
         const tag = enc.tag || 'pre-configure';
         warnLog?.log(`encoder error (${tag}): ${msg}`, stack ?? '');
+        // A fatal error closes the encoder and clears its queue without settling
+        // anything, so fail the in-flight items here rather than three seconds
+        // later when the bundle watchdog notices.
+        try { enc.handleEncoderReset(); } catch { /* ignore */ }
     };
 
     // Per-encode setTimeout/clearTimeout churn was ~750ms / 30s on a 90

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -221,9 +221,21 @@ export const recorderWorkerImpl: RecorderWorker = {
         return MediaCapture.applyFrameRate(track, fps);
     },
 
+    // The frame arrives transferred, so this realm owns it: an absent handler or a throw
+    // out of requireState() has to release it rather than drop it on the floor.
     pushFrame(frame: VideoFrame): Promise<void> {
-        const s = requireState();
-        s.deps.pushFrame?.(frame);
+        let isOwned = true;
+        try {
+            const push = requireState().deps.pushFrame;
+            if (push) {
+                push(frame);
+                isOwned = false;
+            }
+        } finally {
+            if (isOwned)
+                try { frame.close(); } catch { /* ignore */ }
+        }
+
         return Promise.resolve();
     },
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/webgl/downscaler.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/webgl/downscaler.ts
@@ -47,6 +47,7 @@ export function disableWebGlDownscale(): void {
 export function probeWebGl2(): boolean {
     if (webglDownscaleDisabled)
         return false;
+
     try {
         const probe = new OffscreenCanvas(1, 1);
         return probe.getContext('webgl2') !== null;
@@ -62,7 +63,14 @@ export class WebGlDownscaler implements DownscalerLike {
     private positionBuffer: WebGLBuffer | null = null;
     private sourceTexture: WebGLTexture | null = null;
     private uTexture: WebGLUniformLocation | null = null;
-    private disposed = false;
+    private isDisposed = false;
+    // Stored so dispose() can detach it before its own loseContext() — that call
+    // dispatches the same event, and answering it would disable WebGL for the session.
+    // No preventDefault(): restoration is not wanted, and nothing rebuilds the program.
+    private readonly onContextLost = (): void => {
+        warnLog?.log('WebGlDownscaler: context lost — disabling WebGL downscale');
+        disableWebGlDownscale();
+    };
 
     constructor() {
         this.canvas = new OffscreenCanvas(0, 0);
@@ -76,8 +84,29 @@ export class WebGlDownscaler implements DownscalerLike {
         });
         if (!gl)
             throw new Error('WebGlDownscaler: webgl2 context unavailable');
+
         this.gl = gl;
+        this.canvas.addEventListener('webglcontextlost', this.onContextLost);
         this.initGl();
+    }
+
+    dispose(): void {
+        if (this.isDisposed)
+            return;
+
+        this.isDisposed = true;
+        this.canvas.removeEventListener('webglcontextlost', this.onContextLost);
+        const gl = this.gl;
+        if (!gl)
+            return;
+
+        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
+        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
+        if (this.program) gl.deleteProgram(this.program);
+        gl.getExtension('WEBGL_lose_context')?.loseContext();
+        this.gl = null;
+        this.canvas.width = 0;
+        this.canvas.height = 0;
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -85,6 +114,14 @@ export class WebGlDownscaler implements DownscalerLike {
         const gl = this.gl;
         if (!gl)
             throw new Error('WebGlDownscaler: context unavailable');
+
+        // A lost context still accepts draw calls and silently renders black, so the
+        // catch below would never fire and the Canvas2D fallback would never engage.
+        if (gl.isContextLost()) {
+            disableWebGlDownscale();
+            throw new Error('WebGlDownscaler: context lost');
+        }
+
         const topIdx = layers.length - 1;
         const results = new Array<VideoFrame | null>(layers.length).fill(null);
         // Ceiling = the normalized input's visible size. A tier matching it is
@@ -102,6 +139,7 @@ export class WebGlDownscaler implements DownscalerLike {
                     results[i] = input;
                     continue;
                 }
+
                 if (this.canvas.width !== width)
                     this.canvas.width = width;
                 if (this.canvas.height !== height)
@@ -132,21 +170,7 @@ export class WebGlDownscaler implements DownscalerLike {
         }
     }
 
-    dispose(): void {
-        if (this.disposed)
-            return;
-        this.disposed = true;
-        const gl = this.gl;
-        if (!gl)
-            return;
-        if (this.sourceTexture) gl.deleteTexture(this.sourceTexture);
-        if (this.positionBuffer) gl.deleteBuffer(this.positionBuffer);
-        if (this.program) gl.deleteProgram(this.program);
-        gl.getExtension('WEBGL_lose_context')?.loseContext();
-        this.gl = null;
-        this.canvas.width = 0;
-        this.canvas.height = 0;
-    }
+    // Private methods
 
     private initGl(): void {
         const gl = this.gl!;

--- a/src/dotnet/UI.Blazor.App/Services/Video/webgpu/blur.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/webgpu/blur.ts
@@ -64,7 +64,8 @@ const mipmapTextureCache = new Map<string, GPUTexture>();
 function getMipmapTexture(w: number, h: number): GPUTexture {
     const key = `${w},${h}`;
     const cached = mipmapTextureCache.get(key);
-    if (cached) return cached;
+    if (cached)
+        return cached;
 
     const maxMips = Math.floor(Math.log2(Math.max(w, h))) + 1;
     const texture = device!.createTexture({
@@ -96,6 +97,7 @@ const uniform8BufferPool: GPUBuffer[] = [];
 function getUniform8Buffer(): GPUBuffer {
     if (uniform8BufferPool.length > 0)
         return uniform8BufferPool.pop()!;
+
     return device!.createBuffer({
         size: 8,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
@@ -113,28 +115,40 @@ const tempFloat32Array2 = new Float32Array(2);
 // destroy() calls a few frames behind the encode rate, after the GPU has
 // drained the work that referenced the resource.
 let blurFrameCounter = 0;
+// Split by what the closure touches. GPU handles die with the device and must not be
+// dereferenced afterwards; VideoFrames are unaffected and still have to be closed, so
+// a device loss drops the first queue but must drain the second.
 const blurCleanupQueue = new Map<number, (() => void)[]>();
+const blurFrameCloseQueue = new Map<number, (() => void)[]>();
 const BLUR_CLEANUP_DELAY_FRAMES = 3;
 
-function registerBlurDeferredCleanup(cleanupFn: () => void): void {
+function registerDeferred(queue: Map<number, (() => void)[]>, cleanupFn: () => void): void {
     const cleanupFrame = blurFrameCounter + BLUR_CLEANUP_DELAY_FRAMES;
-    const cleanups = blurCleanupQueue.get(cleanupFrame) ?? [];
+    const cleanups = queue.get(cleanupFrame) ?? [];
     cleanups.push(cleanupFn);
-    blurCleanupQueue.set(cleanupFrame, cleanups);
+    queue.set(cleanupFrame, cleanups);
+}
+
+function registerBlurDeferredCleanup(cleanupFn: () => void): void {
+    registerDeferred(blurCleanupQueue, cleanupFn);
 }
 
 function deferTextureDestroy(texture: GPUTexture | null): void {
-    if (!texture) return;
+    if (!texture)
+        return;
+
     registerBlurDeferredCleanup(() => texture.destroy());
 }
 
 function deferBufferDestroy(buffer: GPUBuffer | null): void {
-    if (!buffer) return;
+    if (!buffer)
+        return;
+
     registerBlurDeferredCleanup(() => buffer.destroy());
 }
 
 function deferFrameClose(frame: VideoFrame): void {
-    registerBlurDeferredCleanup(() => {
+    registerDeferred(blurFrameCloseQueue, () => {
         try { frame.close(); } catch { /* already closed */ }
     });
 }
@@ -147,20 +161,36 @@ function clearOffsetBufferCache(): void {
 
 export function processBlurDeferredCleanups(currentFrame: number = ++blurFrameCounter): void {
     const minCleanupFrame = currentFrame - BLUR_CLEANUP_DELAY_FRAMES;
-    for (const [frameNum, cleanups] of blurCleanupQueue) {
+    drainDueDeferred(blurCleanupQueue, minCleanupFrame);
+    drainDueDeferred(blurFrameCloseQueue, minCleanupFrame);
+}
+
+function drainDueDeferred(queue: Map<number, (() => void)[]>, minCleanupFrame: number): void {
+    for (const [frameNum, cleanups] of queue) {
         if (frameNum <= minCleanupFrame) {
-            for (const cleanup of cleanups) {
-                try { cleanup(); } catch (e) { warnLog?.log('Error during deferred cleanup:', e); }
-            }
-            blurCleanupQueue.delete(frameNum);
+            runDeferred(cleanups);
+            queue.delete(frameNum);
         }
+    }
+}
+
+function drainAllDeferred(queue: Map<number, (() => void)[]>): void {
+    for (const cleanups of queue.values())
+        runDeferred(cleanups);
+    queue.clear();
+}
+
+function runDeferred(cleanups: (() => void)[]): void {
+    for (const cleanup of cleanups) {
+        try { cleanup(); } catch (e) { warnLog?.log('Error during deferred cleanup:', e); }
     }
 }
 
 function getOffsetBuffer(targetW: number, targetH: number, blurStrength: number): GPUBuffer {
     const key = `${targetW},${targetH},${blurStrength}`;
     const cached = offsetBufferCache.get(key);
-    if (cached) return cached;
+    if (cached)
+        return cached;
 
     const buffer = device!.createBuffer({
         size: 8,
@@ -462,6 +492,7 @@ export async function initBlurWebGPU(gpuDevice?: GPUDevice): Promise<void> {
     if (device) {
         if (device === sharedDevice)
             return;
+
         infoLog?.log('Reinitializing blur with new shared device');
     }
 
@@ -476,8 +507,10 @@ export async function initBlurWebGPU(gpuDevice?: GPUDevice): Promise<void> {
 // cleanly against a fresh device. Cannot .destroy() the cached
 // textures/buffers — handles are already dead and dereffing them re-triggers
 // the same Dawn "external Instance reference no longer exists" path that
-// crashes the renderer. Maps are .clear()ed; the deferred-cleanup queue is
-// emptied (its closures hold .destroy() calls against dead handles).
+// crashes the renderer. Maps are .clear()ed, and so is the GPU cleanup queue (its
+// closures hold .destroy() calls against dead handles) — but the frame-close queue
+// is drained instead: those VideoFrames outlive the device and back-pressure the
+// decoder until they are closed.
 function onBlurDeviceLost(): void {
     warnLog?.log('Blur invalidated by device.lost');
     device = null;
@@ -505,6 +538,7 @@ function onBlurDeviceLost(): void {
     cachedOutSizeKey = '';
     lastBlurStrength = -1;
     blurCleanupQueue.clear();
+    drainAllDeferred(blurFrameCloseQueue);
     lostDispose = null;
 }
 
@@ -514,7 +548,8 @@ function ensureInitialized(): void {
 }
 
 function initializeGpuResources(): void {
-    if (!device) throw new Error('Device not initialized');
+    if (!device)
+        throw new Error('Device not initialized');
 
     try {
         const gpu = navigator.gpu as GPU | undefined;
@@ -1082,7 +1117,9 @@ export class BgBlurRenderer {
     }
 
     private ensureInit(): void {
-        if (this.initStarted) return;
+        if (this.initStarted)
+            return;
+
         this.initStarted = true;
         void (async () => {
             try {

--- a/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
@@ -6,54 +6,30 @@ import { AC } from 'app-constants';
 
 type ImageState = 'none' | 'skeleton' | 'thumbnail' | 'original';
 
+const ImageStates: readonly string[] = ['skeleton', 'thumbnail', 'original'];
+
 @customElement('image-skeleton')
 export class ImageSkeleton extends LitElement {
-    protected createRenderRoot() {
-        return this;
-    }
+    private _imageRef: Ref<HTMLImageElement> = createRef();
+    private _imageState: ImageState = 'none';
 
-    @property({ reflect: true }) class: string;
     @property() src: string;
     @property() thumbnailSrc: string;
     @property() title = '';
     @property({ type: Number }) width?: number;
     @property({ type: Number }) height?: number;
-
-    private _imageRef: Ref<HTMLImageElement> = createRef();
-    private _imageState: ImageState = 'none';
+    // Razor's one-time seed. It renders a constant, so re-renders can't fight the
+    // `data-image-state` this component writes — see docs/development/ui-components.md.
+    @property({ attribute: 'initial-state' }) initialState = '';
 
     connectedCallback() {
         super.connectedCallback();
-        if (this.classList.contains('show-image-original'))
-            this._imageState = 'original';
-        else if (this.classList.contains('show-image-thumbnail'))
-            this._imageState = 'thumbnail';
-        else if (this.classList.contains('show-image-skeleton'))
-            this._imageState = 'skeleton';
+        // Blazor can detach and re-attach the element; re-seeding here would roll a
+        // state that already advanced back to Razor's one-time value.
+        if (this._imageState === 'none' && ImageStates.includes(this.initialState))
+            this._imageState = this.initialState as ImageState;
+        this.applyState();
     }
-
-    updated(changedProperties: Map<string, unknown>) {
-        if (changedProperties.has('class') && this._imageState !== 'none') {
-            const stateClass = `show-image-${this._imageState}`;
-            if (!this.classList.contains(stateClass)) {
-                this.classList.remove('show-image-skeleton', 'show-image-thumbnail', 'show-image-original');
-                this.classList.add(stateClass);
-            }
-        }
-    }
-
-    // for tests
-    // willUpdate(changedProperties: any) {
-    //     if (changedProperties.has("src")) {
-    //         if (Math.floor(Math.random() * 100) % 2 === 0) {
-    //             const original = this.src;
-    //             this.src = "https://some.host/invalid.svg";
-    //             setTimeout(() => {
-    //                 this.src = original;
-    //             }, 3000)
-    //         }
-    //     }
-    // }
 
     render() {
         const isSubDomain = this.isSubDomain(this.src);
@@ -111,10 +87,17 @@ export class ImageSkeleton extends LitElement {
         }
     }
 
-    async reloadImage(): Promise<void> {
+    // Protected/internal methods
+
+    protected createRenderRoot() {
+        return this;
+    }
+
+    // Private methods
+
+    private async reloadImage(): Promise<void> {
         this._imageState = 'skeleton';
-        this.classList.remove('show-image-original');
-        this.classList.add('show-image-skeleton');
+        this.applyState();
 
         const isSubDomain = this.isSubDomain(this.src);
         for (let attempt = 0; attempt < 10; attempt++) {
@@ -130,25 +113,35 @@ export class ImageSkeleton extends LitElement {
                 return;
             }
         }
+
         if (this._imageRef.value)
             this._imageRef.value.src = this.src;
     }
 
-    imageLoaded(): void {
+    private imageLoaded(): void {
         this._imageState = 'original';
-        this.classList.remove('show-image-skeleton', 'show-image-thumbnail');
-        if (!this.classList.contains('show-image-original'))
-            this.classList.add('show-image-original');
+        this.applyState();
     }
 
-    thumbnailLoaded(): void {
+    // A cached original often loads before a proxied thumbnail; downgrading here would
+    // leave the blurry one showing for good, since imageLoaded() never fires again.
+    private thumbnailLoaded(): void {
+        if (this._imageState === 'original')
+            return;
+
         this._imageState = 'thumbnail';
-        this.classList.remove('show-image-skeleton');
-        if (!this.classList.contains('show-image-thumbnail') && (!this.classList.contains('show-image-original')))
-            this.classList.add('show-image-thumbnail');
+        this.applyState();
     }
 
-    isSubDomain(url: string): boolean {
+    private applyState(): void {
+        if (this._imageState === 'none')
+            return;
+
+        if (this.getAttribute('data-image-state') !== this._imageState)
+            this.setAttribute('data-image-state', this._imageState);
+    }
+
+    private isSubDomain(url: string): boolean {
         return url.includes(AC.prodHost);
     }
 }

--- a/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
@@ -495,18 +495,18 @@ chat-view-footer-skeleton .footer-editor {
 image-skeleton {
     @apply block;
 }
-image-skeleton.show-image-skeleton {
+image-skeleton[data-image-state="skeleton"] {
     @apply bg-05;
     animation: pulse 2s steps(10) infinite;
 }
-image-skeleton.show-image-skeleton .image,
-image-skeleton.show-image-thumbnail .image,
-image-skeleton.show-image-skeleton .image-thumbnail,
-image-skeleton.show-image-original .image-thumbnail {
+image-skeleton[data-image-state="skeleton"] .image,
+image-skeleton[data-image-state="thumbnail"] .image,
+image-skeleton[data-image-state="skeleton"] .image-thumbnail,
+image-skeleton[data-image-state="original"] .image-thumbnail {
     @apply invisible;
 }
-image-skeleton.show-image-original .image,
-image-skeleton.show-image-thumbnail .image-thumbnail {
+image-skeleton[data-image-state="original"] .image,
+image-skeleton[data-image-state="thumbnail"] .image-thumbnail {
     @apply block;
 }
 image-skeleton.image-cover {
@@ -563,7 +563,7 @@ voxt-skeleton {
 body:not(.app-ready) .animated-skeleton,
 body:not(.app-ready) .string-skeleton,
 body:not(.app-ready) voxt-skeleton,
-body:not(.app-ready) image-skeleton.show-image-skeleton,
+body:not(.app-ready) image-skeleton[data-image-state="skeleton"],
 body:not(.app-ready) thin-left-panel-skeleton .button,
 body:not(.app-ready) chat-view-footer-skeleton .footer-button,
 body:not(.app-ready) tab-skeleton .c-line {

--- a/src/dotnet/UI.Blazor/Components/VideoAttachmentThumbnail/VideoAttachmentThumbnail.razor
+++ b/src/dotnet/UI.Blazor/Components/VideoAttachmentThumbnail/VideoAttachmentThumbnail.razor
@@ -16,7 +16,7 @@
         <image-skeleton
             src="@originalUrl"
             thumbnailSrc="@thumbnailUrl"
-            class="show-image-skeleton"
+            initial-state="skeleton"
             width="@Attachment.Media.Width"
             height="@Attachment.Media.Height" />
     }

--- a/src/nodejs/src/actuallab-rpc/index.ts
+++ b/src/nodejs/src/actuallab-rpc/index.ts
@@ -81,6 +81,7 @@ export { RpcSharedObjectTracker } from './rpc-shared-object-tracker.js';
 export {
     RpcPeer,
     RpcConnectionState,
+    RpcPeerChangeKind,
     RpcClientPeer,
     RpcServerPeer,
     RPC_CLOSE_CODE_UNSUPPORTED_FORMAT,

--- a/src/nodejs/src/actuallab-rpc/rpc-call-tracker.ts
+++ b/src/nodejs/src/actuallab-rpc/rpc-call-tracker.ts
@@ -153,6 +153,17 @@ export class RpcOutboundCallTracker {
         return [...this._calls.keys()];
     }
 
+    /** Calls handed to the transport at least once. Must be snapshotted BEFORE the
+     *  peer enters `Connected` — that flushes every queued call, making queued and
+     *  in-flight calls indistinguishable. Mirrors .NET's `GetSentCalls`. */
+    getSentCalls(): RpcOutboundCall[] {
+        const calls: RpcOutboundCall[] = [];
+        for (const call of this._calls.values())
+            if (call.sentAt !== 0)
+                calls.push(call);
+        return calls;
+    }
+
     /** Reject all pending calls with the given error.
      *  Stage-3 compute calls (result resolved, awaiting invalidation) are kept in the tracker. */
     rejectAll(error: Error): void {

--- a/src/nodejs/src/actuallab-rpc/rpc-peer.ts
+++ b/src/nodejs/src/actuallab-rpc/rpc-peer.ts
@@ -788,6 +788,17 @@ export const enum RpcConnectionState {
     Connected = 3,
 }
 
+/** Outcome of comparing an incoming handshake with the previous one. Mirrors
+ *  .NET `RpcPeerChangeKind` — `ChangedToVeryFirst` lets the first handshake skip
+ *  reconnect processing, since there's no prior connection to reconcile with. */
+export const enum RpcPeerChangeKind {
+    Unchanged = 0,
+    ChangedToVeryFirst = 1,
+    Changed = 2,
+}
+
+const peerChangeKindNames = ['Unchanged', 'ChangedToVeryFirst', 'Changed'];
+
 /** Client-side RPC peer — initiates WebSocket connection. ref = URL. */
 export class RpcClientPeer extends RpcPeer {
     private _disposed = false;
@@ -801,7 +812,10 @@ export class RpcClientPeer extends RpcPeer {
      *  `connectionState.Handshake.Index` path in
      *  `RpcOutboundCallTracker.TryReconnect`. */
     private _remoteHandshakeIndex = 0;
-    private _lastRemotePeerId: string | undefined;
+    /** Mirrors .NET's `lastHandshake` local in `RpcPeer.OnRun`: first-ness is keyed
+     *  off "was there a previous handshake", not off `RemotePeerId` — a legacy server
+     *  sends none, so every one of its handshakes would look like the first. */
+    private _lastHandshake: RemoteHandshake | undefined;
     private _pendingHandshake: PromiseSource<RemoteHandshake> | undefined;
     private _reconnectsAt = 0;
     /** Server-issued reconnect secret, from the most recent handshake that
@@ -889,6 +903,7 @@ export class RpcClientPeer extends RpcPeer {
      *  self-invalidate and remote/shared objects are disposed). Pass `false`
      *  to simulate a same-peer reconnect in tests. */
     connectWith(conn: RpcConnection, isPeerChanged = true): void {
+        const sentCalls = this.outboundCalls.getSentCalls();
         this.setupConnection(conn);
         // Test-only: synthesize the "ready for calls" state without running
         // the handshake. Stays off the public state machine on purpose —
@@ -899,7 +914,7 @@ export class RpcClientPeer extends RpcPeer {
         // the listener set directly.
         this._isConnected = true;
         this.connectionStateChanged.trigger(RpcConnectionState.Connected);
-        void this._reconnect(isPeerChanged);
+        void this._reconnect(sentCalls, isPeerChanged);
     }
 
     /** Kick off the reconnect loop. Idempotent — subsequent calls are
@@ -1111,19 +1126,28 @@ export class RpcClientPeer extends RpcPeer {
                         this._reconnectSecret = remoteHandshake.Secret;
 
                     // Peer change detection (like .NET's RpcHandshake.GetPeerChangeKind)
-                    const isPeerChanged = this._detectPeerChange(remoteHandshake);
+                    const peerChangeKind = this._detectPeerChange(remoteHandshake);
                     // Mirrors RpcPeer.cs:316 — "Handshake succeeded".
-                    infoLog?.log(`'${this.ref}': Handshake succeeded, peerChanged=${isPeerChanged}`);
+                    infoLog?.log(
+                        `'${this.ref}': Handshake succeeded, peerChangeKind=${peerChangeKindNames[peerChangeKind]}`);
 
                     // Activate the connection and re-send outbound calls.
                     // All of this happens AFTER the handshake, so the server is ready to process calls.
+                    // Must be snapshotted before `Connected` — see `getSentCalls`.
+                    const sentCalls = this.outboundCalls.getSentCalls();
                     this._setConnectionState(RpcConnectionState.Connected);
                     connectedAt = Date.now();
+                    // No prior connection to reconcile with on the very first
+                    // handshake (RpcPeer.cs:421-424).
                     // Pass the close signal so `_reconcileReconnect`'s inner
                     // `$sys.Reconnect` call cancels cleanly if the socket dies
                     // mid-reconcile — otherwise its pending result.promise would
                     // deadlock the outer _reconnect() await.
-                    await this._reconnect(isPeerChanged, closedController.signal);
+                    if (peerChangeKind !== RpcPeerChangeKind.ChangedToVeryFirst)
+                        await this._reconnect(
+                            sentCalls,
+                            peerChangeKind === RpcPeerChangeKind.Changed,
+                            closedController.signal);
 
                     // Wait until disconnected — use the eager whenClosed promise
                     // so we don't miss an already-fired close event.
@@ -1166,7 +1190,10 @@ export class RpcClientPeer extends RpcPeer {
     }
 
     /**
-     * Reconcile outbound calls after reconnection, then flush pending sends.
+     * Reconcile the calls that were in flight on the connection that just died
+     * (`sentCalls`), then resend the survivors. Calls still waiting for a
+     * connection are deliberately NOT passed in — `AllowReconnect`/`AllowResend`
+     * don't apply to them, and entering `Connected` already sends them.
      *
      * On peer change (different server hubId) or with binary wire format —
      * we blind-resend every eligible call.
@@ -1184,7 +1211,11 @@ export class RpcClientPeer extends RpcPeer {
      * are always self-invalidated — TS doesn't track compute-call stages
      * across reconnect, so the safest behavior is to force a fresh compute.
      */
-    private async _reconnect(isPeerChanged: boolean, closedSignal?: AbortSignal): Promise<void> {
+    private async _reconnect(
+        sentCalls: RpcOutboundCall[],
+        isPeerChanged: boolean,
+        closedSignal?: AbortSignal
+    ): Promise<void> {
         if (this._connection === undefined) return;
 
         // Handle remote and shared objects on reconnect.
@@ -1203,7 +1234,7 @@ export class RpcClientPeer extends RpcPeer {
 
         // Filter calls by RemoteExecutionMode (same logic as before).
         const eligible: RpcOutboundCall[] = [];
-        for (const call of [...this.outboundCalls.values()]) {
+        for (const call of sentCalls) {
             const mode = call.remoteExecutionMode;
             if (!(mode & 2)) {
                 if (!call.result.isCompleted)
@@ -1226,8 +1257,7 @@ export class RpcClientPeer extends RpcPeer {
             // GetReconnectStage (RpcOutboundCall.cs:343). Without it, a call kept
             // (server still knows it) or resent after a long outage would be
             // timed out from its stale pre-disconnect send time.
-            if (call.sentAt !== 0)
-                call.sentAt = Date.now();
+            call.sentAt = Date.now();
         }
 
         // Reconcile with the server on same-peer reconnects. On peer change
@@ -1346,23 +1376,21 @@ export class RpcClientPeer extends RpcPeer {
      *  `RpcHandshake.GetPeerChangeKind` keys off `RemotePeerId`, not
      *  `RemoteHubId` (an idle server peer can be replaced while keeping the
      *  same hub id). On a change it clears the inbound tracker and fires
-     *  `peerChanged`; the very first handshake is never a change. */
-    private _detectPeerChange(handshake: RemoteHandshake): boolean {
-        const remotePeerId = handshake.RemotePeerId;
-        if (remotePeerId === undefined)
-            return false;
+     *  `peerChanged`; the very first handshake is `ChangedToVeryFirst`. */
+    private _detectPeerChange(handshake: RemoteHandshake): RpcPeerChangeKind {
+        const lastHandshake = this._lastHandshake;
+        this._lastHandshake = handshake;
+        if (lastHandshake === undefined)
+            return RpcPeerChangeKind.ChangedToVeryFirst;
 
-        const isPeerChanged =
-            this._lastRemotePeerId !== undefined &&
-            this._lastRemotePeerId !== remotePeerId;
-        this._lastRemotePeerId = remotePeerId;
-        if (isPeerChanged) {
-            this.inboundCalls.clear();
-            // Mirrors RpcPeer.cs:439 (Peer changed branch).
-            infoLog?.log(`'${this.ref}': Peer changed`);
-            this.peerChanged.trigger();
-        }
-        return isPeerChanged;
+        if (handshake.RemotePeerId === lastHandshake.RemotePeerId)
+            return RpcPeerChangeKind.Unchanged;
+
+        this.inboundCalls.clear();
+        // Mirrors RpcPeer.cs:439 (Peer changed branch).
+        infoLog?.log(`'${this.ref}': Peer changed`);
+        this.peerChanged.trigger();
+        return RpcPeerChangeKind.Changed;
     }
 
     protected override _onHandshakeReceived(handshake: RemoteHandshake): void {

--- a/src/nodejs/src/animation-sync.ts
+++ b/src/nodejs/src/animation-sync.ts
@@ -21,7 +21,6 @@ const defaultTickMs = 100;
 // instant. `fastRaf10` schedules onto the same grid.
 export const animationGridMs = 100;
 
-
 // The pseudo-element an animation lives on, where it isn't the element itself. This
 // is the one thing a registration has to state: a pseudo's animation is invisible in
 // the host's computed style, so it can't be derived, and pseudos can't take the inline
@@ -59,13 +58,19 @@ const animationClasses = new Set<string>([
     'animated-skeleton',
     'button',                   // thin-left-panel-skeleton .button
     'footer-button',            // chat-view-footer-skeleton .footer-button
-    'show-image-skeleton',
     'c-line',                   // tab-skeleton .c-line
     'recorder-btn-skeleton',
     'c-circle',                 // wave
     'string-skeleton',
     'voxt-skeleton',
 ]);
+
+// Animated elements a class can't identify. Same registry role as `animationClasses`
+// above — kept beside it so this file remains the one place listing every synced
+// animation.
+const animationSelectors: readonly string[] = [
+    'image-skeleton[data-image-state="skeleton"]', // skeleton shimmer
+];
 
 export class AnimationSync {
     // Explicit opt-in for elements with no class in the registry - notably nodes
@@ -80,7 +85,8 @@ export class AnimationSync {
 
     public static get selector(): string {
         const byClass = [...animationClasses].map(c => `.${c}`).join(',');
-        return `:is(${byClass},[${AnimationSync.attribute}]):not([${AnimationSync.syncedAttribute}])`;
+        const bySelector = animationSelectors.join(',');
+        return `:is(${byClass},${bySelector},[${AnimationSync.attribute}]):not([${AnimationSync.syncedAttribute}])`;
     }
 
     // Phase-aligns every registered element under `root`, returning how many were
@@ -222,7 +228,8 @@ export class AnimationSync {
         const tick = duration / steps;
         if (Math.abs(tick % animationGridMs) > 0.5)
             AnimationSync.warn(element,
-                `ticks every ${tick.toFixed(1)}ms (${duration}ms / steps(${steps})), which is not a multiple of the ${animationGridMs}ms grid`);
+                `ticks every ${tick.toFixed(1)}ms (${duration}ms / steps(${steps})), `
+                + `which is not a multiple of the ${animationGridMs}ms grid`);
     }
 
     // Attribute form: bare, `"::before"`, `"200"`, or `"200 ::before"`. It wins over
@@ -248,7 +255,7 @@ export class AnimationSync {
             if (animationClasses.has(className))
                 return true;
 
-        return false;
+        return animationSelectors.some(s => element.matches(s));
     }
 
     private static pseudoOfClasses(element: HTMLElement): string | undefined {
@@ -258,8 +265,10 @@ export class AnimationSync {
             if (pseudo === undefined || pseudo === found)
                 continue;
             if (found !== undefined) {
-                AnimationSync.warn(element, `matches registered classes with different pseudo-elements (${found}, ${pseudo})`);
+                AnimationSync.warn(element,
+                    `matches registered classes with different pseudo-elements (${found}, ${pseudo})`);
                 break;
+
             }
             found = pseudo;
         }
@@ -268,7 +277,9 @@ export class AnimationSync {
 
     private static warn(element: HTMLElement, message: string): void {
         const name = element.tagName.toLowerCase()
-            + (typeof element.className === 'string' && element.className ? `.${element.className.trim().split(/\s+/).join('.')}` : '');
+            + (typeof element.className === 'string' && element.className
+                ? `.${element.className.trim().split(/\s+/).join('.')}`
+                : '');
         console.warn(`AnimationSync: ${name} ${message}`);
     }
 

--- a/src/nodejs/src/api/streaming-api.ts
+++ b/src/nodejs/src/api/streaming-api.ts
@@ -7,7 +7,9 @@
 //     Api.init('Example', { url, modules: [streamingApi] });
 //     await streamingApi.liveVideoStreams.PushStream(...);
 
-import { defineRpcService, RpcRemoteExecutionMode, RpcType, type RpcHub } from 'actuallab-rpc';
+import {
+    defineRpcService, RpcCallTimeouts, RpcRemoteExecutionMode, RpcType, type RpcHub,
+} from 'actuallab-rpc';
 import { Api, type ApiModule } from './api.js';
 import type { Moment } from './rpc-scalars.js';
 import { coreApi } from './core-api.js';
@@ -19,6 +21,9 @@ import { coreApi } from './core-api.js';
 // the caller recreates them.  Mirror of [RpcMethod] on the .NET interfaces.
 const StreamPushMode = RpcRemoteExecutionMode.AwaitForConnection | RpcRemoteExecutionMode.AllowReconnect;
 const StreamControlMode = RpcRemoteExecutionMode.AwaitForConnection;
+// [RpcMethod(..., ConnectTimeout = 10)] on the .NET ILiveVideoStreams methods:
+// a control call waits at most 10s for the connection, then fails.
+const StreamControlTimeouts = new RpcCallTimeouts(10_000);
 
 // `clientStartAt` is the source's Unix-epoch capture timestamp (seconds, double).
 
@@ -29,9 +34,21 @@ export const LiveVideoStreamsDef = defineRpcService('ILiveVideoStreams', {
         args: ['session', 'chatId', 'clientStartAt', 'format', 'sourceKind', 'frameStream'],
         remoteExecutionMode: StreamPushMode,
     },
-    RequestKeyFrame: { args: ['session', 'streamId'], remoteExecutionMode: StreamControlMode },
-    ChangeRecordingQuality: { args: ['session', 'state', 'info'], remoteExecutionMode: StreamControlMode },
-    ChangePlaybackQuality: { args: ['session', 'qualityByStream', 'info'], remoteExecutionMode: StreamControlMode },
+    RequestKeyFrame: {
+        args: ['session', 'streamId'],
+        remoteExecutionMode: StreamControlMode,
+        timeouts: StreamControlTimeouts,
+    },
+    ChangeRecordingQuality: {
+        args: ['session', 'state', 'info'],
+        remoteExecutionMode: StreamControlMode,
+        timeouts: StreamControlTimeouts,
+    },
+    ChangePlaybackQuality: {
+        args: ['session', 'qualityByStream', 'info'],
+        remoteExecutionMode: StreamControlMode,
+        timeouts: StreamControlTimeouts,
+    },
 });
 
 // --- ILiveAudioStreams (per-stream audio push/pull + transcripts) ---

--- a/src/nodejs/src/main-thread-diagnostics.ts
+++ b/src/nodejs/src/main-thread-diagnostics.ts
@@ -360,12 +360,6 @@ export class MainThreadDiagnostics {
         let lastTick = performance.now();
         let stallStart = 0;
 
-        // Hidden tabs throttle setInterval to ~1s. Without filtering, every
-        // throttled tick (delta ~1000-1100ms) would be reported as a stall.
-        // We only ignore deltas that fit the throttling profile; bigger deltas
-        // are real stalls on top of throttling and still get reported.
-        const HIDDEN_THROTTLE_FLOOR_MS = 1100;
-
         // Re-baseline on visibility transitions: otherwise a stale lastTick
         // from the previous regime (e.g. throttled hidden tick) would make
         // the first tick of the new regime look like a stall.
@@ -386,7 +380,9 @@ export class MainThreadDiagnostics {
             const now = performance.now();
             const delta = now - lastTick;
             const isHidden = typeof document !== 'undefined' && document.visibilityState === 'hidden';
-            if (isHidden && delta < HIDDEN_THROTTLE_FLOOR_MS) {
+            // Hidden-tab timers throttle without an upper bound (minute-long buckets,
+            // or a frozen tab), so a delta measured here says nothing about the thread.
+            if (isHidden) {
                 if (stallStart) {
                     warnLog?.log(`watchdog: recovered after ${Math.round(now - stallStart)}ms total stall (tab hidden)`);
                     stallStart = 0;
@@ -437,7 +433,6 @@ export class MainThreadDiagnostics {
                         : '';
                     errorLog?.log(
                         `watchdog: main thread stalled for ${Math.round(delta)}ms`
-                        + (isHidden ? ' (tab hidden — throttling-adjusted)' : '')
                         + heapTail
                         + snapTail);
                 }

--- a/src/nodejs/src/rpc.ts
+++ b/src/nodejs/src/rpc.ts
@@ -172,6 +172,23 @@ function getTransferables(args: unknown[]): Transferable[] | undefined {
     return result;
 }
 
+// Transferables arrive owned by this realm, so a call that never reaches a method
+// has to release them here — a VideoFrame or AudioData left to the GC back-pressures
+// its codec until collection.
+function closeTransferables(args: unknown[] | undefined): void {
+    if (!args)
+        return;
+
+    for (const arg of args) {
+        if (!isTransferable(arg))
+            continue;
+
+        const closeable = arg as { close?: () => void };
+        if (typeof closeable.close === 'function')
+            try { closeable.close(); } catch { /* ignore */ }
+    }
+}
+
 /**
  * Direct noWait send — skips Proxy.get, proxyMethodCache lookup, RpcCall ctor.
  * Use in hot paths (per audio/video frame). Caller must pass transferables explicitly
@@ -210,7 +227,11 @@ export function rpcServer(
     const onMessage = async (event: MessageEvent<RpcCall>): Promise<void> => {
         const rpcCall = event.data;
         if (!rpcCall.id) {
-            await onUnhandledMessage(event);
+            try {
+                await onUnhandledMessage(event);
+            } finally {
+                closeTransferables(rpcCall.args);
+            }
             return;
         }
         debugLog?.log(`-> ${name}.onMessage[#${rpcCall.id}]:`, rpcCall)
@@ -220,7 +241,11 @@ export function rpcServer(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
             const method = serverImpl[rpcCall.method] as Function | null;
             if (!method) {
-                await onUnhandledMessage(event);
+                try {
+                    await onUnhandledMessage(event);
+                } finally {
+                    closeTransferables(rpcCall.args);
+                }
                 return;
             }
             value = await method.apply(serverImpl, rpcCall.args);
@@ -249,13 +274,19 @@ export function rpcServer(
         dispose() {
             if (!isDisposed) {
                 isDisposed = true;
-                messagePort.onmessage = oldOnMessage;
+                messagePort.onmessage = oldOnMessage ?? drainTransferables;
                 messagePort.onmessageerror = oldOnMessageError;
                 if (onDispose)
                     onDispose();
             }
         }
     }
+}
+
+// Stand-in handler for a port whose server is gone: messages posted before the
+// dispose can still be dispatched, and dropping them strands their transferables.
+function drainTransferables(event: MessageEvent<RpcCall>): void {
+    closeTransferables(event.data.args);
 }
 
 const DefaultRpcClientTimeoutMs = 5_000;
@@ -374,7 +405,7 @@ export function rpcClientServer<TClient extends object>(
 
     const onDispose = () => {
         server.dispose();
-        messagePort.onmessage = oldOnMessage;
+        messagePort.onmessage = oldOnMessage ?? drainTransferables;
         messagePort.onmessageerror = oldOnMessageError;
     }
 

--- a/tests/ts/unit/async-video-encoder.test.ts
+++ b/tests/ts/unit/async-video-encoder.test.ts
@@ -241,6 +241,43 @@ describe('AsyncVideoEncoder', () => {
         expect(onResetReasons[0]).toMatch(/timeout/);
     });
 
+    it('doubles the clean-output bar each time a degraded adapter is restored', async () => {
+        vi.useFakeTimers();
+        const enc = makeEncoder({ timeoutMs: 50 });
+        const mock = MockVideoEncoder.instances[0];
+        // Outputs are verified FIFO by index, so it has to keep climbing across degrades.
+        let nextIndex = 1;
+        const degrade = async (): Promise<void> => {
+            const stuck = enc.encode(makeCaptured(nextIndex++, 'stuck'), { keyFrame: false });
+            const rejection = expect(stuck).rejects.toThrow(/encode timeout/);
+            await vi.advanceTimersByTimeAsync(60);
+            await rejection;
+        };
+        const emitClean = async (count: number): Promise<void> => {
+            for (let i = 0; i < count; i++) {
+                const p = enc.encode(makeCaptured(nextIndex++), { keyFrame: false });
+                mock.emitNext();
+                await p;
+            }
+        };
+
+        // arrange: the first degrade lifts after 30 clean outputs
+        await degrade();
+        await emitClean(29);
+        expect(enc.isDegraded).toBe(true);
+        await emitClean(1);
+        expect(enc.isDegraded).toBe(false);
+
+        // act: degrading again puts the bar at 60
+        await degrade();
+        await emitClean(59);
+
+        // assert
+        expect(enc.isDegraded).toBe(true);
+        await emitClean(1);
+        expect(enc.isDegraded).toBe(false);
+    });
+
     it('uses a wider first-output timeout, then steady-state timeout', async () => {
         vi.useFakeTimers();
         const enc = makeEncoder({ firstTimeoutMs: 1_500, timeoutMs: 300 });

--- a/tests/ts/unit/operators/apply-keyframe-policy.test.ts
+++ b/tests/ts/unit/operators/apply-keyframe-policy.test.ts
@@ -49,7 +49,7 @@ function makeBundle(
     for (let i = 0; i < extraCount + 1; i++) {
         layers.push(makeCaptured(stats, idx, forceKeyframe, isKeepAlive));
     }
-    return { layers, index: idx, dropTrace: [], rotation: 0, stats };
+    return { layers, ladderVersion: 0, index: idx, dropTrace: [], rotation: 0, stats };
 }
 
 async function* source(items: CapturedBundle[]): AsyncIterable<CapturedBundle> {

--- a/tests/ts/unit/operators/encode.test.ts
+++ b/tests/ts/unit/operators/encode.test.ts
@@ -150,12 +150,13 @@ function makeBundle(
     stats: RecorderStats,
     layers: { width: number; height: number }[],
     forceKeyframe = false,
+    ladderVersion = 0,
 ): CapturedBundle {
     if (layers.length === 0) throw new Error('makeBundle: at least one layer');
     // Bottom-first: layers[0] = base layer, layers[last] = top layer.
     const captured: CapturedFrame[] = layers.map(l =>
         makeCaptured(index, stats, l.width, l.height, forceKeyframe));
-    return { layers: captured, index, dropTrace: [], rotation: 0, stats };
+    return { layers: captured, ladderVersion, index, dropTrace: [], rotation: 0, stats };
 }
 
 function fromArray<T>(items: T[]): AsyncIterable<T> {
@@ -602,8 +603,8 @@ describe('encode operator', () => {
             createEncoder: makeFactory(),
         })(fromArray([
             makeBundle(1, stats, [{ width: 640, height: 360 }]),
-            makeBundle(2, stats, [{ width: 640, height: 360 }, { width: 1280, height: 720 }]),
-            makeBundle(3, stats, [{ width: 640, height: 360 }, { width: 1280, height: 720 }]),
+            makeBundle(2, stats, [{ width: 640, height: 360 }, { width: 1280, height: 720 }], false, 1),
+            makeBundle(3, stats, [{ width: 640, height: 360 }, { width: 1280, height: 720 }], false, 1),
         ]));
         const iter: AsyncIterator<EncodedBundle> = seg[Symbol.asyncIterator]();
 
@@ -659,7 +660,7 @@ describe('encode operator', () => {
             makeBundle(2, stats, [
                 { width: 320, height: 180 },
                 { width: 640, height: 360 },
-            ]),
+            ], false, 1),
         ]));
         const iter: AsyncIterator<EncodedBundle> = seg[Symbol.asyncIterator]();
 
@@ -684,5 +685,32 @@ describe('encode operator', () => {
         expect(topEncoder.state).toBe('closed');
 
         await iter.next();
+    });
+
+    it('drops a bundle whose ladder version the controller has moved past', async () => {
+        const stats = makeStats();
+        const controller = new LayerLadderController([cfg(640, 360)]);
+        const seg = encode({
+            controller,
+            createEncoder: makeFactory(),
+        })(fromArray([
+            makeBundle(1, stats, [{ width: 640, height: 360 }]),
+            // Still stamped v0: downscale emitted it before the reconfigure below.
+            makeBundle(2, stats, [{ width: 640, height: 360 }, { width: 1280, height: 720 }]),
+        ]));
+        const iter: AsyncIterator<EncodedBundle> = seg[Symbol.asyncIterator]();
+
+        const next1 = iter.next();
+        await waitForCalls(0, 1);
+        MockVideoEncoder.instances[0].emitNext(80, 'key');
+        expect((await next1).done).toBe(false);
+
+        // act: the ladder moves on while bundle 2 is mid-reshape
+        controller.setConfigs([cfg(640, 360), cfg(1280, 720)]);
+        const r2 = await iter.next();
+
+        // assert: no encoder was built for the stale generation, and it leaked nothing
+        expect(r2.done).toBe(true);
+        expect(MockVideoEncoder.instances).toHaveLength(1);
     });
 });

--- a/tests/ts/unit/paced-encoded-buffer.test.ts
+++ b/tests/ts/unit/paced-encoded-buffer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { pacedEncodedBuffer } from '../../../src/dotnet/UI.Blazor.App/Services/Video/operators/encoded-buffer';
+import { EncodedFrameBuffer } from '../../../src/dotnet/UI.Blazor.App/Services/Video/playback/encoded-frame-buffer';
+import type { ArrivedChunk } from '../../../src/dotnet/UI.Blazor.App/Services/Video/frame-envelopes';
+
+describe('pacedEncodedBuffer', () => {
+    it('settles teardown when the consumer stops while upstream keeps delivering', async () => {
+        // arrange: a live upstream that never ends, as an RpcStream does
+        const source = endlessChunks();
+        const iterator = drainOf(source);
+        await iterator.next();
+
+        // act: return the consumer, which is what a wedge restart does
+        const outcome = await Promise.race([
+            iterator.return!().then(() => 'settled' as const),
+            delay(2000).then(() => 'hung' as const),
+        ]);
+
+        // assert
+        expect(outcome).toBe('settled');
+    });
+
+    it('still ends normally when upstream completes', async () => {
+        // arrange
+        const source = (async function* (): AsyncIterable<ArrivedChunk> {
+            await delay(0);
+            yield makeChunk();
+        })();
+        const iterator = drainOf(source);
+
+        // act
+        const first = await iterator.next();
+        const second = await iterator.next();
+
+        // assert
+        expect(first.done).toBe(false);
+        expect(second.done).toBe(true);
+    });
+
+    it('stops pulling upstream once the consumer is gone', async () => {
+        // arrange
+        let produced = 0;
+        const source = (async function* (): AsyncIterable<ArrivedChunk> {
+            for (;;) {
+                produced++;
+                yield makeChunk();
+
+                await delay(0);
+            }
+        })();
+        const iterator = drainOf(source);
+        await iterator.next();
+
+        // act
+        await iterator.return!();
+        const producedAtStop = produced;
+        await delay(50);
+
+        // assert
+        expect(produced).toBe(producedAtStop);
+    });
+});
+
+function drainOf(source: AsyncIterable<ArrivedChunk>): AsyncIterator<ArrivedChunk> {
+    const buffer = new EncodedFrameBuffer({ targetSpanMs: 0, nowFn: () => 0 });
+    const out = pacedEncodedBuffer({ buffer })(source as never) as AsyncIterable<ArrivedChunk>;
+    return out[Symbol.asyncIterator]();
+}
+
+function endlessChunks(): AsyncIterable<ArrivedChunk> {
+    return (async function* (): AsyncIterable<ArrivedChunk> {
+        for (;;) {
+            yield makeChunk();
+
+            await delay(0);
+        }
+    })();
+}
+
+function makeChunk(): ArrivedChunk {
+    return {
+        chunk: { type: 'key', timestamp: 0, duration: 33_000, byteLength: 1 } as unknown as EncodedVideoChunk,
+        arrivedAt: { timeMs: 0, epoch: 0 },
+        capturedAt: { timeMs: 0, epoch: 0 },
+        index: 0,
+        dropTrace: [],
+        serverArrivedAtUnixMs: 0,
+        isKeyFrame: true,
+    } as unknown as ArrivedChunk;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise<void>(resolve => setTimeout(resolve, ms));
+}

--- a/tests/ts/unit/playback/video-decoder-bridge.test.ts
+++ b/tests/ts/unit/playback/video-decoder-bridge.test.ts
@@ -188,4 +188,40 @@ describe('VideoDecoderBridge', () => {
         bridge.tryPull();
         expect(stats.decodedReadyCount).toBe(0);
     });
+
+    it('throws CODEC_EXHAUSTED once the recovery budget runs out', () => {
+        // arrange: an unproven decoder that fails again on every recovery keyframe
+        const { bridge, decoders } = makeBridge();
+        const stats = createEmptyPlayerStats();
+        for (let i = 0; i < 4; i++) {
+            decoders[decoders.length - 1].handlers.onError(new Error(`decode failed ${i}`));
+            bridge.submit(makeArrived(stats, true, i));
+        }
+
+        // act: maxRecoveries is 5, so the 5th recovery keyframe is the one that gives up
+        decoders[decoders.length - 1].handlers.onError(new Error('decode failed 4'));
+        const arrived = makeArrived(stats, true, 4);
+
+        // assert: it throws, and still closes the chunk it was handed
+        expect(() => bridge.submit(arrived)).toThrow(/CODEC_EXHAUSTED/);
+        expect(stats.recoveryStreak).toBe(5);
+        expect((arrived.chunk as unknown as MockEncodedVideoChunk).closed).toBe(true);
+    });
+
+    it('closes a decoder frame that has no in-flight chunk to pair with', () => {
+        // arrange: one submitted chunk, so the second output has nothing left to pair with
+        const { bridge, decoders } = makeBridge();
+        const stats = createEmptyPlayerStats();
+        bridge.submit(makeArrived(stats, true, 0));
+        let unpairedCloseCount = 0;
+
+        // act
+        decoders[0].handlers.onFrame({ close: () => { /* paired */ } } as unknown as VideoFrame);
+        decoders[0].handlers.onFrame(
+            { close: () => { unpairedCloseCount++; } } as unknown as VideoFrame);
+
+        // assert
+        expect(unpairedCloseCount).toBe(1);
+        expect(stats.decodedReadyCount).toBe(1);
+    });
 });


### PR DESCRIPTION
Started from one console log: a 7.25s main-thread stall on dev that took video
recording and playback down with it. A five-way investigation traced the chain,
and each defect found along the way is one commit. 39 commits, 45 files.

Every mechanism below was read from source; where something was measured or
verified in a browser, it says so.

---

## 1. The render storm — the root cause

**Streaming message render rate.**
*Problem:* `ChatEntryMessageInternalView` inherited the default `IUpdateDelayer`,
which collapses to `MinDelay` (~32ms) whenever `UIActionTracker` reports instant
updates — true for any UI action and for 300ms after one, so effectively always
during chat use. Each recompute becomes its own render batch, SignalR message and
synchronous DOM patch: ~30/sec per streaming message.
*Solution:* `FixedDelayer.Get(0.2)`, which ignores the action tracker and pins the
state to 5 updates/sec — the same 200ms grid the streaming markup already animates on.

**`image-skeleton` fought Blazor for the `class` attribute.**
*Problem:* Two writers owned `class`. Blazor rewrote it on every re-render from a
tree that only knew the initial state; the component restored its own state class in
response. Worse, `thumbnailLoaded()` claimed state `'thumbnail'` even on the branch
where it deliberately left `show-image-original` alone — so once a cached original
beat a proxied thumbnail, the next class write **permanently downgraded a sharp
image to its blurry thumbnail**, and `imageLoaded()` never fires again to undo it.
*Solution:* two commits. First the state desync, so the restore lands on the right
class. Then the conflict itself: state moved to `data-image-state`, which Blazor
never renders, seeded once from Razor through a constant `initial-state` property.
CSS moved to attribute selectors (same specificity), and `animation-sync` gained a
non-class matcher so the skeleton shimmer stays phase-aligned.
*Verified in-browser:* two consecutive Blazor-style class writes leave the state
untouched, the skeleton selector still resolves to `animation-name: pulse`, and a
class write costs **1 mutation record instead of 3**.

`connectedCallback()` had a third bug on the same field: it re-seeded `_imageState`
from the Razor-supplied `initial-state` on **every** attach, so a Blazor move of an
already-loaded image rolled it back to `skeleton` and re-showed the shimmer over a
decoded bitmap. It now seeds only while the state is `none`.

The rule is now written down in `docs/development/ui-components.md`: a Lit
component may *have* a `class` but must never *write* one.

---

## 2. VideoFrame lifetime

**Ceiling frame on downscaler rejection.** *Problem:* the `try/finally` around the
race cleared the hang timer but had no `catch`, and `downscaler.process()` closes
nothing on failure — so every rejection stranded a full-resolution frame. Rejection
is exactly what a lost GPU context produces, **at capture rate**. *Solution:* close
it on the rejection path; also close `produceCeiling`'s input from a `finally`, and
stop a throwing `preview.forward()` — a cosmetic tap — from stranding the ceiling
and every tier.

**Pulled bundle on drain throw.** *Problem:* both drain-and-yield points hold a
bundle the operator owns but has not handed to the encoders; the operator's
`finally` disposes encoders, not the bundle. 1-4 frames per encoder error.
*Solution:* close the bundle's layers before the error propagates.

**RPC transferables.** *Problem:* an `RpcCall`'s transferables arrive owned by the
receiving realm, and three paths dropped them: no call id, no such method, and — the
one that produced `A VideoFrame was garbage collected without being closed` in the
log — a disposed server, which restored a null `onmessage` and let in-flight
messages fall on the floor. *Solution:* release them on the non-delivery paths, and
stand in with a drain handler when there is no previous handler to restore. The
video recorder also defers `Worker.terminate()` by one turn so queued preview frames
reach that handler instead of dying with the worker.

**Keep-alive clone** and **`recorder-worker.pushFrame`.** *Problem:* both drop a
frame when the consumer or handler is gone — a bare `yield` with no guard, and an
optional-chained forward that silently discards when `deps.pushFrame` is absent.
*Solution:* guard both.

**WebGPU device loss.** *Problem:* the deferred-cleanup queue mixed GPU `destroy()`
closures (which must not run after device loss) with `VideoFrame.close()` closures
(which must). `onBlurDeviceLost` cleared the lot. *Solution:* split the queues —
drop the GPU one, drain the frame one.

---

## 3. Sender: encoder recovery

**The fatal-error callback only logged.** *Problem:* per spec a fatal WebCodecs error
closes the encoder and clears its queue without settling anything, so up to five
bundles x two layers stayed pending and nothing noticed until the 3s bundle watchdog.
*Solution:* fail the in-flight items from the callback.

**A closed encoder was a one-way door.** *Problem:* `resetCodec()` returns early on
state `'closed'` **silently**, so the watchdog's "resetting encoders in place"
reported a recovery it had not performed; and `getNotReadyError()` built a plain
`Error`, which falls outside `awaitPending()`'s all-reset sweep and is classified
fatal. The next `submitBundle()` after any fatal codec error was therefore
guaranteed to kill the pipeline. *Solution:* make the not-ready error recoverable,
have `resetCodec` say when it cannot reset, and rebuild any slot whose state is
`closed`/`unconfigured` before submitting, forcing a keyframe so the new encoder
anchors.

**The recovery sweep had no exit.** *Problem:* on that all-reset path every promise
settles, so the 3s bundle watchdog never fires. A codec failing on **every** encode
therefore skipped bundles forever while the pipeline looked healthy and produced
nothing. *Solution:* escalate to `ENCODER_INIT_FAILED` after 30 consecutive skips
with no encoded output; any fulfilled output resets the counter.

**A degraded adapter never recovered.** *Problem:* `degradeAndReset` dropped
`maxInflight` to 1 and nothing raised it again, so one timeout capped throughput for
the session — and with the operator still pipelining five deep, that permanently
armed a `queue full` rejection which was *also* a plain `Error`, i.e. fatal.
*Solution:* make queue-full recoverable and restore the original depth after 30 clean
outputs.

**…and then oscillated.** *Problem:* a machine marginally over budget re-degrades
right after every restore, so a fixed bar produces degrade → restore → timeout
roughly once a second, each turn costing a codec reset and a forced keyframe.
*Solution:* double the bar on each restore (capped at 3840, ~2 min at 30fps) — one
transient hiccup still recovers in a second, a persistently marginal encoder parks
at `maxInflight=1`.

**Reshape mixed two ladder generations.** *Problem (pre-existing):* the reshape sized
the encoder set from the **bundle's** layer count but read its configs from a fresh
controller snapshot. A ladder change landing between the bundle leaving downscale and
the reshape drain completing made those disagree — `cur.configs[i]` is not guaranteed
to exist for every `i < layerCount`, so the slot loop either built encoders from the
wrong generation's dims or threw on an undefined config and killed the pipeline.
*Solution:* `CapturedBundle` carries the `LadderState` version it was built from, and
a bundle the controller has moved past is dropped rather than reshaped.

**Recovery re-entrancy.** *Problem:* `recoveryScheduled` was cleared when the timer
fired, not when recovery finished. An error arriving during `recoverNow` passed the
guard; the overlapping `startWorker` rejected with "already running", which scheduled
another — a self-feeding loop to the attempt cap, which hands the session to
`engageEncoderFallback` and **permanently drops it to software H.264 at 640x360 or
lower**. *Solution:* hold the guard across the whole of `recoverNow` — and bound that
pass at 15s, since its awaits reach a worker that may itself be wedged and an
unbounded one would have retired recovery for the session.

---

## 4. Receiver: decoder and present recovery

**Teardown deadlock.** *Problem:* `pacedEncodedBuffer`'s consumer awaited the
producer unconditionally, and the producer only exits on upstream end or abort. A
wedge restart returns the consumer without raising either while the RpcStream keeps
delivering, so teardown waited on a loop with no reason to end. `[CODEC_EXHAUSTED]`
never escaped: `whenDone()` never rejected, `onError` never fired, and the 30s stall
timer was defeated because arriving chunks kept resetting it — leaving a main-thread
poller as the only thing that could break the wedge, at 6s of black video.
*Solution:* give the producer its own stop signal, raised by the consumer's `finally`.

**Recovery budget.** An earlier commit here reset `consecutiveRecoveries` on *any*
decoder output rather than only a paired one, to stop a merely slow decoder from
exhausting its budget. It was **dropped**: `8b32b6ac6f` on `dev` fixes that failure
from the submit side (the hang deadline no longer expires while waiting for a chunk
the decoder could accept), which is the better place for it, and the looser reset
would have let a decoder emitting stale frames never exhaust at all.

**MSTG present had no ceiling.** *Problem:* `writer.ready` is the pacer's only
backpressure signal and was awaited unbounded, so a wedged `<video>`/compositor
stalled presentation and the decode behind it indefinitely — a second wedge mode.
*Solution:* cap one wait at a second and drop the frame; `presentPacer` already
treats a false result as a presenter drop and closes the frame.

**Stat was stale exactly when quoted.** *Problem:* `encodedQueueCount` was written
only by the latency tap, which rides the decoded-frame stream at ~1Hz — so it froze
the instant decoding stopped, which is when a wedge report quotes it. The `buf=4` in
the incident log was 11.5s stale and reads as something that did not happen.
*Solution:* sample the buffer in `getStats`.

**Tests.** `paced-encoded-buffer.test.ts` is new and verified to fail against the
pre-fix code (the deadlock, with an "ends normally" control). Four more cover paths
the existing suites did not reach: the decoder's `CODEC_EXHAUSTED` budget and its
unpaired-frame close, the stale-ladder-generation drop, and the degrade-restore
backoff. Full suite: **540 passing**.

---

## 5. RPC, build, diagnostics, assets

**RPC first-handshake sweep.** *Problem:* the TS port collapsed .NET's three-state
`RpcPeerChangeKind` to a boolean and lost the `ChangedToVeryFirst` guard, so even a
cold connect ran reconnect processing and swept the very call it had just put on the
wire — the client reported failure for work the server had already executed.
*Solution:* vendored `actuallab-rpc` synced from Fusion `3f794818`, plus **Fusion
14.3.29 to 14.3.34** for the C# half.

**Stream-control calls had no timeout at all.** *Problem:* the TS service defs never
carried `[RpcMethod(ConnectTimeout = 10)]`, and `rpc-peer` skips the timeout sweep
entirely for a call with no `timeouts` — so `RequestKeyFrame`,
`ChangeRecordingQuality` and `ChangePlaybackQuality` could hang forever.
*Solution:* port the 10s connect timeout. Run stays unbounded, which is what .NET
resolves these query-kind methods to as well.

**A failed keyframe request burned the cooldown.** *Problem:* `requestKeyFrame`
stamped `lastKeyFrameRequestTime` before the call and swallowed the rejection, so one
failure blocked retries for the full 10s. *Solution:* stamp on success only, guarded
by a single expiring timestamp — an in-flight flag alone would have latched the hook
off for the life of the player, since the run timeout is unbounded.

**WebGL context loss was invisible — then over-reported.** *Problem:* no surface
listened for `webglcontextlost`, and `WebGlDownscaler` renders black **without
throwing** — so the `catch` that engages its Canvas2D fallback never ran, and a real
context loss was indistinguishable from an ordinary teardown in the logs.
*Solution:* check `isContextLost()` up front and register listeners on all three
surfaces — then **detach them in `dispose()`**, because `dispose()` ends with
`WEBGL_lose_context.loseContext()`, which dispatches the very event just registered.
Left attached, every ordinary teardown ran the loss handler: on `WebGlDownscaler`
that permanently disabled WebGL downscale for the session, and on the two blur
renderers it logged a phantom loss that masked the real ones.

**Hidden-tab throttling reported as a stall.** *Problem:* the watchdog only skipped
hidden ticks under a ~1s throttling profile, but Chrome throttles a background tab
into minute-long buckets and can freeze it outright — producing entries like
`recovered after 892825ms total stall`, which bury the real ones. *Solution:* skip the
check entirely while hidden; a delta measured there carries no information.

**Font preloads never matched the CSS.** *Problem:* preload hrefs went through
`@Assets`, which fingerprints them, while the bundled `@font-face` keeps the plain
path — so every preloaded font was downloaded **twice** and the first copy discarded.
*Solution:* match the URLs. *Measured in-browser before and after:* **~238 KB of
duplicate woff2 per cold load, now zero.** MAUI had the same defect twice —
`icon.woff2` pinned to a stale generated `?t=`, and forkawesome missing the CSS's
`?v=1.2.0`.

---

## Deliberately not done

- **Translation throttling** — written up as
  [`docs/plans/better-translation.md`](docs/plans/better-translation.md) instead. The
  whole-message stream publishes one wire item per LLM chunk with no rate limit; the
  realtime stream is throttled at 500ms, a period chosen for latency though its real
  cost is up to four LLM calls/sec. The plan records the concrete fix, three claims
  from the first analysis that turned out wrong, and a dead overload found on the way.
- **Deferred `Worker.terminate()`** — *left as a one-turn defer.* Acking the drain
  would be deterministic for a live worker, but this is the cosmetic preview tap, not
  a correctness path, and a wedged worker would not drain in any bounded window
  either.
- **`WRITER_READY_TIMEOUT_MS = 1000`** — *left fixed.* Deriving it from frame duration
  would make the tolerance a constant backlog depth, but the failure it guards is
  binary (stuck compositor vs. not), and 1s already sits well above any real hiccup
  and well below the 6s wedge restart.
- **`MaxBufferedUnacknowledgedRenderBatches = 100`** — *profiled, left alone.* A local
  A/B against 30 showed no regression, but that is a null result: on localhost the
  client ACKs inside the burst so the buffer never fills. The latency-independent
  bound settles it — a chat switch sends 150-195 SignalR frames, peaking at **151
  within a 100ms window**. The existing comment is justified.
- **`@key` on the `change-item` loop** — *profiled, not worth it.* 29.3s of live
  transcription: 864 mutation records, peak 388/sec. The change-item machinery is
  ~8.5% of that; the dominant contributor is VirtualList item churn, which `@key` does
  not touch. An earlier claim that this could take the storm to zero does not hold.

## Verification

`tsc --noEmit`, `eslint` and the 540-test unit suite green; `dotnet build` succeeds
for `App.Server` and `UI.Blazor.App`. The UI-visible changes were exercised in a real
browser against the running dev server. The video failure paths were not — they need
a GPU stall to reproduce.

The branch is rebased onto current `origin/dev`, so it already sits on top of
`8b32b6ac6f` and `022d0f6459`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
