### PR TITLE
fix(virtual-list): hold the Show-more reveal through slow renders and grow-in

### DIFF
--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -131,9 +131,11 @@ in a later section looks loaded — most of them are.*
 - **interactive anchor** — *`interactiveAnchor`, `data-vl-hold`.* An opt-in override: when the user
   clicks a control that changes an item's size, *that* item is what the next render holds still.
   Expires after 2s.
-- **screen anchor** — *`screenAnchor`, `data-vl-anchor`, `watchScreenAnchor`.* The stronger override:
-  an element the caller promises to render again under the same id, held at its *rendered* screen
-  position through the render and the height animations that follow. Also expires after 2s.
+- **screen anchor** — *`screenAnchor`, `data-vl-anchor`, `data-anchor="below"`, `watchScreenAnchor`.*
+  The stronger override: an element held at its *rendered* screen position through the render and the
+  height animations that follow — addressed by a `data-vl-anchor` id the caller promises to render
+  again, or by the key of the item below a `data-anchor="below"` control (§3.9). Waits up to 10s for
+  its render; expires 2s after being placed.
 - **re-centre** — *`mustRecentre`, `isChainOffCentre`.* Shift the whole chain back to the middle of the
   scroll space, with the scroll following it. Invisible at a standstill, a jump anywhere else, so it
   waits for a quiet moment.
@@ -504,7 +506,8 @@ overscroll rows are the summary of §3.7.*
 | `scrollToKey` that is not the newest item | any → Placing | suppress new height animations, wait out the ones in flight, then place the item at `center` or `end` | `container.top` then `scrollTop` |
 | `scrollToKey` that *is* the newest item, end loaded | any → Pinned End | pin and re-pin, which in reverse is a follow of a few pixels or nothing at all — so a message you just posted still animates in | `scrollTop` |
 | the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop `onWheel` also clears the pin even inside the guard window | — |
-| a `data-vl-hold` control is clicked or tapped | Pinned → Free, interactive anchor set | the clicked item — or the first content item below it, for `data-anchor="below"` — is what the next render holds; `keep-edge` controls leave a pinned list alone; expires after 2s | — |
+| a `data-vl-hold` control is clicked or tapped | Pinned → Free, interactive anchor set | the clicked item is what the next render holds; `keep-edge` controls leave a pinned list alone; expires after 2s | — |
+| a `data-vl-hold` control marked `data-anchor="below"` | Pinned → Free, key-addressed screen anchor set | the first content item below the control keeps its rendered position; placed only by the render that inserts content directly above that item, however many unrelated renders land first | — |
 | a `data-vl-hold` control inside a `data-vl-anchor` element | Pinned → Free, screen anchor set | the element's rendered screen position is recorded; unpinning is what gives the chain its top anchor (§3.2) | — |
 | the render that follows a screen anchor | — | the chain moves so the element's *flow* position lands where its rendered one was, then a per-frame scroll write holds it there until it has been still 12 frames | `container.top`, then `scrollTop` |
 | the chain eats into the reserve | any → watching for a quiet moment | armed by `applyLayout`, and the watcher cancels itself the moment the chain is no longer off centre | — |
@@ -1331,13 +1334,26 @@ the band with `phase: 'in-band'`, and the chat was blank until something produce
 taps, links and text selection must not affect anchoring — and both a click and a `touchend` on the
 container count. `always` holds the item and drops the pin, a deliberate "read history" action;
 `keep-edge` holds only when the list is not pinned, since a pinned list absorbs the size change through
-its edge re-pin instead. `data-anchor="below"` means the control reveals rows *above* itself, so the
-first content item below it is what must keep its position. The same clamp as above applies: when the
-viewport is deeper into the block than the block is tall, the item itself is what the user gets back.
+its edge re-pin instead. The clamp from above applies: when the viewport is deeper into the block than
+the block is tall, the item itself is what the user gets back.
 
-**Screen anchors** are the second override, and the stronger one: an element marked
-`data-vl-anchor="<id>"` is one the caller promises to render again under that id, and whose position on
-screen is to survive the next render. It beats an interactive anchor when both apply.
+**Screen anchors** are the second override, and the stronger one: an element whose position on screen
+is to survive the render the interaction causes. It beats an interactive anchor when both apply, and
+it is addressed one of two ways. An element marked `data-vl-anchor="<id>"` is one the caller promises
+to render again under that id. A control marked `data-anchor="below"` instead anchors the first
+content **item below itself, by key**: the control reveals rows above that item (the live block's
+Show-more pill), and the item below the insertion is what must keep its rendered position — the rows
+grow upward and everything from the anchor down stays put.
+
+A key-addressed anchor differs from an id-addressed one in when it is spent. It records the content
+key directly above its item at the click, and is **placed only by the render that changes that** — the
+one that actually inserts the revealed rows. A live chat keeps streaming renders in while that one can
+be seconds away on WASM, and placing on whichever render lands first would start (and retire) the
+per-frame watch before there is anything to hold; those renders pass through and re-anchor by the
+viewport top as usual. Its item leaving the item set releases it — an id may be rendered again, but an
+item that is gone has nothing to come back as, and the live block folding away must free
+`checkPosition` (§3.6) rather than sit behind a stale hold. A full replacement releases it the same
+way, since `reanchor` — the path that would notice the vanished key — does not run there.
 
 It exists because an item key is not always enough to name the thing that must hold still, and because
 an item's *modelled* position is not always where it is:
@@ -1371,7 +1387,10 @@ block.
 
 Measured on a conversation header in view, before → after: collapse 16px → 0px, expand 124px → 0px.
 
-A trusted scroll or a 2s timeout (`InteractiveAnchorTtlMs`) clears either anchor.
+A trusted scroll clears either anchor at once. The timeout depends on what the anchor is waiting for:
+a screen anchor still waiting on its render gets `ScreenAnchorRenderTtlMs` (10s) — on WASM that render
+can be seconds away — and everything else, an interactive anchor and a placed screen anchor alike,
+expires `InteractiveAnchorTtlMs` (2s) after the click or the placement.
 
 #### Re-anchor writes are flagged
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -224,12 +224,21 @@ export class InfiniteList extends VirtualList {
     private isEndSkeletonShown = false;
     private revealedAt = 0;
     private interactiveAnchor: { key: string; at: number } | null = null;
-    // An element the caller has promised to render again under the same id, whose position on screen
-    // must survive the next render. Recorded as rendered rather than modelled, which is the whole
-    // point of it: a stuck sticky element is not where the model puts it, and an element inside a
-    // group has no modelled position at all.
-    private screenAnchor:
-        { id: string; top: number; at: number; isPlaced: boolean; corrected: number } | null = null;
+    // An element whose position on screen must survive the next render, recorded as rendered rather
+    // than modelled - a stuck sticky element is not where the model puts it, and an element inside a
+    // group has no modelled position at all. Addressed by data-vl-anchor id, or by item key for a
+    // data-anchor="below" hold; a key-addressed anchor also records the content key above it, and is
+    // placed only by the render that changes that - the one that actually inserts the revealed rows -
+    // so the unrelated renders a live chat streams in the meantime pass through without spending it.
+    private screenAnchor: {
+        id: string | null;
+        key: string | null;
+        aboveKey: string | null;
+        top: number;
+        at: number;
+        isPlaced: boolean;
+        corrected: number;
+    } | null = null;
     private isWatchingScreenAnchor = false;
     private stickyShift = 0;
     // Keys that left a recent render, with the height they had, so an item that comes straight back is
@@ -509,9 +518,13 @@ export class InfiniteList extends VirtualList {
             && !oldKeys.some(key => this.indexByKey.has(key));
         if (isFullReplacement) {
             // Nothing on screen survives, so no animation can be interrupted and nothing needs holding
-            // in place: whatever was animating is gone, and the list is stable by construction.
+            // in place: whatever was animating is gone, and the list is stable by construction. A
+            // key-addressed anchor's item went with everything else, and reanchor - the path that
+            // releases a vanished one - is skipped for a full replacement.
             this.heights?.applyAllInstantly();
             this.stability.releaseAllAnimations();
+            if (this.screenAnchor?.key != null)
+                this.releaseScreenAnchor();
         }
         if (!sameKeys(oldKeys, this.items))
             this.lastSentQuery = null;
@@ -1742,6 +1755,8 @@ export class InfiniteList extends VirtualList {
             this.interactiveAnchor = null;
             this.screenAnchor = {
                 id: anchorId,
+                key: null,
+                aboveKey: null,
                 top: anchorRef.getBoundingClientRect().top - this.ref.getBoundingClientRect().top,
                 at: performance.now(),
                 isPlaced: false,
@@ -1756,11 +1771,30 @@ export class InfiniteList extends VirtualList {
 
         this.setPinnedEdge(null);
         // A control marked data-anchor="below" reveals rows ABOVE itself, so the item below it is what
-        // must keep its screen position - otherwise the revealed rows push everything downward.
-        const anchorKey = target.closest('[data-anchor="below"]') != null
-            ? this.getFirstContentKeyBelow(key) ?? key
-            : key;
-        this.interactiveAnchor = { key: anchorKey, at: performance.now() };
+        // must keep its screen position - otherwise the revealed rows push everything downward. It is
+        // held as a key-addressed screen anchor rather than an interactive one: the render it waits
+        // for can be seconds away on WASM, and the rows it inserts then grow in from zero - the
+        // pending TTL covers the first, watchScreenAnchor the second, and the interactive anchor's
+        // model-level hold covers neither.
+        const belowKey = target.closest('[data-anchor="below"]') != null
+            ? this.getFirstContentKeyBelow(key)
+            : null;
+        if (belowKey != null) {
+            const belowRef = this.items[this.indexByKey.get(belowKey)!].ref;
+            this.interactiveAnchor = null;
+            this.screenAnchor = {
+                id: null,
+                key: belowKey,
+                aboveKey: this.getFirstContentKeyAbove(belowKey),
+                top: belowRef.getBoundingClientRect().top - this.ref.getBoundingClientRect().top,
+                at: performance.now(),
+                isPlaced: false,
+                corrected: 0,
+            };
+            return;
+        }
+
+        this.interactiveAnchor = { key, at: performance.now() };
     };
 
     // Puts the anchored element back where it was on screen. Both readings are rendered positions,
@@ -1776,10 +1810,17 @@ export class InfiniteList extends VirtualList {
             return false;
         }
 
-        const anchorRef = this.containerRef
-            .querySelector<HTMLElement>(`:scope [data-vl-anchor="${CSS.escape(anchor.id)}"]`);
-        if (anchorRef == null)
+        const anchorRef = this.getScreenAnchorRef(anchor);
+        if (anchorRef == null) {
+            // An id names an element its owner promises to render again, so its absence is worth
+            // waiting out. A key names a list item, and an item that has left the set has nothing to
+            // come back as - the live block folding away is the case, and a hold left standing there
+            // keeps checkPosition from fixing the very view the fold stranded.
+            if (anchor.key != null)
+                this.releaseScreenAnchor();
+
             return false;
+        }
 
         // Placed once, on the render the interaction caused. Re-placing it on every render that
         // follows drags the view further off each time, because those renders are the ones growing the
@@ -1789,6 +1830,13 @@ export class InfiniteList extends VirtualList {
             this.watchScreenAnchor();
             return false;
         }
+
+        // A key-addressed anchor is spent on the render that inserts content directly above its item -
+        // that is what data-anchor="below" reveals. A live chat keeps rendering while that one is
+        // still seconds away, and placing on whichever render lands first would start (and retire) the
+        // watch before there is anything to hold.
+        if (anchor.key != null && this.getFirstContentKeyAbove(anchor.key) === anchor.aboveKey)
+            return false;
 
         anchor.isPlaced = true;
         anchor.at = performance.now();
@@ -1846,8 +1894,9 @@ export class InfiniteList extends VirtualList {
 
             // A frame the list may not write is not the element standing still: counting it would
             // release the hold with the correction still owing - twelve frames of a resting finger is
-            // all it takes.
-            const isDeferred = !this.canCorrectPosition;
+            // all it takes. An anchor still waiting on its render has nothing to correct yet either -
+            // and correctScreenAnchor's own 2s deadline would retire it mid-wait if it were asked.
+            const isDeferred = !this.canCorrectPosition || !anchor.isPlaced;
             const moved = isDeferred ? false : this.correctScreenAnchor();
             if (moved == null) {
                 this.releaseScreenAnchor();
@@ -1881,10 +1930,9 @@ export class InfiniteList extends VirtualList {
         if (anchor == null || this.isDisposed || performance.now() - anchor.at > InteractiveAnchorTtlMs)
             return null;
 
-        const anchorRef = this.containerRef
-            .querySelector<HTMLElement>(`:scope [data-vl-anchor="${CSS.escape(anchor.id)}"]`);
+        const anchorRef = this.getScreenAnchorRef(anchor);
         if (anchorRef == null)
-            return false;
+            return anchor.key != null ? null : false;
 
         // Rendered, not flow: this holds what is on screen against content moving under it. An element
         // the viewport edge has stuck is already still and reads a delta of zero, which is right for it.
@@ -1908,6 +1956,13 @@ export class InfiniteList extends VirtualList {
         // bound at all within about thirty of them.
         anchor.corrected += applied;
         return Math.abs(anchor.corrected) > this.maxOverscroll ? null : true;
+    }
+
+    private getScreenAnchorRef(anchor: { id: string | null; key: string | null }): HTMLElement | null {
+        const selector = anchor.key != null
+            ? `:scope .item[data-key="${CSS.escape(anchor.key)}"]`
+            : `:scope [data-vl-anchor="${CSS.escape(anchor.id ?? '')}"]`;
+        return this.containerRef.querySelector<HTMLElement>(selector);
     }
 
     private hasFreshScreenAnchor(): boolean {
@@ -1941,6 +1996,18 @@ export class InfiniteList extends VirtualList {
             return null;
 
         for (let i = index + 1; i < this.items.length; i++)
+            if (!this.items[i].mustSkipKey)
+                return this.items[i].key;
+
+        return null;
+    }
+
+    private getFirstContentKeyAbove(key: string): string | null {
+        const index = this.indexByKey.get(key);
+        if (index == null)
+            return null;
+
+        for (let i = index - 1; i >= 0; i--)
             if (!this.items[i].mustSkipKey)
                 return this.items[i].key;
 


### PR DESCRIPTION
## Summary

Clicking the live block's "Show next N of M" pill lost the lower messages' positions: the revealed rows are meant to grow upward while everything from the pill down stays put (the block's header moves up), and instead the view shifted or bounced. Regression from the virtual-list rewrite.

The pill armed an **interactive key anchor**, which fails it twice:

- **2s TTL vs seconds-away renders.** `InteractiveAnchorTtlMs` runs from the click and is never extended while the render is pending. During a live session a WASM render is routinely seconds away, so the reveal landed with no anchor and re-anchored by the viewport top — pushing the tail down.
- **Model-level hold vs grow-in.** When the render did arrive in time, the anchor held the tail's *model* position only. The revealed rows grow in from zero while the model already counts them settled, so each animation wave (3 items) jumped the tail up by the wave's height and slid it back as the DOM caught up.

## Fix

Both cures already exist on the screen-anchor path, so the pill now arms a **key-addressed screen anchor** instead: the first content item below the control, its rendered top recorded at the click.

- **Placed only by the render that consumes it** — the one that inserts content directly above its item (detected via the content key above, recorded at the click). The unrelated renders a live chat streams in the meantime pass through without spending it; the pending anchor rides the existing 10s `ScreenAnchorRenderTtlMs`.
- **Held through the growth** by the existing `watchScreenAnchor` per-frame scroll-write loop.
- **Releases safely**: its item leaving the item set releases it (a live-block fold must free `checkPosition` rather than sit behind a stale hold), a full replacement releases it the same way, and the watch defers correction for an anchor still waiting on its render — `correctScreenAnchor`'s own 2s deadline would retire it mid-wait otherwise.

Plain `data-vl-hold` controls and `data-vl-anchor` elements keep their existing lifecycles unchanged. Spec (`docs/ui/virtual-list.md`) updated: vocabulary, transitions table, §3.9.

## Testing

- `npm run build:Verify` clean (tsc + eslint + debug build).
- Rig regression + live-session manual pass (pill mid-streaming, pill double-click, click-then-session-close) still owed — rig scenarios never click hold controls, so the change is inert for pure-gesture paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAWTHVwGyg4ktKnRwFVUGB