### PR TITLE
fix(transcription): sweep orphaned Soniox transcriptions and fail loudly on a blown quota #4223

### DIFF
--- a/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
@@ -9,7 +9,7 @@ namespace ActualChat.Transcription;
 /// Soniox async REST API: uploads, transcription jobs, and the deletes that dispose of both.
 /// Shared by <see cref="SonioxOfflineTranscriber"/> and <see cref="SonioxCleaner"/>.
 /// </summary>
-public sealed class SonioxClient
+public sealed class SonioxClient(IServiceProvider services)
 {
     public const string HttpClientName = nameof(SonioxClient);
 
@@ -18,14 +18,8 @@ public sealed class SonioxClient
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    private CoreServerSettings CoreServerSettings { get; }
-    private IHttpClientFactory HttpClientFactory { get; }
-
-    public SonioxClient(IServiceProvider services)
-    {
-        CoreServerSettings = services.GetRequiredService<CoreServerSettings>();
-        HttpClientFactory = services.HttpClientFactory();
-    }
+    private CoreServerSettings CoreServerSettings { get; } = services.GetRequiredService<CoreServerSettings>();
+    private IHttpClientFactory HttpClientFactory { get; } = services.HttpClientFactory();
 
     public async Task<string> UploadFile(Stream stream, string fileName, CancellationToken cancellationToken)
     {
@@ -83,22 +77,16 @@ public sealed class SonioxClient
             .ConfigureAwait(false);
     }
 
-    // Scoped to the key's project, while the stored-file cap Soniox enforces is organization-wide -
-    // so this lists what we can clean, not everything that counts against the cap.
-    public async Task<SonioxFileList> ListFiles(string? cursor, int maxCount, CancellationToken cancellationToken)
-    {
-        using var httpClient = CreateHttpClient();
-        var url = $"{BaseUrl}/files?num_items={maxCount}";
-        if (!cursor.IsNullOrEmpty())
-            url += $"&cursor={Uri.EscapeDataString(cursor)}";
+    // Both lists are scoped to the key's project, while the caps Soniox enforces are organization-wide -
+    // so they list what we can clean, not everything that counts against the caps.
+    public Task<SonioxTranscriptionList> ListTranscriptions(
+        string? cursor,
+        int maxCount,
+        CancellationToken cancellationToken)
+        => ListPage<SonioxTranscriptionList>("transcriptions", cursor, maxCount, cancellationToken);
 
-        using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
-        await EnsureSuccess(response, "list files", cancellationToken).ConfigureAwait(false);
-        var result = await response.Content
-            .ReadFromJsonAsync<SonioxFileList>(JsonOptions, cancellationToken)
-            .ConfigureAwait(false);
-        return result ?? throw StandardError.External("Soniox returned no file list.");
-    }
+    public Task<SonioxFileList> ListFiles(string? cursor, int maxCount, CancellationToken cancellationToken)
+        => ListPage<SonioxFileList>("files", cursor, maxCount, cancellationToken);
 
     public Task DeleteTranscription(string transcriptionId, CancellationToken cancellationToken)
         => Delete($"transcriptions/{transcriptionId}", cancellationToken);
@@ -107,6 +95,27 @@ public sealed class SonioxClient
         => Delete($"files/{fileId}", cancellationToken);
 
     // Private methods
+
+    private async Task<T> ListPage<T>(
+        string path,
+        string? cursor,
+        int maxCount,
+        CancellationToken cancellationToken)
+    {
+        // The parameter is "limit": an unknown one is ignored rather than rejected, which silently
+        // pins the page size to Soniox's own default.
+        using var httpClient = CreateHttpClient();
+        var url = $"{BaseUrl}/{path}?limit={maxCount}";
+        if (!cursor.IsNullOrEmpty())
+            url += $"&cursor={Uri.EscapeDataString(cursor)}";
+
+        using var response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccess(response, $"list of {path}", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsync<T>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result ?? throw StandardError.External($"Soniox returned no {path} list.");
+    }
 
     private async Task Delete(string path, CancellationToken cancellationToken)
     {

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxModels.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxModels.cs
@@ -49,6 +49,21 @@ public sealed class SonioxStatusResponse
     [JsonPropertyName("error_message")] public string? ErrorMessage { get; set; }
 }
 
+public sealed class SonioxTranscription
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = "";
+    [JsonPropertyName("status")] public string? Status { get; set; }
+    [JsonPropertyName("file_id")] public string? FileId { get; set; }
+    [JsonPropertyName("created_at")] public DateTimeOffset? CreatedAt { get; set; }
+}
+
+public sealed class SonioxTranscriptionList
+{
+    [JsonPropertyName("transcriptions")] public SonioxTranscription[]? Transcriptions { get; set; }
+    // Opaque - valid only when passed back verbatim, so it's never parsed or rebuilt.
+    [JsonPropertyName("next_page_cursor")] public string? NextPageCursor { get; set; }
+}
+
 public sealed class SonioxFile
 {
     [JsonPropertyName("id")] public string Id { get; set; } = "";
@@ -60,6 +75,5 @@ public sealed class SonioxFile
 public sealed class SonioxFileList
 {
     [JsonPropertyName("files")] public SonioxFile[]? Files { get; set; }
-    // Opaque - valid only when passed back verbatim, so it's never parsed or rebuilt.
     [JsonPropertyName("next_page_cursor")] public string? NextPageCursor { get; set; }
 }

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxOfflineTranscriber.cs
@@ -9,7 +9,8 @@ namespace ActualChat.Transcription;
 /// </summary>
 public sealed class SonioxOfflineTranscriber : IOfflineTranscriber
 {
-    private const string Model = "stt-async-v5";
+    // It's internal so the tests can create a transcription the same way this transcriber does
+    internal const string Model = "stt-async-v5";
     private static readonly TimeSpan PollPeriod = TimeSpan.FromSeconds(1);
 
     private SonioxClient Client { get; }

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
@@ -3,9 +3,9 @@ using ActualLab.Diagnostics;
 namespace ActualChat.Transcription;
 
 /// <summary>
-/// Periodically deletes Soniox files that <see cref="SonioxCleaner"/> never got to - its queue
-/// lives in memory, so every id it holds is lost when a host dies mid-transcription, and Soniox
-/// caps stored files per organization.
+/// Periodically deletes the transcriptions and files that <see cref="SonioxCleaner"/> never got to -
+/// its queue lives in memory, so every id it holds is lost when a host dies mid-transcription, and
+/// Soniox caps both of them.
 /// </summary>
 public sealed class SonioxSweeper : WorkerBase
 {
@@ -53,49 +53,24 @@ public sealed class SonioxSweeper : WorkerBase
     // It's internal so tests can run a single pass without the loop's delay
     internal async Task<int> Sweep(CancellationToken cancellationToken)
     {
-        var deleted = 0;
-        var kept = 0;
-        var failed = 0;
-        var isTruncated = false;
-        var deleteBefore = SystemClock.Now - Settings.Retention;
-        var cursor = (string?)null;
-        do {
-            var page = await Client
-                .ListFiles(cursor, Settings.PageSize, cancellationToken)
-                .ConfigureAwait(false);
-            cursor = page.NextPageCursor;
-            foreach (var file in page.Files ?? []) {
-                // No timestamp means no way to tell an orphan from a live upload, so it stays.
-                if (file.CreatedAt is not { } createdAt || (Moment)createdAt.UtcDateTime >= deleteBefore) {
-                    kept++;
-                    continue;
-                }
-                if (deleted + failed >= Settings.MaxDeletesPerSweep) {
-                    isTruncated = true;
-                    break;
-                }
-
-                try {
-                    await Client.DeleteFile(file.Id, cancellationToken).ConfigureAwait(false);
-                    deleted++;
-                }
-                catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
-                    // One bad id must not cost the rest of the sweep - the next run retries it.
-                    failed++;
-                    Log.LogWarning(e, "Sweep: couldn't delete file {FileId}", file.Id);
-                }
-            }
-        } while (!cursor.IsNullOrEmpty() && !isTruncated && !cancellationToken.IsCancellationRequested);
-
-        if (isTruncated)
-            Log.LogWarning(
-                "Sweep: stopped at {MaxCount} deletes, more remain - the next sweep continues",
-                Settings.MaxDeletesPerSweep);
-        if (deleted > 0 || failed > 0)
-            DefaultLog?.Log(Settings.LogLevel,
-                "Sweep: deleted {DeletedCount} orphaned file(s), kept {KeptCount}, {FailedCount} failed",
-                deleted, kept, failed);
-        return deleted;
+        // Transcriptions go first: deleting one takes its file with it, which leaves the file pass
+        // with just the uploads whose transcription was never created - the shape a sweep sees once
+        // the transcription cap is hit, since the upload succeeds and the create right after it 429s.
+        var (deletedCount, failedCount) = await SweepPages(
+                "transcription",
+                ListTranscriptionPage,
+                Client.DeleteTranscription,
+                Settings.MaxDeletesPerSweep,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var (deletedFileCount, _) = await SweepPages(
+                "file",
+                ListFilePage,
+                Client.DeleteFile,
+                Settings.MaxDeletesPerSweep - deletedCount - failedCount,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return deletedCount + deletedFileCount;
     }
 
     // Private methods
@@ -105,4 +80,84 @@ public sealed class SonioxSweeper : WorkerBase
         await Sweep(cancellationToken).ConfigureAwait(false);
         await SystemClock.Delay(Settings.Period.Next(), cancellationToken).ConfigureAwait(false);
     }
+
+    private async Task<(int DeletedCount, int FailedCount)> SweepPages(
+        string kind,
+        Func<string?, CancellationToken, Task<SweepPage>> listPage,
+        Func<string, CancellationToken, Task> delete,
+        int maxDeleteCount,
+        CancellationToken cancellationToken)
+    {
+        var deleted = 0;
+        var kept = 0;
+        var failed = 0;
+        var isTruncated = false;
+        var deleteBefore = SystemClock.Now - Settings.Retention;
+        var cursor = (string?)null;
+        do {
+            var page = await listPage(cursor, cancellationToken).ConfigureAwait(false);
+            cursor = page.NextPageCursor;
+            foreach (var item in page.Items) {
+                // No timestamp means no way to tell an orphan from a live upload, so it stays - and
+                // so does anything Soniox is still working on, which it refuses to delete anyway.
+                if (!item.IsDeletable
+                    || item.CreatedAt is not { } createdAt
+                    || (Moment)createdAt.UtcDateTime >= deleteBefore) {
+                    kept++;
+                    continue;
+                }
+                if (deleted + failed >= maxDeleteCount) {
+                    isTruncated = true;
+                    break;
+                }
+
+                try {
+                    await delete(item.Id, cancellationToken).ConfigureAwait(false);
+                    deleted++;
+                }
+                catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+                    // One bad id must not cost the rest of the sweep - the next run retries it.
+                    failed++;
+                    Log.LogWarning(e, "Sweep: couldn't delete {Kind} {Id}", kind, item.Id);
+                }
+            }
+        } while (!cursor.IsNullOrEmpty() && !isTruncated && !cancellationToken.IsCancellationRequested);
+
+        if (isTruncated)
+            Log.LogWarning(
+                "Sweep: stopped at {MaxCount} {Kind} delete(s), more remain - the next sweep continues",
+                maxDeleteCount, kind);
+        if (deleted > 0 || failed > 0)
+            DefaultLog?.Log(Settings.LogLevel,
+                "Sweep: deleted {DeletedCount} orphaned {Kind}(s), kept {KeptCount}, {FailedCount} failed",
+                deleted, kind, kept, failed);
+        return (deleted, failed);
+    }
+
+    private async Task<SweepPage> ListTranscriptionPage(string? cursor, CancellationToken cancellationToken)
+    {
+        var page = await Client
+            .ListTranscriptions(cursor, Settings.PageSize, cancellationToken)
+            .ConfigureAwait(false);
+        var items = (page.Transcriptions ?? [])
+            .Select(x => new SweepItem(x.Id, x.CreatedAt, x.Status is "completed" or "error"))
+            .ToArray();
+        return new SweepPage(items, page.NextPageCursor);
+    }
+
+    private async Task<SweepPage> ListFilePage(string? cursor, CancellationToken cancellationToken)
+    {
+        var page = await Client
+            .ListFiles(cursor, Settings.PageSize, cancellationToken)
+            .ConfigureAwait(false);
+        var items = (page.Files ?? [])
+            .Select(x => new SweepItem(x.Id, x.CreatedAt, true))
+            .ToArray();
+        return new SweepPage(items, page.NextPageCursor);
+    }
+
+    // Nested types
+
+    private readonly record struct SweepItem(string Id, DateTimeOffset? CreatedAt, bool IsDeletable);
+    private readonly record struct SweepPage(SweepItem[] Items, string? NextPageCursor);
 }

--- a/tests/Transcription.IntegrationTests/SonioxSweeperTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxSweeperTest.cs
@@ -21,14 +21,8 @@ public class SonioxSweeperTest(ITestOutputHelper @out, ILogger<SonioxSweeperTest
         var client = services.GetRequiredService<SonioxClient>();
         string orphanId;
         var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
-        await using (stream.ConfigureAwait(false)) {
-            try {
-                orphanId = await client.UploadFile(stream, "orphan.opus", CancellationToken.None);
-            }
-            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
-                return;
-            }
-        }
+        await using (stream.ConfigureAwait(false))
+            orphanId = await client.UploadFile(stream, "orphan.opus", CancellationToken.None);
         WriteLine($"Uploaded orphan {orphanId}");
 
         // act - retention shorter than the upload's age, so the fresh file is the orphan here
@@ -56,14 +50,8 @@ public class SonioxSweeperTest(ITestOutputHelper @out, ILogger<SonioxSweeperTest
         var cleaner = services.GetRequiredService<SonioxCleaner>();
         string keptId;
         var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
-        await using (stream.ConfigureAwait(false)) {
-            try {
-                keptId = await client.UploadFile(stream, "in-flight.opus", CancellationToken.None);
-            }
-            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
-                return;
-            }
-        }
+        await using (stream.ConfigureAwait(false))
+            keptId = await client.UploadFile(stream, "in-flight.opus", CancellationToken.None);
 
         // act - the default retention must protect an upload a transcription is still using
         var sweeper = NewSweeper(services, new SonioxSweeper.Options().Retention);
@@ -78,7 +66,60 @@ public class SonioxSweeperTest(ITestOutputHelper @out, ILogger<SonioxSweeperTest
         await cleaner.Flush().WaitAsync(TimeSpan.FromSeconds(30));
     }
 
+    [Fact(Timeout = 120_000)]
+    public async Task SweepDeletesOrphanedTranscriptions()
+    {
+        // arrange
+        var services = CreateServices();
+        if (services.GetRequiredService<CoreServerSettings>().SonioxKey.IsNullOrEmpty()) {
+            WriteLine("CoreSettings__SonioxKey is not set - skipping.");
+            return;
+        }
+
+        var client = services.GetRequiredService<SonioxClient>();
+        await RequireSonioxCapacity(client, "0004-AK-recoded.opus");
+
+        string fileId;
+        var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
+        await using (stream.ConfigureAwait(false))
+            fileId = await client.UploadFile(stream, "orphan.opus", CancellationToken.None);
+        var request = new Dictionary<string, object?> {
+            ["file_id"] = fileId,
+            ["model"] = SonioxOfflineTranscriber.Model,
+        };
+        var transcriptionId = await client.CreateTranscription(request, CancellationToken.None);
+        await WaitForTerminalStatus(client, transcriptionId);
+        WriteLine($"Created transcription {transcriptionId} of file {fileId}");
+
+        // act - retention shorter than the transcription's age, so it's the orphan here
+        var sweeper = NewSweeper(services, TimeSpan.Zero);
+        var deleted = await sweeper.Sweep(CancellationToken.None);
+
+        // assert - and the transcription's delete takes its file with it
+        WriteLine($"Swept {deleted} item(s)");
+        deleted.Should().BeGreaterThanOrEqualTo(1);
+        var transcriptions = await client.ListTranscriptions(null, 1000, CancellationToken.None);
+        (transcriptions.Transcriptions ?? []).Should().NotContain(x => x.Id == transcriptionId);
+        var files = await client.ListFiles(null, 1000, CancellationToken.None);
+        (files.Files ?? []).Should().NotContain(x => x.Id == fileId);
+    }
+
     // Private methods
+
+    private static async Task WaitForTerminalStatus(SonioxClient client, string transcriptionId)
+    {
+        // A transcription Soniox is still working on is one it refuses to delete, so the sweep can
+        // only be measured once this one settles.
+        var endsAt = CpuTimestamp.Now + TimeSpan.FromSeconds(60);
+        while (CpuTimestamp.Now < endsAt) {
+            var status = await client.GetTranscriptionStatus(transcriptionId, CancellationToken.None);
+            if (status.Status is "completed" or "error")
+                return;
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+        throw StandardError.Timeout($"Transcription {transcriptionId} didn't finish.");
+    }
 
     private static SonioxSweeper NewSweeper(IServiceProvider services, TimeSpan retention)
         => new(new SonioxSweeper.Options { Retention = retention }, services);

--- a/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
+++ b/tests/Transcription.IntegrationTests/SonioxTranscriberTest.cs
@@ -48,8 +48,7 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
 
         var transcriber = new SonioxOfflineTranscriber(services);
         var cleaner = services.GetRequiredService<SonioxCleaner>();
-        if (await IsSonioxAtCapacity(services.GetRequiredService<SonioxClient>(), "0004-AK-recoded.opus"))
-            return;
+        await RequireSonioxCapacity(services.GetRequiredService<SonioxClient>(), "0004-AK-recoded.opus");
 
         var options = new TranscriptionOptions { Language = Language.Parse(languageId) };
         var audio = await GetAudio(fileName);
@@ -78,14 +77,8 @@ public class SonioxTranscriberTest(ITestOutputHelper @out, ILogger<SonioxTranscr
         var cleaner = services.GetRequiredService<SonioxCleaner>();
         var stream = File.OpenRead(GetAudioFilePath("0004-AK-recoded.opus"));
         string fileId;
-        await using (stream.ConfigureAwait(false)) {
-            try {
-                fileId = await client.UploadFile(stream, "speech.opus", CancellationToken.None);
-            }
-            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
-                return;
-            }
-        }
+        await using (stream.ConfigureAwait(false))
+            fileId = await client.UploadFile(stream, "speech.opus", CancellationToken.None);
         WriteLine($"Uploaded file {fileId}");
 
         // act

--- a/tests/Transcription.IntegrationTests/TranscriberTestBase.cs
+++ b/tests/Transcription.IntegrationTests/TranscriberTestBase.cs
@@ -6,6 +6,8 @@ namespace ActualChat.Transcription.IntegrationTests;
 public abstract class TranscriberTestBase(ITestOutputHelper @out, ILogger? log = null)
     : TestBase(@out, log)
 {
+    private const string MissingFileId = "00000000-0000-0000-0000-000000000000";
+
     protected async Task<AudioSource> GetAudio(FilePath fileName, bool? webMStream = null, bool withDelay = false)
     {
         var byteStream = GetAudioFilePath(fileName).ReadByteStream(1024, CancellationToken.None);
@@ -34,34 +36,34 @@ public abstract class TranscriberTestBase(ITestOutputHelper @out, ILogger? log =
     protected static FilePath GetAudioFilePath(FilePath fileName)
         => new FilePath(Environment.CurrentDirectory) & "data" & fileName;
 
-    // Soniox caps stored files per organization, and that cap is shared by every environment and
-    // key we own - GET /v1/files is project-scoped, so what fills it isn't even visible from here,
-    // let alone deletable. Treated like an unset key: an environment we can't fix from the test.
-    protected bool IsExternalQuotaExceeded(Exception e)
+    // Soniox caps stored files and stored transcriptions per organization, and both caps are shared
+    // by every environment and key we own - the GET endpoints are project-scoped, so what fills them
+    // isn't even visible from here, let alone deletable. A capped account is an outage, so this
+    // throws rather than quietly passing a test that never ran.
+    protected async Task RequireSonioxCapacity(SonioxClient client, FilePath audioFileName)
     {
-        if (!e.Message.Contains("limit_exceeded"))
-            return false;
-
-        WriteLine($"External quota exceeded - skipping. {e.Message}");
-        return true;
-    }
-
-    // SonioxOfflineTranscriber turns every failure into null so its failover can try the next
-    // provider, which leaves a test unable to tell a full account from a broken one. An upload is
-    // the only way to ask; it's deleted right back on the way out.
-    protected async Task<bool> IsSonioxAtCapacity(SonioxClient client, FilePath audioFileName)
-    {
+        // SonioxOfflineTranscriber turns every failure into null so its failover can try the next
+        // provider, which leaves the transcriber tests unable to tell a capped account from a broken
+        // one - hence asking the two caps here, where the answers still carry Soniox's own message.
         string fileId;
         var stream = File.OpenRead(GetAudioFilePath(audioFileName));
-        await using (stream.ConfigureAwait(false)) {
-            try {
-                fileId = await client.UploadFile(stream, "probe.opus", CancellationToken.None);
-            }
-            catch (Exception e) when (IsExternalQuotaExceeded(e)) {
-                return true;
-            }
-        }
+        await using (stream.ConfigureAwait(false))
+            fileId = await client.UploadFile(stream, "probe.opus", CancellationToken.None);
         await client.DeleteFile(fileId, CancellationToken.None);
-        return false;
+
+        // The create rejects an over-cap organization before it looks at the file id, so a
+        // nonexistent one asks about the transcription cap without creating anything. Every other
+        // rejection is that file id doing its job.
+        var request = new Dictionary<string, object?> {
+            ["file_id"] = MissingFileId,
+            ["model"] = SonioxOfflineTranscriber.Model,
+        };
+        try {
+            var transcriptionId = await client.CreateTranscription(request, CancellationToken.None);
+            await client.DeleteTranscription(transcriptionId, CancellationToken.None);
+        }
+        catch (Exception e) when (!e.Message.Contains("limit_exceeded")) {
+            WriteLine($"Transcription cap probe rejected as expected: {e.Message}");
+        }
     }
 }

--- a/tests/Transcription.UnitTests/SonioxApiMock.cs
+++ b/tests/Transcription.UnitTests/SonioxApiMock.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace ActualChat.Transcription.UnitTests;
+
+/// <summary>
+/// A stand-in for the parts of the Soniox REST API <see cref="SonioxSweeper"/> depends on: cursor
+/// pagination, the transcription delete that takes its file with it, and the refusal to delete one
+/// that's still processing.
+/// </summary>
+public sealed class SonioxApiMock : HttpMessageHandler
+{
+    private readonly Dictionary<string, Item> _transcriptions = new();
+    private readonly Dictionary<string, Item> _files = new();
+
+    public IReadOnlyCollection<string> TranscriptionIds => _transcriptions.Keys;
+    public IReadOnlyCollection<string> FileIds => _files.Keys;
+    // -1 stands for a request that asked for no page size at all
+    public List<int> RequestedPageSizes { get; } = new();
+    // Recorded before the request is answered, so a refused delete still counts as attempted
+    public List<string> DeleteAttempts { get; } = new();
+
+    public SonioxApiMock AddTranscription(
+        string id,
+        DateTimeOffset createdAt,
+        string status = "completed",
+        string? fileId = null)
+    {
+        _transcriptions.Add(id, new Item(createdAt, status, fileId));
+        return this;
+    }
+
+    public SonioxApiMock AddFile(string id, DateTimeOffset createdAt)
+    {
+        _files.Add(id, new Item(createdAt, null, null));
+        return this;
+    }
+
+    // Protected methods
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var segments = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
+        var isTranscription = segments[1] == "transcriptions";
+        var items = isTranscription ? _transcriptions : _files;
+        if (request.Method == HttpMethod.Delete)
+            return Task.FromResult(Delete(items, segments[2], isTranscription));
+
+        var query = System.Web.HttpUtility.ParseQueryString(request.RequestUri.Query);
+        RequestedPageSizes.Add(int.TryParse(query["limit"], out var limit) ? limit : -1);
+        return Task.FromResult(List(items, isTranscription, limit, query["cursor"]));
+    }
+
+    // Private methods
+
+    private HttpResponseMessage List(
+        Dictionary<string, Item> items,
+        bool isTranscription,
+        int limit,
+        string? cursor)
+    {
+        // The cursor is the last id of the previous page rather than an offset, so a delete
+        // between two pages can't shift the ones that follow out of the sweep.
+        var page = items
+            .Where(x => cursor.IsNullOrEmpty() || string.CompareOrdinal(x.Key, cursor) > 0)
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList();
+        var isLastPage = page.Count < limit;
+        var json = JsonSerializer.Serialize(new Dictionary<string, object?> {
+            [isTranscription ? "transcriptions" : "files"] = page
+                .Select(x => ToJson(x.Key, x.Value, isTranscription))
+                .ToArray(),
+            ["next_page_cursor"] = isLastPage || page.Count == 0 ? null : page[^1].Key,
+        });
+        return Respond(HttpStatusCode.OK, json);
+    }
+
+    private HttpResponseMessage Delete(Dictionary<string, Item> items, string id, bool isTranscription)
+    {
+        DeleteAttempts.Add(id);
+        if (!items.TryGetValue(id, out var item))
+            return Respond(HttpStatusCode.NotFound, "");
+        if (isTranscription && item.Status is not ("completed" or "error"))
+            return Respond(HttpStatusCode.Conflict, "");
+
+        items.Remove(id);
+        if (isTranscription && item.FileId is { } fileId)
+            _files.Remove(fileId);
+
+        return Respond(HttpStatusCode.NoContent, "");
+    }
+
+    private static Dictionary<string, object?> ToJson(string id, Item item, bool isTranscription)
+    {
+        var json = new Dictionary<string, object?> {
+            ["id"] = id,
+            ["created_at"] = item.CreatedAt,
+        };
+        if (isTranscription) {
+            json["status"] = item.Status;
+            json["file_id"] = item.FileId;
+        }
+        return json;
+    }
+
+    private static HttpResponseMessage Respond(HttpStatusCode statusCode, string json)
+    {
+        var response = new HttpResponseMessage(statusCode) { Content = new StringContent(json) };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return response;
+    }
+
+    // Nested types
+
+    private sealed record Item(DateTimeOffset CreatedAt, string? Status, string? FileId);
+}

--- a/tests/Transcription.UnitTests/SonioxSweeperTest.cs
+++ b/tests/Transcription.UnitTests/SonioxSweeperTest.cs
@@ -1,0 +1,114 @@
+using ActualChat.Module;
+
+namespace ActualChat.Transcription.UnitTests;
+
+public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+    private static readonly DateTimeOffset Old = Now - TimeSpan.FromHours(1);
+
+    [Fact]
+    public async Task SweepDeletesOldTranscriptionsWithTheirFiles()
+    {
+        // arrange
+        var api = new SonioxApiMock()
+            .AddTranscription("t1", Old, fileId: "f1")
+            .AddFile("f1", Old);
+
+        // act
+        var deleted = await NewSweeper(api).Sweep(CancellationToken.None);
+
+        // assert - one delete, and it's the transcription's, which takes its file with it
+        api.DeleteAttempts.Should().Equal("t1");
+        deleted.Should().Be(1);
+        api.TranscriptionIds.Should().BeEmpty();
+        api.FileIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SweepKeepsRecentAndInFlightOnes()
+    {
+        // arrange
+        var api = new SonioxApiMock()
+            .AddTranscription("t1", Now, fileId: "f1")
+            .AddTranscription("t2", Old, "processing")
+            .AddFile("f1", Now);
+
+        // act
+        var deleted = await NewSweeper(api).Sweep(CancellationToken.None);
+
+        // assert - never even attempted: Soniox answers a running transcription's delete with 409
+        deleted.Should().Be(0);
+        api.DeleteAttempts.Should().BeEmpty();
+        api.TranscriptionIds.Should().BeEquivalentTo("t1", "t2");
+        api.FileIds.Should().BeEquivalentTo("f1");
+    }
+
+    [Fact]
+    public async Task SweepDeletesFilesLeftByAFailedCreate()
+    {
+        // arrange - what the cap itself produces: the upload succeeds, the create right after 429s
+        var api = new SonioxApiMock()
+            .AddFile("f1", Old)
+            .AddFile("f2", Now);
+
+        // act
+        var deleted = await NewSweeper(api).Sweep(CancellationToken.None);
+
+        // assert
+        deleted.Should().Be(1);
+        api.FileIds.Should().BeEquivalentTo("f2");
+    }
+
+    [Fact]
+    public async Task SweepStopsAtMaxDeletesAcrossBothPasses()
+    {
+        // arrange
+        var api = new SonioxApiMock()
+            .AddTranscription("t1", Old)
+            .AddTranscription("t2", Old)
+            .AddFile("f1", Old)
+            .AddFile("f2", Old);
+
+        // act
+        var deleted = await NewSweeper(api, new SonioxSweeper.Options { MaxDeletesPerSweep = 3 })
+            .Sweep(CancellationToken.None);
+
+        // assert - the budget is what's left of it by the time the file pass runs
+        deleted.Should().Be(3);
+        api.TranscriptionIds.Should().BeEmpty();
+        api.FileIds.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task SweepFollowsThePageCursor()
+    {
+        // arrange
+        var api = new SonioxApiMock();
+        for (var i = 0; i < 25; i++)
+            api.AddTranscription($"t{i:00}", Old);
+
+        // act
+        var deleted = await NewSweeper(api, new SonioxSweeper.Options { PageSize = 10 })
+            .Sweep(CancellationToken.None);
+
+        // assert - and the page size has to reach Soniox, which it doesn't under the wrong parameter
+        deleted.Should().Be(25);
+        api.TranscriptionIds.Should().BeEmpty();
+        api.RequestedPageSizes.Should().OnlyContain(x => x == 10);
+    }
+
+    // Private methods
+
+    private SonioxSweeper NewSweeper(SonioxApiMock api, SonioxSweeper.Options? settings = null)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(MomentClockSet.Default)
+            .AddSingleton(new CoreServerSettings { SonioxKey = "test" })
+            .AddSingleton<SonioxClient>()
+            .AddTestLogging(Out);
+        services.AddHttpClient(SonioxClient.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => api);
+        return new SonioxSweeper(settings ?? new SonioxSweeper.Options(), services.BuildServiceProvider());
+    }
+}


### PR DESCRIPTION
Refs #4223. **This does not clear the 429** — see "What this doesn't fix".

## What the 429 actually is

Soniox enforces two caps — 1,000 stored files and 2,000 stored transcriptions —
and both are **organization-wide**, while every `GET` and `DELETE` is
**project-scoped**. A project can report `{"total": 0}` transcriptions and still
get `429 limit_exceeded` on `POST /v1/transcriptions`, because the backlog sits
in another project of the same org, invisible and undeletable through that key.
That is the current state of the key CI uses. There is no projects API and no
org-level count, so only the Soniox Console can find it.

## 1. The sweeper leaked transcriptions

`SonioxCleaner` deletes both artifacts, but from an in-memory queue — every id
it holds is lost when a host dies mid-transcription. `SonioxSweeper` exists to
recover that, and swept only files: `SonioxClient` could delete a transcription
but had no way to enumerate one. Deleting a transcription takes its file with
it and not the reverse, so each sweep cleaned the file half and left the record.

The sweep now runs transcriptions first, then files. One delete disposes of both
halves, and the file pass is left with uploads whose transcription was never
created — the shape the cap itself produces, since the upload succeeds and the
create right after it 429s. In-flight transcriptions are skipped rather than
attempted, since Soniox answers those with 409.

Also: both list endpoints take `limit`, not `num_items`. Soniox ignores an
unknown query parameter instead of rejecting it, so `PageSize` never reached the
wire — paging silently ran at Soniox's default.

## 2. The tests went green on a blown quota

`SonioxOfflineTranscriber` turns every failure into `null` so its failover can
try the next provider, so a capped account reached `OfflineTranscribeWorks` as a
bare `null` and tripped `NotBeNull()` after ~35s, saying nothing about the 429.

`IsSonioxAtCapacity` was added for exactly this and asked the wrong cap — it
uploaded and deleted a *file*, while the 429 comes from `POST /v1/transcriptions`.
It also answered by skipping, and that skip is an early `return`, which xUnit v2
reports as a **pass**. So the intended behaviour was a green run on a test that
never executed.

`RequireSonioxCapacity` asks both caps up front and lets `limit_exceeded`
through. The transcription cap is probed with a create against a nonexistent
`file_id` — the org check runs before file validation, so it gets the answer
without creating anything. Tests now fail in ~1s carrying Soniox's own message:

```
ActualChat.ExternalError : Soniox create transcription failed: 429
{"error_type": "limit_exceeded", "message": "Total transcription count limit for
 your organization has been exceeded. Please delete some.", ...}
```

## What this doesn't fix

The backlog. The sweeper only cleans the project its key belongs to, and the
records filling the cap are in a project we can't reach from code. **Someone
with Console access has to drain it (or raise the cap) before CI can go green**,
and `deploy-dev` is gated on integration-tests, so the sweeper cannot deploy
until that happens. Order is: drain → CI green → deploy → sweeper keeps it clean.

Note that dev's `flux-team-core` manifests contain no Soniox key at all and set
`StreamingSettings__DeepgramKey` while the code reads `CoreSettings__DeepgramKey`
— worth checking separately that the deployed env vars still bind.

## Testing

- Sweep logic covered offline against a `SonioxApiMock` modelling cursor paging,
  the delete cascade and the 409 — the integration test needs an account with
  capacity, which is what we don't have. Unit tests 95/95.
- Each test mutation-checked: reverting to a files-only sweep fails 3 of 5,
  `num_items` fails 4, dropping the retention filter fails 2, dropping the
  in-flight gate fails 1.
- Soniox integration: 4 pass, 3 skipped (ElevenLabs, static), 3 fail — two on the
  429 as intended, plus `StreamingTranscribeWorks`, a pre-existing realtime
  WebSocket flake unrelated to this change.
- API behaviour verified against live Soniox: `limit` vs `num_items`, list
  shapes, and that the org cap check precedes file-id validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
