### PR TITLE
fix(virtual-list): don't crash on a window whose every leaf is skip-key

### DIFF
--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListData.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListData.cs
@@ -9,12 +9,11 @@ public sealed class VirtualListData<TItem>(IReadOnlyList<TItem> items)
     public bool IsNone
         => ReferenceEquals(this, None);
 
-    /// <summary>
-    /// Inclusive range []
-    /// </summary>
     public Range<string> KeyRange
-        => Items.Count > 0
-            ? new Range<string>(FirstItem!.Key, LastItem!.Key)
+        // Inclusive range []. A non-empty Items isn't enough to build it: both ends resolve to null
+        // when every leaf is skip-key - e.g. a window holding just the live block's header and footer.
+        => FirstItem is { } firstItem && LastItem is { } lastItem
+            ? new Range<string>(firstItem.Key, lastItem.Key)
             : default;
 
     public IReadOnlyList<TItem> Items { get; } = items;
@@ -40,7 +39,6 @@ public sealed class VirtualListData<TItem>(IReadOnlyList<TItem> items)
 
     public bool HasAllItems => HasVeryFirstItem && HasVeryLastItem;
     public TItem? FirstItem => field ??= GetFirst(Items);
-
     public TItem? LastItem => field ??= GetLast(Items);
 
     public bool IsSimilarTo(VirtualListData<TItem> other)
@@ -53,7 +51,7 @@ public sealed class VirtualListData<TItem>(IReadOnlyList<TItem> items)
                 || (SeparatorIndexes?.SequenceEqual(other.SeparatorIndexes ?? []) ?? false))
             && Items.SequenceEqual(other.Items));
 
-    // Private members
+    // Private methods
 
     private static int CalculateCount(TItem item)
     {

--- a/tests/UI.Blazor.UnitTests/VirtualListDataTest.cs
+++ b/tests/UI.Blazor.UnitTests/VirtualListDataTest.cs
@@ -68,6 +68,21 @@ public class VirtualListDataTest(ITestOutputHelper @out) : TestBase(@out)
         keyRange.Should().Be(new Range<string>("1", "11"));
     }
 
+    [Fact]
+    public void KeyRangeShouldBeDefaultWhenEveryLeafIsSkipKey()
+    {
+        // arrange - the live block alone in the window: its header and footer are both skip-key
+        var header = new TestItem("100") { ShouldSkipKey = true };
+        var footer = new TestItem("101") { ShouldSkipKey = true };
+        var data = new VirtualListData<TestItem>([new TestGroup("100", [header, footer])]);
+
+        // act
+        var keyRange = data.KeyRange;
+
+        // assert
+        keyRange.Should().Be(default(Range<string>));
+    }
+
     // Nested types
 
     private class TestItem(string key) : IVirtualListItem


### PR DESCRIPTION
## Problem

`VirtualListData<T>.KeyRange` guarded on `Items.Count > 0` and then dereferenced `FirstItem!` / `LastItem!`. Those two resolve to a *leaf* via `SkipWhile(i => i.ShouldSkipKey)` (since 2cc6ef68b1), so both are `null` whenever a non-empty `Items` contains only skip-key leaves — and the null-forgiving operators turned that into a `NullReferenceException` inside `InfiniteList<T>.BuildRenderTree`, i.e. straight into the error barrier.

Found in an Android dev-build logcat from 2026-08-17: opening a chat whose loaded window held nothing but the live block's `LiveConversationHeader` + `LiveConversationFooter` (both `ShouldSkipKey = true`) crashed the render every time — 14 `ErrorBarrier PageWithHeaderAndFooter-Body activated` in ~32 seconds, so the chat was effectively unopenable.

```
ChatView] GetData: loaded 1 items (2 rows), first=203551, last=203551, hasBefore=True, hasAfter=False
...
System.NullReferenceException
   at ActualChat.UI.Blazor.Components.VirtualListData`1.get_KeyRange()
   at ActualChat.UI.Blazor.Components.InfiniteList`1.BuildRenderTree(RenderTreeBuilder __builder)
```

## Fix

Guard on `FirstItem` / `LastItem` themselves instead of on `Items.Count`. Such a window now yields the same `default` range an empty `Items` already yields — which is the honest answer (skip-key items are deliberately not anchors) and a path callers already handle:

- `ChatView.GetChatDataQuery` null-checks `oldData.FirstItem` and falls back to the chat's lid range;
- the TS side only ever compares `keyRange` (`infinite-list.ts`, `virtual-list.ts`).

Three pre-existing style-guide violations in the same file were fixed along the way, as the style hook requires: an XML doc on a member, a stray blank line between two single-line properties, and `// Private members` → `// Private methods`.

## Tests

`KeyRangeShouldBeDefaultWhenEveryLeafIsSkipKey` reproduces the exact shape from the log. Verified it fails on the old code (`NullReferenceException`) and passes on the new one.

```
tests/UI.Blazor.UnitTests       Passed!  43/43
tests/Chat.UI.Blazor.UnitTests  Passed! 344/344
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKkLdeoVRbnM1EdSw8fUtW
