### PR TITLE
fix(android-audio): keep playback on A2DP instead of grabbing the SCO channel

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
@@ -17,6 +17,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
     private readonly IAudioDeviceRouter _deviceRouter;
     private AudioFocusRequestClass? _focusRequest;
     private bool _hasFocus;
+    private bool _isCommunicationFocus;
     private bool _isCommunicationModeYielded;
 
     public event Action<AudioFocus>? OnFocusChanged;
@@ -49,13 +50,14 @@ public sealed class AndroidAudioFocusHelper : IDisposable
     }
 
     public Task<bool> RequestFocusForCall()
-        => RequestFocusAsync(AudioFocus.GainTransient, AudioUsageKind.VoiceCommunication, AudioContentType.Speech);
+        => RequestFocus(AudioFocus.GainTransient, AudioUsageKind.VoiceCommunication, AudioContentType.Speech);
 
     public Task<bool> RequestFocusForPlayback()
-        => RequestFocusAsync(AudioFocus.Gain, AudioUsageKind.VoiceCommunication, AudioContentType.Speech);
+        // Playback needs no microphone, and the communication route drops a BT peer to SCO - a virtual call.
+        => RequestFocus(AudioFocus.Gain, AudioUsageKind.Media, AudioContentType.Speech);
 
     public Task<bool> RequestFocusForNotification()
-        => RequestFocusAsync(
+        => RequestFocus(
             AudioFocus.GainTransientMayDuck,
             AudioUsageKind.AssistanceSonification,
             AudioContentType.Sonification);
@@ -90,8 +92,9 @@ public sealed class AndroidAudioFocusHelper : IDisposable
             _audioManager.Mode = Mode.Normal;
             _log.LogInformation("WarmUpAudioMode: reverted to Normal");
         }
-        else
+        else {
             _log.LogInformation("WarmUpAudioMode: keeping InCommunication (real focus acquired)");
+        }
     }
 
     public Task EnsureCommunicationRoute(CancellationToken cancellationToken)
@@ -99,8 +102,8 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         // every ~6s for as long as a focus holder stays idle, and answering each one turned into a
         // permanent re-assert loop (13 in 100s, measured). Asserting only when audio is about to
         // play fixes the route where it matters and leaves an idle armed session alone.
-        => _hasFocus
-            ? _deviceRouter.SetCommunicationDeviceAsync(cancellationToken)
+        => _isCommunicationFocus
+            ? _deviceRouter.SelectCommunicationDevice(cancellationToken)
             : Task.FromResult(false);
 
     public void YieldCommunicationMode()
@@ -127,7 +130,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
 
         _log.LogInformation("Restoring the communication mode after the incoming ring");
         _audioManager.Mode = Mode.InCommunication;
-        await _deviceRouter.SetCommunicationDeviceAsync(CancellationToken.None).ConfigureAwait(false);
+        await _deviceRouter.SelectCommunicationDevice(CancellationToken.None).ConfigureAwait(false);
     }
 
     public void AbandonFocus()
@@ -140,6 +143,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         _audioManager.AbandonAudioFocusRequest(_focusRequest);
         _audioManager.Mode = Mode.Normal;
         _hasFocus = false;
+        _isCommunicationFocus = false;
     }
 
     // Private methods
@@ -157,7 +161,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         return new LegacyAudioDeviceRouter(audioManager, context, log);
     }
 
-    private async Task<bool> RequestFocusAsync(
+    private async Task<bool> RequestFocus(
         AudioFocus audioFocus,
         AudioUsageKind audioUsageKind,
         AudioContentType audioContentType)
@@ -183,11 +187,12 @@ public sealed class AndroidAudioFocusHelper : IDisposable
 
         var result = _audioManager.RequestAudioFocus(_focusRequest);
         _hasFocus = result == AudioFocusRequest.Granted;
+        _isCommunicationFocus = _hasFocus && isCommunication;
         _log.LogInformation("Requested audio focus for '{Usage}', granted = {Result}", audioUsageKind, _hasFocus);
 
         // After gaining focus, apply routing preference (handles external devices like Bluetooth)
         if (_hasFocus && isCommunication)
-            await _deviceRouter.SetCommunicationDeviceAsync(CancellationToken.None).ConfigureAwait(false);
+            await _deviceRouter.SelectCommunicationDevice(CancellationToken.None).ConfigureAwait(false);
 
         return _hasFocus;
     }
@@ -206,13 +211,13 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         // Re-route audio if we have active focus in communication mode
         // This handles: BT connected mid-recording, BT disconnected, etc.
         if (_hasFocus && _audioManager.Mode == Mode.InCommunication)
-            _ = HandleDevicesChangedAsync();
+            _ = HandleDevicesChanged();
     }
 
-    private async Task HandleDevicesChangedAsync()
+    private async Task HandleDevicesChanged()
     {
         try {
-            await _deviceRouter.OnDevicesChangedAsync(CancellationToken.None).ConfigureAwait(false);
+            await _deviceRouter.OnDevicesChanged(CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception e) {
             _log.LogWarning(e, "Failed to re-route audio after device change");
@@ -243,9 +248,9 @@ public sealed class AndroidAudioFocusHelper : IDisposable
     private interface IAudioDeviceRouter : IDisposable
     {
         // Completes only once the route has actually landed, not when it's requested.
-        Task<bool> SetCommunicationDeviceAsync(CancellationToken ct);
+        Task<bool> SelectCommunicationDevice(CancellationToken ct);
         void ClearCommunicationDevice();
-        Task OnDevicesChangedAsync(CancellationToken ct);
+        Task OnDevicesChanged(CancellationToken ct);
     }
 
     private sealed class ModernAudioDeviceRouter : IAudioDeviceRouter
@@ -270,7 +275,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
                 _listener);
         }
 
-        public async Task<bool> SetCommunicationDeviceAsync(CancellationToken ct)
+        public async Task<bool> SelectCommunicationDevice(CancellationToken ct)
         {
             try {
                 var devices = _audioManager.AvailableCommunicationDevices;
@@ -328,9 +333,9 @@ public sealed class AndroidAudioFocusHelper : IDisposable
             }
         }
 
-        public Task OnDevicesChangedAsync(CancellationToken ct)
+        public Task OnDevicesChanged(CancellationToken ct)
             // Modern API: just re-select best device when devices change
-            => SetCommunicationDeviceAsync(ct);
+            => SelectCommunicationDevice(ct);
 
         public void Dispose()
         {
@@ -382,7 +387,7 @@ public sealed class AndroidAudioFocusHelper : IDisposable
             _context.RegisterReceiver(_scoReceiver, filter);
         }
 
-        public async Task<bool> SetCommunicationDeviceAsync(CancellationToken ct)
+        public async Task<bool> SelectCommunicationDevice(CancellationToken ct)
         {
             try {
                 var devices = _audioManager.GetDevices(GetDevicesTargets.Outputs) ?? [];
@@ -468,10 +473,10 @@ public sealed class AndroidAudioFocusHelper : IDisposable
             }
         }
 
-        public Task OnDevicesChangedAsync(CancellationToken ct)
+        public Task OnDevicesChanged(CancellationToken ct)
             // Legacy API: re-apply routing when devices change
             // This handles BT connecting mid-recording
-            => SetCommunicationDeviceAsync(ct);
+            => SelectCommunicationDevice(ct);
 
         public void Dispose()
         {

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
@@ -70,8 +70,12 @@ internal sealed class AndroidAudioPlaybackEngine(
         var bufferBytes = Math.Max(minBufferBytes, Constants.Audio.PcmFrameLength * 4);
         AudioTrack audioTrack;
         try {
+            // Media keeps a Bluetooth peer on A2DP; only a live capture session needs the SCO route.
+            var usage = AudioFocusUI.ActiveMode >= AudioFocusMode.Recording
+                ? AudioUsageKind.VoiceCommunication
+                : AudioUsageKind.Media;
             var attributes = new AudioAttributes.Builder()
-                .SetUsage(AudioUsageKind.VoiceCommunication)!
+                .SetUsage(usage)!
                 .SetContentType(AudioContentType.Speech)!
                 .Build();
 

--- a/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
@@ -6,13 +6,14 @@ namespace ActualChat.App.Maui.Services;
 
 public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 {
-    private readonly List<AudioFocusRestoreHandler> _restoreAudioFocusHandlers = new ();
+    private readonly List<AudioFocusRestoreHandler> _restoreAudioFocusHandlers = new();
     private AudioFocusHolder? _lastAudioFocusHolder;
 
     protected readonly AsyncLock OperationLock = new();
 
     protected AppUIHub Hub { get; } = hub;
     protected ILogger Log => field ??= Hub.LogFor(GetType());
+    public override AudioFocusMode ActiveMode => _lastAudioFocusHolder?.Mode ?? AudioFocusMode.Tune;
 
     public override async Task<AudioFocusScope?> TryAcquire(AudioFocusRequester requester)
     {
@@ -65,6 +66,14 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 
     protected abstract Task<MauiAudioFocusHandle?> RequestAudioFocus(AudioFocusMode mode);
 
+    protected virtual AudioFocusMode CalculateAudioFocusMode(IReadOnlyCollection<AudioFocusRequester> requesters)
+    {
+        if (requesters.Count == 0)
+            throw new ArgumentException("No requesters provided", nameof(requesters));
+
+        return requesters.Select(c => c.Kind).Max();
+    }
+
     // Private methods
 
     private async Task ReleaseAudioFocus(AudioFocusRequester requester)
@@ -93,7 +102,7 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 
     private async Task<AudioFocusHolder?> RenewAudioFocus(AudioFocusRequester? requester)
     {
-        AudioFocusHolder? temp = _lastAudioFocusHolder;
+        var temp = _lastAudioFocusHolder;
         if (temp is null && requester is null)
             return null;
 
@@ -149,37 +158,33 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
         }
     }
 
-    private AudioFocusMode CalculateAudioFocusMode(IReadOnlyCollection<AudioFocusRequester>? requesters, AudioFocusRequester? newRequester)
+    private AudioFocusMode CalculateAudioFocusMode(
+        IReadOnlyCollection<AudioFocusRequester>? requesters,
+        AudioFocusRequester? newRequester)
     {
         var list = new List<AudioFocusRequester>();
         if (requesters is not null)
             list.AddRange(requesters);
         if (newRequester is not null)
             list.Add(newRequester.Value);
+
         return CalculateAudioFocusMode(list);
-    }
-
-    protected virtual AudioFocusMode CalculateAudioFocusMode(IReadOnlyCollection<AudioFocusRequester> requesters)
-    {
-        if (requesters.Count == 0)
-            throw new ArgumentException("No requesters provided", nameof(requesters));
-
-        return requesters.Select(c => c.Kind).Max();
     }
 
     private bool FocusModeHasChanged(AudioFocusHolder audioFocusHolder, AudioFocusRequester requester)
     {
         var mode1 = CalculateAudioFocusMode(audioFocusHolder.Scopes.Keys);
         var mode2 = CalculateAudioFocusMode(audioFocusHolder.Scopes.Keys, requester);
+
         return mode1 != mode2;
     }
 
     // Nested types
 
-    private class AudioFocusHolder(AudioFocusMode mode, MauiAudioFocusHandle handle)
+    private sealed class AudioFocusHolder(AudioFocusMode mode, MauiAudioFocusHandle handle)
     {
         public AudioFocusMode Mode => mode;
-        public bool IsSuspended { get; private set;}
+        public bool IsSuspended { get; private set; }
         public MauiAudioFocusHandle Handle => handle;
         public Dictionary<AudioFocusRequester, Scope> Scopes { get; } = new();
 
@@ -187,7 +192,7 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
             => IsSuspended = isSuspended;
     }
 
-    private class Scope(MauiAudioFocusUI owner, AudioFocusRequester requester) : AudioFocusScope
+    private sealed class Scope(MauiAudioFocusUI owner, AudioFocusRequester requester) : AudioFocusScope
     {
         public override void Dispose()
             => _ = owner.ReleaseAudioFocus(requester);

--- a/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
@@ -39,6 +39,8 @@ public abstract class AudioFocusScope : IDisposable
 /// </summary>
 public class AudioFocusUI : ProcessorBase
 {
+    public virtual AudioFocusMode ActiveMode => AudioFocusMode.Tune;
+
     public virtual Task<AudioFocusScope?> TryAcquire(AudioFocusRequester requester)
         => Task.FromResult<AudioFocusScope?>(FakeScope.Instance);
 


### PR DESCRIPTION
## Problem

A user reported that on Android Auto the car display swaps navigation for the
contacts screen whenever they use Voxt, and that the first recording swallows
the audio. He diagnosed it correctly himself: *"aprieto para hablar y ya me saca
el GPS, yo entro en modo llamada, como si fuese una llamada, la API de llamada"*.

We do enter call mode. Listening and replay asked for `USAGE_VOICE_COMMUNICATION`,
which put the platform into `MODE_IN_COMMUNICATION` and made the device router
select `BluetoothSco`. Opening SCO outside a real call is an HFP virtual call:
the head unit sees a call and brings its phone UI up over navigation.

It is also wrong on its own terms — it tears a Bluetooth peer off A2DP onto
narrowband mono for audio that needs no microphone at all.

## Fix

Playback requests `USAGE_MEDIA`, so `isCommunication` is false and neither the
audio mode nor the communication device is touched.

Two things were needed to make that stick:

- `EnsureCommunicationRoute` is gated on a new `_isCommunicationFocus` rather
  than `_hasFocus`. It runs from `AndroidAudioPlaybackEngine.Play` and would
  otherwise have re-acquired SCO regardless.
- The `AudioTrack` picks its usage from the new `AudioFocusUI.ActiveMode` —
  track attributes are what actually decide output routing, so leaving them at
  `VOICE_COMMUNICATION` would have kept playback on the voice path.

## Recording is unaffected

`CalculateAudioFocusMode` returns the max over active scopes, and
`AudioFocusMode` is `{ Tune, Playback, Recording }`. Listening while recording
therefore still resolves to `Recording`, which keeps the communication route and
its hardware echo canceller. The `Playback` branch never runs in the duplex case.

## Verified on device

Xiaomi 2406APNFAG, Android 16, paired headset with both channels available
(`outputs=[BuiltinEarpiece, BuiltinSpeaker, BluetoothSco, BluetoothA2dp, Telephony]`)
— the old code would have picked `BluetoothSco` here:

- replay no longer raises SCO and plays over `bt_a2dp`;
- recording still raises SCO and captures from the first window
  (`audio-capture: first audio`), no `digital silence`, no route-settle warnings;
- after a recording stops SCO drops and no longer comes back — previously the
  post-recording `Playback` scope re-opened it.

For reference, Telegram splits the same way: voice messages go through
`MediaController` with `USAGE_MEDIA`, `MODE_NORMAL` and the built-in mic, while
calls go through `VoIPService` with `USAGE_VOICE_COMMUNICATION`,
`MODE_IN_COMMUNICATION` and the headset mic over SCO.

## Not covered here

The recording side still takes SCO, which is correct for a headset but not for a
car — the remaining work is a car-specific path, plus the router's speaker
fallback and the 300 ms route-settle budget. The reporter's "first recording is
silent" symptom does not reproduce on a headset and still needs a log from the car.

🤖 Generated with [Claude Code](https://claude.com/claude-code)