### PR TITLE
feat(ios): render the share extension in the app's theme #4232

### DIFF
--- a/src/dotnet/App.Maui.IosShareExt/Entitlements.dev.plist
+++ b/src/dotnet/App.Maui.IosShareExt/Entitlements.dev.plist
@@ -8,5 +8,9 @@
 	<array>
 		<string>M287G8G83F.chat.actual.dev.app.shared</string>
 	</array>
+    <key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.actual.dev.app.shared</string>
+	</array>
 </dict>
 </plist>

--- a/src/dotnet/App.Maui.IosShareExt/Entitlements.prod.plist
+++ b/src/dotnet/App.Maui.IosShareExt/Entitlements.prod.plist
@@ -8,5 +8,9 @@
 	<array>
 		<string>M287G8G83F.chat.actual.app.shared</string>
 	</array>
+    <key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.actual.app.shared</string>
+	</array>
 </dict>
 </plist>

--- a/src/dotnet/App.Maui.IosShareExt/README.md
+++ b/src/dotnet/App.Maui.IosShareExt/README.md
@@ -8,3 +8,23 @@ Add the next code to your app project:
     </ProjectReference>
 </ItemGroup>
 ```
+
+## What the extension shares with the app
+
+The extension is a separate process with its own bundle id, so it sees neither the
+app's `localStorage` nor its `NSUserDefaults`. Two entitlements bridge that:
+
+- **Keychain access group** (`M287G8G83F.chat.actual[.dev].app.shared`) — the session,
+  see `AppleSharedSecureStorage`.
+- **App Group** (`group.chat.actual[.dev].app.shared`) — the theme, see
+  `MauiPreferences.Theme`. The app writes it on every theme change
+  (`MauiThemeHandler.OnThemeChanged`); `ShareViewController` reads it per share and
+  applies it to `AppColors` and `OverrideUserInterfaceStyle`. Nothing written means
+  "follow the system appearance", which is what the extension did before.
+
+Both entitlements have to be granted by the provisioning profile the build is signed
+with, otherwise codesign fails with `MT7140`. Adding one means registering it on the
+Apple Developer portal, enabling it for every member id, and regenerating each of their
+profiles — the Debug ones plus `App Store [Share] [Dev]`. The App Group's members are
+`chat.actual[.dev].app`, `chat.actual[.dev].app.share` and `chat.actual[.dev].app.widget`;
+the widget is provisioned but reads nothing yet, see `src/swift/VoxtActivities/README.md`.

--- a/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
+++ b/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
@@ -1,4 +1,5 @@
 ﻿using ActualChat.App.Maui.IosShareExt.Components;
+using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt;
 
@@ -10,6 +11,7 @@ public class ShareViewController : UIViewController
 
     public override void LoadView()
     {
+        ApplyTheme();
         _app = ShareExtensionApplication.Bootstrap(this);
         // Leaving View unset makes UIKit throw NSInvalidArgumentException ("attempt to insert nil
         // object"), so a failed bootstrap used to crash the extension outright - which also killed
@@ -18,5 +20,20 @@ public class ShareViewController : UIViewController
             ? new ErrorContentView("Something went wrong. Please try again.",
                 (_, _) => _ = ExtensionContext?.CompleteRequestAsync([]))
             : _app.View;
+    }
+
+    // Private methods
+
+    private void ApplyTheme()
+    {
+        // Runs ahead of Bootstrap, i.e. ahead of Sentry and the DI container, so a failure here
+        // can only be swallowed - and the system appearance it falls back to is what the
+        // extension used before the App Group carried the theme.
+        try {
+            OverrideUserInterfaceStyle = AppColors.UserInterfaceStyle;
+        }
+        catch (Exception e) {
+            new OSLogLogger(nameof(ShareViewController)).LogWarning(e, "Failed to apply the app's theme");
+        }
     }
 }

--- a/src/dotnet/App.Maui/MauiThemeHandler.cs
+++ b/src/dotnet/App.Maui/MauiThemeHandler.cs
@@ -1,4 +1,5 @@
 using ActualChat.App.Maui.Services;
+using ActualChat.UI;
 using ActualChat.UI.Blazor.Services;
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Core.Platform;
@@ -17,7 +18,6 @@ public class MauiThemeHandler
 
     private Theme? _theme;
     private string _colors = "";
-    private string _serialized;
     private string _appliedColors = "";
     private ILogger? _log;
 
@@ -34,23 +34,18 @@ public class MauiThemeHandler
 
     protected MauiThemeHandler()
     {
-        _serialized = MauiPreferences.Theme;
-        var parts = _serialized.Split('|');
-        if (parts.Length == 2) {
-            _theme = Enum.TryParse<Theme>(parts[0], false, out var v) ? v : null;
-            _colors = parts[1];
-        }
+        _theme = MauiPreferences.Theme;
+        _colors = MauiPreferences.ThemeColors;
     }
 
     public void OnThemeChanged(ThemeInfo themeInfo)
     {
         _theme = themeInfo.Theme;
         _colors = themeInfo.Colors;
-        var serialized = string.Join('|', themeInfo.Theme?.ToString("G") ?? "", themeInfo.Colors);
-        if (serialized != _serialized) {
-            _serialized = serialized;
-            MauiPreferences.Theme = serialized;
-        }
+        // Written on every call, not only on a change: this is also how the iOS share extension
+        // learns the theme, and its App Group may still be empty from an earlier version.
+        MauiPreferences.Theme = themeInfo.Theme;
+        MauiPreferences.ThemeColors = themeInfo.Colors;
         Apply();
     }
 

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidThemeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidThemeHandler.cs
@@ -1,4 +1,4 @@
-using ActualChat.UI.Blazor.Services;
+using ActualChat.UI;
 using AndroidX.Core.View;
 
 namespace ActualChat.App.Maui;

--- a/src/dotnet/App.Maui/Platforms/iOS/Entitlements.dev.plist
+++ b/src/dotnet/App.Maui/Platforms/iOS/Entitlements.dev.plist
@@ -19,5 +19,9 @@
     </array>
 	<key>com.apple.developer.push-to-talk</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.actual.dev.app.shared</string>
+	</array>
 </dict>
 </plist>

--- a/src/dotnet/App.Maui/Platforms/iOS/Entitlements.prod.plist
+++ b/src/dotnet/App.Maui/Platforms/iOS/Entitlements.prod.plist
@@ -17,5 +17,9 @@
 	<array>
 		<string>M287G8G83F.chat.actual.app.shared</string>
     </array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.chat.actual.app.shared</string>
+	</array>
 </dict>
 </plist>

--- a/src/dotnet/Core/UI/Theme.cs
+++ b/src/dotnet/Core/UI/Theme.cs
@@ -1,3 +1,3 @@
-namespace ActualChat.UI.Blazor.Services;
+namespace ActualChat.UI;
 
 public enum Theme { Light = 0, Dark, Ash }

--- a/src/dotnet/Maui/MaciOS/AppColors.cs
+++ b/src/dotnet/Maui/MaciOS/AppColors.cs
@@ -1,8 +1,10 @@
+using ActualChat.UI;
+
 namespace ActualChat.Maui;
 
 /// <summary>
 /// The app's design tokens (see src/nodejs/styles/colors.css) as UIKit colors:
-/// the raw ramp first, then the roles, which resolve per light/dark appearance.
+/// the raw ramp first, then the roles, which resolve per <see cref="Theme"/>.
 /// </summary>
 public static class AppColors
 {
@@ -13,9 +15,11 @@ public static class AppColors
     public static readonly UIColor Gray40 = UIColor.FromRGB(0x77, 0x77, 0x77);
     public static readonly UIColor Gray60 = UIColor.FromRGB(0xA0, 0xA0, 0xA0);
     public static readonly UIColor Gray95 = UIColor.FromRGB(0xF3, 0xF3, 0xF3);
+    public static readonly UIColor Ash10 = UIColor.FromRGB(0x16, 0x16, 0x1A);
     public static readonly UIColor Ash18 = UIColor.FromRGB(0x28, 0x28, 0x2E);
     public static readonly UIColor Ash26 = UIColor.FromRGB(0x3D, 0x3D, 0x47);
     public static readonly UIColor Ash30 = UIColor.FromRGB(0x42, 0x42, 0x4D);
+    public static readonly UIColor Ash40 = UIColor.FromRGB(0x57, 0x57, 0x66);
     public static readonly UIColor Ash50 = UIColor.FromRGB(0x6D, 0x6D, 0x80);
     public static readonly UIColor Ash70 = UIColor.FromRGB(0x9B, 0x9B, 0xB2);
     public static readonly UIColor Ash90 = UIColor.FromRGB(0xCF, 0xCF, 0xE5);
@@ -24,15 +28,30 @@ public static class AppColors
     public static readonly UIColor Blue70 = UIColor.FromRGB(0x54, 0xA6, 0xFF);
     // Roles
     public static readonly UIColor Background01 = Dynamic(White, Ash18);
-    public static readonly UIColor Text01 = Dynamic(Gray05, Ash99);
-    public static readonly UIColor Text03 = Dynamic(Gray40, Ash70);
-    public static readonly UIColor Text04 = Dynamic(Gray60, Ash50);
+    public static readonly UIColor Text01 = Dynamic(Gray05, Ash10, Ash99);
+    public static readonly UIColor Text03 = Dynamic(Gray40, Ash40, Ash70);
+    public static readonly UIColor Text04 = Dynamic(Gray60, Ash50, Ash50);
     public static readonly UIColor Primary = Dynamic(Blue60, Blue70);
     public static readonly UIColor PrimaryTitle = White;
     public static readonly UIColor Input = Dynamic(Black.ColorWithAlpha(0.05f), Ash99.ColorWithAlpha(0.05f));
     public static readonly UIColor Square = Dynamic(Gray95, Ash26);
+    // Read per resolve rather than captured: the dynamic providers below outlive a share, and
+    // the extension's process outlives many of them. Null means "follow the system appearance".
+    private static Theme? Theme => MauiPreferences.Theme;
+    public static UIUserInterfaceStyle UserInterfaceStyle => Theme switch {
+        UI.Theme.Light or UI.Theme.Ash => UIUserInterfaceStyle.Light,
+        UI.Theme.Dark => UIUserInterfaceStyle.Dark,
+        _ => UIUserInterfaceStyle.Unspecified,
+    };
 
     public static UIColor Dynamic(UIColor light, UIColor dark)
-        => UIColor.FromDynamicProvider(traits
-            => traits.UserInterfaceStyle == UIUserInterfaceStyle.Dark ? dark : light);
+        => Dynamic(light, light, dark);
+
+    public static UIColor Dynamic(UIColor light, UIColor ash, UIColor dark)
+        => UIColor.FromDynamicProvider(traits => Theme switch {
+            UI.Theme.Light => light,
+            UI.Theme.Ash => ash,
+            UI.Theme.Dark => dark,
+            _ => traits.UserInterfaceStyle == UIUserInterfaceStyle.Dark ? dark : light,
+        });
 }

--- a/src/dotnet/Maui/Maui.csproj.DotSettings
+++ b/src/dotnet/Maui/Maui.csproj.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=macios/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=platforms/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=platforms_005Candroid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=platforms_005Candroid_005Clogging/@EntryIndexedValue">True</s:Boolean>

--- a/src/dotnet/Maui/MauiPreferences.cs
+++ b/src/dotnet/Maui/MauiPreferences.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using ActualChat.UI;
 using Microsoft.Maui.Storage;
 
 // ReSharper disable InconsistentlySynchronizedField
@@ -14,6 +15,7 @@ public static class MauiPreferences
     private const string HostIpKeyPrefix = "host_ip_";
     private const string IsDataCollectionEnabledKey = "analytics";
     private const string ThemeKey = "Theme";
+    private const string ThemeColorsKey = "ThemeColors";
     private const string MinReportableClientVersionKey = "min_reportable_client_version";
     private const string IsPttArmedKey = "is_ptt_armed";
 
@@ -21,6 +23,20 @@ public static class MauiPreferences
     private static readonly ConcurrentDictionary<string, object?> Cache = new();
     // A sentinel to distinguish "cached null/not-set" from "not yet cached"
     private static readonly object NotCachedTag = new();
+
+#if IOS
+    // The App Group container - the only defaults domain the app and its extensions can both
+    // see, see App.Maui.IosShareExt/README.md.
+    private static string? SharedName => field ??= MauiSettings.IsDevApp
+        ? "group.chat.actual.dev.app.shared"
+        // ReSharper disable once HeuristicUnreachableCode
+        : "group.chat.actual.app.shared";
+#else
+    // Nowhere else shares these: Mac Catalyst has no extensions and isn't even granted the App
+    // Group, and an Android app widget runs in the app's own process. A store name off iOS would
+    // only put them in a second file - one the Android backup rules don't know to exclude.
+    private static string? SharedName => null;
+#endif
 
     public static string? HostOverride {
         get => Get<string>(HostOverrideKey).NullIfEmpty();
@@ -35,9 +51,18 @@ public static class MauiPreferences
         set => Set(IsDataCollectionEnabledKey, value);
     }
 
-    public static string Theme {
-        get => Get<string>(ThemeKey) ?? "";
-        set => Set(ThemeKey, value);
+    // null means "follow the system appearance"
+    public static Theme? Theme {
+        get {
+            var stored = Get<string>(ThemeKey, sharedName: SharedName);
+            return Enum.TryParse<Theme>(stored, false, out var v) ? v : null;
+        }
+        set => Set(ThemeKey, value?.ToString("G"), SharedName);
+    }
+
+    public static string ThemeColors {
+        get => Get<string>(ThemeColorsKey, sharedName: SharedName) ?? "";
+        set => Set(ThemeColorsKey, value, SharedName);
     }
 
     public static string? MinReportableClientVersion {
@@ -61,7 +86,7 @@ public static class MauiPreferences
     // Public helpers
 
     [return: NotNullIfNotNull("factory")]
-    public static T? Get<T>(string key, Func<T>? factory = null)
+    public static T? Get<T>(string key, Func<T>? factory = null, string? sharedName = null)
     {
         var cached = Cache.GetValueOrDefault(key, NotCachedTag);
         if (cached != NotCachedTag)
@@ -74,7 +99,7 @@ public static class MauiPreferences
 
             T? result = default;
             try {
-                var stored = Preferences.Default.Get(key, "");
+                var stored = Preferences.Default.Get(key, "", sharedName);
                 if (stored.IsNullOrEmpty()) {
                     // No stored value
                 }
@@ -89,7 +114,7 @@ public static class MauiPreferences
 
             if (result is null && factory != null) {
                 result = factory.Invoke();
-                Set(key, result); // Sets Cache[key] as well
+                Set(key, result, sharedName); // Sets Cache[key] as well
                 return result!;
             }
 
@@ -98,20 +123,20 @@ public static class MauiPreferences
         }
     }
 
-    public static void Set(string key, object? value)
+    public static void Set(string key, object? value, string? sharedName = null)
     {
         lock (Lock) {
             Cache[key] = value;
             switch (value) {
             case null or string { Length: 0 }:
-                Preferences.Default.Remove(key);
+                Preferences.Default.Remove(key, sharedName);
                 return;
             case string str:
-                Preferences.Default.Set(key, str);
+                Preferences.Default.Set(key, str, sharedName);
                 return;
             default:
                 var stored = Serializers.SystemJson.Write(value, value.GetType());
-                Preferences.Default.Set(key, stored);
+                Preferences.Default.Set(key, stored, sharedName);
                 return;
             }
         }

--- a/src/swift/VoxtActivities/Entitlements.dev.plist
+++ b/src/swift/VoxtActivities/Entitlements.dev.plist
@@ -4,5 +4,9 @@
 <dict>
     <key>application-identifier</key>
     <string>M287G8G83F.chat.actual.dev.app.widget</string>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.chat.actual.dev.app.shared</string>
+    </array>
 </dict>
 </plist>

--- a/src/swift/VoxtActivities/Entitlements.prod.plist
+++ b/src/swift/VoxtActivities/Entitlements.prod.plist
@@ -4,5 +4,9 @@
 <dict>
     <key>application-identifier</key>
     <string>M287G8G83F.chat.actual.app.widget</string>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.chat.actual.app.shared</string>
+    </array>
 </dict>
 </plist>

--- a/src/swift/VoxtActivities/README.md
+++ b/src/swift/VoxtActivities/README.md
@@ -136,8 +136,8 @@ capability exists in the developer portal, and the `com.apple.developer.live-act
 forum threads 791243 and 808712). The only requirement is `NSSupportsLiveActivities` in the
 host app's `src/dotnet/App.Maui/Platforms/iOS/Info.plist` (already present).
 
-Like every embedded app extension, the appex still needs an App ID + provisioning profile
-for device signing — with **no** capabilities ticked:
+Like every embedded app extension, the appex needs an App ID + provisioning profile for
+device signing:
 
 - `chat.actual.dev.app.widget`
 - `chat.actual.app.widget`
@@ -146,9 +146,14 @@ The signed build path passes `-allowProvisioningUpdates`, so Xcode automatic sig
 creates both on first use; manual portal registration is only needed for manually-managed
 distribution profiles.
 
-Capabilities become necessary only for future features: **App Groups** (shared container)
-the moment the Live Activity should show chat avatars — images can't ride the size-limited
-`ContentState` payload — and **Push Notifications** on the host app if push-started/updated
+One capability is ticked on both: **App Groups**, granting
+`group.chat.actual[.dev].app.shared` — the container the app shares with its extensions
+(see `src/dotnet/App.Maui.IosShareExt/README.md`). Nothing here reads it yet; it's
+provisioned ahead of the first feature that needs it, which is chat avatars in the Live
+Activity — images can't ride the size-limited `ContentState` payload. Since profiles
+inherit whatever the App ID carries, that feature is then a code change alone.
+
+**Push Notifications** on the host app would be needed only if push-started/updated
 activities are ever added (out of scope by design; the shim is local-only). Interactive
 buttons (iOS 17+ App Intents, e.g. Stop/Pause parity with the Android notification) need
 no capability at all, just intent code shared into the extension target.


### PR DESCRIPTION
Closes #4232.

The share extension is a separate process with its own defaults domain, so it followed the system appearance while the app was in whatever theme the user picked. An **App Group** — `group.chat.actual[.dev].app.shared`, mirroring the keychain group that already carries the session — is the domain both of them can see.

### How it works

- `MauiPreferences.Theme` moves into the App Group: `Get`/`Set` gained a `sharedName` passthrough to `Preferences.Default`, whose iOS implementation turns it into the group's `NSUserDefaults` suite. The property is typed `Theme?`, where `null` means "follow the system appearance".
- `MauiThemeHandler.OnThemeChanged` writes it on every call, not only on a change — the group can still be empty after an update even when the theme itself hasn't changed since the last run.
- `AppColors` reads the preference itself, on every colour resolve, so nothing has to be assigned before the extension's views are built. `ShareViewController.LoadView` then only sets `OverrideUserInterfaceStyle`, for what UIKit paints on its own — system images, the keyboard, list separators. That line is wrapped in try/catch: it runs ahead of `Bootstrap`, i.e. ahead of Sentry and the DI container, so a failure there can only be swallowed — and it falls back to exactly the old behavior.

`sharedName` is `#if IOS`, not Apple-wide. Mac Catalyst has no extensions and its entitlements don't request the group, so it keeps its own domain; on Android a named store would land in a second prefs file, which the backup rules — they exclude prefs by exact filename — don't know to exclude.

### Supporting changes

- `AppColors` resolves per theme rather than per light/dark trait, so **Ash** is no longer rendered as Light. `Dynamic` gains an ash argument; the 2-arg form keeps ash following light for the roles where `colors.css` says they're the same — which is all of them except `Text01`, `Text03` and `Text04`.
- The `Theme` enum moves to `src/dotnet/Core/UI/Theme.cs` (namespace `ActualChat.UI`) so the extension can name it instead of duplicating it. Files under `ActualChat.UI.Blazor.*` find it by enclosing-namespace lookup, so only the two MAUI theme handlers needed a new `using`.
- The theme and its colors are two preferences now instead of one `"Dark|#28282E;#1E1E24"` string. Unpacking them removed the join/split round trip, the `_serialized` field that guarded writes with it, and the `#if IOS` block from `MauiThemeHandler`.
- **The widget is a member of the group too**, though it reads nothing from it yet. Capabilities live on the App ID and every profile regenerated afterwards inherits them, so provisioning it in the same round of portal work leaves the feature that needs it — avatars in the Live Activity, which can't ride the size-limited `ContentState` payload — a code change alone.

### Apple portal work — done

This needed an entitlement, so it needed profiles; without them every iOS build failed with `error MT7140`. Both groups are registered and ticked on all six App IDs, twelve profiles were regenerated and carry `com.apple.security.application-groups`, and the eight `PROVISIONING_PROFILE_*_BASE64` CI secrets were refreshed from them.

Other developers need the regenerated profiles locally before they can build for a device — Xcode fetches them on the next signing round, or they can be downloaded from the portal.

### Testing

Builds clean: `Maui.csproj` on ios / android / maccatalyst, the share extension, the iOS device build of `App.Maui`, and an Android typecheck of `App.Maui`.

Verified on device (iPhone 15 Pro Max, dev flavor). The signed app and appex both carry `group.chat.actual.dev.app.shared`, and after a launch the group container holds what the app wrote:

```
Library/Preferences/group.chat.actual.dev.app.shared.plist
{
  "Theme" => "Dark"
  "ThemeColors" => "#28282E;#1E1E24"
}
```

Known and accepted: `MauiPreferences` caches values for the life of the process, so an appex process that already served a share keeps the theme it read then. iOS usually reclaims it between shares; if this turns out to be visible, the fix is to drop the cached entry before the read in `ShareViewController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
