### PR TITLE
feat(chat): suppress unread badges while pinned to the chat tail

### DIFF
--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -539,10 +539,27 @@ public partial class Chats(IServiceProvider services) : IChats
                     LinkPreviewMode = linkPreviewMode,
                     ClientId = command.ClientId,
                 }));
+            var userId = chat.Rules.Account.Require().Id;
             textEntry = await Commander.Call(upsertCommand, true, cancellationToken).ConfigureAwait(false);
             if (chatId is PeerChatId peerChatId)
-                await EnsureOwnPeerContactStored(peerChatId, chat.Rules.Account.Require().Id, cancellationToken)
+                await EnsureOwnPeerContactStored(peerChatId, userId, cancellationToken)
                     .ConfigureAwait(false);
+            var readPosition = await ChatPositionsBackend
+                .Get(userId, chatId, ChatPositionKind.Read, cancellationToken)
+                .ConfigureAwait(false);
+            // Advance only for caught-up authors: a scalar read position can't exclude just this
+            // entry, and advancing from behind would wipe the chat's real unreads. Compared against
+            // the new entry's own lid so an insert that races ours can't be skipped over.
+            var isCaughtUp = readPosition.EntryLid >= textEntry.LocalId - 1;
+            if (isCaughtUp)
+                try {
+                    var setPositionCommand = new ChatPositionsBackend_Set(
+                        userId, chatId, ChatPositionKind.Read, new ChatPosition(textEntry.LocalId));
+                    await Commander.Call(setPositionCommand, true, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e) {
+                    Log.LogError(e, "Failed to advance own read position in chat {ChatId}", chatId);
+                }
         }
 
         return textEntry;

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListTabUnreadCount.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListTabUnreadCount.razor
@@ -34,11 +34,13 @@
         var chatListFilter = ChatListFilter;
         // Done w/ preps for .ConfigureAwait(false)
 
-        var count = await ChatListUI.GetUnreadChatCount(placeId, chatListFilter, cancellationToken).ConfigureAwait(false);
+        var count = await ChatListUI.GetUnreadChatCount(placeId, chatListFilter, cancellationToken)
+            .ConfigureAwait(false);
         if (count <= 0)
             return new(count);
 
-        var unmutedCount = await ChatListUI.GetUnmutedUnreadChatCount(placeId, chatListFilter, cancellationToken).ConfigureAwait(false);
+        var unmutedCount = await ChatListUI.GetUnmutedUnreadChatCount(placeId, chatListFilter, cancellationToken)
+            .ConfigureAwait(false);
         return new(count, unmutedCount <= 0);
     }
 
@@ -50,9 +52,12 @@
         if (placeChatListSettings != PlaceChatListSettings)
             return;
 
-        var firstUnreadChat = list.FirstOrDefault(c => c.UnmutedUnreadCount > 0)
-            ?? list.FirstOrDefault(c => c.UnreadCount > 0);
-        if (firstUnreadChat == null || firstUnreadChat.Id == ChatUI.SelectedChatId.Value)
+        // The selected chat is excluded: its raw count can be non-zero while its badge is
+        // gated off, and it sorts first - resolving to it would make the click a silent no-op.
+        var selectedChatId = ChatUI.SelectedChatId.Value?.GetThreadOutermostParentOrSelf();
+        var firstUnreadChat = list.FirstOrDefault(c => c.UnmutedUnreadCount > 0 && c.Id != selectedChatId)
+            ?? list.FirstOrDefault(c => c.UnreadCount > 0 && c.Id != selectedChatId);
+        if (firstUnreadChat == null)
             return;
 
         _ = History.NavigateTo(Links.Chat(firstUnreadChat.Id));

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -351,8 +351,19 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         // Observing new entries
         var entries = entryReader.Observe(chatIdRange.End, cancellationToken);
         await foreach (var entry in entries.ConfigureAwait(false)) {
+            // An observed entry carries a real server-delivered lid, so the anti-synthetic-lid clamp
+            // in UpdateReadPosition may trust it - without this the eager advance below is clamped
+            // back to the tail GetData knew before its update delay, i.e. silently no-ops.
+            _lastKnownEntryLid = Math.Max(_lastKnownEntryLid, entry.LocalId);
             if (entry.AuthorId != authorId) {
                 lastEntryLid = entry.LocalId;
+                // Pinned to the end = the entry is (about to be) on screen; advance immediately
+                // instead of waiting for the IntersectionObserver round trip, so the raw unread
+                // count never rises for the chat being watched. The !IsEmpty guard keeps a retained
+                // pinned flag from marking anything read while no items are actually rendered.
+                var itemVisibility = ItemVisibility.Value;
+                if (itemVisibility.IsPinnedToEnd && !itemVisibility.IsEmpty && ChatUI.IsUserPresent())
+                    UpdateReadPosition(lastEntryLid);
                 continue;
             }
 
@@ -398,6 +409,8 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _shownReadEntryLid.Value = ReadPosition.Value.EntryLid;
             ResetNewMessagesLineState();
             _itemVisibility.Value = ChatViewItemVisibility.Empty;
+            // A report from the pre-suspend rendering may have landed while we awaited visibility
+            ChatUI.ResetItemVisibility(chatId);
         }
 
         // Update delay: we want to collect as many dependencies as possible here,

--- a/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarChatButtons.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarChatButtons.razor
@@ -3,16 +3,16 @@
 @implements ISortableListBackend
 @{
     var m = State.Value;
-    var chats = m.Chats;
+    var items = m.Items;
     var iconSize = ScreenSize.IsNarrow() ? SquareSize.Size10 : SquareSize.Size12;
 }
 
-@if (chats.Any()) {
+@if (items.Any()) {
     <div class=c-delimiter></div>
 }
 
 <div @ref="Ref" class="navbar-chat-buttons">
-    @foreach (var chatInfo in chats) {
+    @foreach (var (chatInfo, unreadState) in items) {
         var attributes = new Dictionary<string, object> {
             { "data-chat-id", chatInfo.Id },
         };
@@ -32,8 +32,8 @@
             </ChildContent>
             <BadgeContent>
                 <UnreadCount
-                    Value="@chatInfo.UnreadCount"
-                    HasMentions="@chatInfo.HasUnreadMentions"
+                    Value="@unreadState.Count"
+                    HasMentions="@unreadState.HasOwnMention"
                     NotificationMode="@chatInfo.ChatUserSettings.NotificationMode"/>
             </BadgeContent>
         </NavbarGroupSelectionButton>
@@ -70,12 +70,20 @@
 
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
         var navbarSettings = await Hub.NavbarUI.Settings.Use(cancellationToken).ConfigureAwait(false);
-        var maybeChats = await navbarSettings.PinnedChats
-            .Select(id => Hub.ChatUI.Get(id, cancellationToken))
+        var maybeItems = await navbarSettings.PinnedChats
+            .Select(GetItem)
             .Collect(ApiConstants.Concurrency.High, cancellationToken)
             .ConfigureAwait(false);
-        var chats = maybeChats.SkipNullItems().ToList();
-        return new() { Chats = chats };
+        return new() { Items = maybeItems.Where(x => x is not null).Select(x => x!.Value).ToList() };
+
+        async Task<(ChatInfo Chat, ChatUnreadState UnreadState)?> GetItem(ChatId chatId) {
+            var chatInfo = await Hub.ChatUI.Get(chatId, cancellationToken).ConfigureAwait(false);
+            if (chatInfo == null)
+                return null;
+
+            var unreadState = await Hub.ChatUI.GetUnreadState(chatId, cancellationToken).ConfigureAwait(false);
+            return (chatInfo, unreadState);
+        }
     }
 
     [JSInvokable]
@@ -84,7 +92,7 @@
 
     // Nested types
 
-    public record Model {
-        public List<ChatInfo> Chats { get; init; } = [];
+    public sealed record Model {
+        public List<(ChatInfo Chat, ChatUnreadState UnreadState)> Items { get; init; } = [];
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
@@ -79,8 +79,10 @@
         var chatId = chat.Id;
         var chatStateTask = ChatUI.GetState(chatId, false, cancellationToken);
         var previewTask = ChatUI.GetPreview(chatId, cancellationToken);
+        var unreadStateTask = ChatUI.GetUnreadState(chatId, cancellationToken);
         var chatState = await chatStateTask.ConfigureAwait(false);
         var preview = await previewTask.ConfigureAwait(false);
+        var unreadState = await unreadStateTask.ConfigureAwait(false);
         if (chatState == null)
             return Model.None;
 
@@ -88,8 +90,8 @@
         return new() {
             Chat = chatState.Chat,
             NotificationMode = chatState.Info.ChatUserSettings.NotificationMode,
-            UnreadCount = chatState.Info.UnreadCount,
-            HasUnreadMentions = chatState.Info.HasUnreadMentions,
+            UnreadCount = unreadState.Count,
+            HasUnreadMentions = unreadState.HasOwnMention,
             LastTextEntry = lastEntry,
             LastTextEntryText = preview.Text,
         };

--- a/src/dotnet/UI.Blazor.App/Services/ChatInfo.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatInfo.cs
@@ -38,4 +38,4 @@ public sealed record ChatInfo(Contact Contact) : IHasId<ChatId>
 
 // The badge-only projection of ChatInfo - value-compared, so ChatUI.GetUnreadState can consolidate it.
 
-public readonly record struct ChatUnreadState(Trimmed<int> Count, bool HasOwnMention);
+public readonly record struct ChatUnreadState(Trimmed<int> Count, bool HasOwnMention, bool HasUnmutedUnread);

--- a/src/dotnet/UI.Blazor.App/Services/ChatInfoExt.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatInfoExt.cs
@@ -3,19 +3,4 @@ namespace ActualChat.UI.Blazor.App.Services;
 public static class ChatInfoExt
 {
     public const int MaxUnreadChatCount = 100;
-
-    public static Trimmed<int> UnreadMessageCount(this IEnumerable<ChatInfo> chats)
-        => chats
-            .Select(c => c.UnreadCount)
-            .Sum();
-
-    public static Trimmed<int> UnreadChatCount(this IEnumerable<ChatInfo> chats)
-        => chats
-            .Select(c => new Trimmed<int>(c.UnreadCount.Value > 0 ? 1 : 0, MaxUnreadChatCount))
-            .Sum();
-
-    public static Trimmed<int> UnmutedUnreadChatCount(this IEnumerable<ChatInfo> chats)
-        => chats
-            .Where(c => c.UnmutedUnreadCount > 0)
-            .UnreadChatCount();
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
@@ -84,7 +84,7 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     public virtual async Task<Trimmed<int>> GetUnreadChatCount(PlaceId? placeId, ChatListFilter filter, CancellationToken cancellationToken = default)
     {
         var chatById = await ListUnordered(placeId, filter, cancellationToken).ConfigureAwait(false);
-        return chatById.Select(c => c.Value).UnreadChatCount();
+        return await ComputeGatedUnreadChatCount(chatById, false, cancellationToken).ConfigureAwait(false);
     }
 
     [ComputeMethod(InvalidationDelay = 0.6)]
@@ -98,7 +98,7 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     public virtual async Task<Trimmed<int>> GetUnmutedUnreadChatCount(PlaceId? placeId, ChatListFilter filter, CancellationToken cancellationToken = default)
     {
         var chatById = await ListUnordered(placeId, filter, cancellationToken).ConfigureAwait(false);
-        return chatById.Select(c => c.Value).UnmutedUnreadChatCount();
+        return await ComputeGatedUnreadChatCount(chatById, true, cancellationToken).ConfigureAwait(false);
     }
 
     [ComputeMethod]
@@ -389,7 +389,35 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     private async Task<Trimmed<int>> ComputeUnreadChatCount(CancellationToken cancellationToken)
     {
         var chatById = await ListAllUnordered(cancellationToken).ConfigureAwait(false);
-        var count = chatById.Values.UnmutedUnreadChatCount();
-        return count;
+        return await ComputeGatedUnreadChatCount(chatById, true, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Trimmed<int>> ComputeGatedUnreadChatCount(
+        IReadOnlyDictionary<ChatId, ChatInfo> chatById,
+        bool mustBeUnmuted,
+        CancellationToken cancellationToken)
+    {
+        // Only the selected chat's badge can be gated off (IsReadingTail short-circuits on
+        // IsSelected), so fold the raw per-chat counts and override that single chat - a
+        // per-chat GetUnreadState fan-out would re-register O(N) dependencies per recompute.
+        var selectedChatId = await ChatUI.SelectedChatId.Use(cancellationToken).ConfigureAwait(false);
+        var gatedChatId = selectedChatId?.GetThreadOutermostParentOrSelf() ?? default;
+        var count = 0;
+        foreach (var (chatId, chatInfo) in chatById) {
+            bool hasUnread;
+            if (chatId == gatedChatId) {
+                var unreadState = await ChatUI.GetUnreadState(chatId, cancellationToken).ConfigureAwait(false);
+                hasUnread = mustBeUnmuted ? unreadState.HasUnmutedUnread : unreadState.Count > 0;
+            }
+            else
+                hasUnread = mustBeUnmuted
+                    ? chatInfo.UnmutedUnreadCount > 0 && chatInfo.UnreadCount > 0
+                    : chatInfo.UnreadCount > 0;
+            if (hasUnread)
+                count++;
+        }
+        return new Trimmed<int>(
+            Math.Min(count, ChatInfoExt.MaxUnreadChatCount),
+            ChatInfoExt.MaxUnreadChatCount);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -296,10 +296,16 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         var isReadingTail = await IsReadingTail(chatId, cancellationToken).ConfigureAwait(false);
         return isReadingTail
             ? default
-            : new ChatUnreadState(chatInfo.UnreadCount, chatInfo.HasUnreadOwnMention);
+            : new ChatUnreadState(
+                chatInfo.UnreadCount,
+                chatInfo.HasUnreadOwnMention,
+                chatInfo.UnmutedUnreadCount > 0 && chatInfo.UnreadCount > 0);
     }
 
-    [ComputeMethod]
+    // Consolidated so streaming-expansion flaps of the end anchor (pushed out, then restored by the
+    // sticky-edge scroll-back) don't propagate: the wrapper serves the old value during the window
+    // and recomputes once after it - only a genuine pin/unpin changes the result.
+    [ComputeMethod(ConsolidationDelay = 0.25)]
     public virtual async Task<bool> IsReadingTail(ChatId chatId, CancellationToken cancellationToken)
     {
         // Must stay in sync with what actually advances the read position (ChatView) - suppressing
@@ -308,7 +314,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             return false;
 
         var itemVisibility = await ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
-        if (itemVisibility.ChatId != chatId || !itemVisibility.IsEndAnchorVisible)
+        if (itemVisibility.ChatId != chatId || !itemVisibility.IsPinnedToEnd)
             return false;
 
         var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
@@ -4,9 +4,10 @@ namespace ActualChat.UI.Blazor.App.Services;
 public sealed record ChatViewItemVisibility(
     ChatId ChatId,
     IReadOnlySet<ChatMessageKey> VisibleKeys,
-    bool IsEndAnchorVisible)
+    bool IsEndAnchorVisible,
+    bool IsPinnedToEnd)
 {
-    public static readonly ChatViewItemVisibility Empty = new(null!, ImmutableHashSet<ChatMessageKey>.Empty, false);
+    public static readonly ChatViewItemVisibility Empty = new(null!, ImmutableHashSet<ChatMessageKey>.Empty, false, false);
 
     public long MinMessageLid { get; } = VisibleKeys.Count == 0 ? -1 : VisibleKeys.Min(x => x.LocalId);
     public long MaxMessageLid { get; } = VisibleKeys.Count == 0 ? -1 : VisibleKeys.Max(x => x.LocalId);
@@ -33,7 +34,8 @@ public sealed record ChatViewItemVisibility(
             source.VisibleKeys
                 .Select(ChatMessageKey.Parse)
                 .ToHashSet(),
-            source.IsEndAnchorVisible)
+            source.IsEndAnchorVisible,
+            source.IsPinnedToEnd)
     { }
 
     public bool IsScrollRequired(long entryLid)
@@ -66,6 +68,9 @@ public sealed record ChatViewItemVisibility(
             return false;
 
         if (IsEndAnchorVisible != other.IsEndAnchorVisible)
+            return false;
+
+        if (IsPinnedToEnd != other.IsPinnedToEnd)
             return false;
 
         foreach (var key in other.VisibleKeys)

--- a/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatViewItemVisibility.cs
@@ -7,7 +7,8 @@ public sealed record ChatViewItemVisibility(
     bool IsEndAnchorVisible,
     bool IsPinnedToEnd)
 {
-    public static readonly ChatViewItemVisibility Empty = new(null!, ImmutableHashSet<ChatMessageKey>.Empty, false, false);
+    public static readonly ChatViewItemVisibility Empty
+        = new(null!, ImmutableHashSet<ChatMessageKey>.Empty, false, false);
 
     public long MinMessageLid { get; } = VisibleKeys.Count == 0 ? -1 : VisibleKeys.Min(x => x.LocalId);
     public long MaxMessageLid { get; } = VisibleKeys.Count == 0 ? -1 : VisibleKeys.Max(x => x.LocalId);
@@ -44,15 +45,14 @@ public sealed record ChatViewItemVisibility(
         if (!found)
             return true;
 
-        var hasBefore = VisibleKeys.Any(x => x.LocalId < entryLid || (x.LocalId == entryLid && x.Kind != ChatMessageKind.None));
+        var hasBefore = VisibleKeys.Any(x => x.LocalId < entryLid
+            || (x.LocalId == entryLid && x.Kind != ChatMessageKind.None));
         var hasAfter = VisibleKeys.Any(x => x.LocalId > entryLid);
 
         if (!hasBefore && !hasAfter) // the only visible item
             return false;
-
         if (hasBefore && hasAfter)
             return false;
-
         if (!hasAfter && IsEndAnchorVisible) // the last item
             return false;
 
@@ -63,13 +63,10 @@ public sealed record ChatViewItemVisibility(
     {
         if (ChatId != other.ChatId)
             return false;
-
         if (VisibleKeys.Count != other.VisibleKeys.Count)
             return false;
-
         if (IsEndAnchorVisible != other.IsEndAnchorVisible)
             return false;
-
         if (IsPinnedToEnd != other.IsPinnedToEnd)
             return false;
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/Internal/IVirtualListBackend.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/Internal/IVirtualListBackend.cs
@@ -6,5 +6,6 @@ public interface IVirtualListBackend
     [JSInvokable]
     Task RequestData(VirtualListDataQuery query);
     [JSInvokable]
-    Task UpdateItemVisibility(string identity, HashSet<string> visibleKeys, bool isIsEndAnchorVisible);
+    Task UpdateItemVisibility(
+        string identity, HashSet<string> visibleKeys, bool isEndAnchorVisible, bool isPinnedToEnd);
 }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -78,7 +78,8 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     }
 
     [JSInvokable]
-    public Task UpdateItemVisibility(string identity, HashSet<string> visibleKeys, bool isEndAnchorVisible)
+    public Task UpdateItemVisibility(
+        string identity, HashSet<string> visibleKeys, bool isEndAnchorVisible, bool isPinnedToEnd)
     {
         if (JSRef == null!) // The component is disposed
             return Task.CompletedTask;
@@ -87,7 +88,8 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
             Log.LogWarning("Expected JS identity to be {Identity}, but has {ActualIdentity}", Identity, identity);
             return Task.CompletedTask;
         }
-        LastReportedItemVisibility = new VirtualListItemVisibility(identity, visibleKeys, isEndAnchorVisible);
+        LastReportedItemVisibility = new VirtualListItemVisibility(
+            identity, visibleKeys, isEndAnchorVisible, isPinnedToEnd);
         ItemVisibilityChanged?.Invoke(LastReportedItemVisibility);
         return Task.CompletedTask;
     }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListItemVisibility.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListItemVisibility.cs
@@ -3,10 +3,10 @@ namespace ActualChat.UI.Blazor.Components;
 public sealed record VirtualListItemVisibility(
     string ListIdentity,
     IReadOnlySet<string> VisibleKeys,
-    bool IsEndAnchorVisible
+    bool IsEndAnchorVisible,
+    bool IsPinnedToEnd
 )
 {
-    public static readonly VirtualListItemVisibility Empty = new("", ImmutableHashSet<string>.Empty, true);
-
+    public static readonly VirtualListItemVisibility Empty = new("", ImmutableHashSet<string>.Empty, true, true);
     public bool IsEmpty => VisibleKeys.Count == 0;
 }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/finite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/finite-list.ts
@@ -279,7 +279,7 @@ export class FiniteList extends VirtualList {
     private updateItemVisibility(): void {
         const isEndAnchorVisible = this.renderState.hasVeryLastItem
             && this.ref.scrollTop + this.ref.clientHeight >= this.ref.scrollHeight - 1;
-        void this.reportVisibility([...this.visibleKeys], isEndAnchorVisible);
+        void this.reportVisibility([...this.visibleKeys], isEndAnchorVisible, isEndAnchorVisible);
     }
 
     // Keys that left the DOM are dropped, but the rest keep their state: clearing the whole set here

--- a/src/dotnet/UI.Blazor/Components/VirtualList/finite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/finite-list.ts
@@ -109,46 +109,6 @@ export class FiniteList extends VirtualList {
         void this.requestData();
     }
 
-    // Wrapper coordinates of the item at `index`, counting the separators that come before it.
-    private topOf(index: number): number {
-        return index * this.itemSize + this.separatorsBefore(index) * this.separatorSize;
-    }
-
-    // How many separators sit above `index`. A separator index is the item it follows, so an index
-    // equal to it is still below the separator.
-    private separatorsBefore(index: number): number {
-        const indexes = this.separatorIndexes;
-        let low = 0;
-        let high = indexes.length;
-        while (low < high) {
-            const mid = (low + high) >> 1;
-            if (indexes[mid] < index)
-                low = mid + 1;
-            else
-                high = mid;
-        }
-        return low;
-    }
-
-    // The inverse of topOf: the index whose row contains `offset`.
-    private indexAt(offset: number): number {
-        if (this.itemSize <= 0)
-            return 0;
-
-        let index = Math.floor(offset / this.itemSize);
-        // Each separator above pushes the answer earlier, and removing them can never uncover another
-        // one below - so this converges in as many steps as there are separators in the way, i.e. one
-        // for the chat list.
-        for (let pass = 0; pass < IndexAtMaxPasses; pass++) {
-            const next = Math.floor((offset - this.separatorsBefore(index) * this.separatorSize) / this.itemSize);
-            if (next === index)
-                break;
-
-            index = next;
-        }
-        return Math.max(0, index);
-    }
-
     protected buildDataQuery(): VirtualListDataQuery | null {
         const rs = this.renderState;
         if (rs.count === 0 || (rs.hasVeryFirstItem && rs.hasVeryLastItem))
@@ -185,6 +145,46 @@ export class FiniteList extends VirtualList {
     }
 
     // Private methods
+
+    // Wrapper coordinates of the item at `index`, counting the separators that come before it.
+    private topOf(index: number): number {
+        return index * this.itemSize + this.separatorsBefore(index) * this.separatorSize;
+    }
+
+    // The inverse of topOf: the index whose row contains `offset`.
+    private indexAt(offset: number): number {
+        if (this.itemSize <= 0)
+            return 0;
+
+        let index = Math.floor(offset / this.itemSize);
+        // Each separator above pushes the answer earlier, and removing them can never uncover another
+        // one below - so this converges in as many steps as there are separators in the way, i.e. one
+        // for the chat list.
+        for (let pass = 0; pass < IndexAtMaxPasses; pass++) {
+            const next = Math.floor((offset - this.separatorsBefore(index) * this.separatorSize) / this.itemSize);
+            if (next === index)
+                break;
+
+            index = next;
+        }
+        return Math.max(0, index);
+    }
+
+    // How many separators sit above `index`. A separator index is the item it follows, so an index
+    // equal to it is still below the separator.
+    private separatorsBefore(index: number): number {
+        const indexes = this.separatorIndexes;
+        let low = 0;
+        let high = indexes.length;
+        while (low < high) {
+            const mid = (low + high) >> 1;
+            if (indexes[mid] < index)
+                low = mid + 1;
+            else
+                high = mid;
+        }
+        return low;
+    }
 
     // The size source is any regular item; irregular ones (block separators) carry extra height and
     // would poison the estimate. Sticking to one key while it stays rendered keeps the value from
@@ -279,7 +279,7 @@ export class FiniteList extends VirtualList {
     private updateItemVisibility(): void {
         const isEndAnchorVisible = this.renderState.hasVeryLastItem
             && this.ref.scrollTop + this.ref.clientHeight >= this.ref.scrollHeight - 1;
-        void this.reportVisibility([...this.visibleKeys], isEndAnchorVisible, isEndAnchorVisible);
+        void this.reportVisibility([...this.visibleKeys], isEndAnchorVisible);
     }
 
     // Keys that left the DOM are dropped, but the rest keep their state: clearing the whole set here

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -1010,6 +1010,11 @@ export class InfiniteList extends VirtualList {
             this.ref.classList.toggle('sticky-end', isStickyEnd);
         if (wasPinned !== edge)
             this.repinChainAnchor(wasPinned);
+
+        // Pin/unpin can happen without any item entering or leaving the viewport, so nothing else
+        // would re-report isPinnedToEnd
+        if ((wasPinned === VirtualListEdge.End) !== isStickyEnd)
+            this.updateVisibilityThrottled();
     }
 
     // Letting go of an edge holds what is on screen; taking one hands the placement back to the model.
@@ -1839,7 +1844,6 @@ export class InfiniteList extends VirtualList {
         this.screenAnchor = null;
     }
 
-
     // Puts the anchored element back where the interaction left it. Returns whether it had to move, or
     // null when there is nothing left to hold - the anchor expired, or the correction has run away.
     private correctScreenAnchor(): boolean | null {
@@ -1974,7 +1978,10 @@ export class InfiniteList extends VirtualList {
         const isEndAnchorVisible = !document.hidden
             && this.renderState.hasVeryLastItem
             && (this.isChainWithinViewport || (this.distanceToEndEdge() ?? Infinity) <= EdgeEpsilon);
-        void this.reportVisibility(visibleKeys.sort(), isEndAnchorVisible);
+        // A level signal for the badge gate: stays true while the list follows its end edge, even
+        // when a streaming expansion momentarily pushes the anchor out before the follow catches up.
+        const isPinnedToEnd = isEndAnchorVisible || this.pinnedEdge === VirtualListEdge.End;
+        void this.reportVisibility(visibleKeys.sort(), isEndAnchorVisible, isPinnedToEnd);
     }
 
     // Tracked per spacer rather than recomputed from the callback's entries: a callback carrying only

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -147,7 +147,7 @@ export abstract class VirtualList implements VirtualListOverlayTarget {
     }
 
     protected async reportVisibility(
-        visibleKeys: string[], isEndAnchorVisible: boolean, isPinnedToEnd: boolean): Promise<void> {
+        visibleKeys: string[], isEndAnchorVisible: boolean, isPinnedToEnd = isEndAnchorVisible): Promise<void> {
         if (this.isDisposed)
             return;
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -146,13 +146,14 @@ export abstract class VirtualList implements VirtualListOverlayTarget {
         }
     }
 
-    protected async reportVisibility(visibleKeys: string[], isEndAnchorVisible: boolean): Promise<void> {
+    protected async reportVisibility(
+        visibleKeys: string[], isEndAnchorVisible: boolean, isPinnedToEnd: boolean): Promise<void> {
         if (this.isDisposed)
             return;
 
         try {
             await this.blazorRef.invokeMethodAsync(
-                'UpdateItemVisibility', this.identity, visibleKeys, isEndAnchorVisible);
+                'UpdateItemVisibility', this.identity, visibleKeys, isEndAnchorVisible, isPinnedToEnd);
         }
         catch (e) {
             // DisposeAsync drops BlazorRef right after the JS dispose(), so a call that passed the

--- a/tests/Chat.IntegrationTests/PostChatMessageTest.cs
+++ b/tests/Chat.IntegrationTests/PostChatMessageTest.cs
@@ -1,4 +1,5 @@
 using ActualChat.Testing.Host;
+using ActualChat.Users;
 
 namespace ActualChat.Chat.IntegrationTests;
 
@@ -9,17 +10,19 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     [Fact]
     public async Task PostMessage()
     {
+        // arrange
         var appHost = AppHost;
         await using var tester = appHost.NewBlazorTester(Out);
         _ = await tester.SignInAsBob();
         var session = tester.Session;
         var commander = tester.Commander;
-
         var (chatId, _) = await tester.CreateChat(true);
 
+        // act
         var cmd = new Chats_UpsertEntry(session, chatId, null) { Text = "Hello!" };
         var chatEntry = await commander.Call(cmd);
 
+        // assert
         chatEntry.ChatId.Should().Be(chatId);
         chatEntry.Content.Should().Be(cmd.Text);
     }
@@ -49,20 +52,21 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     [Fact]
     public async Task EditMessage()
     {
+        // arrange
         var appHost = AppHost;
         await using var tester = appHost.NewBlazorTester(Out);
         _ = await tester.SignInAsBob();
         var session = tester.Session;
         var commander = tester.Commander;
-
         var (chatId, _) = await tester.CreateChat(true);
-
         var cmd = new Chats_UpsertEntry(session, chatId, null) { Text = "Hello!" };
         var chatEntry = await commander.Call(cmd);
 
+        // act
         var cmd2 = new Chats_UpsertEntry(session, chatId, chatEntry.LocalId) { Text = "EditedMessage" };
         var editedChatEntry = await commander.Call(cmd2);
 
+        // assert
         editedChatEntry.ChatId.Should().Be(chatId);
         editedChatEntry.LocalId.Should().Be(chatEntry.LocalId);
         editedChatEntry.Content.Should().Be(cmd2.Text);
@@ -71,22 +75,23 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     [Fact]
     public async Task ReplyMessage()
     {
+        // arrange
         var appHost = AppHost;
         await using var tester = appHost.NewBlazorTester(Out);
         _ = await tester.SignInAsBob();
         var session = tester.Session;
         var commander = tester.Commander;
-
         var (chatId, _) = await tester.CreateChat(true);
-
         var cmd = new Chats_UpsertEntry(session, chatId, null) { Text = "Hello!" };
         var chatEntry = await commander.Call(cmd);
 
+        // act
         var cmd2 = new Chats_UpsertEntry(session, chatId, null) { Text = "Reply",
             RepliedEntryLid = chatEntry.LocalId,
         };
         var replyChatEntry = await commander.Call(cmd2);
 
+        // assert
         replyChatEntry.ChatId.Should().Be(chatId);
         replyChatEntry.Content.Should().Be(cmd2.Text);
         replyChatEntry.RepliedEntryLid.Should().Be(chatEntry.LocalId);
@@ -95,25 +100,25 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     [Fact]
     public async Task EditReplyMessage()
     {
+        // arrange
         var appHost = AppHost;
         await using var tester = appHost.NewBlazorTester(Out);
         _ = await tester.SignInAsBob();
         var session = tester.Session;
         var commander = tester.Commander;
-
         var (chatId, _) = await tester.CreateChat(true);
-
         var cmd = new Chats_UpsertEntry(session, chatId, null) { Text = "Hello!" };
         var chatEntry = await commander.Call(cmd);
-
         var cmd2 = new Chats_UpsertEntry(session, chatId, null) { Text = "Reply",
             RepliedEntryLid = chatEntry.LocalId,
         };
         var replyChatEntry = await commander.Call(cmd2);
 
+        // act
         var cmd3 = new Chats_UpsertEntry(session, chatId, replyChatEntry.LocalId) { Text = "EditedReply" };
         var editedReplyChatEntry = await commander.Call(cmd3);
 
+        // assert
         editedReplyChatEntry.ChatId.Should().Be(chatId);
         editedReplyChatEntry.LocalId.Should().Be(replyChatEntry.LocalId);
         editedReplyChatEntry.Content.Should().Be(cmd3.Text);
@@ -123,21 +128,19 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     [Fact]
     public async Task UpdateAttachments()
     {
+        // arrange
         var appHost = AppHost;
         await using var tester = appHost.NewBlazorTester(Out);
         _ = await tester.SignInAsBob();
         var session = tester.Session;
         var commander = tester.Commander;
         var chats = tester.AppServices.GetRequiredService<IChats>();
-
         var (chatId, _) = await tester.CreateChat(true);
-
-        // Create 3 media files for attachments
         var media1 = await SaveTextFile(tester, chatId, "file1.txt");
         var media2 = await SaveTextFile(tester, chatId, "file2.txt");
         var media3 = await SaveTextFile(tester, chatId, "file3.txt");
 
-        // Create an entry with 3 attachments
+        // act
         var attachments = new[] {
             new ChatEntryAttachment { MediaId = media1 },
             new ChatEntryAttachment { MediaId = media2 },
@@ -148,17 +151,17 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
         };
         var chatEntry = await commander.Call(createCmd);
 
+        // assert
         chatEntry.ChatId.Should().Be(chatId);
         chatEntry.Content.Should().Be(createCmd.Text);
-
-        // Get entry to verify attachments
         var entryId = ChatEntryId.New(chatId, chatEntry.LocalId);
         var entryWith3Attachments = await chats.GetEntry(session, entryId);
         entryWith3Attachments.Should().NotBeNull();
         entryWith3Attachments.Attachments.Should().HaveCount(3);
-        entryWith3Attachments.Attachments.Select(a => a.MediaId).Should().BeEquivalentTo(new[] { media1, media2, media3 });
+        entryWith3Attachments.Attachments.Select(a => a.MediaId).Should()
+            .BeEquivalentTo(new[] { media1, media2, media3 });
 
-        // Update entry to 2 attachments (remove the third one)
+        // act - update to 2 attachments (remove the second one)
         var updatedAttachments = new[] {
             new ChatEntryAttachment { MediaId = media1 },
             new ChatEntryAttachment { MediaId = media3 },
@@ -168,16 +171,110 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
         };
         var updatedEntry = await commander.Call(updateCmd);
 
+        // assert
         updatedEntry.LocalId.Should().Be(chatEntry.LocalId);
         updatedEntry.Content.Should().Be(updateCmd.Text);
-
-        // Get entry to verify attachments were updated
         var entryWith2Attachments = await chats.GetEntry(session, entryId);
         entryWith2Attachments.Should().NotBeNull();
         entryWith2Attachments.Attachments.Should().HaveCount(2);
         entryWith2Attachments.Attachments.Select(a => a.MediaId).Should().BeEquivalentTo(new[] { media1, media3 });
     }
 
+    [Fact]
+    public async Task PostWhileCaughtUpAdvancesReadPosition()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var tester = appHost.NewBlazorTester(Out);
+        _ = await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var chatPositions = tester.AppServices.GetRequiredService<IChatPositions>();
+        var (chatId, _) = await tester.CreateChat(true);
+        await CatchUp(tester, chatId);
+
+        // act
+        await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "First" });
+        var entry2 = await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "Second" });
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var position = await chatPositions.GetOwn(session, chatId, ChatPositionKind.Read, ct);
+            position.EntryLid.Should().Be(entry2.LocalId);
+        });
+    }
+
+    [Fact]
+    public async Task PostWhileBehindKeepsReadPosition()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var tester = appHost.NewBlazorTester(Out);
+        var account = await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var chatPositions = tester.AppServices.GetRequiredService<IChatPositions>();
+        var (chatId, _) = await tester.CreateChat(true);
+        await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "First" });
+        await commander.Call(new ChatPositionsBackend_Set(
+            account.Id, chatId, ChatPositionKind.Read, new ChatPosition(0), Force: true));
+
+        // act
+        await commander.Call(new Chats_UpsertEntry(session, chatId, null) { Text = "Second" });
+
+        // assert - the advance (if any) happens synchronously inside the command handler,
+        // so the position is already final here
+        var position = await chatPositions.GetOwn(session, chatId, ChatPositionKind.Read, CancellationToken.None);
+        position.EntryLid.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ForwardWhileCaughtUpAdvancesReadPosition()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var tester = appHost.NewBlazorTester(Out);
+        _ = await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var commander = tester.Commander;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var chatPositions = tester.AppServices.GetRequiredService<IChatPositions>();
+        var (sourceChatId, _) = await tester.CreateChat(true);
+        var (targetChatId, _) = await tester.CreateChat(true);
+        await CatchUp(tester, targetChatId);
+        var entry = await commander.Call(new Chats_UpsertEntry(session, sourceChatId, null) { Text = "To forward" });
+
+        // act
+        await commander.Call(new Chats_ForwardEntries(
+            session, sourceChatId, [ChatEntryId.New(sourceChatId, entry.LocalId)], [targetChatId]));
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var targetNews = await chats.GetNews(session, targetChatId, ct);
+            var lastLid = targetNews.TextEntryLidRange.End - 1;
+            lastLid.Should().BeGreaterThan(0);
+            var position = await chatPositions.GetOwn(session, targetChatId, ChatPositionKind.Read, ct);
+            position.EntryLid.Should().Be(lastLid);
+        });
+    }
+
     private static Task<MediaId> SaveTextFile(IWebTester tester, ChatId chatId, string fileName)
         => tester.SaveTextFile(chatId, fileName, $"Test content for {fileName}");
+
+    private async Task CatchUp(IWebTester tester, ChatId chatId)
+    {
+        // Simulates the client marking the chat fully read (what ChatView does when the end anchor is
+        // visible). The chat's initial system entry is written asynchronously, so wait for it first -
+        // otherwise the position is set to 0 and the author is "behind" the moment the entry lands.
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var lastLid = 0L;
+        await ComputedTest.When(async ct => {
+            var news = await chats.GetNews(tester.Session, chatId, ct);
+            lastLid = news.TextEntryLidRange.End - 1;
+            lastLid.Should().BeGreaterThan(0);
+        });
+        Out.WriteLine($"CatchUp: chatId={chatId}, lastLid={lastLid}");
+        await tester.Commander.Call(new ChatPositions_Set(
+            tester.Session, chatId, ChatPositionKind.Read, new ChatPosition(lastLid)));
+    }
 }

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -741,6 +741,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
                 ChatMessageKey.New(ChatMessageKind.None, v + 3),
                 ChatMessageKey.New(ChatMessageKind.None, v + 4),
             },
+            false,
             false));
 
         // act 1 - a summary pass widens the live pipeline's known coverage over v+3/v+4, but they're
@@ -758,6 +759,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, tailEntry.LocalId) },
+            false,
             false));
 
         // assert - the boundary advances past v+3/v+4, folding them
@@ -1342,6 +1344,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false,
             false));
 
         // assert - the governed boundary (not just the summary-covered range) advances to the viewport
@@ -1458,6 +1461,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, idRange.End - 1) },
+            false,
             false));
 
         // assert - the fold stops below the streaming entry
@@ -1514,6 +1518,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false,
             false));
 
         long foldedBoundary = 0;
@@ -1580,6 +1585,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             => chatUI.SetItemVisibility(new ChatViewItemVisibility(
                 chat.Id,
                 new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, lid) },
+                false,
                 false));
 
         // drive the fold boundary up to the live tail
@@ -1653,6 +1659,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false,
             false));
 
         long foldedBoundary = 0;
@@ -1737,6 +1744,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SetItemVisibility(new ChatViewItemVisibility(
             chat.Id,
             new HashSet<ChatMessageKey> { ChatMessageKey.New(ChatMessageKind.None, viewportTop) },
+            false,
             false));
 
         // assert - the count is the true number of folded messages, not a lid-span approximation

--- a/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/TranslationUITest.cs
@@ -476,16 +476,18 @@ public class TranslationUITest(TranslationAppHostFixture fixture, ITestOutputHel
         var lids = entries.Select(x => x.LocalId).ToHashSet();
         ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId,
             lids.Select(lid => ChatMessageKey.New(ChatMessageKind.None, lid)).ToHashSet(),
+            true,
             true));
     }
 
     private void SetVisibleThreads(ChatId chatId, IEnumerable<long> threadStartLids)
         => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId,
             threadStartLids.Select(lid => ChatMessageKey.New(ChatMessageKind.Thread, lid)).ToHashSet(),
+            true,
             true));
 
     private void ClearVisibleItems(ChatId chatId)
-        => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId, ReadOnlySet<ChatMessageKey>.Empty, true));
+        => ChatUI.SetItemVisibility(new ChatViewItemVisibility(chatId, ReadOnlySet<ChatMessageKey>.Empty, true, true));
 
     private Task AssertIsSubHeaderVisible(ChatId chatId, bool expected)
         => ComputedTest.When(async ct => {


### PR DESCRIPTION
## Problem

The unread badge for the chat you're actively at keeps rising and dropping during live sessions: streamed entries advance the text lid range immediately, while the read position catches up ~1.6s later (or only on the next item-visibility event). The existing `IsReadingTail` gate covers only the chat-list row and reads the instantaneous `IsEndAnchorVisible`, which flaps while a streaming expansion outruns the edge-follow; the navbar pinned buttons, thread rows, and tab/aggregate badges consume the raw `ChatInfo.UnreadCount` and bounce on every utterance.

## Fix

- **`isPinnedToEnd`** — the virtual list now reports a level signal (`end anchor visible || pinned to the end edge`) alongside the instantaneous anchor flag; the infinite list re-reports it on pin/unpin, since that can happen without any item entering or leaving the viewport.
- **`IsReadingTail`** gates on `IsSelected` → `IsPinnedToEnd` → presence grace, with `ConsolidationDelay = 0.25` so residual flaps don't propagate.
- **Eager read-position advance** — while pinned to the end and present, another author's entry advances the read position immediately instead of waiting for the IntersectionObserver round trip, so the raw count never rises for the chat being watched.
- **All badge surfaces consume the gated `ChatUnreadState`** — thread rows, navbar pinned buttons, and the aggregate chat counts (`GetUnreadChatCount` / `GetUnmutedUnreadChatCount`) now route through `ChatUI.GetUnreadState` instead of raw `ChatInfo.UnreadCount`.
- **Server: own post advances the read position when caught up** — posting while at the tail no longer counts your own message as unread on other consumers; advancing from behind is excluded so real unreads are never wiped.

## Verification

- `PostChatMessageTest` 9/9, including 3 new tests: `PostWhileCaughtUpAdvancesReadPosition`, `PostWhileBehindKeepsReadPosition`, `ForwardWhileCaughtUpAdvancesReadPosition`
- `TranslationUITest` 14/14, `LiveConversationDisplayTest` green
- `npm run build:Verify` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qGDtFnYsaEqzDW7ASWhdi
