### PR TITLE
fix(users): say why no channel delivered the verification code

### DIFF
--- a/src/dotnet/Users.Service/Phone/Internal/CompositeVerificationCodeSender.cs
+++ b/src/dotnet/Users.Service/Phone/Internal/CompositeVerificationCodeSender.cs
@@ -39,17 +39,31 @@ public sealed class CompositeVerificationCodeSender(IServiceProvider services) :
     {
         // The prefix must be checked before calling Telegram.Send: a positive checkSendAbility is billed,
         // so a matching prefix has to skip the call entirely, not just discard its result.
-        if (Telegram is null || IsTelegramSkipped(phone)) {
+        if (Telegram is null) {
+            SkipChannel(TotpChannel.Telegram, phone, "unconfigured");
+
+            throw NoChannelLeft(phone, "the Telegram channel isn't configured");
+        }
+        if (IsTelegramSkipped(phone)) {
             SkipChannel(TotpChannel.Telegram, phone, "prefix");
 
-            throw Errors.DeliveryFailed();
+            throw NoChannelLeft(phone, "the number matches SkipTelegramPhonePrefixes");
         }
 
         var channel = await TrySend(Telegram, TotpChannel.Telegram, phone, message).ConfigureAwait(false);
         if (channel is null)
-            throw Errors.DeliveryFailed();
+            throw NoChannelLeft(phone, "Telegram couldn't deliver it either");
 
         return channel.Value;
+    }
+
+    private Exception NoChannelLeft(ActualChat.Phone phone, string reason)
+    {
+        Log.LogError(
+            "No channel delivered a verification code to {Phone}: {Reason}",
+            phone.E164Value.ToPrivate(), reason);
+
+        return Errors.DeliveryFailed();
     }
 
     private bool IsTelegramSkipped(ActualChat.Phone phone)

--- a/tests/Users.UnitTests/Phone/CompositeVerificationCodeSenderTest.cs
+++ b/tests/Users.UnitTests/Phone/CompositeVerificationCodeSenderTest.cs
@@ -265,6 +265,26 @@ public class CompositeVerificationCodeSenderTest
     }
 
     [Fact]
+    public async Task ShouldTagTelegramSkippedWithUnconfiguredReasonWhenItIsMissing()
+    {
+        // arrange
+        var measurements = Collect();
+        using var listener = StartListener(measurements);
+        var twilio = new FakeSender(null);
+        var sender = CreateSender(null, null, twilio);
+
+        // act
+        var send = () => sender.Send(ArmenianPhone, TestMessage);
+
+        // assert
+        await send.Should().ThrowAsync<ExternalError>();
+        measurements.Should().Contain(m
+                => m.Name == "app.verification_code.channel_skipped"
+                    && m.Channel == "Telegram" && m.Reason == "unconfigured",
+            "a missing channel and a deliberately skipped one are different operational problems");
+    }
+
+    [Fact]
     public async Task ShouldTagTelegramSkippedWithPrefixReasonWhenSkipRuleFires()
     {
         // arrange


### PR DESCRIPTION
A failed send left nothing in the log. CompositeVerificationCodeSender threw Errors.DeliveryFailed() after recording a metric and no more, so a dev incident where SMS.to answered 412 "Invalid API Key or Token" read as the SMS provider failing and then silence - nothing said why the Telegram fallback hadn't rescued it. Every dead end now logs one line naming the phone (scrubbed) and the reason the cascade ran out of channels.

The same branch also tagged "Telegram isn't configured" as reason=prefix, which sends anyone reading the metric looking for a SkipTelegramPhonePrefixes rule that doesn't exist. The two cases are now told apart as unconfigured and prefix, matching what the SMS leg already does.