### PR TITLE
perf(ios): compile the share extension illustrations into an asset catalog #4214

### DIFF
--- a/scripts/prepare-images.cmd
+++ b/scripts/prepare-images.cmd
@@ -40,8 +40,9 @@ EOF
 fi
 
 # Only the SVGs the iOS app extension bundles as PNGs - UIKit can't render SVG, unlike the
-# web, which is served every other file under $inDir as-is. Add a name here when a native
-# view needs one. @2x/@3x come from the SVG's own size, so each image keeps its dimensions.
+# web, which is served every other file under $inDir as-is. A new name also needs an .imageset
+# - Contents.json plus an ImageAsset link - in every project that renders it.
+# @2x/@3x come from the SVG's own size, so each image keeps its dimensions.
 names="error-cat-dark error-cat-light share-cat-dark share-cat-light"
 
 inDir="src/nodejs/images"

--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -68,11 +68,15 @@
     <DefineConstants>$(DefineConstants);IS_PRODUCTION_ENV</DefineConstants>
   </PropertyGroup>
 
-
+  <!-- The image sets' Contents.json come from the default ImageAsset glob; the PNGs they name
+       stay in resources\ so another extension can link the same files into its own catalog.
+       ACTool clones every ImageAsset to its Link path before compiling, which is what lets the
+       two halves live apart. Generated from src\nodejs\images\*.svg by scripts\prepare-images.cmd. -->
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
-    <!-- Generated from src\nodejs\images\*.svg by scripts\prepare-images.cmd; the glob picks up @2x/@3x -->
-    <BundleResource Include="..\..\..\resources\images\converted\error-cat*.png" Link="%(Filename)%(Extension)" />
-    <BundleResource Include="..\..\..\resources\images\converted\share-cat*.png" Link="%(Filename)%(Extension)" />
+    <ImageAsset Include="..\..\..\resources\images\converted\error-cat*.png"
+                Link="Assets.xcassets\error-cat.imageset\%(Filename)%(Extension)" />
+    <ImageAsset Include="..\..\..\resources\images\converted\share-cat*.png"
+                Link="Assets.xcassets\share-cat.imageset\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <!-- TODO: Move GoogleService-Info.plist files to Maui project and define BundleResource there,

--- a/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/Contents.json
+++ b/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/error-cat.imageset/Contents.json
+++ b/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/error-cat.imageset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x",
+      "filename" : "error-cat-light.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "1x",
+      "filename" : "error-cat-dark.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x",
+      "filename" : "error-cat-light@2x.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x",
+      "filename" : "error-cat-dark@2x.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x",
+      "filename" : "error-cat-light@3x.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x",
+      "filename" : "error-cat-dark@3x.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/share-cat.imageset/Contents.json
+++ b/src/dotnet/App.Maui.IosShareExt/Assets.xcassets/share-cat.imageset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x",
+      "filename" : "share-cat-light.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "1x",
+      "filename" : "share-cat-dark.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x",
+      "filename" : "share-cat-light@2x.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x",
+      "filename" : "share-cat-dark@2x.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x",
+      "filename" : "share-cat-light@3x.png"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x",
+      "filename" : "share-cat-dark@3x.png",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/dotnet/App.Maui.IosShareExt/UI/AppImages.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/AppImages.cs
@@ -1,30 +1,11 @@
 namespace ActualChat.App.Maui.IosShareExt.UI;
 
 /// <summary>
-/// The illustrations the extension bundles, each a light/dark pair behind a
-/// <see cref="UIImageAsset"/> so UIKit swaps them with the appearance, exactly
-/// as it would for an asset catalog entry.
+/// The illustrations the extension bundles, each a light/dark image set in
+/// <c>Assets.xcassets</c> that UIKit re-resolves as the appearance changes.
 /// </summary>
 public static class AppImages
 {
-    public static UIImage? ErrorCat => field ??= Load("error-cat");
-    public static UIImage? ShareCat => field ??= Load("share-cat");
-
-    // Private methods
-
-    private static UIImage? Load(string name)
-    {
-        var light = UIImage.FromBundle(name + "-light.png");
-        var dark = UIImage.FromBundle(name + "-dark.png");
-        if (light is null || dark is null)
-            return light ?? dark;
-
-        var lightTraits = UITraitCollection.FromUserInterfaceStyle(UIUserInterfaceStyle.Light);
-        var asset = new UIImageAsset();
-        asset.RegisterImage(light, lightTraits);
-        asset.RegisterImage(dark, UITraitCollection.FromUserInterfaceStyle(UIUserInterfaceStyle.Dark));
-        // Taking the image back from the asset is what carries the asset on it, and that's
-        // what makes UIImageView re-resolve it when the appearance changes.
-        return asset.FromTraitCollection(lightTraits);
-    }
+    public static UIImage? ErrorCat => field ??= UIImage.FromBundle("error-cat");
+    public static UIImage? ShareCat => field ??= UIImage.FromBundle("share-cat");
 }


### PR DESCRIPTION
Loose `BundleResource` files are never sliced by App Store app thinning — only asset catalogs are. So every device downloaded all three scales of both illustrations and used one.

Measured against the **appex**, not the app bundle, which is what makes this worth doing: in the last signed Release IPA the extension is 13.6 MB uncompressed / **4.84 MB compressed**, and PNGs don't compress in the IPA zip (the one PNG there went 29,789 → 29,628, 99%). The 12 loose PNGs were ~11% of the extension's download.

| | bytes |
|---|---|
| loose PNGs (before) | 627,233 |
| `Assets.car`, all scales | 522,888 |
| thinned to a 3x device | **276,856** |
| thinned to a 2x device | **183,928** |

Roughly 11% → 5% of the appex download.

### What changed

- The two illustrations become image sets in `App.Maui.IosShareExt/Assets.xcassets`. Only the `Contents.json` manifests live in the project — the PNGs stay in `resources/images/converted/`, linked in via `ImageAsset` + `Link`, so a second extension can link the same files into its own catalog.
- `AppImages` drops from 27 lines to 11. The catalog resolves the light/dark pair itself, so the hand-built `UIImageAsset` is gone; `FromBundle("error-cat")` returns the trait-aware image and `UIImageView` re-resolves it on an appearance change as before.
- `scripts/prepare-images.cmd` is unchanged apart from one comment — the flat output layout still fits.

The split layout works because the `ACTool` task clones every `ImageAsset` to its `Link` path into `obj/…/actool/cloned-assets/` before invoking `actool`. Relative paths inside `Contents.json` do **not** work — actool refuses to traverse out of the image set and silently emits no `Assets.car` at all.

### Verification

- Clean rebuild (obj + bin wiped), `dotnet build -c Debug`: 0 errors.
- The appex in the app bundle contains `Assets.car` (522,888 B, 12 entries — both names × 3 scales × `UIAppearanceDark`) and **zero loose PNGs**.
- Installed and launched on an iPhone (iOS 26.6). Confirmed on device: the cats render and swap correctly between Light and Dark.

### Not included

- The `@1x` entries stay in the catalog. They cost 79,922 B of the `.car` and nothing on iOS 16.4+ selects them, but thinning drops them per-device anyway.
- This is one slice of #4214, not the whole appex-size story. The bulk is elsewhere: 13.6 MB of assemblies the appex duplicates from the app, plus its own 49.8 MB R2R framework in `Frameworks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
