### PR TITLE
feat(rpc): select the RPC endpoint independently, and fall back when it stops carrying traffic

### DIFF
--- a/src/dotnet/Api.Contracts/Module/ApiContractsModule.cs
+++ b/src/dotnet/Api.Contracts/Module/ApiContractsModule.cs
@@ -112,7 +112,7 @@ public sealed class ApiContractsModule(IServiceProvider moduleServices)
                     var settings = client.Options;
                     var urlMapper = client.Services.UrlMapper();
                     var sb = ActualLab.Text.StringBuilderExt.Acquire();
-                    sb.Append(urlMapper.WebsocketBaseUrl);
+                    sb.Append(RpcEndpointSelector.ApplyTo(urlMapper.WebsocketBaseUrl));
                     sb.Append(settings.RequestPath);
                     sb.Append('?');
                     sb.Append(settings.ClientIdParameterName);
@@ -179,7 +179,7 @@ public sealed class ApiContractsModule(IServiceProvider moduleServices)
                     var settings = client.Options;
                     var urlMapper = client.Services.UrlMapper();
                     var sb = ActualLab.Text.StringBuilderExt.Acquire();
-                    sb.Append(urlMapper.BaseUrl.TrimSuffix("/"));
+                    sb.Append(RpcEndpointSelector.ApplyTo(urlMapper.BaseUrl.TrimSuffix("/")));
                     sb.Append(settings.RequestPath);
                     sb.Append('?');
                     sb.Append(settings.ClientIdParameterName);

--- a/src/dotnet/Api.Contracts/Module/ApiContractsModule.cs
+++ b/src/dotnet/Api.Contracts/Module/ApiContractsModule.cs
@@ -122,7 +122,10 @@ public sealed class ApiContractsModule(IServiceProvider moduleServices)
                     sb.Append(settings.SerializationFormatParameterName);
                     sb.Append('=');
                     sb.Append(peer.SerializationFormat.Key);
-                    return sb.ToStringAndRelease().ToUri();
+                    var uri = sb.ToStringAndRelease().ToUri();
+                    client.Services.LogFor<RpcWebSocketClient>()
+                        .LogInformation("RPC WebSocket endpoint: {Host}", uri.Host);
+                    return uri;
                 },
             };
             if (hostKind.IsMauiApp())
@@ -189,7 +192,10 @@ public sealed class ApiContractsModule(IServiceProvider moduleServices)
                     sb.Append(settings.SerializationFormatParameterName);
                     sb.Append('=');
                     sb.Append(peer.SerializationFormat.Key);
-                    return sb.ToStringAndRelease().ToUri();
+                    var uri = sb.ToStringAndRelease().ToUri();
+                    client.Services.LogFor<RpcHttpClient>()
+                        .LogInformation("RPC HTTP endpoint: {Host}", uri.Host);
+                    return uri;
                 },
                 HttpClientFactory = _ => {
                     var handler = new SocketsHttpHandler {

--- a/src/dotnet/Api.Contracts/Users/ISystemProperties.cs
+++ b/src/dotnet/Api.Contracts/Users/ISystemProperties.cs
@@ -10,6 +10,10 @@ public interface ISystemProperties : IComputeService
     // Not a [ComputeMethod]! ConnectTimeout stops a clock probe from parking until reconnect.
     [RpcMethod(ConnectTimeout = 0.5)]
     Task<double> GetTime(CancellationToken cancellationToken);
+    // Not a [ComputeMethod]! The payload must cross the wire on every call - it measures
+    // sustained throughput, so a cached or compressible result would prove nothing.
+    [RpcMethod(ConnectTimeout = 0.5)]
+    Task<byte[]> GetProbePayload(int size, CancellationToken cancellationToken);
     [ComputeMethod, RemoteComputeMethod(CacheMode = RemoteComputedCacheMode.NoCache)]
     Task<ServerApiInfo> GetServerApiInfo(string expectedVersion, CancellationToken cancellationToken);
     Task<ServerApiInfo> GetServerApiInfoNC(string expectedVersion, CancellationToken cancellationToken);

--- a/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
@@ -29,7 +29,11 @@ public sealed class MauiConnectivityUI : ConnectivityUI
     {
         // A different network is unproven, and it may well be unrestricted, so we always
         // go back to the origin and let the connection quality demote us again if needed.
-        RpcEndpointSelector.Instance?.UseDirect();
+        if (RpcEndpointSelector.Instance is { } endpointSelector) {
+            endpointSelector.UseDirect();
+            Log.LogInformation("Network changed to {Profiles}, RPC endpoint reset to the origin",
+                e.ConnectionProfiles.ToDelimitedString());
+        }
         _isOnline.Value = e.NetworkAccess.IsOnline();
     }
 }

--- a/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
@@ -11,6 +11,7 @@ namespace ActualChat.App.Maui.Services;
 public sealed class MauiConnectivityUI : ConnectivityUI
 {
     private readonly MutableState<bool> _isOnline;
+    private string _connectionProfiles;
 
     public override IState<bool> IsOnline => _isOnline;
 
@@ -20,6 +21,7 @@ public sealed class MauiConnectivityUI : ConnectivityUI
         var connectivity = Connectivity.Current;
         var isOnline = connectivity.NetworkAccess.IsOnline();
         _isOnline = hub.StateFactory.NewMutable(isOnline, StateCategories.Get(GetType(), nameof(IsOnline)));
+        _connectionProfiles = connectivity.ConnectionProfiles.ToDelimitedString();
         connectivity.ConnectivityChanged += OnConnectivityChanged;
         hub.RegisterDisposable((Action)(() => connectivity.ConnectivityChanged -= OnConnectivityChanged));
         _ = Initialize();
@@ -29,10 +31,13 @@ public sealed class MauiConnectivityUI : ConnectivityUI
     {
         // A different network is unproven, and it may well be unrestricted, so we always
         // go back to the origin and let the connection quality demote us again if needed.
-        if (RpcEndpointSelector.Instance is { } endpointSelector) {
-            endpointSelector.UseDirect();
-            Log.LogInformation("Network changed to {Profiles}, RPC endpoint reset to the origin",
-                e.ConnectionProfiles.ToDelimitedString());
+        var profiles = e.ConnectionProfiles.ToDelimitedString();
+        if (profiles != _connectionProfiles) {
+            _connectionProfiles = profiles;
+            if (RpcEndpointSelector.Instance is { } endpointSelector) {
+                endpointSelector.UseDirect();
+                Log.LogInformation("Network changed to {Profiles}, RPC endpoint reset to the origin", profiles);
+            }
         }
         _isOnline.Value = e.NetworkAccess.IsOnline();
     }

--- a/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
@@ -1,3 +1,4 @@
+using ActualChat.Rpc;
 using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.Services;
 
@@ -25,5 +26,10 @@ public sealed class MauiConnectivityUI : ConnectivityUI
     }
 
     private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
-        => _isOnline.Value = e.NetworkAccess.IsOnline();
+    {
+        // A different network is unproven, and it may well be unrestricted, so we always
+        // go back to the origin and let the connection quality demote us again if needed.
+        RpcEndpointSelector.Instance?.UseDirect();
+        _isOnline.Value = e.NetworkAccess.IsOnline();
+    }
 }

--- a/src/dotnet/App.Maui/wwwroot/_startup.js
+++ b/src/dotnet/App.Maui/wwwroot/_startup.js
@@ -26,9 +26,9 @@
             await window.App.whenBundleReady;
             return true;
         },
-        browserInit: async function (hostKind, appKind, apiVersion, baseUri, suppoertedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef) {
+        browserInit: async function (hostKind, appKind, apiVersion, baseUri, rpcBaseUri, suppoertedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef) {
             await window.App.whenBundleReady;
-            await window.ui.BrowserInit.init(hostKind, appKind, apiVersion, baseUri, suppoertedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef);
+            await window.ui.BrowserInit.init(hostKind, appKind, apiVersion, baseUri, rpcBaseUri, suppoertedHosts, sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef);
         },
     };
     window.App.whenBlazorReady = new Promise((resolve, _) => {

--- a/src/dotnet/App.Server/Components/Pages/RootServerPage.razor
+++ b/src/dotnet/App.Server/Components/Pages/RootServerPage.razor
@@ -131,11 +131,11 @@
                 return true;
             },
             browserInit: async function(
-                hostKind, appKind, apiVersion, baseUri, supportedHosts,
+                hostKind, appKind, apiVersion, baseUri, rpcBaseUri, supportedHosts,
                 sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef) {
                 await window.App.whenBundleReady;
                 window.ui.BrowserInit.init(
-                    hostKind, appKind, apiVersion, baseUri, supportedHosts,
+                    hostKind, appKind, apiVersion, baseUri, rpcBaseUri, supportedHosts,
                     sessionHash, appConstants, browserInfoBackendRef, clipboardInteropRef);
             },
         };

--- a/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
+++ b/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
@@ -1,0 +1,36 @@
+namespace ActualChat.Rpc;
+
+/// <summary>
+/// Picks the host used for RPC connections, which may differ from the app's base
+/// host — content URLs keep using the base host.
+/// </summary>
+public abstract class RpcEndpointSelector
+{
+    public static RpcEndpointSelector? Instance { get; set; }
+
+    public static string ApplyTo(string baseUrl)
+    {
+        // Returns baseUrl with just its host replaced by the selected RPC endpoint.
+        if (Instance is not { } instance)
+            return baseUrl;
+
+        var schemeEnd = baseUrl.IndexOf("://");
+        if (schemeEnd < 0)
+            return baseUrl;
+
+        var hostStart = schemeEnd + 3;
+        var hostEnd = baseUrl.IndexOfAny(['/', ':', '?'], hostStart);
+        if (hostEnd < 0)
+            hostEnd = baseUrl.Length;
+
+        var host = baseUrl[hostStart..hostEnd];
+        var endpoint = instance.Get(host);
+        return string.Equals(host, endpoint, StringComparison.OrdinalIgnoreCase)
+            ? baseUrl
+            : string.Concat(baseUrl.AsSpan(0, hostStart), endpoint, baseUrl.AsSpan(hostEnd));
+    }
+
+    public abstract string Get(string host);
+    public abstract void UseDirect();
+    public abstract bool MoveNext();
+}

--- a/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
+++ b/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
@@ -4,13 +4,58 @@ namespace ActualChat.Rpc;
 /// Picks the host used for RPC connections, which may differ from the app's base
 /// host — content URLs keep using the base host.
 /// </summary>
-public abstract class RpcEndpointSelector
+public class RpcEndpointSelector
 {
     public static RpcEndpointSelector? Instance { get; set; }
 
+    private readonly string[] _candidates;
+    private string _current;
+    private int _version;
+
+    public string OriginHost => _candidates[0];
+    public string Current => Volatile.Read(ref _current);
+    public bool IsOnOrigin => string.Equals(Current, OriginHost, StringComparison.OrdinalIgnoreCase);
+    public int Version
+        // Bumped whenever the selection is re-evaluated, including a reset that picks the
+        // same endpoint again - a new network makes an old verdict meaningless.
+        => Volatile.Read(ref _version);
+
+    public RpcEndpointSelector(string[] candidates, string? current = null)
+    {
+        if (candidates.Length == 0)
+            throw new ArgumentOutOfRangeException(nameof(candidates));
+
+        _candidates = candidates;
+        _current = current != null && candidates.Contains(current, StringComparer.OrdinalIgnoreCase)
+            ? current
+            : candidates[0];
+    }
+
+    public string Get(string host)
+        => string.Equals(host, OriginHost, StringComparison.OrdinalIgnoreCase) ? Current : host;
+
+    public void UseDirect()
+    {
+        Interlocked.Increment(ref _version);
+        Set(OriginHost);
+    }
+
+    public bool MoveNext()
+    {
+        Interlocked.Increment(ref _version);
+        var index = Array.FindIndex(_candidates,
+            x => string.Equals(x, Current, StringComparison.OrdinalIgnoreCase));
+        var nextIndex = index + 1;
+        if (nextIndex >= _candidates.Length)
+            return false;
+
+        Set(_candidates[nextIndex]);
+        return true;
+    }
+
     public static string ApplyTo(string baseUrl)
     {
-        // Returns baseUrl with just its host replaced by the selected RPC endpoint.
+        // Scheme, port, path and query are preserved - only the host moves.
         if (Instance is not { } instance)
             return baseUrl;
 
@@ -30,11 +75,19 @@ public abstract class RpcEndpointSelector
             : string.Concat(baseUrl.AsSpan(0, hostStart), endpoint, baseUrl.AsSpan(hostEnd));
     }
 
-    // Bumped whenever the selection is re-evaluated, including a reset that picks the
-    // same endpoint again - a new network makes an old verdict meaningless.
-    public abstract int Version { get; }
+    // Protected/internal methods
 
-    public abstract string Get(string host);
-    public abstract void UseDirect();
-    public abstract bool MoveNext();
+    protected virtual void OnChanged(string endpoint) { }
+
+    // Private methods
+
+    private void Set(string endpoint)
+    {
+        if (string.Equals(Current, endpoint, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        // Publication: Get() reads this without a lock.
+        Volatile.Write(ref _current, endpoint);
+        OnChanged(endpoint);
+    }
 }

--- a/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
+++ b/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
@@ -30,6 +30,10 @@ public abstract class RpcEndpointSelector
             : string.Concat(baseUrl.AsSpan(0, hostStart), endpoint, baseUrl.AsSpan(hostEnd));
     }
 
+    // Bumped whenever the selection is re-evaluated, including a reset that picks the
+    // same endpoint again - a new network makes an old verdict meaningless.
+    public abstract int Version { get; }
+
     public abstract string Get(string host);
     public abstract void UseDirect();
     public abstract bool MoveNext();

--- a/src/dotnet/Maui/MauiPreferences.cs
+++ b/src/dotnet/Maui/MauiPreferences.cs
@@ -10,6 +10,7 @@ public static class MauiPreferences
     public const string ChatAttentionStateKey = "ChatAttention";
 
     private const string HostOverrideKey = "app_server_instance_override";
+    private const string RpcEndpointKey = "rpc_endpoint";
     private const string DbEncryptionKeyKey = "db_encryption_key";
     private const string HostIpKeyPrefix = "host_ip_";
     private const string IsDataCollectionEnabledKey = "analytics";
@@ -25,6 +26,10 @@ public static class MauiPreferences
     public static string? HostOverride {
         get => Get<string>(HostOverrideKey).NullIfEmpty();
         set => Set(HostOverrideKey, value ?? "");
+    }
+    public static string? RpcEndpoint {
+        get => Get<string>(RpcEndpointKey).NullIfEmpty();
+        set => Set(RpcEndpointKey, value ?? "");
     }
 
     public static byte[] DbEncryptionKey

--- a/src/dotnet/Maui/MauiRpcEndpointSelector.cs
+++ b/src/dotnet/Maui/MauiRpcEndpointSelector.cs
@@ -1,0 +1,57 @@
+using ActualChat.Rpc;
+
+namespace ActualChat.Maui;
+
+public sealed class MauiRpcEndpointSelector : RpcEndpointSelector
+{
+    private readonly string _originHost;
+    private readonly string[] _candidates;
+    private string _current;
+
+    public static void Use()
+        => Instance = new MauiRpcEndpointSelector(MauiSettings.Host, MauiSettings.RpcEndpoints);
+
+    private MauiRpcEndpointSelector(string originHost, string[] candidates)
+    {
+        _originHost = originHost;
+        _candidates = candidates;
+        var stored = MauiPreferences.RpcEndpoint;
+        _current = stored != null && candidates.Contains(stored, StringComparer.OrdinalIgnoreCase)
+            ? stored
+            : originHost;
+    }
+
+    public override string Get(string host)
+        => string.Equals(host, _originHost, StringComparison.OrdinalIgnoreCase)
+            ? Volatile.Read(ref _current)
+            : host;
+
+    public override void UseDirect()
+        => Set(_originHost);
+
+    public override bool MoveNext()
+    {
+        var current = Volatile.Read(ref _current);
+        var index = Array.FindIndex(_candidates, x => string.Equals(x, current, StringComparison.OrdinalIgnoreCase));
+        var nextIndex = index + 1;
+        if (nextIndex >= _candidates.Length)
+            return false;
+
+        Set(_candidates[nextIndex]);
+        return true;
+    }
+
+    // Private methods
+
+    private void Set(string endpoint)
+    {
+        if (string.Equals(Volatile.Read(ref _current), endpoint, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        // Publication: Get() reads this without a lock.
+        Volatile.Write(ref _current, endpoint);
+        MauiPreferences.RpcEndpoint = string.Equals(endpoint, _originHost, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : endpoint;
+    }
+}

--- a/src/dotnet/Maui/MauiRpcEndpointSelector.cs
+++ b/src/dotnet/Maui/MauiRpcEndpointSelector.cs
@@ -2,63 +2,14 @@ using ActualChat.Rpc;
 
 namespace ActualChat.Maui;
 
-public sealed class MauiRpcEndpointSelector : RpcEndpointSelector
+public sealed class MauiRpcEndpointSelector(string[] candidates, string? current)
+    : RpcEndpointSelector(candidates, current)
 {
-    private readonly string _originHost;
-    private readonly string[] _candidates;
-    private string _current;
-    private int _version;
-
     public static void Use()
-        => Instance = new MauiRpcEndpointSelector(MauiSettings.Host, MauiSettings.RpcEndpoints);
+        => Instance = new MauiRpcEndpointSelector(MauiSettings.RpcEndpoints, MauiPreferences.RpcEndpoint);
 
-    private MauiRpcEndpointSelector(string originHost, string[] candidates)
-    {
-        _originHost = originHost;
-        _candidates = candidates;
-        var stored = MauiPreferences.RpcEndpoint;
-        _current = stored != null && candidates.Contains(stored, StringComparer.OrdinalIgnoreCase)
-            ? stored
-            : originHost;
-    }
+    // Protected/internal methods
 
-    public override int Version => Volatile.Read(ref _version);
-
-    public override string Get(string host)
-        => string.Equals(host, _originHost, StringComparison.OrdinalIgnoreCase)
-            ? Volatile.Read(ref _current)
-            : host;
-
-    public override void UseDirect()
-    {
-        Interlocked.Increment(ref _version);
-        Set(_originHost);
-    }
-
-    public override bool MoveNext()
-    {
-        Interlocked.Increment(ref _version);
-        var current = Volatile.Read(ref _current);
-        var index = Array.FindIndex(_candidates, x => string.Equals(x, current, StringComparison.OrdinalIgnoreCase));
-        var nextIndex = index + 1;
-        if (nextIndex >= _candidates.Length)
-            return false;
-
-        Set(_candidates[nextIndex]);
-        return true;
-    }
-
-    // Private methods
-
-    private void Set(string endpoint)
-    {
-        if (string.Equals(Volatile.Read(ref _current), endpoint, StringComparison.OrdinalIgnoreCase))
-            return;
-
-        // Publication: Get() reads this without a lock.
-        Volatile.Write(ref _current, endpoint);
-        MauiPreferences.RpcEndpoint = string.Equals(endpoint, _originHost, StringComparison.OrdinalIgnoreCase)
-            ? null
-            : endpoint;
-    }
+    protected override void OnChanged(string endpoint)
+        => MauiPreferences.RpcEndpoint = IsOnOrigin ? null : endpoint;
 }

--- a/src/dotnet/Maui/MauiRpcEndpointSelector.cs
+++ b/src/dotnet/Maui/MauiRpcEndpointSelector.cs
@@ -7,6 +7,7 @@ public sealed class MauiRpcEndpointSelector : RpcEndpointSelector
     private readonly string _originHost;
     private readonly string[] _candidates;
     private string _current;
+    private int _version;
 
     public static void Use()
         => Instance = new MauiRpcEndpointSelector(MauiSettings.Host, MauiSettings.RpcEndpoints);
@@ -21,16 +22,22 @@ public sealed class MauiRpcEndpointSelector : RpcEndpointSelector
             : originHost;
     }
 
+    public override int Version => Volatile.Read(ref _version);
+
     public override string Get(string host)
         => string.Equals(host, _originHost, StringComparison.OrdinalIgnoreCase)
             ? Volatile.Read(ref _current)
             : host;
 
     public override void UseDirect()
-        => Set(_originHost);
+    {
+        Interlocked.Increment(ref _version);
+        Set(_originHost);
+    }
 
     public override bool MoveNext()
     {
+        Interlocked.Increment(ref _version);
         var current = Volatile.Read(ref _current);
         var index = Array.FindIndex(_candidates, x => string.Equals(x, current, StringComparison.OrdinalIgnoreCase));
         var nextIndex = index + 1;

--- a/src/dotnet/Maui/MauiSettings.cs
+++ b/src/dotnet/Maui/MauiSettings.cs
@@ -32,6 +32,7 @@ public static class MauiSettings
                 ? Constants.Hosts.DevVoxt
                 : Constants.Hosts.Voxt;
     public static readonly string Host;
+    public static readonly string[] RpcEndpoints;
     public static bool IsHostOverridden => !string.Equals(Host, DefaultHost, StringComparison.OrdinalIgnoreCase);
     public static readonly Uri BaseUri;
     public static readonly string BaseUrl;
@@ -42,6 +43,7 @@ public static class MauiSettings
     static MauiSettings()
     {
         Host = MauiPreferences.HostOverride ?? DefaultHost;
+        RpcEndpoints = [Host, "kz1.edge." + Host];
         BaseUrl = "https://" + Host + "/";
         BaseUri = BaseUrl.ToUri();
 
@@ -58,6 +60,7 @@ public static class MauiSettings
 #endif
         AppUserAgent = AppKind.ToUserAgent(ApiConstants.FullVersionString);
         MauiHostNameRemapper.Use();
+        MauiRpcEndpointSelector.Use();
     }
 
     // Nested types

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
@@ -356,7 +356,7 @@ export class OpusMediaRecorder implements RecorderStateServer {
         debugLog?.log(`init(): call create on workers`);
         // kind=audio tells the server this connection carries media streams,
         // so it skips WebSocket compression for it.
-        const apiUrl = new URL('/rpc/ws?kind=audio', this.origin).toString().replace(/^http/, 'ws');
+        const apiUrl = BrowserInit.getRpcUrl('/rpc/ws?kind=audio').replace(/^http/, 'ws');
         SharedSettings.update({ apiUrl });
 
         await this.encoderWorker.create(

--- a/src/dotnet/UI.Blazor.App/Components/Settings/DeveloperTools.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/DeveloperTools.razor
@@ -1,3 +1,4 @@
+@using ActualChat.Rpc
 @using ActualChat.UI.App.Services
 @inherits ComputedStateComponent<AppUIHub, DeveloperTools.Model>
 @{
@@ -15,6 +16,12 @@
         <TileTopic Topic="@L.DevTools_Host"/>
         <Tile Class="host-switcher-tile">
             <ServerInstanceSelector Selector="@ServerInstanceSelector" />
+            @if (m.RpcEndpoint.Length != 0) {
+                <TileItem>
+                    <Content>RPC endpoint</Content>
+                    <Caption>@m.RpcEndpoint</Caption>
+                </TileItem>
+            }
         </Tile>
     }
 
@@ -108,7 +115,8 @@
             account.IsAdmin,
             appSettings.IsLogViewerEnabledOrDefault,
             isVideoDiagnosticsEnabled,
-            isAudioDiagnosticsEnabled);
+            isAudioDiagnosticsEnabled,
+            RpcEndpointSelector.Instance?.Current ?? "");
     }
 
     private Task OnExperimentalFeatureEnabledClick()
@@ -149,8 +157,9 @@
         bool IsAdmin,
         bool IsLogUIEnabled,
         bool IsVideoDiagnosticsEnabled,
-        bool IsAudioDiagnosticsEnabled)
+        bool IsAudioDiagnosticsEnabled,
+        string RpcEndpoint)
     {
-        public static readonly Model None = new(false, false, false, false, false, false);
+        public static readonly Model None = new(false, false, false, false, false, false, "");
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -698,7 +698,7 @@ export class VideoPlayer {
             // Pre-warm the worker's Fusion RPC peer so the WS handshake
             // overlaps the rest of init. kind=video tells the server this
             // connection carries media streams, so it skips WS compression.
-            const apiUrl = BrowserInit.getUrl('/rpc/ws?kind=video').replace(/^http/, 'ws');
+            const apiUrl = BrowserInit.getRpcUrl('/rpc/ws?kind=video').replace(/^http/, 'ws');
             void this.playerWorker.prewarmRpc(apiUrl, rpcNoWait);
 
             debugLog?.log('Player worker initialized');

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -2123,7 +2123,7 @@ export class VideoRecorder {
 
         // kind=video tells the server this connection carries media streams,
         // so it skips WebSocket compression for it.
-        const apiUrl = BrowserInit.getUrl('/rpc/ws?kind=video').replace(/^http/, 'ws');
+        const apiUrl = BrowserInit.getRpcUrl('/rpc/ws?kind=video').replace(/^http/, 'ws');
         // SharedSettings is the legacy worker plumbing; the new worker
         // doesn't observe it. Keep the call so the audio path (which
         // still uses SharedSettings) is unaffected.

--- a/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
+++ b/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
@@ -179,6 +179,7 @@ public sealed class AppScopedServiceStarter
         //   transition, and the first track is built before the route reaches the speaker.
         services.GetService<ServerTimeSync>()?.Start();
         services.GetRequiredService<ConnectivityUI>().Start();
+        services.GetRequiredService<RpcEndpointMonitor>().Start();
         _ = hub.AudioFocusUI.WarmUp();
         _ = hub.TuneUI;
         _ = hub.IncomingVoiceActivityUI;

--- a/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
+++ b/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
@@ -105,6 +105,7 @@ public sealed class BlazorUICoreModule(IServiceProvider moduleServices)
             services.AddScoped<ConnectivityUI>(c => new ServerConnectivityUI(c.UIHub()));
         else if (!isMauiApp) // MauiConnectivityUI is registered in MauiApp
             services.AddScoped<ConnectivityUI>(c => new WebConnectivityUI(c.UIHub()));
+        services.AddScoped<RpcEndpointMonitor>(c => new RpcEndpointMonitor(c.UIHub()));
         if (!isMauiApp) {
             services.AddScoped<BackgroundStateTracker>(c => new WebBackgroundStateTracker(c));
             services.AddScoped<ThermalTracker>(c => new WebThermalTracker(c));

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/BrowserInit.cs
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/BrowserInit.cs
@@ -1,3 +1,4 @@
+using ActualChat.Rpc;
 using ActualChat.UI.Blazor.Module;
 
 namespace ActualChat.UI.Blazor.Services;
@@ -30,6 +31,7 @@ public sealed class BrowserInit(UIHub hub) : UIServiceBase<UIHub>(hub)
                     appKind.ToString(),
                     apiVersion,
                     baseUri,
+                    RpcEndpointSelector.Instance is null ? "" : RpcEndpointSelector.ApplyTo(baseUri),
                     HostInfo.GetHosts(),
                     sessionHash,
                     appConstants,

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
@@ -91,6 +91,17 @@ export class BrowserInit {
         return baseUri ? new URL(url, baseUri).toString() : url;
     }
 
+    // Media workers read this when they start, so a change reaches a stream on its next
+    // start rather than mid-flight - moving a live peer would mean rebuilding the pipeline.
+    public static setRpcBaseUri(rpcBaseUri: string): void {
+        const newRpcBaseUri = rpcBaseUri || BrowserInit.baseUri;
+        if (newRpcBaseUri === BrowserInit.rpcBaseUri)
+            return;
+
+        BrowserInit.rpcBaseUri = newRpcBaseUri;
+        warnLog?.log(`RPC endpoint changed: ${new URL(newRpcBaseUri).host}`);
+    }
+
     // Only /rpc/* goes here: the RPC endpoint may differ from baseUri, while content
     // URLs (cdn./media./maps.) must keep using baseUri.
     public static getRpcUrl(url: string) : string {

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
@@ -22,6 +22,7 @@ const sessionStorage = globalThis?.sessionStorage;
 export class BrowserInit {
     public static apiVersion = '';
     public static baseUri = '';
+    public static rpcBaseUri = '';
     public static sessionHash = '';
     public static windowId = '';
     public static firebaseApp?: FirebaseApp;
@@ -36,6 +37,7 @@ export class BrowserInit {
         appKind: AppKind,
         apiVersion: string,
         baseUri: string,
+        rpcBaseUri: string,
         supportedHosts: string[],
         sessionHash: string,
         appConstants: AppConstants,
@@ -51,8 +53,9 @@ export class BrowserInit {
             this.apiVersion = apiVersion;
             const documentBaseUri = new URL(document.baseURI);
             this.baseUri = supportedHosts.includes(documentBaseUri.host) ? `${documentBaseUri.protocol}//${documentBaseUri.host}` : baseUri;
+            this.rpcBaseUri = rpcBaseUri || this.baseUri;
             Api.init('MainThread', {
-                url: this.getUrl('/rpc/ws').replace(/^http/, 'ws'),
+                url: this.getRpcUrl('/rpc/ws').replace(/^http/, 'ws'),
                 modules: [streamingApi, uploadsApi],
                 connectivityUI: ConnectivityUI,
                 sessionTokenProvider: minLifespanMs => SessionTokens.get(minLifespanMs),
@@ -85,6 +88,13 @@ export class BrowserInit {
     public static getUrl(url: string) : string {
         const baseUri = BrowserInit.baseUri;
         return baseUri ? new URL(url, baseUri).toString() : url;
+    }
+
+    // Only /rpc/* goes here: the RPC endpoint may differ from baseUri, while content
+    // URLs (cdn./media./maps.) must keep using baseUri.
+    public static getRpcUrl(url: string) : string {
+        const rpcBaseUri = BrowserInit.rpcBaseUri || BrowserInit.baseUri;
+        return rpcBaseUri ? new URL(url, rpcBaseUri).toString() : url;
     }
 
     public static removeWebSplash(instantly = false) {

--- a/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInit/browser-init.ts
@@ -45,7 +45,7 @@ export class BrowserInit {
         clipboardInteropRef: DotNet.DotNetObject | null,
     ): void {
         try {
-            infoLog?.log(`-> init, apiVersion: ${apiVersion}, baseUri: ${baseUri}, sessionHash: ${sessionHash}`);
+            infoLog?.log(`-> init, apiVersion: ${apiVersion}, baseUri: ${baseUri}, rpcBaseUri: ${rpcBaseUri}, sessionHash: ${sessionHash}`);
             initAppConstants(appConstants);
             if (!BrowserInit.isProdBaseUri(baseUri))
                 MainThreadDiagnostics.init();
@@ -54,6 +54,7 @@ export class BrowserInit {
             const documentBaseUri = new URL(document.baseURI);
             this.baseUri = supportedHosts.includes(documentBaseUri.host) ? `${documentBaseUri.protocol}//${documentBaseUri.host}` : baseUri;
             this.rpcBaseUri = rpcBaseUri || this.baseUri;
+            warnLog?.log(`RPC endpoint: ${new URL(this.rpcBaseUri).host}`);
             Api.init('MainThread', {
                 url: this.getRpcUrl('/rpc/ws').replace(/^http/, 'ws'),
                 modules: [streamingApi, uploadsApi],

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -14,7 +14,10 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     // Must exceed the ~16KB some networks let through before capping a connection,
     // otherwise a fully throttled link passes the probe.
     private const int ProbeSize = 64 * 1024;
-    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(3);
+    // 64KB in 10s is ~52 kbps. Well under what a weak but usable link sustains, and well
+    // over a capped one, which needs ~37s for this payload. A tighter deadline would
+    // demand ~175 kbps and start failing links that are merely slow.
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ProbeRetryDelay = TimeSpan.FromSeconds(1);
     // The probe costs the user traffic and tells us nothing a working app doesn't already
     // show, so it waits until startup is over rather than competing with it.

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -19,6 +19,9 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     // The probe costs the user traffic and tells us nothing a working app doesn't already
     // show, so it waits until startup is over rather than competing with it.
     private static readonly TimeSpan ProbeDelay = TimeSpan.FromSeconds(60);
+    // The probe only runs once connected, so an endpoint that never connects would trap
+    // us here. The origin gets no deadline: there is nowhere better to go.
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
     private int _verifiedVersion = -1;
     private ISystemProperties SystemProperties => field ??= Services.GetRequiredService<ISystemProperties>();
     private ReconnectUI ReconnectUI => field ??= Services.GetRequiredService<ReconnectUI>();
@@ -44,7 +47,10 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     {
         var selector = RpcEndpointSelector.Instance!;
         var state = ReconnectUI.State;
-        await state.Computed.When(x => x.IsConnected, cancellationToken).ConfigureAwait(false);
+        if (!await WaitUntilConnected(selector, cancellationToken).ConfigureAwait(false)) {
+            MoveToNextEndpoint(selector);
+            return;
+        }
         if (selector.Version == _verifiedVersion) {
             await WaitUntilDisconnected(cancellationToken).ConfigureAwait(false);
             return;
@@ -62,6 +68,28 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
         }
 
         MoveToNextEndpoint(selector);
+    }
+
+    private async Task<bool> WaitUntilConnected(
+        RpcEndpointSelector selector,
+        CancellationToken cancellationToken)
+    {
+        var state = ReconnectUI.State;
+        if (selector.IsOnOrigin) {
+            await state.Computed.When(x => x.IsConnected, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        using var cts = cancellationToken.CreateLinkedTokenSource();
+        cts.CancelAfter(ConnectTimeout);
+        try {
+            await state.Computed.When(x => x.IsConnected, cts.Token).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+            Log.LogWarning("RPC endpoint did not connect within {Timeout}", ConnectTimeout.ToShortString());
+            return false;
+        }
     }
 
     private Task WaitUntilDisconnected(CancellationToken cancellationToken)

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -1,0 +1,118 @@
+using ActualChat.Rpc;
+using ActualChat.Users;
+using ActualLab.Fusion.Extensions;
+using ActualLab.Rpc;
+
+namespace ActualChat.UI.Blazor.Services;
+
+/// <summary>
+/// Moves the client to the next RPC endpoint when the current one connects but
+/// cannot carry traffic — the failure mode <see cref="RpcPeerState"/> can't see.
+/// </summary>
+public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
+{
+    // Must exceed the ~16KB some networks let through before capping a connection,
+    // otherwise a fully throttled link passes the probe.
+    private const int ProbeSize = 64 * 1024;
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ProbeRetryDelay = TimeSpan.FromSeconds(1);
+    // The probe costs the user traffic and tells us nothing a working app doesn't already
+    // show, so it waits until startup is over rather than competing with it.
+    private static readonly TimeSpan ProbeDelay = TimeSpan.FromSeconds(60);
+    private int _verifiedVersion = -1;
+    private ISystemProperties SystemProperties => field ??= Services.GetRequiredService<ISystemProperties>();
+    private ReconnectUI ReconnectUI => field ??= Services.GetRequiredService<ReconnectUI>();
+    private RpcClientPeer? Peer => Hub.RpcHub.GetClientPeer(RpcRef.Default);
+
+    // Protected/internal methods
+
+    protected override Task OnRun(CancellationToken cancellationToken)
+    {
+        if (RpcEndpointSelector.Instance is null)
+            return Task.CompletedTask;
+
+        return AsyncChain.From(MonitorEndpoint)
+            .Log(LogLevel.Debug, Log)
+            .RetryForever(RetryDelaySeq.Exp(1, 30), Log)
+            .CycleForever()
+            .Run(cancellationToken);
+    }
+
+    // Private methods
+
+    private async Task MonitorEndpoint(CancellationToken cancellationToken)
+    {
+        var selector = RpcEndpointSelector.Instance!;
+        var state = ReconnectUI.State;
+        await state.Computed.When(x => x.IsConnected, cancellationToken).ConfigureAwait(false);
+        if (selector.Version == _verifiedVersion) {
+            await WaitUntilDisconnected(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await Clocks.CpuClock.Delay(ProbeDelay, cancellationToken).ConfigureAwait(false);
+        if (!state.Value.IsConnected)
+            return;
+
+        var version = selector.Version;
+        if (await IsEndpointUsable(cancellationToken).ConfigureAwait(false)) {
+            _verifiedVersion = version;
+            await WaitUntilDisconnected(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        MoveToNextEndpoint(selector);
+    }
+
+    private Task WaitUntilDisconnected(CancellationToken cancellationToken)
+        => ReconnectUI.State.Computed.When(x => !x.IsConnected, cancellationToken);
+
+    private async Task<bool> IsEndpointUsable(CancellationToken cancellationToken)
+    {
+        if (await Probe(cancellationToken).ConfigureAwait(false))
+            return true;
+
+        // One failure can be an ordinary blip; only a repeat means the endpoint is unusable.
+        await Clocks.CpuClock.Delay(ProbeRetryDelay, cancellationToken).ConfigureAwait(false);
+        return await Probe(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> Probe(CancellationToken cancellationToken)
+    {
+        var startedAt = Clocks.CpuClock.Now;
+        try {
+            using var cts = cancellationToken.CreateLinkedTokenSource();
+            cts.CancelAfter(ProbeTimeout);
+            var payload = await SystemProperties.GetProbePayload(ProbeSize, cts.Token).ConfigureAwait(false);
+            var elapsed = Clocks.CpuClock.Now - startedAt;
+            if (payload.Length < ProbeSize) {
+                Log.LogWarning("RPC endpoint probe returned {Size} of {ExpectedSize} bytes",
+                    payload.Length, ProbeSize);
+                return false;
+            }
+
+            Log.LogInformation("RPC endpoint probe passed: {Size} bytes in {Elapsed}",
+                ProbeSize, elapsed.ToShortString());
+            return true;
+        }
+        catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+            var elapsed = Clocks.CpuClock.Now - startedAt;
+            Log.LogWarning(e, "RPC endpoint probe failed after {Elapsed}", elapsed.ToShortString());
+            return false;
+        }
+    }
+
+    private void MoveToNextEndpoint(RpcEndpointSelector selector)
+    {
+        if (selector.MoveNext())
+            Log.LogWarning("Switching to the next RPC endpoint");
+        else {
+            // Every endpoint failed, so the network is likely down rather than the endpoint bad.
+            Log.LogWarning("No usable RPC endpoint left, going back to the origin");
+            selector.UseDirect();
+        }
+
+        Peer?.Disconnect();
+        ReconnectUI.ResetReconnectDelays();
+    }
+}

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -97,15 +97,15 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
 
     private async Task<bool> IsEndpointUsable(CancellationToken cancellationToken)
     {
-        if (await Probe(cancellationToken).ConfigureAwait(false))
+        if (await Probe(cancellationToken).ConfigureAwait(false) != ProbeResult.Failed)
             return true;
 
         // One failure can be an ordinary blip; only a repeat means the endpoint is unusable.
         await Clocks.CpuClock.Delay(ProbeRetryDelay, cancellationToken).ConfigureAwait(false);
-        return await Probe(cancellationToken).ConfigureAwait(false);
+        return await Probe(cancellationToken).ConfigureAwait(false) != ProbeResult.Failed;
     }
 
-    private async Task<bool> Probe(CancellationToken cancellationToken)
+    private async Task<ProbeResult> Probe(CancellationToken cancellationToken)
     {
         var startedAt = Clocks.CpuClock.Now;
         try {
@@ -116,17 +116,23 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
             if (payload.Length < ProbeSize) {
                 Log.LogWarning("RPC endpoint probe returned {Size} of {ExpectedSize} bytes",
                     payload.Length, ProbeSize);
-                return false;
+                return ProbeResult.Inconclusive;
             }
 
             Log.LogInformation("RPC endpoint probe passed: {Size} bytes in {Elapsed}",
                 ProbeSize, elapsed.ToShortString());
-            return true;
+            return ProbeResult.Passed;
         }
         catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+            // A throttled link makes the payload arrive late or not at all, so only a
+            // timeout indicts the endpoint. A fast failure means something a different
+            // endpoint cannot fix - an older server without this method, say - and acting
+            // on it would force reconnects that never help.
             var elapsed = Clocks.CpuClock.Now - startedAt;
-            Log.LogWarning(e, "RPC endpoint probe failed after {Elapsed}", elapsed.ToShortString());
-            return false;
+            var isTimeout = elapsed >= ProbeTimeout;
+            Log.LogWarning(e, "RPC endpoint probe {Outcome} after {Elapsed}",
+                isTimeout ? "timed out" : "failed for an unrelated reason", elapsed.ToShortString());
+            return isTimeout ? ProbeResult.Failed : ProbeResult.Inconclusive;
         }
     }
 
@@ -142,5 +148,14 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
 
         Peer?.Disconnect();
         ReconnectUI.ResetReconnectDelays();
+    }
+
+    // Nested types
+
+    private enum ProbeResult
+    {
+        Passed = 0,
+        Failed,
+        Inconclusive,
     }
 }

--- a/src/dotnet/Users.Service/SystemProperties.cs
+++ b/src/dotnet/Users.Service/SystemProperties.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using ActualChat.Users.Db;
 using ActualLab.Fusion.EntityFramework;
 using ActualLab.Fusion.Internal;
@@ -7,12 +8,23 @@ namespace ActualChat.Users;
 public class SystemProperties(IServiceProvider services)
     : DbServiceBase<UsersDbContext>(services), ISystemProperties
 {
+    private const int MinProbePayloadSize = 1024;
+    private const int MaxProbePayloadSize = 256 * 1024;
     private static readonly Version MinCompatibleVersion = new(2, 15);
     private static readonly Version MinReportableClientVersion = MinCompatibleVersion;
 
     // Not a [ComputeMethod]!
     public Task<double> GetTime(CancellationToken cancellationToken)
         => Task.FromResult(Clocks.SystemClock.Now.EpochOffset.TotalSeconds);
+
+    // Not a [ComputeMethod]!
+    public Task<byte[]> GetProbePayload(int size, CancellationToken cancellationToken)
+    {
+        // Random rather than zeroed: WebSocket deflate would shrink a compressible payload
+        // to nothing, so it would cross a throttled link just fine and prove nothing.
+        size = size.Clamp(MinProbePayloadSize, MaxProbePayloadSize);
+        return Task.FromResult(RandomNumberGenerator.GetBytes(size));
+    }
 
     // [ComputeMethod]
     public virtual Task<ServerApiInfo> GetServerApiInfo(string expectedVersion, CancellationToken cancellationToken)

--- a/tests/Core.UnitTests/Rpc/RpcEndpointSelectorTest.cs
+++ b/tests/Core.UnitTests/Rpc/RpcEndpointSelectorTest.cs
@@ -1,0 +1,159 @@
+using ActualChat.Rpc;
+
+namespace ActualChat.Core.UnitTests.Rpc;
+
+public class RpcEndpointSelectorTest
+{
+    private const string Origin = "voxt.ai";
+    private const string Edge1 = "kz1.edge.voxt.ai";
+    private const string Edge2 = "tr1.edge.voxt.ai";
+
+    [Fact]
+    public void ShouldStartOnTheOrigin()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1]);
+
+        // assert
+        selector.Current.Should().Be(Origin);
+        selector.IsOnOrigin.Should().BeTrue();
+        selector.Get(Origin).Should().Be(Origin);
+    }
+
+    [Fact]
+    public void ShouldRestoreAKnownStoredEndpoint()
+    {
+        // act
+        var selector = new RpcEndpointSelector([Origin, Edge1], Edge1);
+
+        // assert
+        selector.Current.Should().Be(Edge1);
+        selector.IsOnOrigin.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldIgnoreAStoredEndpointThatIsNoLongerACandidate()
+    {
+        // act
+        var selector = new RpcEndpointSelector([Origin, Edge1], "retired.edge.voxt.ai");
+
+        // assert
+        selector.Current.Should().Be(Origin,
+            because: "a stored endpoint dropped from the candidate list must not be dialed");
+    }
+
+    [Fact]
+    public void ShouldWalkCandidatesInOrderThenReportExhaustion()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1, Edge2]);
+
+        // act & assert
+        selector.MoveNext().Should().BeTrue();
+        selector.Current.Should().Be(Edge1);
+        selector.MoveNext().Should().BeTrue();
+        selector.Current.Should().Be(Edge2);
+        selector.MoveNext().Should().BeFalse(because: "there is nothing after the last candidate");
+    }
+
+    [Fact]
+    public void ShouldReturnToTheOriginOnUseDirect()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1]);
+        selector.MoveNext();
+
+        // act
+        selector.UseDirect();
+
+        // assert
+        selector.Current.Should().Be(Origin);
+        selector.IsOnOrigin.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldBumpVersionEvenWhenTheEndpointDoesNotChange()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1]);
+        var version = selector.Version;
+
+        // act
+        selector.UseDirect();
+
+        // assert
+        selector.Current.Should().Be(Origin);
+        selector.Version.Should().NotBe(version,
+            because: "a network change must expire an earlier verdict about this endpoint");
+    }
+
+    [Fact]
+    public void ShouldOnlyRemapTheOriginHost()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1]);
+        selector.MoveNext();
+
+        // assert
+        selector.Get(Origin).Should().Be(Edge1);
+        selector.Get("cdn.voxt.ai").Should().Be("cdn.voxt.ai",
+            because: "content hosts must stay on their own origins");
+    }
+
+    [Theory]
+    [InlineData("wss://voxt.ai", "wss://kz1.edge.voxt.ai")]
+    [InlineData("https://voxt.ai", "https://kz1.edge.voxt.ai")]
+    [InlineData("https://voxt.ai/rpc/ws?x=1", "https://kz1.edge.voxt.ai/rpc/ws?x=1")]
+    [InlineData("https://voxt.ai:443/x", "https://kz1.edge.voxt.ai:443/x")]
+    [InlineData("https://cdn.voxt.ai/a.png", "https://cdn.voxt.ai/a.png")]
+    public void ApplyToShouldReplaceOnlyTheHost(string baseUrl, string expected)
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1]);
+        selector.MoveNext();
+        RpcEndpointSelector.Instance = selector;
+        try {
+            // act & assert
+            RpcEndpointSelector.ApplyTo(baseUrl).Should().Be(expected);
+        }
+        finally {
+            RpcEndpointSelector.Instance = null;
+        }
+    }
+
+    [Fact]
+    public void ApplyToShouldBeANoOpWithoutASelector()
+    {
+        // arrange
+        RpcEndpointSelector.Instance = null;
+
+        // act & assert
+        RpcEndpointSelector.ApplyTo("wss://voxt.ai").Should().Be("wss://voxt.ai");
+    }
+
+    [Fact]
+    public void ShouldReportChangesForPersistence()
+    {
+        // arrange
+        var changes = new List<string>();
+        var selector = new TestSelector([Origin, Edge1], changes);
+
+        // act
+        selector.MoveNext();
+        selector.UseDirect();
+        selector.UseDirect();
+
+        // assert
+        changes.Should().Equal([Edge1, Origin],
+            because: "a reset that selects the same endpoint again is not a change");
+    }
+
+    // Nested types
+
+    private sealed class TestSelector(string[] candidates, List<string> changes)
+        : RpcEndpointSelector(candidates)
+    {
+        protected override void OnChanged(string endpoint)
+            => changes.Add(endpoint);
+    }
+}


### PR DESCRIPTION
Lets the client use a different host for RPC than for everything else, and move to
another one when the current host connects but cannot actually carry traffic. This
improves connectivity in regions where reaching the origin directly is unreliable.

## What it does

`RpcEndpointSelector` picks the host used for `/rpc/ws` and `/rpc/http`. Content
URLs (`cdn.`, `media.`, `maps.`) keep using the base host, so only the RPC
connection moves. `Instance` is null on web and server, leaving their behaviour
unchanged; MAUI is the only host that sets one.

Both client stacks follow it:
- the .NET Fusion peer, via `ConnectionUriResolver`
- the JS worker peers — main, video and audio — via `BrowserInit.getRpcUrl`

The audio recorder built its URL from its own `origin` rather than `BrowserInit`,
so it needed redirecting separately; otherwise audio would have silently stayed on
the old host while everything else moved.

## How a bad endpoint is detected

`ISystemProperties.GetProbePayload` returns a random payload of the requested size.
Random rather than zeroed, because WebSocket deflate would shrink a compressible
payload to nothing and let it cross a capped link, proving nothing.

`RpcEndpointMonitor` runs it over the live connection — a separate connection would
get its own allowance and measure something else — and moves to the next endpoint
when 64KB will not cross within 3s while the peer still reports `Connected`. That
is the failure mode `RpcPeerState` cannot see: the peer is connected, so the UI
shows no problem, but nothing of size gets through.

## Cost in the common case: none

The probe is deliberately lazy. It waits a minute after connecting, and runs once
per selection rather than per connect, so the ordinary case where the origin works
costs no traffic and nothing competes with startup. A `Version` counter expires the
verdict when the selection is re-evaluated — including a network change that
re-picks the same endpoint, since a new network makes an old measurement
meaningless.

A network change also returns the client to the origin: a different network is
unproven and may well be fine, so we prefer the origin and let the probe demote us
again if needed. `MauiConnectivityUI` compares connection profiles so an
offline/online blip on the same network does not bounce the selection.

## Observability

The host actually dialed is logged on every connect, from both stacks, so the
selection can be read off `adb logcat` without any UI:

```
adb logcat | grep -i "RPC .*endpoint"
```

Logging the dialed URI rather than the selector's state means the log reflects what
really happened, including any remapping below it.

## Tests

14 unit tests in `Core.UnitTests` cover ordering, exhaustion, version bumps and
host-only rewriting. Writing them surfaced a real gap: the probe only runs once
connected, so an endpoint that never connects trapped the monitor and stranded the
client on it. Non-origin endpoints now get a connect deadline; the origin keeps
none, since there is nowhere better to go.

`RpcEndpointMonitor` itself is not unit-tested — it needs a connected RPC peer, so
covering it means an integration test.

## Verified

- `dotnet build src/dotnet/App.Server` — succeeded
- `dotnet build src/dotnet/App.Maui -f net11.0-android` — succeeded
- `npm run build:Verify` — tsc, eslint and bundle clean
- `dotnet test tests/Core.UnitTests --filter RpcEndpointSelectorTest` — 14 passed

Not exercised on a real device against a real alternate endpoint yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb6YqifLtnYRzwtyi4xXF7
