### PR TITLE
fix(transcription): pace Soniox sweeps against the shared rate limit

### DIFF
--- a/.claude/skills/soniox-sweep/SKILL.md
+++ b/.claude/skills/soniox-sweep/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: soniox-sweep
+description: |
+  Inspect and manually purge the Soniox artifacts — transcriptions and uploaded
+  audio files — that offline transcription leaves behind, on dev or prod. Use
+  when offline transcription silently stops working, when Soniox answers 429
+  `limit_exceeded`, when `SonioxTranscriberTest.OfflineTranscribeWorks` and
+  `CleanerDeletesEnqueuedArtifacts` fail together, or when the user says
+  "sweep Soniox", "soniox/sonoix sweep", "sonoix swipe", "purge Soniox",
+  "check Soniox files", or "is Soniox at the cap".
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Sweeping Soniox artifacts
+
+Every offline transcription leaves two artifacts on Soniox: the uploaded
+**file** and the **transcription**. Both count against caps enforced **per
+organization**, not per key or per project — so dev and prod share one budget,
+and a backlog on either starves both.
+
+`SonioxCleaner` deletes both as each transcription ends, and `SonioxSweeper`
+sweeps up whatever it dropped every ~4h. This skill is the manual fallback for
+when they have already fallen behind — enough hosts died mid-transcription, or
+the deployed server predates the fix.
+
+## Two things to know before touching anything
+
+**`GET /v1/files` under-reports.** A transcription holds its file, so an account
+at the cap can list **0 files and 2000 transcriptions**. Always look at both,
+and always delete transcriptions first — deleting one cascades to its file.
+
+**The API allows ~500 requests/minute per organization, and live transcription
+spends from the same budget.** A purge that runs flat out both fails with `429
+limit_exceeded` and breaks transcription for real users while it runs. The
+script below paces itself at 200/min, serialized. **Do not raise the rate or add
+concurrency.** A full 2000-artifact purge takes ~10 minutes; that is the cost.
+
+## Keys
+
+| Environment | Key |
+|---|---|
+| dev | `$CoreSettings__SonioxKey` — already in the host/container env |
+| prod | a key file the user names; **default `tmp/sonoix-prod.key`** |
+
+The prod key is **not** in the environment and must be passed explicitly. If a
+prod sweep is requested without a path, use `tmp/sonoix-prod.key` and say so. If
+that file is missing, ask for the path — never fall back to the dev key for a
+prod request, and never the reverse.
+
+## Step 1 — always summarize first, never delete first
+
+```bash
+node .claude/skills/soniox-sweep/sweep.mjs                                  # dev
+node .claude/skills/soniox-sweep/sweep.mjs --key-file tmp/sonoix-prod.key   # prod
+```
+
+Without `--purge` the script only reports. Report back to the user:
+
+- totals for both kinds, and how many are older than the cutoff
+- oldest and newest `created_at` — **a newest that is hours or days old means
+  the leak is historical, not live**
+- the per-day histogram — bursts on a few days point at restarts/deploys losing
+  `SonioxCleaner`'s in-memory queue; a steady trickle points at a code path
+  dropping ids
+- status counts (`completed` / `error` / `processing`)
+
+Exactly **2000 transcriptions with nothing recent** is the signature of a full
+account: uploads are already 429ing, so nothing new can be created.
+
+## Step 2 — ask before purging
+
+**Never purge without explicit confirmation.** State the environment, the count,
+the age range, and the ~10 min/2000 artifacts it will take, then wait for a yes.
+Deletion is irreversible, and on prod it shares the rate limit with live users.
+
+Anything still `processing` is left alone — Soniox answers its delete with 409,
+and it may be a live transcription running on another host.
+
+## Step 3 — purge
+
+```bash
+node .claude/skills/soniox-sweep/sweep.mjs --key-file tmp/sonoix-prod.key --purge --older-than 1h
+```
+
+`--older-than` defaults to `1h` and accepts `15m`-style values. Keep it above
+the longest in-flight offline transcription so a live one isn't deleted
+mid-flight: `1h` is safe, and `15m` — matching
+`SonioxSweeper.Options.Retention` — is the practical floor.
+
+The script re-lists both kinds afterwards; confirm it ends at 0 left, or explain
+what didn't go.
+
+## If the account keeps filling up
+
+A purge buys time, it isn't the fix. Check, in order:
+
+1. **Is the deployed server new enough?** `SonioxSweeper` only learned to sweep
+   transcriptions in `11bbc663de` (2026-08-21). An older pod sweeps files only,
+   sees the empty file list, and reports nothing — while transcriptions pile up
+   invisibly. This is exactly how prod reached the cap on 2026-08-21.
+2. **Server logs.** `SonioxCleaner` logs `Enqueue failed, leaving transcription
+   {TranscriptionId} and file {FileId} on Soniox` at Warning; `SonioxSweeper`
+   logs `Sweep: deleted N orphaned ...` at Information and `Sweep: rate-limited,
+   retrying ...` at Warning. Search for `Soniox` via `/gcloud-prod-logs` or
+   `/gcloud-dev-logs`.
+3. **Restart churn.** The cleaner's queue lives in memory, so every host that
+   dies mid-transcription drops the ids it holds. The sweeper is the backstop —
+   if the backlog outruns one sweep per 4h, lower
+   `SonioxSweeper.Options.Period`.

--- a/.claude/skills/soniox-sweep/sweep.mjs
+++ b/.claude/skills/soniox-sweep/sweep.mjs
@@ -1,0 +1,115 @@
+// Reports, and optionally purges, the Soniox artifacts left by offline transcription.
+// See SKILL.md - in particular, do not raise the request rate.
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+    const i = args.indexOf(name);
+    return i >= 0 ? args[i + 1] : fallback;
+};
+
+const keyFile = flag('--key-file');
+const fs = await import('node:fs');
+if (keyFile && !fs.existsSync(keyFile)) {
+    console.error(`No key file at ${keyFile}. Ask for the path - never fall back to the other environment's key.`);
+    process.exit(1);
+}
+const key = keyFile ? fs.readFileSync(keyFile, 'utf8').trim() : process.env.CoreSettings__SonioxKey;
+if (!key) {
+    console.error('No Soniox key: pass --key-file <path> or set CoreSettings__SonioxKey.');
+    process.exit(1);
+}
+
+const isPurge = args.includes('--purge');
+const olderThan = flag('--older-than', '1h');
+const hours = parseFloat(olderThan) * (olderThan.endsWith('m') ? 1 / 60 : 1);
+if (!(hours > 0))
+    throw new Error(`Bad --older-than: ${olderThan}. Use e.g. 15m or 1h.`);
+
+const cutoff = new Date(Date.now() - hours * 3600_000).toISOString();
+const base = 'https://api.soniox.com/v1';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// ~500 requests/minute is the organization-wide limit and live transcription spends from the
+// same budget, so every call goes through one pacer at 200/min. Do not raise this.
+const minIntervalMs = 300;
+let nextAt = 0;
+
+async function call(method, path) {
+    for (let attempt = 0; ; attempt++) {
+        const wait = nextAt - Date.now();
+        if (wait > 0)
+            await sleep(wait);
+        nextAt = Date.now() + minIntervalMs;
+        const r = await fetch(`${base}/${path}`, { method, headers: { Authorization: `Bearer ${key}` } });
+        if (r.status !== 429 || attempt >= 10)
+            return r;
+        const delay = Math.min(60_000, 10_000 * 2 ** Math.min(attempt, 2));
+        console.log(`  429, backing off ${delay / 1000}s`);
+        nextAt = Date.now() + delay;
+    }
+}
+
+async function listAll(kind) {
+    const out = [];
+    let cursor = null;
+    do {
+        const q = new URLSearchParams({ limit: '1000' });
+        if (cursor)
+            q.set('cursor', cursor);
+        const r = await call('GET', `${kind}?${q}`);
+        if (!r.ok)
+            throw new Error(`GET ${kind}: ${r.status} ${await r.text()}`);
+        const d = await r.json();
+        out.push(...d[kind]);
+        cursor = d.next_page_cursor;
+    } while (cursor);
+    return out;
+}
+
+function summarize(kind, all) {
+    const stale = all.filter(x => x.created_at < cutoff);
+    console.log(`\n${kind}: ${all.length} total, ${stale.length} older than ${olderThan} (${cutoff})`);
+    if (!all.length)
+        return stale;
+    const dates = all.map(x => x.created_at).sort();
+    console.log(`  oldest ${dates[0]}   newest ${dates[dates.length - 1]}`);
+    const count = f => all.reduce((m, x) => (m[f(x)] = (m[f(x)] || 0) + 1, m), {});
+    if (kind === 'transcriptions')
+        console.log('  status:', JSON.stringify(count(x => x.status)));
+    const byDay = Object.entries(count(x => x.created_at.slice(0, 10))).sort();
+    console.log('  by day:', JSON.stringify(Object.fromEntries(byDay)));
+    return stale;
+}
+
+async function purge(kind, stale) {
+    let ok = 0;
+    let failed = 0;
+    for (const item of stale) {
+        const r = await call('DELETE', `${kind}/${item.id}`);
+        if (r.ok || r.status === 404) {
+            if (++ok % 200 === 0)
+                console.log(`  ${ok}/${stale.length} deleted`);
+        }
+        else {
+            failed++;
+            if (failed <= 5)
+                console.log(`  ! ${kind}/${item.id}: ${r.status} ${(await r.text()).slice(0, 100)}`);
+        }
+    }
+    console.log(`${kind}: deleted ${ok}, failed ${failed}`);
+}
+
+console.log(`Soniox ${isPurge ? 'purge' : 'report'} - key from ${keyFile ?? 'CoreSettings__SonioxKey'}`);
+if (isPurge)
+    console.log(`Pacing at ${Math.round(60_000 / minIntervalMs)} requests/minute.`);
+
+// Transcriptions first - deleting one cascades to the file it holds.
+for (const kind of ['transcriptions', 'files']) {
+    const stale = summarize(kind, await listAll(kind));
+    if (isPurge && stale.length)
+        await purge(kind, stale);
+}
+if (isPurge) {
+    console.log('\n--- after ---');
+    for (const kind of ['transcriptions', 'files'])
+        console.log(`${kind}: ${(await listAll(kind)).length} left`);
+}

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxClient.cs
@@ -14,6 +14,9 @@ public sealed class SonioxClient(IServiceProvider services)
     public const string HttpClientName = nameof(SonioxClient);
 
     private const string BaseUrl = "https://api.soniox.com/v1";
+    // Used when a 429 carries no Retry-After, and to cap the one it does carry
+    private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(5);
     private static readonly JsonSerializerOptions JsonOptions = new() {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
@@ -77,12 +80,12 @@ public sealed class SonioxClient(IServiceProvider services)
             .ConfigureAwait(false);
     }
 
-    // Both lists are scoped to the key's project, while the caps Soniox enforces are organization-wide -
-    // so they list what we can clean, not everything that counts against the caps.
     public Task<SonioxTranscriptionList> ListTranscriptions(
         string? cursor,
         int maxCount,
         CancellationToken cancellationToken)
+        // Both lists are scoped to the key's project, while the caps Soniox enforces are
+        // organization-wide - so they list what we can clean, not everything that counts against them.
         => ListPage<SonioxTranscriptionList>("transcriptions", cursor, maxCount, cancellationToken);
 
     public Task<SonioxFileList> ListFiles(string? cursor, int maxCount, CancellationToken cancellationToken)
@@ -152,7 +155,21 @@ public sealed class SonioxClient(IServiceProvider services)
         if (response.IsSuccessStatusCode)
             return;
 
+        // Soniox rate-limits requests per minute per organization, and both storage caps answer with
+        // the same status - so a 429 is transient here, and the callers that spend the budget in bulk
+        // need it typed to tell it apart from the failures that are worth retrying immediately.
+        if (response.StatusCode is HttpStatusCode.TooManyRequests)
+            throw new RateLimitExceededException(GetRetryDelay(response));
+
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         throw StandardError.External($"Soniox {step} failed: {(int)response.StatusCode} {body}");
+    }
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage response)
+    {
+        var retryAfter = response.Headers.RetryAfter;
+        var delay = retryAfter?.Delta
+            ?? (retryAfter?.Date is { } date ? date - DateTimeOffset.UtcNow : DefaultRetryDelay);
+        return delay <= TimeSpan.Zero ? DefaultRetryDelay : TimeSpanExt.Min(delay, MaxRetryDelay);
     }
 }

--- a/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/SonioxSweeper.cs
@@ -20,6 +20,12 @@ public sealed class SonioxSweeper : WorkerBase
         public TimeSpan Retention { get; init; } = TimeSpan.FromMinutes(15);
         public int PageSize { get; init; } = 1000;
         public int MaxDeletesPerSweep { get; init; } = 5000;
+        // Soniox meters requests per minute across the whole organization, and live transcription
+        // spends from the same budget - so a sweep paces itself far below it, leaving room for the
+        // transcribers and for the other hosts sweeping on their own schedule.
+        public TimeSpan DeleteDelay { get; init; } = TimeSpan.FromSeconds(1);
+        public TimeSpan RateLimitDelay { get; init; } = TimeSpan.FromSeconds(30);
+        public int MaxRateLimitRetryCount { get; init; } = 5;
         public RetryDelaySeq RetryDelays { get; init; }
             = RetryDelaySeq.Exp(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(30));
         public LogLevel LogLevel { get; init; } = LogLevel.Information;
@@ -106,20 +112,17 @@ public sealed class SonioxSweeper : WorkerBase
                     kept++;
                     continue;
                 }
+
                 if (deleted + failed >= maxDeleteCount) {
                     isTruncated = true;
                     break;
                 }
 
-                try {
-                    await delete(item.Id, cancellationToken).ConfigureAwait(false);
+                if (await TryDelete(delete, kind, item.Id, cancellationToken).ConfigureAwait(false))
                     deleted++;
-                }
-                catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
-                    // One bad id must not cost the rest of the sweep - the next run retries it.
+                else
                     failed++;
-                    Log.LogWarning(e, "Sweep: couldn't delete {Kind} {Id}", kind, item.Id);
-                }
+                await SystemClock.Delay(Settings.DeleteDelay, cancellationToken).ConfigureAwait(false);
             }
         } while (!cursor.IsNullOrEmpty() && !isTruncated && !cancellationToken.IsCancellationRequested);
 
@@ -132,6 +135,32 @@ public sealed class SonioxSweeper : WorkerBase
                 "Sweep: deleted {DeletedCount} orphaned {Kind}(s), kept {KeptCount}, {FailedCount} failed",
                 deleted, kind, kept, failed);
         return (deleted, failed);
+    }
+
+    private async Task<bool> TryDelete(
+        Func<string, CancellationToken, Task> delete,
+        string kind,
+        string id,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 0;; attempt++) {
+            try {
+                await delete(id, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (RateLimitExceededException e) when (attempt < Settings.MaxRateLimitRetryCount) {
+                // Waiting the limit out beats spending the sweep's budget on deletes that can't land,
+                // and the transcribers sharing the budget are the ones that must get through it.
+                var delay = e.RetryDelay > TimeSpan.Zero ? e.RetryDelay : Settings.RateLimitDelay;
+                Log.LogWarning("Sweep: rate-limited, retrying {Kind} {Id} in {Delay}", kind, id, delay);
+                await SystemClock.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+                // One bad id must not cost the rest of the sweep - the next run retries it.
+                Log.LogWarning(e, "Sweep: couldn't delete {Kind} {Id}", kind, id);
+                return false;
+            }
+        }
     }
 
     private async Task<SweepPage> ListTranscriptionPage(string? cursor, CancellationToken cancellationToken)

--- a/tests/Transcription.UnitTests/SonioxApiMock.cs
+++ b/tests/Transcription.UnitTests/SonioxApiMock.cs
@@ -19,6 +19,9 @@ public sealed class SonioxApiMock : HttpMessageHandler
     public List<int> RequestedPageSizes { get; } = new();
     // Recorded before the request is answered, so a refused delete still counts as attempted
     public List<string> DeleteAttempts { get; } = new();
+    // Answers this many deletes with the 429 Soniox returns once the per-minute budget is spent
+    public int RateLimitedDeleteCount { get; set; }
+    public TimeSpan? RetryAfter { get; set; }
 
     public SonioxApiMock AddTranscription(
         string id,
@@ -81,6 +84,14 @@ public sealed class SonioxApiMock : HttpMessageHandler
     private HttpResponseMessage Delete(Dictionary<string, Item> items, string id, bool isTranscription)
     {
         DeleteAttempts.Add(id);
+        if (RateLimitedDeleteCount > 0) {
+            RateLimitedDeleteCount--;
+            var response = Respond(HttpStatusCode.TooManyRequests, "");
+            if (RetryAfter is { } retryAfter)
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(retryAfter);
+            return response;
+        }
+
         if (!items.TryGetValue(id, out var item))
             return Respond(HttpStatusCode.NotFound, "");
         if (isTranscription && item.Status is not ("completed" or "error"))
@@ -103,6 +114,7 @@ public sealed class SonioxApiMock : HttpMessageHandler
             json["status"] = item.Status;
             json["file_id"] = item.FileId;
         }
+
         return json;
     }
 

--- a/tests/Transcription.UnitTests/SonioxSweeperTest.cs
+++ b/tests/Transcription.UnitTests/SonioxSweeperTest.cs
@@ -2,7 +2,7 @@ using ActualChat.Module;
 
 namespace ActualChat.Transcription.UnitTests;
 
-public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
+public sealed class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
 {
     private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
     private static readonly DateTimeOffset Old = Now - TimeSpan.FromHours(1);
@@ -71,8 +71,8 @@ public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
             .AddFile("f2", Old);
 
         // act
-        var deleted = await NewSweeper(api, new SonioxSweeper.Options { MaxDeletesPerSweep = 3 })
-            .Sweep(CancellationToken.None);
+        var settings = new SonioxSweeper.Options { MaxDeletesPerSweep = 3, DeleteDelay = TimeSpan.Zero };
+        var deleted = await NewSweeper(api, settings).Sweep(CancellationToken.None);
 
         // assert - the budget is what's left of it by the time the file pass runs
         deleted.Should().Be(3);
@@ -89,7 +89,7 @@ public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
             api.AddTranscription($"t{i:00}", Old);
 
         // act
-        var deleted = await NewSweeper(api, new SonioxSweeper.Options { PageSize = 10 })
+        var deleted = await NewSweeper(api, new SonioxSweeper.Options { PageSize = 10, DeleteDelay = TimeSpan.Zero })
             .Sweep(CancellationToken.None);
 
         // assert - and the page size has to reach Soniox, which it doesn't under the wrong parameter
@@ -98,10 +98,71 @@ public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
         api.RequestedPageSizes.Should().OnlyContain(x => x == 10);
     }
 
+    [Fact]
+    public async Task SweepWaitsOutARateLimitAndKeepsGoing()
+    {
+        // arrange - the budget is shared with live transcription, so a 429 says "later", not "no"
+        var api = new SonioxApiMock()
+            .AddTranscription("t1", Old)
+            .AddTranscription("t2", Old);
+        api.RateLimitedDeleteCount = 1;
+        api.RetryAfter = TimeSpan.FromMilliseconds(10);
+        var settings = new SonioxSweeper.Options { DeleteDelay = TimeSpan.Zero };
+
+        // act
+        var deleted = await NewSweeper(api, settings).Sweep(CancellationToken.None);
+
+        // assert - the refused one is retried rather than written off, and both still land
+        deleted.Should().Be(2);
+        api.DeleteAttempts.Should().Equal("t1", "t1", "t2");
+        api.TranscriptionIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SweepGivesUpOnAnEndlessRateLimit()
+    {
+        // arrange
+        var api = new SonioxApiMock().AddTranscription("t1", Old);
+        api.RateLimitedDeleteCount = int.MaxValue;
+        api.RetryAfter = TimeSpan.FromMilliseconds(1);
+        var settings = new SonioxSweeper.Options {
+            DeleteDelay = TimeSpan.Zero,
+            MaxRateLimitRetryCount = 3,
+        };
+
+        // act
+        var deleted = await NewSweeper(api, settings).Sweep(CancellationToken.None);
+
+        // assert - the id survives for the next sweep rather than stalling this one forever
+        deleted.Should().Be(0);
+        api.DeleteAttempts.Should().HaveCount(4);
+        api.TranscriptionIds.Should().BeEquivalentTo("t1");
+    }
+
+    [Fact]
+    public async Task SweepPacesItsDeletes()
+    {
+        // arrange
+        var api = new SonioxApiMock()
+            .AddTranscription("t1", Old)
+            .AddTranscription("t2", Old);
+        var settings = new SonioxSweeper.Options { DeleteDelay = TimeSpan.FromMilliseconds(200) };
+
+        // act
+        var startedAt = CpuTimestamp.Now;
+        var deleted = await NewSweeper(api, settings).Sweep(CancellationToken.None);
+
+        // assert
+        deleted.Should().Be(2);
+        startedAt.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(300));
+    }
+
     // Private methods
 
     private SonioxSweeper NewSweeper(SonioxApiMock api, SonioxSweeper.Options? settings = null)
     {
+        // The clock is the real one, so every test that isn't about pacing turns it off.
+        settings ??= new SonioxSweeper.Options { DeleteDelay = TimeSpan.Zero };
         var services = new ServiceCollection()
             .AddSingleton(MomentClockSet.Default)
             .AddSingleton(new CoreServerSettings { SonioxKey = "test" })
@@ -109,6 +170,6 @@ public class SonioxSweeperTest(ITestOutputHelper @out) : TestBase(@out)
             .AddTestLogging(Out);
         services.AddHttpClient(SonioxClient.HttpClientName)
             .ConfigurePrimaryHttpMessageHandler(() => api);
-        return new SonioxSweeper(settings ?? new SonioxSweeper.Options(), services.BuildServiceProvider());
+        return new SonioxSweeper(settings, services.BuildServiceProvider());
     }
 }


### PR DESCRIPTION
## Context

Prod hit the Soniox organization storage cap: **2000 stored transcriptions, 0 files**, dating 2026-08-07 → 08-19. Offline transcription had been silently degraded — `SonioxOfflineTranscriber` catches, logs, and returns null.

Two things made it invisible:

- `GET /v1/files` under-reports, because a transcription holds its file. The account listed **0 files** while sitting at the cap.
- The sweeper only learned to list transcriptions in `11bbc663de`, which landed on `dev` earlier today and is not in prod yet. Older pods sweep files only, see an empty list, and report nothing.

The backlog has been purged manually — prod is back to 0/0.

## What this PR fixes

Purging it surfaced a third problem, which is what this PR is about: **Soniox meters ~500 requests/minute across the whole organization, and live transcription spends from the same budget as the sweeper.** My first purge attempt died after exactly 494 deletes + 2 list calls.

An unpaced sweep of a large backlog therefore does two bad things at once:

- it 429s partway through and writes off every remaining id as `failed`, burning `MaxDeletesPerSweep` on deletes that cannot land, and
- it starves the transcribers for real users while it runs.

So:

- **`SonioxClient`** — a 429 now throws `RateLimitExceededException` (`ITransientException`, `IHasRetryDelay`) instead of a generic `StandardError.External`, carrying `Retry-After` when Soniox sends one, defaulted to 30s and capped at 5min.
- **`SonioxSweeper`** — `TryDelete` waits a rate limit out and retries (up to `MaxRateLimitRetryCount`, default 5) rather than counting it as a failure; every other exception behaves as before. Deletes are spaced by `DeleteDelay` (default 1s), which holds a sweeping host at ~60 req/min and leaves headroom for the transcribers and for other hosts sweeping on their own schedule.

## Also

Adds the `soniox-sweep` skill — the manual fallback for when the cleaner and sweeper have already fallen behind. It reports before it deletes, asks for confirmation, defaults the prod key to `tmp/sonoix-prod.key`, and paces its own purge at 200/min.

## Tests

`SonioxApiMock` can now answer N deletes with a 429, with or without `Retry-After`. Three new cases: the sweep waits out a limit and still lands both deletes; it gives up after `MaxRateLimitRetryCount` and leaves the id for the next sweep; and it actually paces. All 29 Soniox unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU2NH17tsffcLLNHHgHaKv
