### PR TITLE
fix(l10n): detect the UI language in the native apps again

### DIFF
--- a/src/dotnet/App.Maui/Services/MauiBrowserInfo.cs
+++ b/src/dotnet/App.Maui/Services/MauiBrowserInfo.cs
@@ -48,6 +48,7 @@ public class MauiBrowserInfo : BrowserInfo
         var screenSize = TryParseScreenSize(initResult.ScreenSizeText) ?? UI.Blazor.Services.ScreenSize.Unknown;
         Update(screenSize, initResult.IsHoverable, initResult.IsVisible);
         WindowId = initResult.WindowId;
+        UpdateUILanguageInfo(initResult.UILanguageInfo);
         // We don't want to change any other properties here
 
         WhenReadySource.TrySetResult();

--- a/src/dotnet/UI.Blazor/Services/BrowserInfo/BrowserInfo.cs
+++ b/src/dotnet/UI.Blazor/Services/BrowserInfo/BrowserInfo.cs
@@ -71,9 +71,7 @@ public class BrowserInfo : UIServiceBase<UIHub>, IBrowserInfoBackend
         _windowHeight.Value = initResult.WindowHeight;
         UtcOffset = TimeSpan.FromMinutes(initResult.UtcOffset);
         TimeZone = initResult.TimeZone;
-        ClientLanguages = initResult.UILanguageInfo.ClientLanguages;
-        UILanguageOverride = initResult.UILanguageInfo.UrlOverride;
-        StoredUILanguage = Language.TryParse(initResult.UILanguageInfo.Selected, allowNull: true);
+        UpdateUILanguageInfo(initResult.UILanguageInfo);
         IsMobile = initResult.IsMobile;
         IsAndroid = initResult.IsAndroid;
         IsIos = initResult.IsIos;
@@ -154,6 +152,13 @@ public class BrowserInfo : UIServiceBase<UIHub>, IBrowserInfoBackend
             TryParseTheme(themeInfo.DefaultTheme) ?? Theme.Light,
             TryParseTheme(themeInfo.CurrentTheme) ?? Theme.Light,
             themeInfo.Colors);
+
+    protected void UpdateUILanguageInfo(IBrowserInfoBackend.UILanguageInfo uiLanguageInfo)
+    {
+        ClientLanguages = uiLanguageInfo.ClientLanguages;
+        UILanguageOverride = uiLanguageInfo.UrlOverride;
+        StoredUILanguage = Language.TryParse(uiLanguageInfo.Selected, allowNull: true);
+    }
 
     protected static ScreenSize? TryParseScreenSize(string? screenSize)
         => Enum.TryParse<ScreenSize>(screenSize ?? "", true, out var v) ? v : null;


### PR DESCRIPTION
Fixes #4234.

## The bug

In the native (MAUI) apps the app language was English on every launch, no matter what the device language was, and an explicit pick in the picker was forgotten on the next start. The web build was unaffected.

## Root cause

`fcce793fd6` started shipping the UI-language data from JS to .NET inside `BrowserInfo.InitResult`, unpacked by `BrowserInfo.OnInitialized` into `ClientLanguages`, `StoredUILanguage` and `UILanguageOverride`.

`MauiBrowserInfo` overrides `OnInitialized` and keeps only a few of those values on purpose — the rest come from native APIs in its constructor. The three new fields were never added to the override, so they stayed at their defaults and `Languages.ResolveUILanguage(null, null, [])` returned `Languages.Main` every time. `?ui-language=` was ignored in the apps for the same reason.

Before that commit `LanguageUI` read `navigator.languages` over JS interop directly, bypassing `BrowserInfo` — which is why this only regressed now.

## Fix

The three assignments move into a `protected UpdateUILanguageInfo(...)` on `BrowserInfo`, next to the `UpdateThemeInfo` it mirrors, and `MauiBrowserInfo.OnInitialized` calls it. A comment on the declaration says these come from the WebView, so the next edit to that override doesn't drop them again.

`LanguageUI.CreateLanguageSettings` seeds a new account's *spoken* languages from the same `ClientLanguages`, so those were defaulting to English in the apps too — same fix covers it.

## Testing

- `UI.Blazor` and `App.Maui -f net11.0-ios` build clean; `UILanguageResolutionTest` (23 cases) passes.
- Built with a fresh `npm ci` + `build:Debug` bundle, deployed to an iPhone: the app now comes up in the device language with the picker on Auto.