### PR TITLE
fix(rpc): measure endpoints up front instead of waiting for failure

### DIFF
--- a/src/dotnet/Api.Contracts/Module/RpcServerProbe.cs
+++ b/src/dotnet/Api.Contracts/Module/RpcServerProbe.cs
@@ -12,15 +12,13 @@ public sealed class RpcServerProbe(IServiceProvider services)
 {
     private const string ProbePath = "/rpc/check";
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(3);
-
     private HttpClient? _httpClient;
-
-    // Assumed until a server answers without honoring "size", i.e. predates the sized probe.
-    public bool IsSizedProbeSupported { get; private set; } = true;
     private IServiceProvider Services { get; } = services;
     private UrlMapper UrlMapper => field ??= Services.UrlMapper();
     private ILogger Log => field ??= Services.LogFor(GetType());
-
+    // False while a server answers without honoring "size" - it predates the sized probe, or
+    // this client has no session yet to be served one. Both can resolve, so this can go back.
+    public bool IsSizedProbeSupported { get; private set; } = true;
     public async Task<bool> IsServerReachable(CancellationToken cancellationToken)
     {
         var url = UrlMapper.BaseUrl.TrimSuffix("/") + ProbePath;
@@ -56,6 +54,7 @@ public sealed class RpcServerProbe(IServiceProvider services)
             var payload = await httpClient.GetByteArrayAsync(url, cts.Token).ConfigureAwait(false);
             var elapsed = CpuTimestamp.Now - startedAt;
             if (payload.Length >= size) {
+                IsSizedProbeSupported = true;
                 Log.LogInformation("RPC transfer probe to {Host}: {Size} bytes in {Elapsed}",
                     host, payload.Length, elapsed.ToShortString());
                 return elapsed;
@@ -71,6 +70,35 @@ public sealed class RpcServerProbe(IServiceProvider services)
         catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
             Log.LogWarning(e, "RPC transfer probe to {Host}: FAILED after {Elapsed}",
                 host, (CpuTimestamp.Now - startedAt).ToShortString());
+            return null;
+        }
+    }
+
+    public async Task<TimeSpan?> MeasureRoundTrip(
+        string host,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        // The unsized reply is 2 bytes, which crosses even a fully capped link, so this
+        // times distance rather than bandwidth - the one ranks candidates, the other vets them.
+        var url = RpcEndpointSelector.WithHost(UrlMapper.BaseUrl.TrimSuffix("/"), host) + ProbePath;
+        var httpClient = _httpClient ??= CreateHttpClient();
+        var startedAt = CpuTimestamp.Now;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+        try {
+            using var response = await httpClient.GetAsync(url, cts.Token).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                Log.LogWarning("RPC round-trip probe to {Host}: {StatusCode}", host, (int)response.StatusCode);
+                return null;
+            }
+
+            var elapsed = CpuTimestamp.Now - startedAt;
+            Log.LogInformation("RPC round-trip probe to {Host}: {Elapsed}", host, elapsed.ToShortString());
+            return elapsed;
+        }
+        catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+            Log.LogWarning(e, "RPC round-trip probe to {Host}: FAILED", host);
             return null;
         }
     }

--- a/src/dotnet/Api.Contracts/Module/RpcServerProbe.cs
+++ b/src/dotnet/Api.Contracts/Module/RpcServerProbe.cs
@@ -1,10 +1,12 @@
+using ActualChat.Rpc;
 using ActualLab.Rpc.Clients;
 
 namespace ActualChat.Module;
 
 /// <summary>
 /// Probes the server over plain HTTP to tell "the server is unreachable"
-/// apart from "this RPC transport is broken".
+/// apart from "this RPC transport is broken", and to measure what a given
+/// host can actually carry.
 /// </summary>
 public sealed class RpcServerProbe(IServiceProvider services)
 {
@@ -13,6 +15,8 @@ public sealed class RpcServerProbe(IServiceProvider services)
 
     private HttpClient? _httpClient;
 
+    // Assumed until a server answers without honoring "size", i.e. predates the sized probe.
+    public bool IsSizedProbeSupported { get; private set; } = true;
     private IServiceProvider Services { get; } = services;
     private UrlMapper UrlMapper => field ??= Services.UrlMapper();
     private ILogger Log => field ??= Services.LogFor(GetType());
@@ -33,6 +37,41 @@ public sealed class RpcServerProbe(IServiceProvider services)
         catch (Exception e) {
             Log.LogWarning(e, "RPC probe to {Url}: FAILED", url);
             return false;
+        }
+    }
+
+    public async Task<TimeSpan?> MeasureTransfer(
+        string host,
+        int size,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = RpcEndpointSelector.WithHost(UrlMapper.BaseUrl.TrimSuffix("/"), host);
+        var url = $"{baseUrl}{ProbePath}?size={size}";
+        var httpClient = _httpClient ??= CreateHttpClient();
+        var startedAt = CpuTimestamp.Now;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+        try {
+            var payload = await httpClient.GetByteArrayAsync(url, cts.Token).ConfigureAwait(false);
+            var elapsed = CpuTimestamp.Now - startedAt;
+            if (payload.Length >= size) {
+                Log.LogInformation("RPC transfer probe to {Host}: {Size} bytes in {Elapsed}",
+                    host, payload.Length, elapsed.ToShortString());
+                return elapsed;
+            }
+
+            // A server predating the "size" parameter answers "ok", which proves reachability
+            // but says nothing about throughput - the only thing this probe is for.
+            IsSizedProbeSupported = false;
+            Log.LogWarning("RPC transfer probe to {Host}: {Size} of {ExpectedSize} bytes",
+                host, payload.Length, size);
+            return null;
+        }
+        catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+            Log.LogWarning(e, "RPC transfer probe to {Host}: FAILED after {Elapsed}",
+                host, (CpuTimestamp.Now - startedAt).ToShortString());
+            return null;
         }
     }
 

--- a/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiConnectivityUI.cs
@@ -29,14 +29,15 @@ public sealed class MauiConnectivityUI : ConnectivityUI
 
     private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
     {
-        // A different network is unproven, and it may well be unrestricted, so we always
-        // go back to the origin and let the connection quality demote us again if needed.
+        // A different network makes every earlier verdict meaningless, so the endpoints get
+        // re-measured. The current one is kept until that finishes: dropping to an unproven
+        // origin costs a reconnect, and strands the app there when the origin is the bad one.
         var profiles = e.ConnectionProfiles.ToDelimitedString();
         if (profiles != _connectionProfiles) {
             _connectionProfiles = profiles;
             if (RpcEndpointSelector.Instance is { } endpointSelector) {
-                endpointSelector.UseDirect();
-                Log.LogInformation("Network changed to {Profiles}, RPC endpoint reset to the origin", profiles);
+                endpointSelector.Invalidate();
+                Log.LogInformation("Network changed to {Profiles}, RPC endpoints will be re-measured", profiles);
             }
         }
         _isOnline.Value = e.NetworkAccess.IsOnline();

--- a/src/dotnet/App.Server/Module/AppServerModule.cs
+++ b/src/dotnet/App.Server/Module/AppServerModule.cs
@@ -50,6 +50,9 @@ namespace ActualChat.App.Server.Module;
 public sealed class AppServerModule(IServiceProvider moduleServices)
     : HostModule<HostSettings>(moduleServices), IWebServerModule
 {
+    // Incompressible, so what a probe measures is the link rather than the compressor, and
+    // built once because the alternative is a CSPRNG run per request on a public route.
+    private static readonly byte[] ProbePayload = RandomNumberGenerator.GetBytes(256 * 1024);
     public IWebHostEnvironment Env => field ??= ModuleServices.GetRequiredService<IWebHostEnvironment>();
 
     public void ConfigureApp(WebApplication app)
@@ -158,15 +161,17 @@ public sealed class AppServerModule(IServiceProvider moduleServices)
         }
         app.MapRpcWebSocketServer();
         app.MapRpcHttpServer();
-        app.MapGet("/rpc/check", (int? size, HttpResponse response) => {
+        app.MapGet("/rpc/check", (int? size, HttpContext httpContext) => {
             // "size" makes this a throughput probe rather than a reachability one: some
             // networks let a connection's first few KB through and cap it after that, so
-            // only a payload larger than that allowance tells the two apart. Random bytes
-            // because a compressible one would arrive as a fraction of its size.
-            response.Headers.CacheControl = "no-store";
-            return size is not { } byteCount
-                ? Results.Text("ok")
-                : Results.Bytes(RandomNumberGenerator.GetBytes(Math.Clamp(byteCount, 1024, 256 * 1024)));
+            // only a payload larger than that allowance tells the two apart. It answers
+            // that to clients only - the bare "ok" has to stay open, because it's what
+            // RpcSwitchingClient falls back to exactly when RPC itself can't get through.
+            httpContext.Response.Headers.CacheControl = "no-store";
+            if (size is not { } byteCount || httpContext.TryGetSessionFromHeader() is null)
+                return Results.Text("ok");
+
+            return Results.Bytes(ProbePayload.AsMemory(0, Math.Clamp(byteCount, 1024, ProbePayload.Length)));
         });
         if (HostInfo.HasRole(HostRole.Api)) {
             app.MapFusionAuthEndpoints(); // /signIn, /signOut

--- a/src/dotnet/App.Server/Module/AppServerModule.cs
+++ b/src/dotnet/App.Server/Module/AppServerModule.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Security.Cryptography;
 using ActualChat.App.Server.Components.Pages;
 using ActualChat.App.Server.Flows;
 using ActualChat.App.Server.Health;
@@ -157,7 +158,16 @@ public sealed class AppServerModule(IServiceProvider moduleServices)
         }
         app.MapRpcWebSocketServer();
         app.MapRpcHttpServer();
-        app.MapGet("/rpc/check", () => Results.Text("ok"));
+        app.MapGet("/rpc/check", (int? size, HttpResponse response) => {
+            // "size" makes this a throughput probe rather than a reachability one: some
+            // networks let a connection's first few KB through and cap it after that, so
+            // only a payload larger than that allowance tells the two apart. Random bytes
+            // because a compressible one would arrive as a fraction of its size.
+            response.Headers.CacheControl = "no-store";
+            return size is not { } byteCount
+                ? Results.Text("ok")
+                : Results.Bytes(RandomNumberGenerator.GetBytes(Math.Clamp(byteCount, 1024, 256 * 1024)));
+        });
         if (HostInfo.HasRole(HostRole.Api)) {
             app.MapFusionAuthEndpoints(); // /signIn, /signOut
             app.MapFusionRenderModeEndpoints(); // /fusion/renderMode

--- a/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
+++ b/src/dotnet/Core/Rpc/RpcEndpointSelector.cs
@@ -12,12 +12,13 @@ public class RpcEndpointSelector
     private string _current;
     private int _version;
 
+    public IReadOnlyList<string> Candidates => _candidates;
     public string OriginHost => _candidates[0];
     public string Current => Volatile.Read(ref _current);
     public bool IsOnOrigin => string.Equals(Current, OriginHost, StringComparison.OrdinalIgnoreCase);
     public int Version
-        // Bumped whenever the selection is re-evaluated, including a reset that picks the
-        // same endpoint again - a new network makes an old verdict meaningless.
+        // Bumped only when a new network makes every earlier verdict meaningless. Moving
+        // between endpoints doesn't bump it, so a fresh move isn't mistaken for a reset.
         => Volatile.Read(ref _version);
 
     public RpcEndpointSelector(string[] candidates, string? current = null)
@@ -34,15 +35,26 @@ public class RpcEndpointSelector
     public string Get(string host)
         => string.Equals(host, OriginHost, StringComparison.OrdinalIgnoreCase) ? Current : host;
 
+    public void Invalidate()
+        => Interlocked.Increment(ref _version);
+
     public void UseDirect()
     {
         Interlocked.Increment(ref _version);
         Set(OriginHost);
     }
 
+    public bool Use(string endpoint)
+    {
+        if (!_candidates.Contains(endpoint, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        Set(endpoint);
+        return true;
+    }
+
     public bool MoveNext()
     {
-        Interlocked.Increment(ref _version);
         var index = Array.FindIndex(_candidates,
             x => string.Equals(x, Current, StringComparison.OrdinalIgnoreCase));
         var nextIndex = index + 1;
@@ -55,18 +67,12 @@ public class RpcEndpointSelector
 
     public static string ApplyTo(string baseUrl)
     {
-        // Scheme, port, path and query are preserved - only the host moves.
         if (Instance is not { } instance)
             return baseUrl;
 
-        var schemeEnd = baseUrl.IndexOf("://");
-        if (schemeEnd < 0)
+        var (hostStart, hostEnd) = GetHostRange(baseUrl);
+        if (hostStart < 0)
             return baseUrl;
-
-        var hostStart = schemeEnd + 3;
-        var hostEnd = baseUrl.IndexOfAny(['/', ':', '?'], hostStart);
-        if (hostEnd < 0)
-            hostEnd = baseUrl.Length;
 
         var host = baseUrl[hostStart..hostEnd];
         var endpoint = instance.Get(host);
@@ -75,11 +81,31 @@ public class RpcEndpointSelector
             : string.Concat(baseUrl.AsSpan(0, hostStart), endpoint, baseUrl.AsSpan(hostEnd));
     }
 
+    public static string WithHost(string baseUrl, string host)
+    {
+        var (hostStart, hostEnd) = GetHostRange(baseUrl);
+        return hostStart < 0
+            ? baseUrl
+            : string.Concat(baseUrl.AsSpan(0, hostStart), host, baseUrl.AsSpan(hostEnd));
+    }
+
     // Protected/internal methods
 
     protected virtual void OnChanged(string endpoint) { }
 
     // Private methods
+
+    private static (int Start, int End) GetHostRange(string baseUrl)
+    {
+        // Scheme, port, path and query are preserved - only the host moves.
+        var schemeEnd = baseUrl.IndexOf("://");
+        if (schemeEnd < 0)
+            return (-1, -1);
+
+        var hostStart = schemeEnd + 3;
+        var hostEnd = baseUrl.IndexOfAny(['/', ':', '?'], hostStart);
+        return (hostStart, hostEnd < 0 ? baseUrl.Length : hostEnd);
+    }
 
     private void Set(string endpoint)
     {

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -1,3 +1,4 @@
+using ActualChat.Module;
 using ActualChat.Rpc;
 using ActualChat.UI.Blazor.Module;
 using ActualChat.Users;
@@ -7,37 +8,47 @@ using ActualLab.Rpc;
 namespace ActualChat.UI.Blazor.Services;
 
 /// <summary>
-/// Moves the client to the next RPC endpoint when the current one connects but
-/// cannot carry traffic — the failure mode <see cref="RpcPeerState"/> can't see.
+/// Keeps the client on an RPC endpoint that can actually carry traffic — the failure
+/// mode <see cref="RpcPeerState"/> can't see. It picks one up front by measuring the
+/// candidates, and demotes one that degrades later.
 /// </summary>
 public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
 {
     // Must exceed the ~16KB some networks let through before capping a connection,
     // otherwise a fully throttled link passes the probe.
     private const int ProbeSize = 64 * 1024;
+    // Selection runs before the app is usable, so this deadline is what a user on a
+    // restricted network waits out. 64KB in 6s is ~87 kbps - far above a capped link,
+    // and low enough that a weak but working one still keeps the origin.
+    private static readonly TimeSpan SelectTimeout = TimeSpan.FromSeconds(6);
+    // A healthy origin answers well inside this, so the relays are dialed only once the
+    // origin is already in doubt - on a good network they cost no traffic at all.
+    private static readonly TimeSpan SelectHedgeDelay = TimeSpan.FromSeconds(1.5);
     // 64KB in 10s is ~52 kbps. Well under what a weak but usable link sustains, and well
     // over a capped one, which needs ~37s for this payload. A tighter deadline would
     // demand ~175 kbps and start failing links that are merely slow.
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ProbeRetryDelay = TimeSpan.FromSeconds(1);
-    // The probe costs the user traffic and tells us nothing a working app doesn't already
-    // show, so it waits until startup is over rather than competing with it. It cannot wait
-    // much longer: a degraded connection often drops within a minute, and a probe that
-    // never fires on a bad link is worse than no probe at all.
-    private static readonly TimeSpan ProbeDelay = TimeSpan.FromSeconds(20);
+    // This probe mostly guards against an endpoint that degrades mid-session - selection
+    // already vetted it - so it waits for startup traffic to clear rather than competing
+    // with it. It stays short because it's also the whole fallback when measuring can't run.
+    private static readonly TimeSpan ProbeDelay = TimeSpan.FromSeconds(10);
     // The probe only runs once connected, so an endpoint that never connects would trap
     // us here - including the origin, which is exactly the case a relay exists for.
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
     private static readonly string JSSetRpcBaseUriMethod
         = $"{BlazorUICoreModule.ImportName}.BrowserInit.setRpcBaseUri";
     private static readonly TimeSpan PushToJSTimeout = TimeSpan.FromSeconds(2);
+    private int _selectedVersion = -1;
     private int _verifiedVersion = -1;
     private string _pushedEndpoint = "";
     private ISystemProperties SystemProperties => field ??= Services.GetRequiredService<ISystemProperties>();
+    private RpcServerProbe ServerProbe => field ??= Services.GetRequiredService<RpcServerProbe>();
     private ReconnectUI ReconnectUI => field ??= Services.GetRequiredService<ReconnectUI>();
     private ConnectivityUI ConnectivityUI => field ??= Services.GetRequiredService<ConnectivityUI>();
     private IAppActivityState ActivityState => field ??= Services.GetRequiredService<IAppActivityState>();
     private RpcClientPeer? Peer => Hub.RpcHub.GetClientPeer(RpcRef.Default);
+    private bool IsBackgroundIdle => ActivityState.State.Value == AppActivityState.BackgroundIdle;
 
     // Protected/internal methods
 
@@ -55,14 +66,10 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
 
     // Private methods
 
-    private bool IsBackgroundIdle
-        => ActivityState.State.Value == AppActivityState.BackgroundIdle;
-
     private async Task MonitorEndpoint(CancellationToken cancellationToken)
     {
         var selector = RpcEndpointSelector.Instance!;
         var state = ReconnectUI.State;
-        await PushEndpointToJS(cancellationToken).ConfigureAwait(false);
         // A backgrounded app has its networking suspended, so a failure seen there says
         // nothing about the endpoint. BackgroundActive is different: a foreground service
         // (PTT, sync, recording) keeps the network, and that is when connectivity matters
@@ -70,10 +77,13 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
         await ActivityState.State.Computed
             .When(x => x != AppActivityState.BackgroundIdle, cancellationToken)
             .ConfigureAwait(false);
+        await SelectEndpoint(selector, cancellationToken).ConfigureAwait(false);
+        await PushEndpointToJS(cancellationToken).ConfigureAwait(false);
         if (!await WaitUntilConnected(cancellationToken).ConfigureAwait(false)) {
             MoveToNextEndpoint(selector);
             return;
         }
+
         if (selector.Version == _verifiedVersion) {
             await WaitUntilDisconnected(cancellationToken).ConfigureAwait(false);
             return;
@@ -87,13 +97,101 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
         if (await IsEndpointUsable(cancellationToken).ConfigureAwait(false))
             _verifiedVersion = version;
         else if (!IsBackgroundIdle) {
+            // Slipping into the background mid-probe means we have no verdict rather than
+            // a bad one, so nothing is recorded and the next connection tries again.
             MoveToNextEndpoint(selector);
             return;
         }
-        // Slipping into the background mid-probe means we have no verdict rather than a
-        // good one, so nothing is recorded and the next connection tries again.
 
         await WaitUntilDisconnected(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SelectEndpoint(RpcEndpointSelector selector, CancellationToken cancellationToken)
+    {
+        // Waiting for the connection to prove itself bad costs the better part of a minute,
+        // during which the app is unusable and looks broken. Measuring the candidates
+        // directly answers the same question in about a second.
+        var version = selector.Version;
+        if (version == _selectedVersion)
+            return;
+
+        var endpoint = await FindBestEndpoint(selector, cancellationToken).ConfigureAwait(false);
+        if (endpoint is null && ServerProbe.IsSizedProbeSupported) {
+            // Nothing answered, and the server can measure - so the network is simply down.
+            // That's no verdict rather than a bad one; the next cycle tries again.
+            return;
+        }
+
+        _selectedVersion = version;
+        // A server predating the sized probe can't be measured at all, so this falls back to
+        // the older rule: a new network gets the origin, and a failing probe demotes us again.
+        endpoint ??= selector.OriginHost;
+        if (endpoint == selector.Current)
+            return;
+
+        Log.LogWarning("Selected RPC endpoint: {Endpoint}", endpoint);
+        selector.Use(endpoint);
+        _verifiedVersion = -1;
+        Peer?.Disconnect();
+        ReconnectUI.ResetReconnectDelays();
+    }
+
+    private async Task<string?> FindBestEndpoint(
+        RpcEndpointSelector selector,
+        CancellationToken cancellationToken)
+    {
+        var candidates = selector.Candidates;
+        if (candidates.Count < 2)
+            return null;
+
+        var origin = selector.OriginHost;
+        using var cts = cancellationToken.CreateLinkedTokenSource();
+        try {
+            var originTask = ServerProbe.MeasureTransfer(origin, ProbeSize, SelectTimeout, cts.Token);
+            var hedgeTask = Clocks.CpuClock.Delay(SelectHedgeDelay, cancellationToken);
+            var completedTask = await Task.WhenAny(originTask, hedgeTask).ConfigureAwait(false);
+            if (completedTask == originTask && await originTask.ConfigureAwait(false) is not null)
+                return origin;
+
+            var probeTasks = new Task<TimeSpan?>[candidates.Count];
+            probeTasks[0] = originTask;
+            for (var i = 1; i < candidates.Count; i++)
+                probeTasks[i] = ServerProbe.MeasureTransfer(candidates[i], ProbeSize, SelectTimeout, cts.Token);
+            var elapsed = await Task.WhenAll(probeTasks).ConfigureAwait(false);
+            // The origin wins whenever it works at all: a relay adds a hop and is shared by
+            // everyone who needs one, so it's only worth taking when the direct path isn't.
+            if (elapsed[0] is not null)
+                return origin;
+
+            var bestIndex = -1;
+            for (var i = 1; i < elapsed.Length; i++)
+                if (elapsed[i] is { } x && (bestIndex < 0 || x < elapsed[bestIndex]!.Value))
+                    bestIndex = i;
+
+            return bestIndex < 0 ? null : candidates[bestIndex];
+        }
+        finally {
+            cts.Cancel();
+        }
+    }
+
+    private async Task PushEndpointToJS(CancellationToken cancellationToken)
+    {
+        // The media workers read this when they start, so a switch reaches audio and video
+        // on their next start - moving a live peer would mean rebuilding the pipeline.
+        var endpoint = RpcEndpointSelector.ApplyTo(Services.UrlMapper().BaseUrl.TrimSuffix("/"));
+        if (endpoint == _pushedEndpoint)
+            return;
+
+        try {
+            using var cts = cancellationToken.CreateLinkedTokenSource();
+            cts.CancelAfter(PushToJSTimeout);
+            await JS.InvokeVoidAsync(JSSetRpcBaseUriMethod, cts.Token, endpoint).ConfigureAwait(false);
+            _pushedEndpoint = endpoint;
+        }
+        catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+            Log.LogWarning(e, "Failed to push the RPC endpoint to JS");
+        }
     }
 
     private async Task<bool> WaitUntilConnected(CancellationToken cancellationToken)
@@ -117,28 +215,6 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
             }
         }
     }
-
-    private async Task PushEndpointToJS(CancellationToken cancellationToken)
-    {
-        // The media workers read this when they start, so a switch reaches audio and video
-        // on their next start - moving a live peer would mean rebuilding the pipeline.
-        var endpoint = RpcEndpointSelector.ApplyTo(Services.UrlMapper().BaseUrl.TrimSuffix("/"));
-        if (endpoint == _pushedEndpoint)
-            return;
-
-        try {
-            using var cts = cancellationToken.CreateLinkedTokenSource();
-            cts.CancelAfter(PushToJSTimeout);
-            await JS.InvokeVoidAsync(JSSetRpcBaseUriMethod, cts.Token, endpoint).ConfigureAwait(false);
-            _pushedEndpoint = endpoint;
-        }
-        catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
-            Log.LogWarning(e, "Failed to push the RPC endpoint to JS");
-        }
-    }
-
-    private Task WaitUntilDisconnected(CancellationToken cancellationToken)
-        => ReconnectUI.State.Computed.When(x => !x.IsConnected, cancellationToken);
 
     private async Task<bool> IsEndpointUsable(CancellationToken cancellationToken)
     {
@@ -183,16 +259,21 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
         }
     }
 
+    private Task WaitUntilDisconnected(CancellationToken cancellationToken)
+        => ReconnectUI.State.Computed.When(x => !x.IsConnected, cancellationToken);
+
     private void MoveToNextEndpoint(RpcEndpointSelector selector)
     {
-        if (selector.MoveNext())
+        if (selector.MoveNext()) {
             Log.LogWarning("Switching to the next RPC endpoint");
+        }
         else {
-            // Every endpoint failed, so the network is likely down rather than the endpoint bad.
+            // Every endpoint failed, so the network is likely down rather than the endpoint
+            // bad. UseDirect also expires the selection, so the next cycle re-measures.
             Log.LogWarning("No usable RPC endpoint left, going back to the origin");
             selector.UseDirect();
         }
-
+        _verifiedVersion = -1;
         Peer?.Disconnect();
         ReconnectUI.ResetReconnectDelays();
     }

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -24,6 +24,10 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     // A healthy origin answers well inside this, so the relays are dialed only once the
     // origin is already in doubt - on a good network they cost no traffic at all.
     private static readonly TimeSpan SelectHedgeDelay = TimeSpan.FromSeconds(1.5);
+    // Measuring every relay at once has them competing for the same bottleneck, so the
+    // measurement would degrade with each relay added. Only the nearest few are measured.
+    private const int MaxThroughputProbes = 2;
+    private static readonly TimeSpan RoundTripTimeout = TimeSpan.FromSeconds(3);
     // 64KB in 10s is ~52 kbps. Well under what a weak but usable link sustains, and well
     // over a capped one, which needs ~37s for this payload. A tighter deadline would
     // demand ~175 kbps and start failing links that are merely slow.
@@ -153,26 +157,49 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
             if (completedTask == originTask && await originTask.ConfigureAwait(false) is not null)
                 return origin;
 
-            var probeTasks = new Task<TimeSpan?>[candidates.Count];
-            probeTasks[0] = originTask;
-            for (var i = 1; i < candidates.Count; i++)
-                probeTasks[i] = ServerProbe.MeasureTransfer(candidates[i], ProbeSize, SelectTimeout, cts.Token);
+            var relays = await ShortlistRelays(candidates, cts.Token).ConfigureAwait(false);
+            var probeTasks = relays
+                .Select(x => ServerProbe.MeasureTransfer(x, ProbeSize, SelectTimeout, cts.Token))
+                .ToArray();
             var elapsed = await Task.WhenAll(probeTasks).ConfigureAwait(false);
             // The origin wins whenever it works at all: a relay adds a hop and is shared by
             // everyone who needs one, so it's only worth taking when the direct path isn't.
-            if (elapsed[0] is not null)
+            if (await originTask.ConfigureAwait(false) is not null)
                 return origin;
 
             var bestIndex = -1;
-            for (var i = 1; i < elapsed.Length; i++)
+            for (var i = 0; i < elapsed.Length; i++)
                 if (elapsed[i] is { } x && (bestIndex < 0 || x < elapsed[bestIndex]!.Value))
                     bestIndex = i;
 
-            return bestIndex < 0 ? null : candidates[bestIndex];
+            return bestIndex < 0 ? null : relays[bestIndex];
         }
         finally {
             cts.Cancel();
         }
+    }
+
+    private async Task<string[]> ShortlistRelays(
+        IReadOnlyList<string> candidates,
+        CancellationToken cancellationToken)
+    {
+        var relays = candidates.Skip(1).ToArray();
+        if (relays.Length <= MaxThroughputProbes)
+            return relays;
+
+        var rttTasks = relays
+            .Select(x => ServerProbe.MeasureRoundTrip(x, RoundTripTimeout, cancellationToken))
+            .ToArray();
+        var rtt = await Task.WhenAll(rttTasks).ConfigureAwait(false);
+        var nearest = relays.Zip(rtt)
+            .Where(x => x.Second is not null)
+            .OrderBy(x => x.Second!.Value)
+            .Take(MaxThroughputProbes)
+            .Select(x => x.First)
+            .ToArray();
+        // Nothing answered the cheap probe, yet the expensive one may still get through -
+        // so fall back to the declared order rather than giving up on every relay at once.
+        return nearest.Length > 0 ? nearest : relays.Take(MaxThroughputProbes).ToArray();
     }
 
     private async Task PushEndpointToJS(CancellationToken cancellationToken)

--- a/tests/Core.Server.IntegrationTests/Web/RpcCheckTest.cs
+++ b/tests/Core.Server.IntegrationTests/Web/RpcCheckTest.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using ActualChat.Testing.Host;
+
+namespace ActualChat.Core.Server.IntegrationTests.Web;
+
+public class RpcCheckTest(ITestOutputHelper @out)
+    : AppHostTestBase($"x-{nameof(RpcCheckTest)}", @out)
+{
+    private const int ProbeSize = 64 * 1024;
+
+    [Fact]
+    public async Task ShouldAnswerOkWithoutASize()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        using var httpClient = host.NewHttpClient();
+
+        // act
+        var payload = await httpClient.GetByteArrayAsync("rpc/check");
+
+        // assert
+        Encoding.UTF8.GetString(payload).Should().Be("ok",
+            because: "the reachability probe must answer even when RPC itself can't get through");
+    }
+
+    [Fact]
+    public async Task ShouldServeTheRequestedSizeToASession()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        using var httpClient = host.NewHttpClient();
+        var session = Session.New();
+        httpClient.DefaultRequestHeaders.Add(Constants.Session.HeaderName, session.Id);
+
+        // act
+        var payload = await httpClient.GetByteArrayAsync($"rpc/check?size={ProbeSize}");
+
+        // assert
+        payload.Length.Should().Be(ProbeSize);
+    }
+
+    [Fact]
+    public async Task ShouldNotServeASizedPayloadAnonymously()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        using var httpClient = host.NewHttpClient();
+
+        // act
+        var payload = await httpClient.GetByteArrayAsync($"rpc/check?size={ProbeSize}");
+
+        // assert
+        Encoding.UTF8.GetString(payload).Should().Be("ok",
+            because: "an anonymous caller must not be able to pull a large payload on demand");
+    }
+
+    [Fact]
+    public async Task ShouldClampTheRequestedSize()
+    {
+        // arrange
+        await using var host = await NewAppHost();
+        using var httpClient = host.NewHttpClient();
+        var session = Session.New();
+        httpClient.DefaultRequestHeaders.Add(Constants.Session.HeaderName, session.Id);
+
+        // act
+        var tiny = await httpClient.GetByteArrayAsync("rpc/check?size=1");
+        var huge = await httpClient.GetByteArrayAsync("rpc/check?size=99999999");
+
+        // assert
+        tiny.Length.Should().Be(1024);
+        huge.Length.Should().Be(256 * 1024);
+    }
+}

--- a/tests/Core.UnitTests/Rpc/RpcEndpointSelectorTest.cs
+++ b/tests/Core.UnitTests/Rpc/RpcEndpointSelectorTest.cs
@@ -72,6 +72,59 @@ public class RpcEndpointSelectorTest
     }
 
     [Fact]
+    public void ShouldSelectAnyCandidate()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1, Edge2]);
+
+        // act & assert
+        selector.Use(Edge2).Should().BeTrue();
+        selector.Current.Should().Be(Edge2);
+        selector.Use("retired.edge.voxt.ai").Should().BeFalse(because: "only candidates may be dialed");
+        selector.Current.Should().Be(Edge2);
+    }
+
+    [Fact]
+    public void ShouldNotExpireTheVerdictOnMoveNextOrUse()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1, Edge2]);
+        var version = selector.Version;
+
+        // act
+        selector.MoveNext();
+        selector.Use(Edge2);
+
+        // assert
+        selector.Version.Should().Be(version,
+            because: "moving between endpoints is not a new network, so measurements still hold");
+    }
+
+    [Fact]
+    public void ShouldExpireTheVerdictOnInvalidateWithoutMoving()
+    {
+        // arrange
+        var selector = new RpcEndpointSelector([Origin, Edge1], Edge1);
+        var version = selector.Version;
+
+        // act
+        selector.Invalidate();
+
+        // assert
+        selector.Current.Should().Be(Edge1,
+            because: "a working endpoint must be kept until the new network is measured");
+        selector.Version.Should().NotBe(version);
+    }
+
+    [Theory]
+    [InlineData("wss://voxt.ai", "wss://kz1.edge.voxt.ai")]
+    [InlineData("https://voxt.ai/rpc/check?size=1", "https://kz1.edge.voxt.ai/rpc/check?size=1")]
+    [InlineData("https://cdn.voxt.ai/a.png", "https://kz1.edge.voxt.ai/a.png")]
+    [InlineData("not-a-url", "not-a-url")]
+    public void WithHostShouldReplaceTheHostUnconditionally(string baseUrl, string expected)
+        => RpcEndpointSelector.WithHost(baseUrl, Edge1).Should().Be(expected);
+
+    [Fact]
     public void ShouldBumpVersionEvenWhenTheEndpointDoesNotChange()
     {
         // arrange


### PR DESCRIPTION
Follow-up to #4247. Failover worked on device, but took so long that the app looked broken: a cold start on RU cellular showed "not connected", and a cellular reconnect sat on the throttled origin for about a minute before switching.

## What was wrong

`RpcEndpointMonitor` only reacted to a connection that had already proven itself unusable, and the proof was deliberately slow:

```
ProbeDelay 20s  +  Probe 10s  +  retry 1s  +  Probe 10s  =  41s after connect
```

plus `ConnectTimeout` 30s first if the origin never connects at all. On top of that, `MauiConnectivityUI` called `UseDirect()` on every network-profile change, forcing the client back to the throttled origin — so that 41s was re-paid on every cellular reconnect. The arithmetic matches the reported timeline exactly.

## What changed

Candidates are now measured directly over HTTP before the connection has to prove anything, which answers the same question in about a second.

- `/rpc/check` takes a `size` parameter and returns that many bytes, so it reports throughput rather than reachability. Payloads above the per-connection allowance some networks grant are what tells a capped link from a merely slow one.
- The origin is probed first and relays only after a 1.5s hedge, so a healthy network never dials a relay and pays no extra traffic. The origin wins whenever it works at all — a relay adds a hop and is shared by everyone who needs one.
- A network change now expires the verdict instead of resetting the endpoint, so a working relay is kept until the new network has actually been measured.
- Relays are shortlisted by an unsized round trip before any throughput probe. Measuring every relay at once has them competing for the same bottleneck, so the measurement degraded with each relay added. Below three relays the shortlist is skipped and nothing changes.

Result: ~1s on a good network, 6s worst case to land on a relay, down from 41–70s.

## Security

The sized reply is served only to a caller presenting a session header; anonymous callers get the same 2-byte `ok` as before. The bare reachability probe has to stay open, because `RpcSwitchingClient` falls back to it exactly when RPC itself can't get through. The payload is sliced from one buffer built at startup rather than generated per request, so the route costs no CSPRNG work.

The gate is a well-formed session header, not a signed-in account — deliberately. Requiring a server-known session would deadlock a fresh install on a restricted network, since establishing one needs the connection the probe exists to repair.

## Invariant worth reviewing

`Version` no longer moves when the client walks to the next endpoint — only `Invalidate()` and `UseDirect()` bump it. Otherwise a fresh failover reads as a network change and the re-measurement immediately undoes it. This is held up by `ShouldNotExpireTheVerdictOnMoveNextOrUse`.

## Testing

`RpcCheckTest` (new, integration, against the real pipeline):

| request | result |
|---|---|
| no `size` | `ok` |
| session + 64KB | exactly 65536 |
| anonymous + 64KB | `ok` — the gate |
| `size=1` / `size=99999999` | 1024 / 262144 — clamping |

4/4 pass. 679/679 unit tests pass, including 5 new `RpcEndpointSelectorTest` cases. `App.Server` and `App.Maui` (android) both build.

**Not yet tested on a device** — that is the only thing that has ever caught a defect in this subsystem, and it should happen before merge.

## Known limitations

- The probe rides a fresh HTTPS connection, not the long-lived WebSocket that actually suffers. If the carrier's allowance is per-connection, the probe can be more optimistic than the live peer. The 64KB threshold is a guess at that allowance.
- The pass/fail bar is a fixed 87 kbps (64KB / 6s) and includes handshake time, so high-RTT users face a stricter test. That sits inside the range of working-but-bad EDGE, so genuinely slow links worldwide can be relayed unnecessarily. Detecting the throttle by transfer *shape* rather than average would remove the guess; deferred pending device numbers.
- Nothing re-evaluates on a timer, so returning to the origin still requires a network change.
- `kz1` remains a single point of failure, and faster failover concentrates more traffic on it.
- Web/WASM is unaffected — `RpcEndpointSelector` is MAUI-only. iOS untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFfRhQAQuFBYaaijwRKJQn