### PR TITLE
fix: Harden the Windows audio capture pipeline (and restore Windows app logging)

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -129,3 +129,31 @@ edited. The reason can be as short as whose decision it was.
   the discrete bands the effect was moved away from
 - L184 `mask-position: var(--c-wipe-from);`
   — same, in the `content-swap-wipe-out` keyframes the rule above runs
+
+## src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
+
+- L20 `private ILogger Log { get; } = log;`
+  — blank line after a single-line property — the hook alternates between
+  demanding and forbidding the blank line after this property on successive
+  runs; settled on no blank line, which is what "0 blank lines around
+  single-line properties, fields, and methods" says literally
+
+## src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+
+- L14 `private readonly MutableState<AudioRecorderState> _state;`
+  — blank lines between members — the hook reads "0 blank lines inside types" as
+  "strip every blank line between members"; every other type in the repo separates
+  members with blank lines, so the file is left as it is. NEEDS ALEX'S CALL
+- L19 `private readonly AudioFocusRequester _audioFocusRequester;`
+  — readonly field after a mutable one — field order predates this branch and
+  reordering it is unrelated churn. NEEDS ALEX'S CALL
+- L37 `public AudioRecorder(AppUIHub hub)`
+  — explicit constructor instead of a primary constructor — the ctor body assigns
+  four fields including a MutableState built from `Hub`, so the conversion is a real
+  refactor, not a style fix. NEEDS ALEX'S CALL
+- L146 `throw new AudioRecorderException("Failed to start the recording.", e);`
+  — missing blank line before the final throw — it follows a run of guard clauses,
+  which the guide's own exemption covers
+- L109 `await StopRecordingUnsafe().ConfigureAwait(false);`
+  — blank line after an if/else-if chain ending in `return` — the chain ends in an
+  `else if`, which the guide's exemption covers

--- a/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
@@ -8,17 +8,18 @@ using Windows.Media.Render;
 using ActualChat.App.Maui.Services.Recording;
 using ActualChat.Audio.APM;
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 using NAudio.Wave;
 using Role = NAudio.CoreAudioApi.Role;
 
 namespace ActualChat.App.Maui.Audio;
 
-public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCapture
+public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCapture
 {
     private const int CaptureBufferMs = Constants.Audio.ApmFrameDurationMs;
-    private const int MicDelaySamples = Constants.Audio.RecordingSampleRate * 40 / 1000; // 40ms delay
-    public ILogger<WindowsAudioCapture> Log { get; } = log;
-
+    private const int MicDelaySamples = Constants.Audio.RecordingSampleRate * 40 / 1000;
+    private static readonly TimeSpan GraphRetryDelay = TimeSpan.FromMilliseconds(250);
+    private ILogger Log { get; } = log;
     public async Task<IAsyncEnumerable<IMemoryOwner<float>>?> Capture(CancellationToken cancellationToken)
     {
         var apm = new AudioProcessingModule(
@@ -26,7 +27,6 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
             new StreamConfig(Constants.Audio.RecordingSampleRate, Constants.Audio.Channels));
 
         try {
-            // apm.SetDelay(40);
             apm.Configure(cfg => cfg
                 .EnableEchoCanceller(true)
                 .EnableNoiseSuppression(true, NoiseSuppressionLevel.Moderate)
@@ -39,21 +39,16 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
             Log.LogWarning(e, "Failed to configure AudioProcessingModule; proceeding without APM features");
         }
 
-        // Desired input format: LPCM float32 mono for microphone
         var micEncoding = AudioEncodingProperties.CreatePcm(
             Constants.Audio.RecordingSampleRate,
             Constants.Audio.Channels,
-            32); // 32-bit for float
+            32);
         micEncoding.Subtype = MediaEncodingSubtypes.Float;
         var settings = new AudioGraphSettings(AudioRenderCategory.Other) {
             // Use a non-communications category to avoid OS voice processing (AEC/NS/AGC) on capture
             QuantumSizeSelectionMode = QuantumSizeSelectionMode.ClosestToDesired,
             DesiredSamplesPerQuantum = Constants.Audio.RecordingSampleRate / 1000 * CaptureBufferMs,
         };
-
-        // Create NAudio captures for loopback
-        WasapiCapture? loopbackCapture = null;
-        MMDevice? micDevice = null;
 
         var outputBuffer = new BlockRingBuffer<float>(Constants.Audio.RecordingSampleRate * 10);
         var microphoneBuffer = new BlockRingBuffer<float>(Constants.Audio.RecordingSampleRate * 10);
@@ -64,158 +59,245 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
             * Constants.Audio.ApmFrameDurationMs
             * Constants.Audio.Channels;
 
-        var graphCreate = await AudioGraph.CreateAsync(settings).AsTask(cancellationToken).ConfigureAwait(true);
-        if (graphCreate.Status != AudioGraphCreationStatus.Success || graphCreate.Graph is null) {
-            apm.DisposeSilently();
-            throw new InvalidOperationException($"AudioGraph creation failed: {graphCreate.Status}");
-        }
-
-        var graph = graphCreate.Graph;
-
-        var inputCreate = await graph
-            .CreateDeviceInputNodeAsync(MediaCategory.Other, micEncoding)
-            .AsTask(cancellationToken)
-            .ConfigureAwait(true);
-        if (inputCreate.Status != AudioDeviceNodeCreationStatus.Success || inputCreate.DeviceInputNode is null) {
-            // Unable to get microphone stream
-            graph.DisposeSilently();
-            apm.DisposeSilently();
-            return null;
-        }
-
-        var inputNode = inputCreate.DeviceInputNode;
-
-        // Ensure no built-in audio effects are applied on the capture path
-        inputNode.EffectDefinitions.Clear();
-
-        // Frame output for microphone
-        var outputNode = graph.CreateFrameOutputNode(micEncoding);
-        inputNode.AddOutgoingConnection(outputNode);
-
-        graph.QuantumStarted += QuantumEventHandler;
+        // Everything below is acquired inside the try and released by Stop(), so a failure at any
+        // step - or a caller that never enumerates the result - can't leave a running graph behind
+        AudioGraph? graph = null;
+        AudioDeviceInputNode? inputNode = null;
+        AudioFrameOutputNode? outputNode = null;
+        WasapiCapture? loopbackCapture = null;
+        MMDeviceEnumerator? deviceEnumerator = null;
+        DefaultCaptureDeviceWatcher? deviceWatcher = null;
+        MMDevice? micDevice = null;
+        AudioEndpointVolume? endpointVolume = null;
+        CancellationTokenSource? processingCts = null;
+        Task? processingTask = null;
+        var whenStopped = TaskCompletionSourceExt.New();
+        var isStopping = 0;
+        var currentVolume = 0.5f;
+        var initialVolume = 0.5f;
+        var lastAppliedVolume = float.NaN;
 
         try {
-            // Default communications microphone and loopback render device
-            var devices = new MMDeviceEnumerator();
-            micDevice = devices.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
-            var loopbackDevice = devices.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-            loopbackCapture = new CustomWasapiLoopbackCapture(loopbackDevice, true, CaptureBufferMs);
-            loopbackCapture.DataAvailable += OnLoopbackCaptureOnDataAvailable;
-            loopbackCapture.WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(Constants.Audio.RecordingSampleRate, 1);
-        }
-        catch (Exception e) {
-            // Under NativeAOT, ILC emits an invalid body for NAudio's COM ComObject wrapper
-            // ctor (InvalidProgramException on MMDeviceEnumeratorComObject..ctor()).
-            // TrimmerRootAssembly on NAudio.Wasapi does not fix it. Same pattern as the
-            // WindowConfigurator / WindowsAppIconBadge known issues: wrap and degrade.
-            // The mic itself goes through WinRT AudioGraph above (AOT-safe), so we continue
-            // without the AEC loopback reverse stream and without mic volume control.
-            Log.LogWarning(e, "NAudio capture devices unavailable; continuing without AEC loopback and mic volume control");
-            loopbackCapture.DisposeSilently();
-            loopbackCapture = null;
-            micDevice.DisposeSilently();
-            micDevice = null;
-        }
+            // A wedged WinRT audio session sometimes clears on its own, and one retry costs a
+            // quarter of a second against a failure the user can otherwise only fix by restarting
+            var isGraphCreated = await TryCreateGraph().ConfigureAwait(true);
+            if (!isGraphCreated) {
+                await Task.Delay(GraphRetryDelay, cancellationToken).ConfigureAwait(true);
+                isGraphCreated = await TryCreateGraph().ConfigureAwait(true);
+            }
+            if (!isGraphCreated) {
+                await Stop().ConfigureAwait(false);
+                return null;
+            }
 
-        // Throttled access to microphone volume to avoid per-frame COM calls
-        var endpointVolume = micDevice?.AudioEndpointVolume;
-        var currentVolume = Math.Clamp(endpointVolume?.MasterVolumeLevelScalar ?? 0.5f, 0f, 1f);
-        endpointVolume?.OnVolumeNotification += OnVolumeChanged;
-
-        // Processing loop to emit mic frames through APM
-        var processingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var processingToken = processingCts.Token;
-        var processingTask = BackgroundTask.Run(async () => {
-            var emptyArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
-            var emptyMemory = emptyArray.AsMemory(0, apmFrameSize);
-            emptyMemory.Span.Clear();
             try {
-                while (!processingToken.IsCancellationRequested) {
-                    // Check if we have enough microphone samples to enforce the delay
-                    if (microphoneBuffer.Count < apmFrameSize + MicDelaySamples) {
-                        var whenReady = microphoneBuffer.WhenReadyToRead();
-                        if (whenReady != null)
-                            await whenReady.WaitAsync(processingToken).ConfigureAwait(false);
-                        else
-                            await Task.Delay(1, processingToken).ConfigureAwait(false);
-                        continue;
-                    }
+                deviceEnumerator = new MMDeviceEnumerator();
+                micDevice = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+                var loopbackDevice = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                loopbackCapture = new CustomWasapiLoopbackCapture(loopbackDevice, true, CaptureBufferMs);
+                loopbackCapture.DataAvailable += OnLoopbackCaptureOnDataAvailable;
+                loopbackCapture.WaveFormat =
+                    WaveFormat.CreateIeeeFloatWaveFormat(Constants.Audio.RecordingSampleRate, 1);
+            }
+            catch (Exception e) {
+                // Under NativeAOT, ILC emits an invalid body for NAudio's COM ComObject wrapper
+                // ctor (InvalidProgramException on MMDeviceEnumeratorComObject..ctor()).
+                // TrimmerRootAssembly on NAudio.Wasapi does not fix it. Same pattern as the
+                // WindowConfigurator / WindowsAppIconBadge known issues: wrap and degrade.
+                // The mic itself goes through WinRT AudioGraph above (AOT-safe), so we continue
+                // without the AEC loopback reverse stream and without mic volume control.
+                Log.LogWarning(e,
+                    "NAudio capture devices unavailable; continuing without AEC loopback and mic volume control");
+                loopbackCapture.DisposeSilently();
+                loopbackCapture = null;
+                micDevice.DisposeSilently();
+                micDevice = null;
+                deviceEnumerator.DisposeSilently();
+                deviceEnumerator = null;
+            }
 
-                    // Pull delayed microphone data
-                    var micArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
-                    var micIn = micArray.AsSpan(0, apmFrameSize);
-                    if (!microphoneBuffer.TryRead(micIn, out var micWhenReady)) {
-                        ArrayPools.SharedFloatPool.Return(micArray);
-                        await micWhenReady.WaitAsync(processingToken).ConfigureAwait(false);
-                        continue;
-                    }
-
-                    var outArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
-                    var outSpan = outArray.AsSpan(0, apmFrameSize);
-
-                    // Pull loopback data (use the most recent or zeros)
-                    var loopArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
-                    var loopSpan = loopArray.AsSpan(0, apmFrameSize);
-                    var hasLoopback = loopbackBuffer.TryRead(loopSpan, out _);
-                    var loopIn = hasLoopback
-                        ? loopSpan
-                        : emptyMemory.Span;
-
-                    // Feed loopback data to APM
-                    apm.AnalyzeReverseStream(loopIn);
-
-                    // Inform APM about current analog microphone level (mapped from system scalar 0..1 to 0..255)
-                    var currentLevel = Math.Clamp((int)MathF.Round(currentVolume * 255f), 0, 255);
-                    apm.SetAnalogLevel(currentLevel);
-
-                    // Process delayed microphone input
-                    apm.ProcessStream(micIn, outSpan);
-
-                    // After processing, get APM recommended analog level and apply back to system microphone volume
-                    var recommendedLevel = apm.GetRecommendedAnalogLevel();
-                    var recommendedVolume = Math.Clamp(Math.Clamp(recommendedLevel, 0, 255) / 255f, 0f, 1f);
-                    if (Math.Abs(currentVolume - recommendedVolume) > 0.02f)
-                        endpointVolume?.MasterVolumeLevelScalar = recommendedVolume;
-
-                    // Log.LogDebug("APM.ProcessStream gains for mic and loopback: {GainMic} {GainLoop}", AudioExt.ApproximateGain(micIn), AudioExt.ApproximateGain(loopIn));
-
-                    // Push processed output (fire-and-forget: drop if full)
-                    outputBuffer.TryWrite(outSpan);
-                    ArrayPools.SharedFloatPool.Return(micArray);
-                    ArrayPools.SharedFloatPool.Return(outArray);
-                    ArrayPools.SharedFloatPool.Return(loopArray);
+            if (deviceEnumerator != null) {
+                try {
+                    deviceWatcher = new DefaultCaptureDeviceWatcher(OnDefaultCaptureDeviceChanged);
+                    deviceEnumerator.RegisterEndpointNotificationCallback(deviceWatcher);
+                }
+                catch (Exception e) {
+                    // Registering a managed COM callback is the most AOT-fragile call here, and
+                    // losing it only costs the device-change handling
+                    Log.LogWarning(e, "Can't watch for default capture device changes");
+                    deviceWatcher = null;
                 }
             }
-            catch (OperationCanceledException) { /* expected */ }
-            catch (Exception ex) {
-                Log.LogError(ex, "Mic processing loop failed");
+
+            // Throttled access to microphone volume to avoid per-frame COM calls
+            endpointVolume = micDevice?.AudioEndpointVolume;
+            currentVolume = Math.Clamp(endpointVolume?.MasterVolumeLevelScalar ?? 0.5f, 0f, 1f);
+            initialVolume = currentVolume;
+            endpointVolume?.OnVolumeNotification += OnVolumeChanged;
+
+            processingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var processingToken = processingCts.Token;
+            processingTask = BackgroundTask.Run(async () => {
+                var emptyArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
+                var emptyMemory = emptyArray.AsMemory(0, apmFrameSize);
+                emptyMemory.Span.Clear();
+                var isSilent = true;
+                var windowPeak = 0f;
+                var lastSilenceCheckStamp = Stopwatch.GetTimestamp();
+                try {
+                    while (!processingToken.IsCancellationRequested) {
+                        // Enough samples must be buffered to enforce MicDelaySamples
+                        if (microphoneBuffer.Count < apmFrameSize + MicDelaySamples) {
+                            var whenReady = microphoneBuffer.WhenReadyToRead();
+                            if (whenReady != null)
+                                await whenReady.WaitAsync(processingToken).ConfigureAwait(false);
+                            else
+                                await Task.Delay(1, processingToken).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        var micArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
+                        var micIn = micArray.AsSpan(0, apmFrameSize);
+                        if (!microphoneBuffer.TryRead(micIn, out var micWhenReady)) {
+                            ArrayPools.SharedFloatPool.Return(micArray);
+                            await micWhenReady.WaitAsync(processingToken).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        // A withheld mic still delivers frames, just all-zero ones. Checked pre-APM,
+                        // where no OS voice processing can have gated the samples to zero.
+                        if (isSilent) {
+                            foreach (var sample in micIn) {
+                                var level = MathF.Abs(sample);
+                                if (level > windowPeak)
+                                    windowPeak = level;
+                            }
+                            var silenceCheckStamp = Stopwatch.GetTimestamp();
+                            if (Stopwatch.GetElapsedTime(lastSilenceCheckStamp, silenceCheckStamp).TotalSeconds >= 1.0) {
+                                lastSilenceCheckStamp = silenceCheckStamp;
+                                if (windowPeak > 0f) {
+                                    isSilent = false;
+                                    Log.LogInformation("Microphone capture: first audio, peak {Peak:F3}", windowPeak);
+                                }
+                                else
+                                    Log.LogWarning("Microphone capture: nothing but digital silence so far");
+                                windowPeak = 0f;
+                            }
+                        }
+
+                        var outArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
+                        var outSpan = outArray.AsSpan(0, apmFrameSize);
+
+                        // Zeros when the loopback capture is unavailable - the APM still needs a reverse stream
+                        var loopArray = ArrayPools.SharedFloatPool.Rent(apmFrameSize);
+                        var loopSpan = loopArray.AsSpan(0, apmFrameSize);
+                        var hasLoopback = loopbackBuffer.TryRead(loopSpan, out _);
+                        var loopIn = hasLoopback
+                            ? loopSpan
+                            : emptyMemory.Span;
+
+                        apm.AnalyzeReverseStream(loopIn);
+
+                        // The APM's analog level is 0..255, the system scalar is 0..1
+                        var currentLevel = Math.Clamp((int)MathF.Round(currentVolume * 255f), 0, 255);
+                        apm.SetAnalogLevel(currentLevel);
+                        apm.ProcessStream(micIn, outSpan);
+
+                        var recommendedLevel = apm.GetRecommendedAnalogLevel();
+                        var recommendedVolume = Math.Clamp(Math.Clamp(recommendedLevel, 0, 255) / 255f, 0f, 1f);
+                        if (Math.Abs(currentVolume - recommendedVolume) > 0.02f) {
+                            endpointVolume?.MasterVolumeLevelScalar = recommendedVolume;
+                            lastAppliedVolume = recommendedVolume;
+                        }
+
+                        // Fire-and-forget: drop if full
+                        outputBuffer.TryWrite(outSpan);
+                        ArrayPools.SharedFloatPool.Return(micArray);
+                        ArrayPools.SharedFloatPool.Return(outArray);
+                        ArrayPools.SharedFloatPool.Return(loopArray);
+                    }
+                }
+                catch (OperationCanceledException) {
+                    /* Expected */
+                }
+                catch (Exception ex) {
+                    Log.LogError(ex, "Mic processing loop failed");
+                }
+                finally {
+                    ArrayPools.SharedFloatPool.Return(emptyArray);
+                }
+            }, processingCts.Token);
+
+            try {
+                loopbackCapture?.StartRecording();
+                graph!.Start();
+                inputNode!.Start();
             }
-            finally {
-                ArrayPools.SharedFloatPool.Return(emptyArray);
+            catch (Exception e) {
+                Log.LogError(e, "Failed to start audio capture");
+                await Stop().ConfigureAwait(false);
+                return null;
             }
-        }, processingCts.Token);
-        // Start recording
-        try {
-            loopbackCapture?.StartRecording();
-            graph.Start();
-            inputNode.Start();
         }
         catch (Exception e) {
-            Log.LogError(e, "Failed to start NAudio recording");
-            processingCts.CancelAndDisposeSilently();
-            apm.DisposeSilently();
-            graph.DisposeSilently();
-            loopbackCapture.DisposeSilently();
-            micDevice?.DisposeSilently();
-            return null;
+            await Stop().ConfigureAwait(false);
+            if (e is not OperationCanceledException)
+                Log.LogError(e, "Failed to set up audio capture");
+
+            throw;
         }
 
-        // Return async iterator
-        var enumerateToken = cancellationToken;
-        return Enumerate(enumerateToken);
+        // Stop() must stay reachable without the enumerator: the caller can fail between here and
+        // the first MoveNextAsync, and an abandoned running graph wedges WinRT audio for this
+        // process - every later AudioGraph.CreateAsync then fails until the app is restarted.
+        var stopRegistration = cancellationToken.Register(() => _ = Stop());
+        return Enumerate(cancellationToken);
 
-        async IAsyncEnumerable<IMemoryOwner<float>> Enumerate([EnumeratorCancellation] CancellationToken ct)
-        {
+        async Task<bool> TryCreateGraph() {
+            graph.DisposeSilently();
+            graph = null;
+            inputNode = null;
+            outputNode = null;
+
+            var graphCreate = await AudioGraph.CreateAsync(settings).AsTask(cancellationToken).ConfigureAwait(true);
+            if (graphCreate.Status != AudioGraphCreationStatus.Success || graphCreate.Graph is null) {
+                // ExtendedError carries the HRESULT - without it "UnknownFailure" is all we ever see
+                Log.LogWarning(graphCreate.ExtendedError,
+                    "AudioGraph creation failed: {Status}",
+                    graphCreate.Status);
+                return false;
+            }
+
+            graph = graphCreate.Graph;
+            var inputCreate = await graph
+                .CreateDeviceInputNodeAsync(MediaCategory.Other, micEncoding)
+                .AsTask(cancellationToken)
+                .ConfigureAwait(true);
+            if (inputCreate.Status != AudioDeviceNodeCreationStatus.Success || inputCreate.DeviceInputNode is null) {
+                Log.LogWarning(inputCreate.ExtendedError,
+                    "Microphone input node creation failed: {Status} - is the mic available?",
+                    inputCreate.Status);
+                return false;
+            }
+
+            inputNode = inputCreate.DeviceInputNode;
+            Log.LogInformation(
+                "Microphone capture ready: '{DeviceName}', {SamplesPerQuantum} samples/quantum at {SampleRate}Hz",
+                inputNode.Device?.Name,
+                graph.SamplesPerQuantum,
+                graph.EncodingProperties.SampleRate);
+
+            // Ensure no built-in audio effects are applied on the capture path
+            inputNode.EffectDefinitions.Clear();
+
+            outputNode = graph.CreateFrameOutputNode(micEncoding);
+            inputNode.AddOutgoingConnection(outputNode);
+            graph.QuantumStarted += QuantumEventHandler;
+            graph.UnrecoverableErrorOccurred += OnUnrecoverableError;
+            return true;
+        }
+
+        async IAsyncEnumerable<IMemoryOwner<float>> Enumerate([EnumeratorCancellation] CancellationToken ct) {
             try {
                 const int frameLen = Constants.Audio.OpusFrameLength;
                 while (!ct.IsCancellationRequested) {
@@ -225,11 +307,25 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
                         await whenReady.WaitAsync(ct).ConfigureAwait(false);
                         continue;
                     }
+
                     yield return owner;
                 }
             }
             finally {
-                // Stop and cleanup
+                stopRegistration.Dispose();
+                await Stop().ConfigureAwait(false);
+            }
+        }
+
+        Task Stop() {
+            if (Interlocked.Exchange(ref isStopping, 1) == 0)
+                _ = StopInternal();
+
+            return whenStopped.Task;
+        }
+
+        async Task StopInternal() {
+            try {
                 try {
                     inputNode?.Stop();
                     outputNode?.Stop();
@@ -240,28 +336,93 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
                     /* Ignore */
                 }
 
-                await processingCts.CancelAsync().ConfigureAwait(false);
-                try { await processingTask.ConfigureAwait(false); }
-                catch {
-                    /* Ignore */
+                UnwatchDefaultCaptureDevice();
+
+                // The processing loop touches apm and endpointVolume, so it has to be drained
+                // before either of them is released
+                if (processingCts != null)
+                    await processingCts.CancelAsync().ConfigureAwait(false);
+                if (processingTask != null) {
+                    try {
+                        await processingTask.ConfigureAwait(false);
+                    }
+                    catch {
+                        /* Ignore */
+                    }
                 }
+
+                RestoreMicrophoneVolume();
                 apm.DisposeSilently();
                 inputNode?.DisposeSilently();
                 outputNode?.DisposeSilently();
                 graph?.DisposeSilently();
                 micDevice?.DisposeSilently();
+                deviceEnumerator?.DisposeSilently();
                 loopbackCapture?.Dispose();
+                processingCts.DisposeSilently();
+                outputBuffer.Dispose();
+                microphoneBuffer.Dispose();
+                loopbackBuffer.Dispose();
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "Failed to release the audio capture pipeline");
+            }
+            finally {
+                whenStopped.TrySetResult();
             }
         }
 
-        void QuantumEventHandler(AudioGraph sender, object args)
-        {
-            // Quantum callback: pull frames and push decoded float32 mono samples processed by APM (AEC+AGC)
-            if (cancellationToken.IsCancellationRequested)
+        void UnwatchDefaultCaptureDevice() {
+            if (deviceEnumerator == null || deviceWatcher == null)
                 return;
 
             try {
-                // 2) Pull microphone frame and process through APM
+                deviceEnumerator.UnregisterEndpointNotificationCallback(deviceWatcher);
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "Failed to stop watching default capture device changes");
+            }
+            deviceWatcher = null;
+        }
+
+        void RestoreMicrophoneVolume() {
+            if (endpointVolume == null)
+                return;
+
+            try {
+                endpointVolume.OnVolumeNotification -= OnVolumeChanged;
+                // Only undo what the APM's AGC did: a manual change made while recording wins.
+                // Without this the app permanently moves the user's Windows microphone level.
+                if (!float.IsNaN(lastAppliedVolume)
+                    && Math.Abs(endpointVolume.MasterVolumeLevelScalar - lastAppliedVolume) < 0.01f)
+                    endpointVolume.MasterVolumeLevelScalar = initialVolume;
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "Failed to restore the microphone volume");
+            }
+        }
+
+        void OnUnrecoverableError(AudioGraph sender, AudioGraphUnrecoverableErrorOccurredEventArgs args) {
+            // WinRT's own "this graph is dead" signal. Leaving it running is what wedges audio for
+            // the rest of the process, so end the capture and let the next attempt build a new one.
+            Log.LogWarning("AudioGraph hit an unrecoverable error: {Error}", args.Error);
+            _ = Stop();
+        }
+
+        void OnDefaultCaptureDeviceChanged() {
+            // The graph is bound to the endpoint it opened, so it goes on delivering silence from a
+            // device that is no longer the user's. Ending the capture is honest; recording resumes
+            // on the new device the next time it's started.
+            Log.LogWarning("Default capture device changed - ending the capture");
+            _ = Stop();
+        }
+
+        void QuantumEventHandler(AudioGraph sender, object args) {
+            // Guard flag: Stop() may already be disposing outputNode on another thread
+            if (Volatile.Read(ref isStopping) != 0 || cancellationToken.IsCancellationRequested)
+                return;
+
+            try {
                 using var frame = outputNode!.GetFrame();
                 if (frame is null)
                     return;
@@ -272,7 +433,7 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
                     return;
 
                 unsafe {
-                    WindowsRuntimeMarshal.TryGetDataUnsafe(reference, out IntPtr dataPtr, out var capacity);
+                    WindowsRuntimeMarshal.TryGetDataUnsafe(reference, out var dataPtr, out var capacity);
                     if (dataPtr == IntPtr.Zero || capacity == 0)
                         return;
 
@@ -283,26 +444,24 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
             }
             catch (Exception e) {
                 Log.LogError(e, "Failed to process audio frame");
-                // Best effort: ignore frame-level issues
             }
         }
 
-        void OnLoopbackCaptureOnDataAvailable(object? _, WaveInEventArgs args)
-        {
-            if (cancellationToken.IsCancellationRequested)
+        void OnLoopbackCaptureOnDataAvailable(object? _, WaveInEventArgs args) {
+            // Guard flag: Stop() may already be disposing loopbackCapture on another thread
+            if (Volatile.Read(ref isStopping) != 0 || cancellationToken.IsCancellationRequested)
                 return;
-
             if (args.BytesRecorded == 0)
                 return;
 
-            PushToBuffer(args, loopbackCapture.WaveFormat, loopbackBuffer);
+            PushToBuffer(args, loopbackCapture!.WaveFormat, loopbackBuffer);
         }
 
         void OnVolumeChanged(AudioVolumeNotificationData data)
-        {
-            currentVolume = Math.Clamp(data.MasterVolume, 0f, 1f);
-        }
+            => currentVolume = Math.Clamp(data.MasterVolume, 0f, 1f);
     }
+
+    // Private methods
 
     private static void PushToBuffer(WaveInEventArgs args, WaveFormat format, BlockRingBuffer<float> ringBuffer)
     {
@@ -324,14 +483,27 @@ public class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAudioCaptu
             var sampleCount = bytesRecorded / 2;
             Span<float> tmp = sampleCount <= 4096 ? stackalloc float[sampleCount] : new float[sampleCount];
             for (int i = 0, o = 0; i < bytesRecorded; i += 2, o++) {
-                short s = (short)(buffer[i] | (buffer[i + 1] << 8));
+                var s = (short)(buffer[i] | (buffer[i + 1] << 8));
                 tmp[o] = s / 32768f;
             }
             ringBuffer.TryWrite(tmp);
         }
-        else {
-            // Unsupported format: best effort - treat as bytes and skip
-            // In practice, most devices provide 16-bit PCM or 32-bit float
+        // Any other format is dropped on purpose: in practice devices deliver one of the two above.
+    }
+
+    // Nested types
+
+    private sealed class DefaultCaptureDeviceWatcher(Action onChanged) : IMMNotificationClient
+    {
+        public void OnDefaultDeviceChanged(DataFlow dataFlow, Role role, string defaultDeviceId)
+        {
+            if (dataFlow == DataFlow.Capture && role == Role.Communications)
+                onChanged();
         }
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
+        public void OnDeviceAdded(string deviceId) { }
+        public void OnDeviceRemoved(string deviceId) { }
+        public void OnPropertyValueChanged(string deviceId, PropertyKey propertyKey) { }
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Windows/WindowsLogAccessor.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/WindowsLogAccessor.cs
@@ -5,7 +5,7 @@ using ActualLab.Fusion.UI;
 
 namespace ActualChat.App.Maui;
 
-public class WindowsLogAccessor : IMauiLogAccessor
+public sealed class WindowsLogAccessor : IMauiLogAccessor
 {
     private readonly IServiceProvider _services;
     private readonly ILogger _log;
@@ -16,22 +16,23 @@ public class WindowsLogAccessor : IMauiLogAccessor
     public WindowsLogAccessor(IServiceProvider services)
     {
         _services = services;
-        _log = services.LogFor<WindowsLogAccessor>();
+        _log = services.LogFor(GetType());
         if (!MauiDiagnostics.AppDataLogFilePath.IsEmpty)
             GetLogFile = OpenLogFileInternal;
     }
 
- #pragma warning disable CA1822
+#pragma warning disable CA1822
     public string ActionName => "Open log file";
- #pragma warning restore CA1822
+#pragma warning restore CA1822
 
     public Func<Task>? GetLogFile { get; }
 
     private Task OpenLogFileInternal()
     {
+        var filePath = GetCurrentLogFilePath();
         try {
             var started = new Process {
-                StartInfo = new ProcessStartInfo(MauiDiagnostics.AppDataLogFilePath) {
+                StartInfo = new ProcessStartInfo(filePath) {
                     UseShellExecute = true,
                 },
             }.Start();
@@ -41,9 +42,28 @@ public class WindowsLogAccessor : IMauiLogAccessor
             }
         }
         catch (Exception e) {
-            _log.LogWarning(e, "Failed to open log file: {FilePath}", MauiDiagnostics.AppDataLogFilePath);
+            _log.LogWarning(e, "Failed to open log file: {FilePath}", filePath);
         }
+
         UICommander.ShowError(StandardError.Constraint("Failed to get log file."));
         return Task.CompletedTask;
+    }
+
+    private string GetCurrentLogFilePath()
+    {
+        // The sink rolls on size, so the file being written to is the newest
+        // "ActualChat*.log" rather than AppDataLogFilePath itself.
+        var basePath = MauiDiagnostics.AppDataLogFilePath;
+        try {
+            var pattern = basePath.FileNameWithoutExtension.Value + "*" + basePath.Extension;
+            var newestFile = new DirectoryInfo(basePath.DirectoryPath.Value)
+                .EnumerateFiles(pattern)
+                .MaxBy(x => x.LastWriteTimeUtc);
+            return newestFile?.FullName ?? basePath.Value;
+        }
+        catch (Exception e) {
+            _log.LogWarning(e, "Failed to find the current log file in {Folder}", basePath.DirectoryPath.Value);
+            return basePath.Value;
+        }
     }
 }

--- a/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
+++ b/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
@@ -48,7 +48,7 @@ public class MauiRecorderEngine : IAudioRecorderEngine
             _ => { SetSignalDetected(false); return Task.CompletedTask; });
     }
 
-    public async Task<bool> Start(
+    public async Task<RecorderStartResult> Start(
         ChatId chatId,
         ChatEntryId? repliedChatEntryId,
         CancellationToken cancellationToken = default)
@@ -85,12 +85,18 @@ public class MauiRecorderEngine : IAudioRecorderEngine
                 recordingToken)
             .ConfigureAwait(false);
         if (microphoneStream is null) {
-            Log.LogWarning("Microphone stream is unavailable");
+            // Capture fails both when the OS withholds the mic and when the audio device won't
+            // open, and only the permission check tells those two apart
+            var hasPermission = await MicrophonePermissionHandler.Check(cancellationToken).ConfigureAwait(false);
+            Log.LogWarning("Microphone stream is unavailable, permission: {HasPermission}", hasPermission);
             var releasedCts = Interlocked.CompareExchange(ref _recordingCts, null, recordingCts);
             if (ReferenceEquals(releasedCts, recordingCts))
                 recordingCts.CancelAndDisposeSilently();
             await SetRecording(false).ConfigureAwait(false);
-            return false;
+
+            return hasPermission == false
+                ? RecorderStartResult.NoPermission
+                : RecorderStartResult.NoDevice;
         }
 
         // Set the recording context
@@ -105,7 +111,8 @@ public class MauiRecorderEngine : IAudioRecorderEngine
             Log,
             "Failed to process microphone stream",
             recordingToken);
-        return true;
+
+        return RecorderStartResult.Started;
     }
 
     public async Task<bool> Stop(CancellationToken cancellationToken = default)

--- a/src/dotnet/Maui/MauiDiagnostics.cs
+++ b/src/dotnet/Maui/MauiDiagnostics.cs
@@ -91,9 +91,13 @@ public static class MauiDiagnostics
 #if WINDOWS
         AppDataLogFilePath = Path.Combine(FileSystem.AppDataDirectory, "Logs", "ActualChat.log");
         logging = logging.WriteTo.Debug(outputTemplate: LoggingExt.OutputTemplate);
+        // Without rollOnFileSizeLimit Serilog silently stops writing once the file hits
+        // fileSizeLimitBytes - which left the Windows app with no logs at all for 2 years.
         logging = logging.WriteTo.File(AppDataLogFilePath,
             outputTemplate: LoggingExt.OutputTemplate,
-            fileSizeLimitBytes: LoggingExt.FileSizeLimit);
+            fileSizeLimitBytes: LoggingExt.FileSizeLimit,
+            rollOnFileSizeLimit: true,
+            retainedFileCountLimit: LoggingExt.RetainedFileCountLimit);
         if (!LoggingExt.DevLog.IsEmpty)
             logging = logging.WriteTo.File(LoggingExt.DevLog,
                 outputTemplate: LoggingExt.OutputTemplate,

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
@@ -106,7 +106,7 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
                 return; // Already started
         }
         else if (state.ChatId is not null)
-            await StopRecordingUnsafe();
+            await StopRecordingUnsafe().ConfigureAwait(false);
 
         MarkStarting(chatId);
         try {
@@ -114,14 +114,19 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
             if (_audioFocusScope is null)
                 Log.LogWarning("Failed to gain audio focus for recording. Continue without it");
 
-            var isStarted = await _engine.Start(chatId, repliedChatEntryId, cancellationToken).WaitAsync(StartRecordingTimeout, cancellationToken).ConfigureAwait(false);
-            if (!isStarted) {
-                MicrophonePermission.ForgetCached();
-                Log.LogWarning(nameof(StartRecording) + ": chat #{ChatId} - can't access the microphone", chatId);
-                // Cancel recording
+            var startResult = await _engine.Start(chatId, repliedChatEntryId, cancellationToken)
+                .WaitAsync(StartRecordingTimeout, cancellationToken)
+                .ConfigureAwait(false);
+            if (startResult != RecorderStartResult.Started) {
+                var isPermissionIssue = startResult == RecorderStartResult.NoPermission;
+                // Forgetting the cached permission re-prompts on the next attempt
+                if (isPermissionIssue)
+                    MicrophonePermission.ForgetCached();
+                Log.LogWarning(nameof(StartRecording) + ": chat #{ChatId} - {Result}", chatId, startResult);
                 MarkStopped();
-                throw new AudioRecorderException(
-                    "Can't access the microphone - please check if the microphone access permission is granted.");
+                throw new AudioRecorderException(isPermissionIssue
+                    ? "Can't access the microphone - please check if the microphone access permission is granted."
+                    : "Can't access the microphone - the audio device didn't open.");
             }
         }
         catch (Exception e) when (e is not AudioRecorderException) {
@@ -130,7 +135,7 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
                 DebugLog?.LogDebug($"{nameof(StartRecording)} is cancelled");
             else
                 // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
-                Log.LogError(e,$"{nameof(StartRecording)} failed");
+                Log.LogError(e, $"{nameof(StartRecording)} failed");
 
             await StopRecordingUnsafe().ConfigureAwait(false);
 
@@ -167,21 +172,15 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         return state.IsRecording;
     }
 
-    // JS backend callback handlers
     [JSInvokable]
     public void OnRecordingStateChange(bool isRecording, bool isSignalDetected, bool isConnected, bool isVoiceActive)
     {
-        // Log.LogInformation(
-        //     "OnRecordingStateChange: isRecording={IsRecording}, isSignalDetected={IsSignalDetected}, isConnected={IsConnected}, isVoiceActive={IsVoiceActive}",
-        //     isRecording,
-        //     isSignalDetected,
-        //     isConnected,
-        //     isVoiceActive);
         var state = State.Value;
         if (state.ChatId is null) {
             if (isRecording)
                 throw StandardError.Internal(
-                    "Something is off: OnRecordingStateChange() is called with active microphone, but ChatId.IsNone == true.");
+                    "Something is off: OnRecordingStateChange() is called with active microphone, "
+                    + "but ChatId.IsNone == true.");
 
             isVoiceActive = false;
         }
@@ -240,14 +239,15 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         catch (Exception e) {
             var reason = e is TimeoutException ? "timed out" : "failed";
             // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
-            Log.LogError(e, $"{nameof(StopRecordingUnsafe)}: chat #{{ChatId}} - {reason}, recorder state is in doubt", chatId);
+            Log.LogError(e,
+                $"{nameof(StopRecordingUnsafe)}: chat #{{ChatId}} - {reason}, recorder state is in doubt",
+                chatId);
             return false;
         }
+
         MarkStopped();
         return true;
     }
-
-    // MarkXxx
 
     private void MarkStarting(ChatId chatId)
     {
@@ -308,7 +308,9 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         // Do nothing even app lost the audio focus.
         => null;
 
-    public class AudioDiagnosticsState
+    // Nested types
+
+    public sealed class AudioDiagnosticsState
     {
         public bool? IsPlayerInitialized { get; init; }
         public bool? IsRecorderInitialized { get; init; }
@@ -328,10 +330,26 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         public long? LastEncoderWorkletFrameProcessedAt { get; init; }
 
         public override string ToString()
-            => $"{nameof(AudioDiagnosticsState)} {{ {nameof(IsPlayerInitialized)}: {IsPlayerInitialized}, {nameof(IsRecorderInitialized)}: {IsRecorderInitialized}, {nameof(HasMicrophonePermission)}: {HasMicrophonePermission}, {nameof(IsAudioContextSourceMaintained)}: {IsAudioContextSourceMaintained}, {nameof(IsAudioContextRunning)}: {IsAudioContextRunning}, {nameof(HasMicrophoneStream)}: {HasMicrophoneStream}, {nameof(IsVadActive)}: {IsVadActive}, {nameof(LastVadEvent)}: {LastVadEvent}, {nameof(LastVadFrameProcessedAt)}: {LastVadFrameProcessedAt}, {nameof(IsConnected)}: {IsConnected}, {nameof(IsSignalDetected)}: {IsSignalDetected}, {nameof(LastFrameProcessedAt)}: {LastFrameProcessedAt}, {nameof(VadWorkletState)}: {VadWorkletState}, {nameof(LastVadWorkletFrameProcessedAt)}: {LastVadWorkletFrameProcessedAt}, {nameof(EncoderWorkletState)}: {EncoderWorkletState}, {nameof(LastEncoderWorkletFrameProcessedAt)}: {LastEncoderWorkletFrameProcessedAt} }}";
+            => $"{nameof(AudioDiagnosticsState)} {{ "
+                + $"{nameof(IsPlayerInitialized)}: {IsPlayerInitialized}, "
+                + $"{nameof(IsRecorderInitialized)}: {IsRecorderInitialized}, "
+                + $"{nameof(HasMicrophonePermission)}: {HasMicrophonePermission}, "
+                + $"{nameof(IsAudioContextSourceMaintained)}: {IsAudioContextSourceMaintained}, "
+                + $"{nameof(IsAudioContextRunning)}: {IsAudioContextRunning}, "
+                + $"{nameof(HasMicrophoneStream)}: {HasMicrophoneStream}, "
+                + $"{nameof(IsVadActive)}: {IsVadActive}, "
+                + $"{nameof(LastVadEvent)}: {LastVadEvent}, "
+                + $"{nameof(LastVadFrameProcessedAt)}: {LastVadFrameProcessedAt}, "
+                + $"{nameof(IsConnected)}: {IsConnected}, "
+                + $"{nameof(IsSignalDetected)}: {IsSignalDetected}, "
+                + $"{nameof(LastFrameProcessedAt)}: {LastFrameProcessedAt}, "
+                + $"{nameof(VadWorkletState)}: {VadWorkletState}, "
+                + $"{nameof(LastVadWorkletFrameProcessedAt)}: {LastVadWorkletFrameProcessedAt}, "
+                + $"{nameof(EncoderWorkletState)}: {EncoderWorkletState}, "
+                + $"{nameof(LastEncoderWorkletFrameProcessedAt)}: {LastEncoderWorkletFrameProcessedAt} }}";
     }
 
-    public class VadEvent
+    public sealed class VadEvent
     {
         public string? Kind { get; init; }
         public double Offset { get; init; }
@@ -339,6 +357,7 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         public double SpeechProb { get; init; }
 
         public override string ToString()
-            => $"{nameof(VadEvent)} {{ {nameof(Kind)}: {Kind}, {nameof(Offset)}: {Offset}, {nameof(Duration)}: {Duration}, {nameof(SpeechProb)}: {SpeechProb} }}";
+            => $"{nameof(VadEvent)} {{ {nameof(Kind)}: {Kind}, {nameof(Offset)}: {Offset}, "
+                + $"{nameof(Duration)}: {Duration}, {nameof(SpeechProb)}: {SpeechProb} }}";
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/Guides/RecordingTroubleshooterModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/Guides/RecordingTroubleshooterModal.razor
@@ -36,7 +36,7 @@
     }
 
     var title = L.MicGuide_TroubleshooterTitle;
-    var buttonTitle = RecordingPermissionRequester.CanRequest
+    var buttonTitle = CanOpenSettings
         ? L.Common_Settings
         : L.Common_OK;
 }
@@ -100,11 +100,18 @@
 
     [Parameter] public Model ModalModel { get; set; } = null!;
 
+    private bool CanOpenSettings
+        // The settings screen is a dead end for a device failure - only offer it for permissions
+        => ModalModel.MayBePermission && RecordingPermissionRequester.CanRequest;
+
     private async Task OnClick() {
-        if (RecordingPermissionRequester.CanRequest)
+        if (CanOpenSettings)
             await RecordingPermissionRequester.TryRequest();
         Modal.Close();
     }
 
-    public sealed record Model(GuideType? TestGuideType = null, bool IsUnknown = false);
+    public sealed record Model(
+        GuideType? TestGuideType = null,
+        bool IsUnknown = false,
+        bool MayBePermission = true);
 }

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/IAudioRecorderEngine.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/IAudioRecorderEngine.cs
@@ -2,7 +2,10 @@ namespace ActualChat.UI.Blazor.App.Components;
 
 public interface IAudioRecorderEngine
 {
-    Task<bool> Start(ChatId chatId, ChatEntryId? repliedChatEntryId, CancellationToken cancellationToken = default);
+    Task<RecorderStartResult> Start(
+        ChatId chatId,
+        ChatEntryId? repliedChatEntryId,
+        CancellationToken cancellationToken = default);
     Task<bool> Stop(CancellationToken cancellationToken = default);
     ValueTask ConversationSignal(CancellationToken cancellationToken);
     Task<AudioRecorder.AudioDiagnosticsState> RunDiagnostics(CancellationToken cancellationToken);

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/RecorderStartResult.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/RecorderStartResult.cs
@@ -1,0 +1,12 @@
+namespace ActualChat.UI.Blazor.App.Components;
+
+/// <summary>
+/// Why a recorder engine didn't start recording. A withheld microphone and an audio
+/// device that won't open need different advice, so they can't share one failure value.
+/// </summary>
+public enum RecorderStartResult
+{
+    Started = 0,
+    NoPermission,
+    NoDevice,
+}

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/WebRecorderEngine.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/WebRecorderEngine.cs
@@ -3,22 +3,29 @@ using ActualChat.UI.Blazor.App.Services;
 
 namespace ActualChat.UI.Blazor.App.Components;
 
-public class WebRecorderEngine(AppUIHub hub) : IAudioRecorderEngine
+public sealed class WebRecorderEngine(AppUIHub hub) : IAudioRecorderEngine
 {
     private static readonly string JSCreateMethod = $"{BlazorUIAppModule.ImportName}.AudioRecorder.create";
     private IJSObjectReference _jsRef = null!;
+    private AppUIHub Hub { get; } = hub;
 
-    public async Task<bool> Start(ChatId chatId, ChatEntryId? repliedChatEntryId, CancellationToken cancellationToken = default)
+    public async Task<RecorderStartResult> Start(
+        ChatId chatId,
+        ChatEntryId? repliedChatEntryId,
+        CancellationToken cancellationToken = default)
     {
         await EnsureInitialized(cancellationToken).ConfigureAwait(false);
 
-        return await _jsRef.InvokeAsync<bool>("startRecording",
+        var isStarted = await _jsRef.InvokeAsync<bool>("startRecording",
                 CancellationToken.None,
                 chatId,
                 repliedChatEntryId)
             .AsTask()
             .WaitAsync(AudioRecorder.StartRecordingTimeout, cancellationToken)
             .ConfigureAwait(false);
+        // The JS recorder gives back a bare false, and on the web that's getUserMedia
+        // denying access far more often than a device that won't open
+        return isStarted ? RecorderStartResult.Started : RecorderStartResult.NoPermission;
     }
 
     public async Task<bool> Stop(CancellationToken cancellationToken = default)
@@ -60,9 +67,11 @@ public class WebRecorderEngine(AppUIHub hub) : IAudioRecorderEngine
         if (_jsRef != null)
             return;
 
-        var js = hub.JS;
-        var backend = hub.Services.GetRequiredService<IAudioRecorderBackend>();
+        var js = Hub.JS;
+        var backend = Hub.Services.GetRequiredService<IAudioRecorderBackend>();
         var blazorRef = DotNetObjectReference.Create(backend);
-        _jsRef = await js.InvokeAsync<IJSObjectReference>(JSCreateMethod, cancellationToken, blazorRef).ConfigureAwait(false);
+        _jsRef = await js
+            .InvokeAsync<IJSObjectReference>(JSCreateMethod, cancellationToken, blazorRef)
+            .ConfigureAwait(false);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -8,6 +8,7 @@ public partial class ChatAudioUI
     private static readonly TimeSpan Epsilon = TimeSpan.FromMilliseconds(50);
     private static readonly TimeSpan MinListeningPlayerPlayDurationToConsiderHealthy = TimeSpan.FromSeconds(10);
     private static readonly int MaxStopRecordingTryCount = 3;
+    private static readonly TimeSpan DiagnosticsTimeout = TimeSpan.FromSeconds(5);
 
     protected override async Task OnRun(CancellationToken cancellationToken)
     {
@@ -1040,7 +1041,8 @@ public partial class ChatAudioUI
         }
     }
 
-    private async Task ShowRecordingTroubleshooter(TimeSpan delay, CancellationToken cancellationToken) {
+    private async Task ShowRecordingTroubleshooter(TimeSpan delay, CancellationToken cancellationToken)
+    {
         await Clocks.CpuClock.Delay(delay, cancellationToken).ConfigureAwait(false);
         if (!Hub.WhenInitialized.IsCompleted) {
             // A headless scope has no renderer, so Dispatcher would throw and WhenInitialized never completes.
@@ -1049,12 +1051,20 @@ public partial class ChatAudioUI
         }
 
         await Dispatcher.InvokeAsync(async () => {
-            var model = new RecordingTroubleshooterModal.Model(null, true);
-            var modalRef = await ModalUI.Show(model, cancellationToken).ConfigureAwait(true);
-
+            // Diagnostics run before the dialog because they decide what it may claim: the guide's
+            // "grant the microphone permission" advice is misleading when permission is already granted
             Log.LogWarning("Recording issue. Capturing diagnostics state...");
-            var diagnostics = await AudioRecorder.RunDiagnostics(CancellationToken.None).ConfigureAwait(true);
+            var diagnostics = await AudioRecorder.RunDiagnostics(CancellationToken.None)
+                .WaitAsync(DiagnosticsTimeout, CancellationToken.None)
+                .SuppressExceptions()
+                .ConfigureAwait(true);
             Log.LogWarning("Recording issue. Diagnostics State = {State}", diagnostics);
+
+            var model = new RecordingTroubleshooterModal.Model(
+                null,
+                true,
+                diagnostics?.HasMicrophonePermission != true);
+            var modalRef = await ModalUI.Show(model, cancellationToken).ConfigureAwait(true);
 
             try {
                 await modalRef.WhenClosed.WaitAsync(cancellationToken).ConfigureAwait(true);

--- a/src/dotnet/UI/LoggingExt.cs
+++ b/src/dotnet/UI/LoggingExt.cs
@@ -7,6 +7,7 @@ public static class LoggingExt
 {
     public const string OutputTemplate = "{Timestamp:HH:mm:ss.fff} {Level:u3} T{ThreadID} [{SourceContext}] {Message:l}{NewLine}{Exception}";
     public const long FileSizeLimit = 10_000_000L;
+    public const int RetainedFileCountLimit = 3;
     public const long DevLogFileSizeLimit = 100_000_000L;
 
     public static readonly FilePath DevLog;


### PR DESCRIPTION
## Why

Recording stopped working in a long-running Windows release build (v2.16.608): clicking record did nothing and the recording troubleshooter appeared ~7.5s later. Restarting the app fixed it.

Diagnosis: the WinRT `AudioGraph` path in `WindowsAudioCapture` had wedged **process-wide**. Not permissions (consent = `Allow`, and the same process had recorded successfully hours earlier), not the device (no PnP/audio events, `Audiosrv` up for 10 days, no sleep/resume). During a failing click the process threw a burst of `wil::ResultException` plus exception code `40080201` (`RoOriginateError`) — a WinRT API returning a failure HRESULT.

Sentry has the same failure recorded before: `InvalidOperationException: AudioGraph creation failed: UnknownFailure`, paired at the same second with `AudioRecorderException: Failed to start the recording.`

## The structural problem

Windows is the outlier among the three capture implementations:

- **Apple** (`AppleAudioCapture`) acquires nothing until the iterator body runs, so its `finally` can't be skipped.
- **Android** (`AndroidAudioCapture`) acquires in `Capture()` but releases from the producer thread's own `finally` plus `cancellationToken.Register(...)`.
- **Windows** acquired *and started* the APM, AudioGraph, input/output nodes, WASAPI loopback and the processing task in `Capture()`, then put every release in the returned iterator's `finally` — which never runs if nobody enumerates.

Two such windows exist today: `MauiRecorderEngine.Start` awaits `InitializeRecordingState` (a JSI roundtrip) before it starts consuming, and `AudioStreamProcessor.Process` awaits VAD initialization before its `await foreach`. Both have failure modes with existing Sentry issues.

## Commits

1. **Restore Windows app logging** — the app-data sink passed `fileSizeLimitBytes` without `rollOnFileSizeLimit`, so Serilog silently stopped writing at 10MB. The Windows app has had no logs since **May 2024**, and "Open log file" served that stale file.
2. **Style pass on `WindowsAudioCapture`** — no behavior change, done first so the later diffs stay readable.
3. **Log why capture failed** — the device-input-node failure path returned `null` without a single log line. Now logs `AudioDeviceNodeCreationStatus` + `ExtendedError` (the HRESULT), and the device the graph actually picked.
4. **Release the graph even if nobody enumerates it** — teardown moved into an idempotent `Stop()` reachable from the construction failure paths, a cancellation-token registration, and the iterator's `finally`. Also closes the partial-construction leaks and disposes the three `BlockRingBuffer`s.
5. **Stop permanently changing the system mic volume** — the APM's AGC wrote its recommended level to the Windows microphone volume and never restored it. Now restored, unless the user changed it manually mid-recording.
6. **Digital-silence warning** — a withheld mic still delivers all-zero frames, so frame flow alone reported a healthy capture. Same check Android already does.
7. **Stop reporting a dead device as a missing permission** — engines return `RecorderStartResult`; only a real permission failure forgets the cached permission, and the troubleshooter drops its Settings button (a dead end) when permission is already granted. Diagnostics now run before the dialog so it can tell.
8. **Recover instead of staying wedged** — retry graph creation once after 250ms; subscribe `AudioGraph.UnrecoverableErrorOccurred` (previously unhandled, so dead graphs stayed alive and running — exactly what wedges the process); end capture on a default-capture-device change instead of recording silence from the old endpoint.

## Notes for review

- The device-change and unrecoverable-error paths end the capture cleanly rather than switching seamlessly. Recording resumes on the next start. A seamless in-place graph rebuild is possible but wasn't worth the risk here.
- Commit 7 changes graph-creation failure from throwing to returning `null`, so both creation failures now reach `AudioRecorder` as `NoDevice`. The HRESULT still reaches Sentry via a logged warning.
- `.claude/style-bypasses.md` has new entries marked **NEEDS ALEX'S CALL** — the style hook demanded a whole-file restructure of `AudioRecorder.cs` (strip every blank line between members, reorder fields, convert to a primary constructor) that contradicts the rest of the codebase.

## Testing

Not yet tested on a device — @alexyakunin will run this on Windows. Every commit builds clean (`App.Maui`, `net11.0-windows10.0.22621.0`, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ipZTmePNx2xYhSYcBbuF9