### PR TITLE
fix: Restore the chat footer that slid off-screen

### DIFF
--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -268,6 +268,9 @@ h1.section:nth-child(1), h2.section:nth-child(1), h3.section:nth-child(1), h4.se
    mid-close slides the whole layout sideways with nothing to scroll it back. clip cannot scroll. */
 .base-layout-body > .c-layout-content {
     @apply flex-1;
+    /* Explicit, because `overflow: clip` is not a scroll container: a flex item's automatic
+       minimum size is only zero for one of those, and `overflow-hidden` used to supply that. */
+    @apply min-h-0;
     overflow: clip;
     @apply bg-01;
 }


### PR DESCRIPTION
## Symptom

On a wide screen the chat footer — message editor, record button, voice settings — is not on screen. The chat content runs to the bottom edge and the whole footer sits below the fold.

## Cause

`.base-layout-body > .c-layout-content` is a flex item of a **column** container. Its height floor comes from `min-height: auto`, which resolves to zero **only for a scroll container**.

`overflow-hidden` made it one. `eea3eb8e1b` ("fix(ui): make the UI fit long translations") swapped that for `overflow: clip` — deliberately, and for a good reason: `hidden` left the box programmatically scrollable sideways, so one `focus()` inside a closing side panel slid the whole layout across with nothing to scroll it back. But `clip` is not a scroll container, so the automatic minimum came back, the item stopped shrinking, and the layout grew past the viewport.

## Fix

```css
.base-layout-body > .c-layout-content {
    @apply flex-1;
    @apply min-h-0;      /* ← states the floor outright */
    overflow: clip;
    @apply bg-01;
}
```

One line. It does nothing to the horizontal behaviour `eea3eb8e1b` was protecting — `overflow: clip` stays, so the box still cannot scroll sideways.

## Measurements

With the right panel open, its rigid `.c-top-region` (308px, `flex: 0 0 auto`) plus the panel content came to **1205px against a 945px viewport**, putting the message editor at y=1205 — 260px below the fold. Hiding `.side-nav-right` alone collapsed it back to 945, which is what identified the trigger.

| | `.c-layout-content` | editor bottom | footer visible |
|---|---|---|---|
| before | 1205px | 1205 | ❌ |
| after | 945px | 945 | ✅ |

Verified with the browser window **inside the screen bounds** (outer 1513×933 vs available 1920×1032), so the overflow is not an artifact of a window larger than the display — the first measurements were taken with an oversized window and were re-run once that was corrected.

Reproduced on plain `dev` before any of my other work was in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUB6VAFPEF2SHE2ds3RN4i