### PR TITLE
Android ANR fixes: FCM cold-start path (A1-A4 + instrumentation)

### DIFF
--- a/docs/plans/android-anr-issues.md
+++ b/docs/plans/android-anr-issues.md
@@ -1,8 +1,8 @@
 # Android ANRs — FCM cold-start stalls
 
-Status: **A1–A4 implemented on `feat/android-anr-startup` (2026-08-25); A5/B1
-and the Crashlytics/Analytics decisions pending.** Data pulled from Play
-Console on 2026-08-25.
+Status: **A1–A4 + instrumentation implemented on `feat/android-anr-startup`
+(2026-08-25); measure a dev/beta cycle before deciding on A5/B1.** Data pulled
+from Play Console on 2026-08-25.
 
 Implementation notes (deviations from the plan below):
 
@@ -16,8 +16,14 @@ Implementation notes (deviations from the plan below):
 - A3 gates on API level only (`< 31`): during `Application.OnCreate` the FCM
   exemption window isn't open yet even on a push start, and on API 31+ user
   launches MainActivity raises the service moments later anyway.
-- Crashlytics (Android) is still referenced — awaiting the "deliberate or
-  vestigial?" answer (open question 2).
+- Crashlytics (Android) stays — the developer confirmed it's deliberate
+  (open question 2 closed: keep).
+- Instrumentation landed: a `start reason: Importance/ImportanceReasonCode`
+  mark at the top of `CreateMauiApp`, an `Application.OnCreate completed`
+  mark, and `MauiStartupBreadcrumbs` now buffers marks and flushes them in
+  one append off the main thread (250ms debounce; rotation deferred off the
+  startup path too). No `WarmUpWebView` sub-marks — A2 took it off the push
+  path entirely.
 
 ## Summary
 

--- a/docs/plans/android-anr-issues.md
+++ b/docs/plans/android-anr-issues.md
@@ -1,7 +1,23 @@
 # Android ANRs — FCM cold-start stalls
 
-Status: **investigation complete, nothing implemented yet.** Data pulled from
-Play Console on 2026-08-25.
+Status: **A1–A4 implemented on `feat/android-anr-startup` (2026-08-25); A5/B1
+and the Crashlytics/Analytics decisions pending.** Data pulled from Play
+Console on 2026-08-25.
+
+Implementation notes (deviations from the plan below):
+
+- A4 preferred form (dropping the `Xamarin.AndroidX.Work.Runtime` package) is
+  impossible: `Xamarin.Google.AI.Edge.LiteRT` → `Play.AI.Delivery` →
+  `Play.Asset.Delivery` pulls it back transitively. Landed the fallback:
+  manifest `tools:node="remove"` for `WorkManagerInitializer` +
+  `MainApplication : Configuration.IProvider` for on-demand init. Verified
+  gone from the merged manifest; ProfileInstaller/ProcessLifecycle/EmojiCompat
+  initializers untouched.
+- A3 gates on API level only (`< 31`): during `Application.OnCreate` the FCM
+  exemption window isn't open yet even on a push start, and on API 31+ user
+  launches MainActivity raises the service moments later anyway.
+- Crashlytics (Android) is still referenced — awaiting the "deliberate or
+  vestigial?" answer (open question 2).
 
 ## Summary
 

--- a/src/dotnet/App.Maui/MauiProgram.cs
+++ b/src/dotnet/App.Maui/MauiProgram.cs
@@ -42,6 +42,9 @@ public static partial class MauiProgram
     {
         using var _1 = Tracer.MethodRegion();
         MauiStartupBreadcrumbs.Add("CreateMauiApp");
+#if ANDROID
+        MauiStartupBreadcrumbs.Add($"start reason: {AndroidUtils.GetProcessStartReason()}");
+#endif
 
         // Parse -t <seconds> for auto-shutdown (used for AOT testing)
         var args = Environment.GetCommandLineArgs();

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidManifest.xml
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidManifest.xml
@@ -22,6 +22,22 @@
     See https://developer.android.com/training/data-storage/shared/photopicker#device-availability for details.
     The service declaration below triggers Google Play services to install the backported photo picker module.
     -->
+    <!--
+    Nothing here schedules persistent work, yet WorkManager's androidx.startup initializer opens
+    its SQLite db and spins up four WM.task-* threads on every process start - including FCM
+    cold starts, where that contention shows up as ANRs. The package itself can't be dropped
+    (Xamarin.Google.AI.Edge.LiteRT pulls it transitively), so only the initializer is removed;
+    MainApplication implements Configuration.IProvider so an on-demand WorkManager.getInstance()
+    still initializes lazily instead of throwing.
+    -->
+    <provider
+      android:name="androidx.startup.InitializationProvider"
+      android:authorities="${applicationId}.androidx-startup"
+      tools:node="merge">
+      <meta-data
+        android:name="androidx.work.WorkManagerInitializer"
+        tools:node="remove" />
+    </provider>
     <service android:name="com.google.android.gms.metadata.ModuleDependencies"
              android:enabled="false"
              android:exported="false"

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
@@ -43,6 +43,21 @@ public static class AndroidUtils
         return false;
     }
 
+    public static string GetProcessStartReason()
+    {
+        // Importance separates a broadcast-started process from a user launch: an FCM wake reads
+        // as a receiver/cached importance, a user launch as Foreground (AMS marks the process
+        // top-bound at bind time, before any activity exists).
+        try {
+            var processInfo = new ActivityManager.RunningAppProcessInfo();
+            ActivityManager.GetMyMemoryState(processInfo);
+            return $"{processInfo.Importance}/{processInfo.ImportanceReasonCode}";
+        }
+        catch (System.Exception e) {
+            return e.GetType().Name;
+        }
+    }
+
     public static bool IsMainThread()
         => Looper.MainLooper!.IsCurrentThread;
 

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -75,6 +75,8 @@ public partial class MainActivity : MauiAppCompatActivity
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
+        WarmUpWebView();
+
         // Before base.OnCreate, which calls setContentView - the listener has to be registered
         // before that for the dismissal logic to see it.
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
@@ -305,6 +307,26 @@ public partial class MainActivity : MauiAppCompatActivity
              .SetMediaType(visualMediaType)
              .Build();
         _pickVisualMediaLauncher.Launch(pickVisualMediaRequest);
+    }
+
+    private static void WarmUpWebView()
+    {
+        // Without this the WebView provider is loaded on the UI thread inside performStart, right
+        // before BlazorAndroidWebView is constructed. GetDefaultUserAgent forces the same load and
+        // is safe off the UI thread, moving ~10ms off the critical path. Here rather than in
+        // MainApplication.OnCreate: a push-started process has no WebView coming, and the eager
+        // ThreadPool spin-up + JNI type-load only added lock contention to the FCM cold start.
+        // Nothing waits on this: Chromium's own provider lock already makes WebView construction
+        // block until the load finishes, and it posts its native init back to the UI thread - so
+        // blocking the UI thread on this task instead would deadlock.
+        _ = Task.Run(() => {
+            try {
+                _ = Android.Webkit.WebSettings.GetDefaultUserAgent(Platform.AppContext);
+            }
+            catch (Exception e) {
+                Android.Util.Log.Warn(MauiDiagnostics.LogTag, $"WebView warm-up failed: {e.Message}");
+            }
+        });
     }
 
     private void CloseHeadlessScope()

--- a/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
@@ -22,6 +22,9 @@ public sealed class MainApplication : MauiApplication, AndroidX.Work.Configurati
     public override void OnCreate()
     {
         base.OnCreate();
+        // The moment the main looper is free to dispatch the broadcast that may have started us;
+        // the delta from "CreateMauiApp completed" is pure MAUI framework overhead.
+        MauiStartupBreadcrumbs.Add("Application.OnCreate completed");
         // Any process start, not only a user launch. A message push starts us with no MainActivity
         // and no Blazor scope, so nothing else raises the armed service - leaving no PTT badge and
         // no media session for the headset button. Android 12+ bans foreground-service starts from

--- a/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
@@ -7,44 +7,31 @@ namespace ActualChat.App.Maui;
 #pragma warning disable // Can be static
 
 [Application]
-public class MainApplication : MauiApplication
+public sealed class MainApplication : MauiApplication, AndroidX.Work.Configuration.IProvider
 {
+    // On-demand WorkManager init: AndroidManifest.xml removes WorkManagerInitializer to keep its
+    // db + threads off the process-start path, and this keeps WorkManager.getInstance() working
+    // for the transitive dependencies that may still call it.
+    public AndroidX.Work.Configuration WorkManagerConfiguration
+        => new AndroidX.Work.Configuration.Builder().Build();
+
     public MainApplication(IntPtr handle, JniHandleOwnership ownership)
         : base(handle, ownership)
         => Android.Util.Log.Info(MauiDiagnostics.LogTag, "---- Started ----");
 
     public override void OnCreate()
     {
-        WarmUpWebView();
         base.OnCreate();
         // Any process start, not only a user launch. A message push starts us with no MainActivity
         // and no Blazor scope, so nothing else raises the armed service - leaving no PTT badge and
-        // no media session for the headset button. Android refuses a background start without an
-        // exemption; TryStart logs that rather than throwing.
-        if (MauiPreferences.IsPttArmed)
+        // no media session for the headset button. Android 12+ bans foreground-service starts from
+        // the background outright, so there the attempt is skipped: user launches raise the service
+        // in MainActivity while visible, and PTT wakes raise it inside the FCM exemption window.
+        // The API check goes first - IsPttArmed forces the synchronous SharedPreferences load.
+        if (!OperatingSystem.IsAndroidVersionAtLeast(31) && MauiPreferences.IsPttArmed)
             AndroidActivitiesForegroundService.TryStartArmed(this);
     }
 
     protected override MauiApp CreateMauiApp()
         => MauiProgram.CreateMauiApp();
-
-    // Private methods
-
-    private static void WarmUpWebView()
-    {
-        // Without this the WebView provider is loaded on the UI thread inside MainActivity's
-        // performStart, right before BlazorAndroidWebView is constructed. GetDefaultUserAgent
-        // forces the same load and is safe off the UI thread, moving ~10ms off the critical path.
-        // Nothing waits on this: Chromium's own provider lock already makes WebView construction
-        // block until the load finishes, and it posts its native init back to the UI thread - so
-        // blocking the UI thread on this task instead would deadlock.
-        _ = Task.Run(() => {
-            try {
-                _ = Android.Webkit.WebSettings.GetDefaultUserAgent(Android.App.Application.Context);
-            }
-            catch (Exception e) {
-                Android.Util.Log.Warn(MauiDiagnostics.LogTag, $"WebView warm-up failed: {e.Message}");
-            }
-        });
-    }
 }

--- a/src/dotnet/Maui/MauiStartupBreadcrumbs.cs
+++ b/src/dotnet/Maui/MauiStartupBreadcrumbs.cs
@@ -10,12 +10,17 @@ namespace ActualChat.Maui;
 public static class MauiStartupBreadcrumbs
 {
     private const int MaxPreviousLength = 2048;
+    private static readonly TimeSpan FlushDelay = TimeSpan.FromMilliseconds(250);
 
     private static readonly Lock WriteLock = new();
+    private static readonly List<string> PendingLines = new();
     private static CpuTimestamp _startedAt;
     private static FilePath _filePath;
     private static FilePath _previousFilePath;
-    private static volatile bool _isInitialized;
+    private static System.Threading.Timer? _flushTimer;
+    private static bool _isRotated;
+    // Publication guard for the fields Initialize sets; accessed via Volatile.Read/Write.
+    private static bool _isInitialized;
 
     public static void Initialize()
     {
@@ -29,25 +34,30 @@ public static class MauiStartupBreadcrumbs
             var cacheDir = (FilePath)FileSystem.CacheDirectory;
             _filePath = cacheDir & "startup-breadcrumbs.txt";
             _previousFilePath = cacheDir & "startup-breadcrumbs.prev.txt";
-            if (File.Exists(_filePath))
-                File.Move(_filePath, _previousFilePath, overwrite: true);
-            _isInitialized = true;
+            Volatile.Write(ref _isInitialized, true);
             Add("process started");
         }
         catch {
-            _isInitialized = false;
+            Volatile.Write(ref _isInitialized, false);
         }
     }
 
     public static void Add(string phase)
     {
-        if (!_isInitialized)
+        // Buffered: marks land on the startup path's main thread, where a synchronous append per
+        // mark would feed the very stalls the breadcrumbs exist to diagnose. A timer flushes each
+        // burst in one append; an ANR kill fires no earlier than 10s in, so nothing that matters
+        // is still pending by then.
+        if (!Volatile.Read(ref _isInitialized))
             return;
 
         try {
             var elapsed = CpuTimestamp.Now - _startedAt;
-            lock (WriteLock)
-                File.AppendAllText(_filePath, $"+{elapsed.TotalSeconds:F3}s {phase}\n");
+            lock (WriteLock) {
+                PendingLines.Add($"+{elapsed.TotalSeconds:F3}s {phase}\n");
+                _flushTimer ??= new System.Threading.Timer(
+                    _ => Flush(), null, FlushDelay, System.Threading.Timeout.InfiniteTimeSpan);
+            }
         }
         catch {
             // Intended: see Initialize
@@ -56,15 +66,52 @@ public static class MauiStartupBreadcrumbs
 
     public static string ReadPrevious()
     {
-        if (!_isInitialized || !File.Exists(_previousFilePath))
+        if (!Volatile.Read(ref _isInitialized))
             return "";
 
         try {
+            lock (WriteLock)
+                EnsureRotated();
+            if (!File.Exists(_previousFilePath))
+                return "";
+
             var text = File.ReadAllText(_previousFilePath);
             return text.Length <= MaxPreviousLength ? text : text[..MaxPreviousLength];
         }
         catch {
             return "";
         }
+    }
+
+    // Private methods
+
+    private static void Flush()
+    {
+        try {
+            lock (WriteLock) {
+                _flushTimer?.Dispose();
+                _flushTimer = null;
+                if (PendingLines.Count == 0)
+                    return;
+
+                EnsureRotated();
+                File.AppendAllText(_filePath, string.Concat(PendingLines));
+                PendingLines.Clear();
+            }
+        }
+        catch {
+            // Intended: see Initialize
+        }
+    }
+
+    private static void EnsureRotated()
+    {
+        // Deferred from Initialize to keep its file IO off the main thread too.
+        if (_isRotated)
+            return;
+
+        if (File.Exists(_filePath))
+            File.Move(_filePath, _previousFilePath, overwrite: true);
+        _isRotated = true;
     }
 }

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -184,7 +184,10 @@ public class FirebaseMessagingClient(
             Data = data,
             Android = new AndroidConfig {
                 Data = data,
-                Priority = Priority.High,
+                // Normal, not High: nothing here is worth waking the device out of Doze. High would
+                // cold-start a dead app on the 10s foreground-broadcast ANR budget and, being
+                // non-notifying, spend the high-priority allowance real notifications need.
+                Priority = Priority.Normal,
                 TimeToLive = TimeSpan.FromDays(1),
             },
             Apns = new ApnsConfig {


### PR DESCRIPTION
Implements steps A1–A4 plus the instrumentation from
[docs/plans/android-anr-issues.md](../blob/feat/android-anr-startup/docs/plans/android-anr-issues.md):
66% of our Android ANRs are an FCM push waking a dead process and
`Application.onCreate` missing the 10s foreground-broadcast budget on
A51-class devices.

- **A1** — the dismissal/badge push goes out at `Priority.Normal`: it's silent
  and non-urgent, yet it cold-started dead apps on the 10s clock and burned
  the high-priority allowance real notifications need.
- **A2** — `WarmUpWebView` moved from `MainApplication.OnCreate` (every
  process start) to `MainActivity.OnCreate`: on a push start no WebView is
  coming, and its eager ThreadPool/JIT/JNI work is the leading suspect for
  the runtime mutex the main thread blocks on in the top cluster's dump.
- **A3** — the armed-service start in `Application.OnCreate` is skipped on
  Android 12+ (40 of 67 CSV events), where a background FGS start is a
  guaranteed-failure binder round-trip; MainActivity and the PTT wake path
  (FCM exemption window) still raise it where it can succeed.
- **A4** — WorkManager's androidx.startup initializer is removed from the
  merged manifest (workdb SQLite + four `WM.task-*` threads on every process
  start, zero WorkManager use in our code). The package itself can't go —
  `Xamarin.Google.AI.Edge.LiteRT` pulls it transitively — so `MainApplication`
  implements `Configuration.IProvider` for lazy on-demand init instead.
  Verified in the merged manifest; ProfileInstaller/ProcessLifecycle/
  EmojiCompat initializers untouched.
- **Instrumentation** — a `start reason` (process importance) mark and an
  `Application.OnCreate completed` mark, and `MauiStartupBreadcrumbs` now
  buffers marks and flushes off the main thread (the old per-mark synchronous
  append fed the stalls it measured). One dev/beta cycle should show where
  the 10s actually goes before we commit to B1 (lazy idle-primed MauiApp).

Deliberate trade-off: on a dozing device the badge/dismissal update may now
arrive at the next maintenance window instead of immediately.

Crashlytics (Android) stays — confirmed deliberate. A5/B1 deferred until the
breadcrumb data is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mqjvfB5bQztHYqiSW4bak