### PR TITLE
Video: iOS self-preview freeze — combined change set for review

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -157,3 +157,13 @@ edited. The reason can be as short as whose decision it was.
 - L109 `await StopRecordingUnsafe().ConfigureAwait(false);`
   — blank line after an if/else-if chain ending in `return` — the chain ends in an
   `else if`, which the guide's exemption covers
+
+## src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+
+- L53 `// Forces WebKit to recomposite a <video> that decodes but never paints.`
+  — comment longer than the guide's limit — Alex Yakunin's decision: this is a
+  four-line workaround for an upstream browser bug whose symptom (a healthy,
+  advancing, correctly-sized `<video>` painting nothing) reads as a no-op, and
+  whose cause lives in two CSS properties in another file. Without the reasoning
+  written down the next reader deletes it. Records the WebKit bug id, the
+  measured evidence, and why `contain`/`will-change` are nudged, not removed.

--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -158,6 +158,15 @@ edited. The reason can be as short as whose decision it was.
   — blank line after an if/else-if chain ending in `return` — the chain ends in an
   `else if`, which the guide's exemption covers
 
+## src/dotnet/UI.Blazor.App/Services/NotificationsPanelUI.cs
+
+- L10 `public class NotificationsPanelUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyInitialized`
+  — type not sealed — required: Fusion generates a proxy over the `[ComputeMethod]`
+- L23 `public NotificationsPanelUI(AppUIHub hub) : base(hub)`
+  — explicit constructor instead of a primary one — required: the body reads
+  `StateFactory`, a base-class member, which a primary constructor's field
+  initializers can't reach
+
 ## src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
 
 - L53 `// Forces WebKit to recomposite a <video> that decodes but never paints.`

--- a/docs/ui/components.md
+++ b/docs/ui/components.md
@@ -217,6 +217,42 @@ To find the rest of them, cross-reference two lists: Razor elements carrying bot
 `@ref` and a `@`-interpolated `class`, and TS lines writing `classList`/`className`
 on `this.element` / `this.ref` / `parentElement` / `closest()`.
 
+## A promoted `<video>` layer can decode without painting
+
+On iOS WebKit a `<video>` can hold a healthy, advancing stream and still paint
+nothing. The self-preview hit this after a camera switch: the element was
+`display: block`, `visibility: visible`, `paused: false`, `readyState: 4`, at the
+right size and on the right track, and `drawImage(videoEl)` returned **fresh
+pixels every frame** — while the screen showed an empty rectangle.
+
+The trigger is compositing, not media. `.video-track-player` sets
+`contain: strict` and the surfaces inside it carry `will-change: transform`
+(plus `scaleX(-1)` when the camera is mirrored). Re-attaching a track to a
+promoted layer inside a strictly-contained parent can leave WebKit with a
+GraphicsLayer it never repaints. Both properties are load-bearing — see the
+`contain` / `will-change` notes in `video-panel.css` — so the layer is nudged
+instead: `forceRecomposite()` in `recorder-preview-view.ts` toggles `display`
+once on `loadeddata`, which forces a fresh compositing pass.
+
+**How to tell this apart from a frame-delivery failure**, because they look
+identical on screen:
+
+- `<video>.currentTime` is **useless** — it advances with the wall clock on a
+  MediaStream-backed element whether or not frames arrive. A fully frozen
+  preview reported 14.992 s of progress over 14.993 s.
+- `requestVideoFrameCallback` is also useless on its own: `presentedFrames`
+  keeps incrementing on a frozen element and `mediaTime` sits at 0.
+- **Hash the pixels.** Draw the element into a small offscreen canvas, hash the
+  `ImageData`, and compare samples seconds apart. Changing hash + blank screen
+  ⇒ compositing. Constant hash ⇒ delivery.
+
+If it is delivery, the sender-side tally is already there: turn on
+`logLevels.override('*Video*', 1)` and read `previewTrace` (forwarded / refused /
+written / resolved / inFlight) and `recorderStats` (captured / offered / encoded
+/ shipped) on the main thread. The preview tap runs in a worker whose console the
+inspector cannot reach, so `previewTrace` is pulled over RPC — never add
+diagnostic `console` output in that realm expecting to read it.
+
 ## No Inline Tailwind in Razor
 
 Do NOT write Tailwind utility classes directly in `.razor` markup. Instead, assign a CSS class and use `@apply` in the CSS file.

--- a/docs/ui/components.md
+++ b/docs/ui/components.md
@@ -141,12 +141,16 @@ body.hoverable .amazing-panel > button:hover,
 }
 ```
 
-## Lit Components: Blazor owns `class`
+## Blazor owns `class`
 
 A Lit custom element rendered from Razor has **two** potential writers for its host
 attributes — Blazor, which rewrites the element's markup on every re-render, and the
 component itself. Anything both of them write ends up in a permanent tug-of-war,
 because Blazor's render tree never learns what the component changed.
+
+This is **not** limited to Lit. It applies to every plain-TS component that receives
+a Razor element through `@ref`, and to every element it reaches from there
+(`parentElement`, `closest()`, a `querySelector` hit that Razor also renders).
 
 **The rule: a Lit component may *have* a `class`, but must never *write* one.**
 `class` belongs to Blazor. The component owns only attributes Blazor does not render.
@@ -191,6 +195,27 @@ re-renders write the same value and never conflict.
 
 The same reasoning applies to any attribute Razor emits — `style`, `title`, `id`. If
 Razor renders it, the component must not write it.
+
+### Why it looks intermittent
+
+Blazor diffs per attribute and writes `class` only when the Razor-computed string
+actually *changes*. A JS-added class therefore survives indefinitely on an element
+whose Razor class is constant, and disappears the first time some unrelated
+expression in that same attribute flips. That makes the failure look like a race
+rather than a rule violation, and it hides in review: the offending line reads fine,
+and the element it targets is several files away.
+
+The iOS camera-preview bug was exactly this. `VideoStreamingPreview.razor` renders
+`class="video-track-player video-streaming-preview @Class @recordingCls @screenCastCls"`,
+and `RecorderPreviewView` set `preview-backend-mstg` on that same element to hide the
+idle render surface. Starting a recording flipped `@recordingCls` from `""` to
+`"recording"`, Blazor rewrote `class`, and the backend class vanished — leaving a
+never-painted `<canvas>` (`z-index: 1`) covering the live `<video>` beneath it. The
+preview went blank while the camera and the outbound stream were working perfectly.
+
+To find the rest of them, cross-reference two lists: Razor elements carrying both
+`@ref` and a `@`-interpolated `class`, and TS lines writing `classList`/`className`
+on `this.element` / `this.ref` / `parentElement` / `closest()`.
 
 ## No Inline Tailwind in Razor
 

--- a/src/dotnet/UI.Blazor.App/Components/JoinVideoCallModal/join-video-call-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/JoinVideoCallModal/join-video-call-modal.css
@@ -51,9 +51,9 @@
 /* Canvas-fallback backend (Edge/Firefox/iOS): RecorderPreviewView paints
    frames to the canvas, not the <video> (which has no track). Reveal the
    canvas as the primary surface — it sits after the <video> in the DOM, so it
-   covers the empty element. preview-backend-canvas is set by the view on
+   covers the empty element. data-preview-backend is set by the view on
    attach. */
-.join-video-call-modal .video-frame.preview-backend-canvas .camera-preview {
+.join-video-call-modal .video-frame[data-preview-backend="canvas"] .camera-preview {
     @apply block;
 }
 /* Mirror toggle — overrides the default scaleX(-1). Placed on .c-video (owned

--- a/src/dotnet/UI.Blazor.App/Components/JoinVideoCallModal/join-video-call-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/JoinVideoCallModal/join-video-call-modal.css
@@ -11,6 +11,13 @@
     @apply overflow-hidden;
     @apply bg-03;
 }
+/* Query container for the .rotated-video axis swap below, scoped to the canvas
+   painter so the generated-track path keeps its original layout untouched.
+   Safe to size-contain here: the surfaces inside are absolutely positioned, so
+   the frame's height comes from min-h-56 rather than from its content. */
+.join-video-call-modal .video-frame[data-preview-backend="canvas"] {
+    container-type: size;
+}
 .join-video-call-modal .video-frame .plug-text {
     @apply text-title-1 text-02;
 }
@@ -35,7 +42,8 @@
     @apply object-cover;
     @apply rounded-2xl;
     @apply hidden;
-    transform: scaleX(-1);
+    transform: scaleX(-1) rotate(var(--video-rotation, 0deg));
+    transform-origin: center center;
 }
 /* Native <video> visible when Join mode has a live track. Blur-on case swaps
    the <video>'s srcObject to the worker's MediaStreamTrackGenerator output,
@@ -61,7 +69,25 @@
    Blazor re-renders don't wipe out the JS-added classes. */
 .join-video-call-modal .c-video.no-mirror .video-frame .camera-preview,
 .join-video-call-modal .c-video.no-mirror .video-frame .camera-preview-video {
-    transform: none;
+    transform: rotate(var(--video-rotation, 0deg));
+}
+/* Quarter-turn: the canvas painter draws the raw capture, which on iOS stays
+   landscape (MSTP does not auto-rotate), so CSS owns the turn. The generated
+   track needed none of this - the <video> auto-oriented it and the view
+   reported rotation 0 - which is why this only mattered once WebKit moved to
+   the canvas painter. Swap the box's axes so a portrait frame still fills it. */
+.join-video-call-modal .video-frame .camera-preview.rotated-video,
+.join-video-call-modal .video-frame .camera-preview-video.rotated-video {
+    inset: auto;
+    width: 100cqh;
+    height: 100cqw;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%) scaleX(-1) rotate(var(--video-rotation, 0deg));
+}
+.join-video-call-modal .c-video.no-mirror .video-frame .camera-preview.rotated-video,
+.join-video-call-modal .c-video.no-mirror .video-frame .camera-preview-video.rotated-video {
+    transform: translate(-50%, -50%) rotate(var(--video-rotation, 0deg));
 }
 /* Encoder-unavailable state: dim the preview and overlay the actionable
    restart prompt centred on the frame. Triggered by the modal's encoder

--- a/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/ShareLocationModal/share-location-modal.css
@@ -44,7 +44,7 @@ body.device-android .share-location-modal.picking .c-map-area {
     background: var(--black-05);
     content: '';
 }
-.share-location-modal .c-map-area .map-view.moving ~ .c-center-pin {
+.share-location-modal .c-map-area .map-view[data-moving] ~ .c-center-pin {
     transform: translateY(-0.375rem);
 }
 .share-location-modal .c-permission-prompt {

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -2663,6 +2663,16 @@ export class VideoRecorder {
                     const scale = 1000 / dt;
                     this.capturedPerSec =
                         Math.max(0, stats.framesCaptured - previous.framesCaptured) * scale;
+                    const offeredPerSec =
+                        Math.max(0, stats.framesOffered - previous.framesOffered) * scale;
+                    const encodedPerSec =
+                        Math.max(0, stats.bundlesEncoded - previous.bundlesEncoded) * scale;
+                    debugLog?.log(
+                        `recorderStats: captured=${Math.round(this.capturedPerSec)}/s `
+                        + `offered=${Math.round(offeredPerSec)}/s `
+                        + `encoded=${Math.round(encodedPerSec)}/s `
+                        + `shipped=${Math.round(this.bundlesPerSec)}/s `
+                        + `targetFps=${this.lastTargetFps}`);
                     this.bundlesPerSec =
                         Math.max(0, stats.bundlesShipped - previous.bundlesShipped) * scale;
                     this.bytesPerSec =

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -65,10 +65,13 @@ import {
     type LayerConfig,
 } from './layer-ladder';
 import { computeCaptureFps, computeTargetFps } from './fps-policy';
+import { isPreviewCanvasPreferred } from '../../Services/Video/preview-backend-override';
+import { isPreviewTraceEnabled } from '../../Services/Video/operators/preview-forwarder';
 import { getCaptureFpsOverride } from '../../Services/Video/capture-fps-override';
 import { MediaCapture } from '../../Services/Video/services/media-capture';
 import {
     type PreviewFramePresentation,
+    type PreviewTrace,
     type RecorderWorker,
     type RecorderWorkerCallbacks,
     type WireSafeRecorderConfig,
@@ -553,6 +556,7 @@ export class VideoRecorder {
     private _traceKillRegistration: Disposable | null = null;
     private recorderHealthTimer: number | null = null;
     private recorderHealthInFlight = false;
+    private lastPreviewTrace: PreviewTrace | null = null;
     private lastRecorderHealthStats: RecorderStats | null = null;
     private lastRecorderHealthWasPeerConnected = false;
 
@@ -780,6 +784,29 @@ export class VideoRecorder {
      */
     public toggleBlur(enabled: boolean): void {
         this.setIsBlurEnabled(enabled);
+    }
+
+    // Called by the preview view once the generated track is on a <video>.
+    // Until then the worker keeps the writable closed - see setPreviewAttached.
+    public notifyPreviewAttached(isAttached: boolean): void {
+        void this.worker?.setPreviewAttached(isAttached).catch(() => undefined);
+    }
+
+    // Rung 2 of the preview stall ladder: throw the generator away and publish a
+    // fresh track, which re-attaches the view through the usual listener path.
+    public rebuildPreviewGenerator(): void {
+        void this.worker?.rebuildPreviewGenerator().catch(() => undefined);
+    }
+
+    // Rung 3: give up on the generated track for the rest of the session and
+    // paint the preview from frames posted to main instead.
+    public forcePreviewCanvasFallback(): void {
+        warnLog?.log('forcePreviewCanvasFallback: generated preview track kept stalling');
+        void this.worker?.setPreviewAttached(false).catch(() => undefined);
+        this.cleanupGeneratedPreviewTrack();
+        this.previewCanvasFallback = true;
+        this.previewTrack = null;
+        this.notifyPreviewTrackChanged();
     }
 
     public getPreviewTrack(): MediaStreamTrack | null {
@@ -2177,7 +2204,7 @@ export class VideoRecorder {
         // No main-side generator (Safari): ask the worker to build one in its
         // realm and ship the track back via onPreviewTrackReady. Leave the
         // preview pending (don't commit to canvas yet) until that arrives.
-        const createPreviewInWorker = !previewGenerator;
+        const createPreviewInWorker = !previewGenerator && !isPreviewCanvasPreferred();
         if (previewGenerator) {
             this.setPreviewFramePresentation(null);
             this.previewCanvasFallback = false;
@@ -2186,6 +2213,13 @@ export class VideoRecorder {
                 this.notifyPreviewTrackChanged();
         } else {
             this.setPreviewFramePresentation(null);
+            // Nothing will report a track when the worker isn't building one, so
+            // commit to canvas here or the view never attaches at all.
+            if (!createPreviewInWorker) {
+                this.previewCanvasFallback = true;
+                this.previewTrack = null;
+                this.notifyPreviewTrackChanged();
+            }
         }
 
         void this.worker.start(
@@ -2641,6 +2675,41 @@ export class VideoRecorder {
         this.lastRecorderHealthWasPeerConnected = false;
     }
 
+    // The preview tap lives in the worker, whose console the inspector cannot
+    // reach — pulling the tally is the only way to see where frames stop.
+    // Deltas, so a stalled stage reads 0 while the ones before it keep moving.
+    private async reportPreviewTrace(): Promise<void> {
+        const worker = this.worker;
+        if (!worker)
+            return;
+
+        let trace: PreviewTrace;
+        try {
+            trace = await worker.getPreviewTrace();
+        } catch {
+            return;
+        }
+
+        const previous = this.lastPreviewTrace;
+        this.lastPreviewTrace = trace;
+        if (!previous)
+            return;
+
+        const d = (key: keyof PreviewTrace): number =>
+            Math.max(0, (trace[key] as number) - (previous[key] as number));
+        const sinceWriteMs = trace.lastWriteResolvedAtMs > 0
+            ? Math.round(trace.lastForwardedAtMs - trace.lastWriteResolvedAtMs)
+            : -1;
+        debugLog?.log(
+            `previewTrace: forwarded=${d('forwarded')} noConsumer=${d('noConsumer')} `
+            + `refused=${d('refused')} cloneFailed=${d('cloneFailed')} `
+            + `written=${d('writeCalled')} resolved=${d('writeResolved')} `
+            + `rejected=${d('writeRejected')} reported=${d('reported')} `
+            + `inFlight=${trace.writeCalled - trace.writeResolved - trace.writeRejected} `
+            + `desiredSize=${trace.lastDesiredSize} sinceResolvedMs=${sinceWriteMs}`
+            + (trace.lastError ? ` lastError=${trace.lastError}` : ''));
+    }
+
     private async reportRecorderStats(): Promise<void> {
         if (this.recorderHealthInFlight || !this.worker)
             return;
@@ -2671,6 +2740,8 @@ export class VideoRecorder {
                         + `encoded=${perSec(stats.bundlesEncoded, previous.bundlesEncoded)}/s `
                         + `shipped=${Math.round(this.bundlesPerSec)}/s `
                         + `targetFps=${this.lastTargetFps}`);
+                    if (debugLog && isPreviewTraceEnabled())
+                        void this.reportPreviewTrace();
                     this.bundlesPerSec =
                         Math.max(0, stats.bundlesShipped - previous.bundlesShipped) * scale;
                     this.bytesPerSec =
@@ -2814,6 +2885,10 @@ export class VideoRecorder {
 
     private createGeneratedPreviewTrack(): PreviewTrackGenerator | null {
         this.cleanupGeneratedPreviewTrack();
+        if (isPreviewCanvasPreferred()) {
+            debugLog?.log('createGeneratedPreviewTrack: canvas painter preferred');
+            return null;
+        }
         if (pickRenderBackendKind() !== 'mstg') {
             debugLog?.log('createGeneratedPreviewTrack: canvas preview selected');
             return null;

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -2663,14 +2663,12 @@ export class VideoRecorder {
                     const scale = 1000 / dt;
                     this.capturedPerSec =
                         Math.max(0, stats.framesCaptured - previous.framesCaptured) * scale;
-                    const offeredPerSec =
-                        Math.max(0, stats.framesOffered - previous.framesOffered) * scale;
-                    const encodedPerSec =
-                        Math.max(0, stats.bundlesEncoded - previous.bundlesEncoded) * scale;
+                    const perSec = (now: number, before: number): number =>
+                        Math.round(Math.max(0, now - before) * scale);
                     debugLog?.log(
                         `recorderStats: captured=${Math.round(this.capturedPerSec)}/s `
-                        + `offered=${Math.round(offeredPerSec)}/s `
-                        + `encoded=${Math.round(encodedPerSec)}/s `
+                        + `offered=${perSec(stats.framesOffered, previous.framesOffered)}/s `
+                        + `encoded=${perSec(stats.bundlesEncoded, previous.bundlesEncoded)}/s `
                         + `shipped=${Math.round(this.bundlesPerSec)}/s `
                         + `targetFps=${this.lastTargetFps}`);
                     this.bundlesPerSec =

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -786,29 +786,6 @@ export class VideoRecorder {
         this.setIsBlurEnabled(enabled);
     }
 
-    // Called by the preview view once the generated track is on a <video>.
-    // Until then the worker keeps the writable closed - see setPreviewAttached.
-    public notifyPreviewAttached(isAttached: boolean): void {
-        void this.worker?.setPreviewAttached(isAttached).catch(() => undefined);
-    }
-
-    // Rung 2 of the preview stall ladder: throw the generator away and publish a
-    // fresh track, which re-attaches the view through the usual listener path.
-    public rebuildPreviewGenerator(): void {
-        void this.worker?.rebuildPreviewGenerator().catch(() => undefined);
-    }
-
-    // Rung 3: give up on the generated track for the rest of the session and
-    // paint the preview from frames posted to main instead.
-    public forcePreviewCanvasFallback(): void {
-        warnLog?.log('forcePreviewCanvasFallback: generated preview track kept stalling');
-        void this.worker?.setPreviewAttached(false).catch(() => undefined);
-        this.cleanupGeneratedPreviewTrack();
-        this.previewCanvasFallback = true;
-        this.previewTrack = null;
-        this.notifyPreviewTrackChanged();
-    }
-
     public getPreviewTrack(): MediaStreamTrack | null {
         return this.previewTrack;
     }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-streaming-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-streaming-preview.css
@@ -47,10 +47,10 @@ body.wide .video-panel.expanded .video-streaming-preview .call-video-native {
    iOS (mstg) the idle one is the canvas, which is never drawn at all: the preview
    sink writes to the VideoTrackGenerator and skips the frame listeners that paint
    it. The receiver has always done this, in JS (video-player.ts applyBackendVisibility). */
-.video-streaming-preview.preview-backend-canvas .call-video-native {
+.video-streaming-preview[data-preview-backend="canvas"] .call-video-native {
     display: none;
 }
-.video-streaming-preview.preview-backend-mstg .call-video {
+.video-streaming-preview[data-preview-backend="mstg"] .call-video {
     display: none;
 }
 .video-streaming-preview .btn-h.btn-settings {
@@ -64,8 +64,8 @@ body.hoverable .video-streaming-preview .btn-h.btn-settings:hover {
     @apply hidden;
 }
 
-/* Loading spinner — JS (video-streaming-preview.ts) toggles `.starting` in the
-   render loop whenever a recorder is present, not interrupted, and the first
+/* Loading spinner — JS (video-streaming-preview.ts) toggles `data-starting` in
+   the render loop whenever a recorder is present, not interrupted, and the first
    frame hasn't landed yet. */
 .video-streaming-preview .video-loading {
     @apply absolute inset-0;
@@ -74,7 +74,7 @@ body.hoverable .video-streaming-preview .btn-h.btn-settings:hover {
     @apply hidden;
 }
 /* Loading spinner — shown while camera is starting */
-.video-streaming-preview.starting .video-loading {
+.video-streaming-preview[data-starting] .video-loading {
     @apply flex;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-streaming-preview.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-streaming-preview.ts
@@ -4,7 +4,7 @@ import { isBgBlurOff } from '../../Services/Video/playback/bg-blur-override';
 export class VideoStreamingPreview {
     private readonly element: HTMLElement;
     private readonly view: RecorderPreviewView;
-    private disposed = false;
+    private isDisposed = false;
 
     static create(element: HTMLElement, sourceKind: number): VideoStreamingPreview {
         return new VideoStreamingPreview(element, sourceKind);
@@ -26,14 +26,15 @@ export class VideoStreamingPreview {
             videoEl,
             bgCanvas,
             sourceKinds: [sourceKind],
+            // Attributes, not classes: Blazor owns `class` here and overwrites it.
             onFirstFrame: () => {
-                this.element.classList.add('has-video');
+                this.element.toggleAttribute('data-has-video', true);
             },
             onDetach: () => {
-                this.element.classList.remove('has-video');
+                this.element.toggleAttribute('data-has-video', false);
             },
             onStartingChange: (starting) => {
-                this.element.classList.toggle('starting', starting);
+                this.element.toggleAttribute('data-starting', starting);
             },
         });
     }
@@ -46,8 +47,10 @@ export class VideoStreamingPreview {
     }
 
     public dispose(): void {
-        if (this.disposed) return;
-        this.disposed = true;
+        if (this.isDisposed)
+            return;
+
+        this.isDisposed = true;
         this.view.dispose();
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/NotificationsPanelUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationsPanelUI.cs
@@ -16,6 +16,10 @@ public class NotificationsPanelUI : UIWorkerBase<AppUIHub>, IComputeService, INo
     private readonly StoredState<RetainedRead[]> _reads;
     private readonly MutableState<int> _tick;
     private readonly MutableState<Moment?> _panelOpenedAt;
+    // Last observed unread set per filter, and the chats an explicit dismissal has opted out of
+    // retention. Both are per-filter and only ever touched under _lock.
+    private readonly Dictionary<string, HashSet<ChatId>> _lastUnread = new();
+    private readonly Dictionary<string, HashSet<ChatId>> _suppressed = new();
 
     private ChatListUI ChatListUI => Hub.ChatListUI;
     private Moment Now => Clocks.SystemClock.Now;
@@ -44,6 +48,20 @@ public class NotificationsPanelUI : UIWorkerBase<AppUIHub>, IComputeService, INo
 
     public void Close()
         => _panelOpenedAt.Value = null;
+
+    public void DismissAll()
+    {
+        // Retention exists so the list doesn't vanish under someone who is reading; an explicit
+        // dismissal is the one case where it must not keep chats on screen. The chats it clears go
+        // read only once the server round-trip lands, so clearing _reads alone would race with the
+        // Track loop re-adding them - the currently unread ones are opted out up front instead.
+        lock (_lock) {
+            foreach (var (filterId, unread) in _lastUnread)
+                _suppressed[filterId] = [..unread];
+            if (_reads.Value.Length > 0)
+                _reads.Value = [];
+        }
+    }
 
     // Read chats still retained for the given panel filter under the current retention setting.
     [ComputeMethod]

--- a/src/dotnet/UI.Blazor.App/Services/NotificationsPanelUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationsPanelUI.cs
@@ -1,190 +1,160 @@
-using ActualChat.Kvas;
-using ActualChat.Users;
 using ActualLab.Interception;
 
 namespace ActualChat.UI.Blazor.App.Services;
 
+/// <summary>
+/// Keeps a chat in the notifications panel for a grace period after it stops being unread, so the
+/// list doesn't collapse under someone who is reading it.
+/// </summary>
 public class NotificationsPanelUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyInitialized
 {
     private static readonly ChatListFilter[] Filters =
         [ChatListFilter.Unread, ChatListFilter.UnreadPeople, ChatListFilter.UnreadMentions];
-    private static readonly TimeSpan GcPeriod = TimeSpan.FromSeconds(60);
-    // Storage upper bound: entries older than this can never be shown under any retention setting.
-    private static readonly TimeSpan MaxRetention = NotificationsPanelRetention.Hours24.ToTimeSpan();
+
+    // Not configurable: candidates live in memory, so a longer window couldn't be honoured anyway.
+    private static readonly TimeSpan Grace = TimeSpan.FromMinutes(5);
 
     private readonly object _lock = new();
-    private readonly StoredState<RetainedRead[]> _reads;
-    private readonly MutableState<int> _tick;
-    private readonly MutableState<Moment?> _panelOpenedAt;
-    // Last observed unread set per filter, and the chats an explicit dismissal has opted out of
-    // retention. Both are per-filter and only ever touched under _lock.
-    private readonly Dictionary<string, HashSet<ChatId>> _lastUnread = new();
-    private readonly Dictionary<string, HashSet<ChatId>> _suppressed = new();
+    private readonly Dictionary<Symbol, FilterState> _states = new();
+    private readonly MutableState<int> _version;
 
     private ChatListUI ChatListUI => Hub.ChatListUI;
+    private ChatUI ChatUI => Hub.ChatUI;
     private Moment Now => Clocks.SystemClock.Now;
 
     public NotificationsPanelUI(AppUIHub hub) : base(hub)
     {
-        _reads = StateFactory.NewKvasStored<RetainedRead[]>(
-            new(LocalSettings, nameof(NotificationsPanelUI)) {
-                InitialValue = [],
-                Category = StateCategories.Get(GetType(), nameof(_reads)),
-            });
-        _tick = StateFactory.NewMutable(0, StateCategories.Get(GetType(), nameof(_tick)));
-        _panelOpenedAt = StateFactory.NewMutable(
-            (Moment?)null, StateCategories.Get(GetType(), nameof(_panelOpenedAt)));
+        _version = StateFactory.NewMutable(0, StateCategories.Get(GetType(), nameof(_version)));
+        foreach (var filter in Filters)
+            _states[filter.Id] = new FilterState();
     }
 
     void INotifyInitialized.Initialized()
         => this.Start();
 
-    public void Open()
+    [ComputeMethod]
+    public virtual async Task<IReadOnlyDictionary<ChatId, ChatInfo>> GetExpiring(
+        Symbol filterId, CancellationToken cancellationToken = default)
     {
-        // Panel open/close - only matters for the UntilPanelClosed retention mode.
-        if (_panelOpenedAt.Value == null)
-            _panelOpenedAt.Value = Now;
-    }
+        // Chats that left the unread set recently enough to still be shown. The selected chat is
+        // held regardless of its exit time - it must not vanish from under the reader.
+        _ = await _version.Use(cancellationToken).ConfigureAwait(false);
+        var selectedChatId = await ChatUI.SelectedChatId.Use(cancellationToken).ConfigureAwait(false);
+        var now = Now;
+        var result = new Dictionary<ChatId, ChatInfo>();
+        var nearestExpiresAt = (Moment?)null;
+        lock (_lock) {
+            var state = _states[filterId];
+            var expiredIds = new List<ChatId>();
+            foreach (var (chatId, candidate) in state.Candidates) {
+                if (chatId == selectedChatId) {
+                    result.Add(chatId, candidate.ChatInfo);
+                    continue;
+                }
 
-    public void Close()
-        => _panelOpenedAt.Value = null;
+                var expiresAt = candidate.ExitedAt + Grace;
+                if (expiresAt <= now) {
+                    expiredIds.Add(chatId);
+                    continue;
+                }
+
+                result.Add(chatId, candidate.ChatInfo);
+                if (nearestExpiresAt is not { } nearest || expiresAt < nearest)
+                    nearestExpiresAt = expiresAt;
+            }
+            foreach (var chatId in expiredIds)
+                state.Candidates.Remove(chatId);
+        }
+
+        // Nothing else invalidates a purely time-based exit, so the nearest one schedules its pass.
+        if (nearestExpiresAt is { } at)
+            Computed.GetCurrent().InvalidateSafely(at - now);
+
+        return result;
+    }
 
     public void DismissAll()
     {
-        // Retention exists so the list doesn't vanish under someone who is reading; an explicit
-        // dismissal is the one case where it must not keep chats on screen. The chats it clears go
-        // read only once the server round-trip lands, so clearing _reads alone would race with the
-        // Track loop re-adding them - the currently unread ones are opted out up front instead.
+        // Clearing the candidates isn't enough on its own: the dismissal makes those chats read a
+        // round-trip later, and the tracker would then see them leaving and re-add them. Dropping
+        // the previous snapshot too means it never observes that exit at all.
+        var selectedChatId = ChatUI.SelectedChatId.Value;
         lock (_lock) {
-            foreach (var (filterId, unread) in _lastUnread)
-                _suppressed[filterId] = [..unread];
-            if (_reads.Value.Length > 0)
-                _reads.Value = [];
-        }
-    }
-
-    // Read chats still retained for the given panel filter under the current retention setting.
-    [ComputeMethod]
-    public virtual async Task<ImmutableHashSet<ChatId>> GetRetainedSet(
-        Symbol filterId, CancellationToken cancellationToken = default)
-    {
-        _ = await _tick.Use(cancellationToken).ConfigureAwait(false);
-        var reads = await _reads.Use(cancellationToken).ConfigureAwait(false);
-        if (reads.Length == 0)
-            return ImmutableHashSet<ChatId>.Empty;
-
-        var settings = await UserSettingsUI.UserNotificationsPanelSettings()
-            .Get(cancellationToken).ConfigureAwait(false);
-        var retention = settings.Retention;
-        if (retention == NotificationsPanelRetention.Immediately)
-            return ImmutableHashSet<ChatId>.Empty;
-
-        var filterKey = filterId.Value;
-        var result = ImmutableHashSet.CreateBuilder<ChatId>();
-        if (retention == NotificationsPanelRetention.UntilPanelClosed) {
-            var openedAt = await _panelOpenedAt.Use(cancellationToken).ConfigureAwait(false);
-            if (openedAt is not { } since)
-                return ImmutableHashSet<ChatId>.Empty;
-            foreach (var read in reads)
-                if (read.FilterId == filterKey && read.ReadAt >= since)
-                    result.Add(read.ChatId);
-            return result.ToImmutable();
+            var now = Now;
+            foreach (var state in _states.Values) {
+                // The chat on screen survives its own dismissal - it may be unread, or already read
+                // and holding a place in the list, and either way pulling it out from under the
+                // reader is what the grace period exists to prevent.
+                var kept = GetKept(state, selectedChatId, now);
+                state.Candidates.Clear();
+                if (kept is not null && selectedChatId is { } chatId)
+                    state.Candidates.Add(chatId, kept);
+                state.Previous = ImmutableDictionary<ChatId, ChatInfo>.Empty;
+            }
         }
 
-        var duration = retention.ToTimeSpan();
-        if (duration <= TimeSpan.Zero)
-            return ImmutableHashSet<ChatId>.Empty;
-
-        var now = Now;
-        foreach (var read in reads)
-            if (read.FilterId == filterKey && now - read.ReadAt < duration)
-                result.Add(read.ChatId);
-        return result.ToImmutable();
+        _version.Value++;
     }
+
+    // Protected methods
+
+    protected override Task OnRun(CancellationToken cancellationToken)
+        => Task.WhenAll(Filters.Select(filter => Track(filter, cancellationToken)));
 
     // Private methods
 
-    protected override async Task OnRun(CancellationToken cancellationToken)
-    {
-        await _reads.WhenRead.ConfigureAwait(false);
-        foreach (var filter in Filters)
-            _ = Track(filter, cancellationToken);
-
-        while (!cancellationToken.IsCancellationRequested) {
-            CollectGarbage();
-            // Re-publish so a time-based window is re-evaluated even when nothing was read/expired.
-            // Immediately / UntilPanelClosed don't depend on wall-clock, so they need no periodic tick.
-            if (_reads.Value.Length > 0 && await IsTimeBased(cancellationToken).ConfigureAwait(false))
-                _tick.Value++;
-            await Task.Delay(GcPeriod, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
     private async Task Track(ChatListFilter filter, CancellationToken cancellationToken)
     {
-        try {
-            HashSet<ChatId>? previous = null;
-            var computed = await Computed
-                .Capture(() => ChatListUI.ListUnordered(null, filter, cancellationToken), cancellationToken)
-                .ConfigureAwait(false);
-            await foreach (var c in computed.Changes(cancellationToken).ConfigureAwait(false)) {
-                if (c.HasError)
-                    continue;
-                var current = c.Value.Keys.ToHashSet();
-                OnUnreadChanged(filter.Id.Value, previous, current);
-                previous = current;
-            }
-        }
-        catch (OperationCanceledException) {
-            // Worker stopped
+        var computed = await Computed
+            .Capture(() => ChatListUI.ListUnordered(null, filter, cancellationToken), cancellationToken)
+            .ConfigureAwait(false);
+        await foreach (var c in computed.Changes(cancellationToken).ConfigureAwait(false)) {
+            if (c.HasError)
+                continue;
+
+            OnUnreadChanged(filter.Id, c.Value);
         }
     }
 
-    private async Task<bool> IsTimeBased(CancellationToken cancellationToken)
+    private void OnUnreadChanged(Symbol filterId, IReadOnlyDictionary<ChatId, ChatInfo> current)
     {
-        var settings = await UserSettingsUI.UserNotificationsPanelSettings()
-            .Get(cancellationToken).ConfigureAwait(false);
-        return settings.Retention
-            is not (NotificationsPanelRetention.Immediately or NotificationsPanelRetention.UntilPanelClosed);
-    }
-
-    private void OnUnreadChanged(string filterId, HashSet<ChatId>? previous, HashSet<ChatId> current)
-    {
+        var hasChanges = false;
         lock (_lock) {
-            var list = _reads.Value.ToList();
-            var changed = false;
-            // A chat that was unread and no longer is has just been read - start retaining it.
-            if (previous != null)
-                foreach (var chatId in previous)
-                    if (!current.Contains(chatId)
-                        && !list.Any(r => r.FilterId == filterId && r.ChatId == chatId)) {
-                        list.Add(new RetainedRead(filterId, chatId, Now));
-                        changed = true;
-                    }
-            // A chat that's unread again must not be retained - it shows via the live list instead.
-            changed |= list.RemoveAll(r => r.FilterId == filterId && current.Contains(r.ChatId)) > 0;
-            if (changed)
-                _reads.Value = list.ToArray();
-        }
-    }
-
-    private void CollectGarbage()
-    {
-        lock (_lock) {
-            var reads = _reads.Value;
-            if (reads.Length == 0)
-                return;
-
+            var state = _states[filterId];
             var now = Now;
-            var kept = reads.Where(r => now - r.ReadAt < MaxRetention).ToArray();
-            if (kept.Length != reads.Length)
-                _reads.Value = kept;
+            foreach (var (chatId, chatInfo) in state.Previous)
+                if (!current.ContainsKey(chatId) && state.Candidates.TryAdd(chatId, new Candidate(chatInfo, now)))
+                    hasChanges = true;
+            // A chat that's unread again shows via the live list, so it must not also be a candidate.
+            foreach (var chatId in current.Keys)
+                hasChanges |= state.Candidates.Remove(chatId);
+            state.Previous = current;
         }
+
+        if (hasChanges)
+            _version.Value++;
+    }
+
+    private static Candidate? GetKept(FilterState state, ChatId? selectedChatId, Moment now)
+    {
+        if (selectedChatId is not { } chatId)
+            return null;
+        if (state.Candidates.TryGetValue(chatId, out var candidate))
+            return candidate with { ExitedAt = now };
+
+        return state.Previous.TryGetValue(chatId, out var chatInfo)
+            ? new Candidate(chatInfo, now)
+            : null;
+    }
+
+    // Nested types
+
+    private sealed record Candidate(ChatInfo ChatInfo, Moment ExitedAt);
+
+    private sealed class FilterState
+    {
+        public Dictionary<ChatId, Candidate> Candidates { get; } = new();
+        public IReadOnlyDictionary<ChatId, ChatInfo> Previous { get; set; }
+            = ImmutableDictionary<ChatId, ChatInfo>.Empty;
     }
 }
-
-[DataContract, MessagePackObject]
-public sealed partial record RetainedRead(
-    [property: DataMember, Key(0)] string FilterId,
-    [property: DataMember, Key(1)] ChatId ChatId,
-    [property: DataMember, Key(2)] Moment ReadAt);

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
@@ -6,6 +6,9 @@ import { HAS_VF_ROTATION_INIT, wrapWithRotation } from '../video-frame-caps';
 const { warnLog } = getLogs('VideoPipeline');
 // Log first, then 1-in-N — prevents flooding when a device-level failure drops every clone.
 const LogEveryN = 30;
+// WebKit's VideoTrackGenerator can stop draining for good — a new <video> on the
+// same track stays frozen too, so only a fresh generator clears it.
+const JamThresholdMs = 1000;
 
 export interface PreviewSinkOptions {
     // iOS Safari's <video> auto-orients a generated (VTG) track to upright on
@@ -18,6 +21,8 @@ export interface PreviewSinkOptions {
     getWriter: () => WritableStreamDefaultWriter<VideoFrame> | null;
     reportFrame?: (frame: VideoFrame) => void | Promise<void>;
     reportPresentation?: (presentation: PreviewFramePresentation) => void;
+    // Writer refused every frame for JamThresholdMs; host should rebuild it.
+    onWriterJam?: () => void;
 }
 
 // The self-preview tap. `forward` takes a clone of the normalized ceiling
@@ -47,13 +52,37 @@ export interface PreviewSink {
 }
 
 export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
-    const { isIos, getWriter, reportFrame, reportPresentation } = opts;
+    const { isIos, getWriter, reportFrame, reportPresentation, onWriterJam } = opts;
     let failures = 0;
     let lastReportedRotation: number | null = null;
+    let refusedCount = 0;
+    let firstRefusalAtMs = 0;
     const reportFailure = (where: string, e: unknown): void => {
         failures++;
         if (failures === 1 || failures % LogEveryN === 0)
             warnLog?.log(`previewSink: ${where} failed (#${failures}):`, e);
+    };
+    // Re-arms itself: the window restarts after each report, so a generator that
+    // stays dead re-reports once per JamThresholdMs instead of once ever.
+    const noteWriterRefusal = (): void => {
+        const nowMs = performance.now();
+        if (refusedCount === 0)
+            firstRefusalAtMs = nowMs;
+
+        refusedCount++;
+        const elapsedMs = nowMs - firstRefusalAtMs;
+        if (elapsedMs < JamThresholdMs)
+            return;
+
+        warnLog?.log(
+            `previewSink: writer jammed — ${refusedCount} frames refused over ` +
+            `${Math.round(elapsedMs)}ms; asking the host for a fresh generator`);
+        refusedCount = 0;
+        try {
+            onWriterJam?.();
+        } catch (e) {
+            reportFailure('onWriterJam', e);
+        }
     };
     const reportPresentationOnce = (rotation: number): void => {
         if (!reportPresentation || lastReportedRotation === rotation)
@@ -127,10 +156,14 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
             // Writer back-pressure: drop instead of buffer. The downstream
             // <video> element drains MSTG at its render cadence; if desiredSize
             // is exhausted, the renderer is stalled and queueing here only
-            // delays the same drop while holding a GPU plane.
-            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0)
+            // delays the same drop while holding a GPU plane. A stall that
+            // never clears is a dead generator, not a slow renderer.
+            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0) {
+                noteWriterRefusal();
                 return;
+            }
 
+            refusedCount = 0;
             let clone: VideoFrame;
             try {
                 clone = source.clone();

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
@@ -1,11 +1,16 @@
 import { getLogs } from 'logging';
 import type { RotationQuarter } from '../orientation/quantize';
-import type { PreviewFramePresentation } from '../sender/recorder-worker-contract';
+import type { PreviewFramePresentation, PreviewTrace } from '../sender/recorder-worker-contract';
 import { HAS_VF_ROTATION_INIT, wrapWithRotation } from '../video-frame-caps';
 
 const { warnLog } = getLogs('VideoPipeline');
 // Log first, then 1-in-N — prevents flooding when a device-level failure drops every clone.
 const LogEveryN = 30;
+// Per-stage preview tally. Off in production - it costs an RPC per second and a
+// counter bump per frame. Flip to true to diagnose a frozen or blank preview;
+// see docs/ui/components.md.
+export const IS_PREVIEW_TRACE_ENABLED = false;
+export const isPreviewTraceEnabled = (): boolean => IS_PREVIEW_TRACE_ENABLED;
 
 export interface PreviewSinkOptions {
     // iOS Safari's <video> auto-orients a generated (VTG) track to upright on
@@ -18,6 +23,8 @@ export interface PreviewSinkOptions {
     getWriter: () => WritableStreamDefaultWriter<VideoFrame> | null;
     reportFrame?: (frame: VideoFrame) => void | Promise<void>;
     reportPresentation?: (presentation: PreviewFramePresentation) => void;
+    // Per-stage tally; main pulls it via getPreviewTrace().
+    trace?: PreviewTrace;
 }
 
 // The self-preview tap. `forward` takes a clone of the normalized ceiling
@@ -47,11 +54,14 @@ export interface PreviewSink {
 }
 
 export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
-    const { isIos, getWriter, reportFrame, reportPresentation } = opts;
+    const { isIos, getWriter, reportFrame, reportPresentation, trace } = opts;
     let failures = 0;
     let lastReportedRotation: number | null = null;
     const reportFailure = (where: string, e: unknown): void => {
         failures++;
+        if (trace)
+            trace.lastError = where + ': ' + (e instanceof Error ? e.message : String(e));
+
         if (failures === 1 || failures % LogEveryN === 0)
             warnLog?.log(`previewSink: ${where} failed (#${failures}):`, e);
     };
@@ -96,10 +106,28 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
         reportPresentationOnce(displayRotation);
 
         if (writer) {
+            if (trace)
+                trace.writeCalled++;
+
             writer.write(frame)
-                .catch((e: unknown) => reportFailure('writer.write', e))
+                .then(() => {
+                    if (!trace)
+                        return;
+
+                    trace.writeResolved++;
+                    trace.lastWriteResolvedAtMs = performance.now();
+                })
+                .catch((e: unknown) => {
+                    if (trace)
+                        trace.writeRejected++;
+
+                    reportFailure('writer.write', e);
+                })
                 .finally(() => closeFrame(frame));
         } else if (reportFrame) {
+            if (trace)
+                trace.reported++;
+
             const result = reportFrame(frame);
             if (result && typeof result.then === 'function') {
                 result
@@ -121,21 +149,37 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
                 return;
             }
 
-            if (!writer && !reportFrame)
+            if (trace) {
+                trace.forwarded++;
+                trace.lastForwardedAtMs = performance.now();
+                trace.lastDesiredSize = writer ? writer.desiredSize : null;
+            }
+            if (!writer && !reportFrame) {
+                if (trace)
+                    trace.noConsumer++;
+
                 return;
+            }
 
 
             // Writer back-pressure: drop instead of buffer. The downstream
             // <video> element drains MSTG at its render cadence; if desiredSize
             // is exhausted, the renderer is stalled and queueing here only
             // delays the same drop while holding a GPU plane.
-            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0)
+            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0) {
+                if (trace)
+                    trace.refused++;
+
                 return;
+            }
 
             let clone: VideoFrame;
             try {
                 clone = source.clone();
             } catch (e) {
+                if (trace)
+                    trace.cloneFailed++;
+
                 reportFailure('frame clone', e);
                 return;
             }

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
@@ -3,7 +3,10 @@ import type { RotationQuarter } from '../orientation/quantize';
 import type { PreviewFramePresentation } from '../sender/recorder-worker-contract';
 import { HAS_VF_ROTATION_INIT, wrapWithRotation } from '../video-frame-caps';
 
-const { warnLog } = getLogs('VideoPipeline');
+const { warnLog, debugLog } = getLogs('VideoPipeline');
+// Frozen self-previews are otherwise invisible: nothing on this path logs, and
+// <video>.currentTime keeps advancing whether or not frames arrive.
+const StatsIntervalMs = 1000;
 // Log first, then 1-in-N — prevents flooding when a device-level failure drops every clone.
 const LogEveryN = 30;
 // WebKit's VideoTrackGenerator can stop draining for good — a new <video> on the
@@ -57,6 +60,27 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
     let lastReportedRotation: number | null = null;
     let refusedCount = 0;
     let firstRefusalAtMs = 0;
+    let statsAtMs = 0;
+    let forwardedCount = 0;
+    let deliveredCount = 0;
+    let refusedTotal = 0;
+    const reportStats = (desiredSize: number | null): void => {
+        const nowMs = performance.now();
+        if (statsAtMs === 0)
+            statsAtMs = nowMs;
+
+        if (nowMs - statsAtMs < StatsIntervalMs)
+            return;
+
+        debugLog?.log(
+            `previewSink: forwarded=${forwardedCount} delivered=${deliveredCount} ` +
+            `refused=${refusedTotal} desiredSize=${desiredSize} over ` +
+            `${Math.round(nowMs - statsAtMs)}ms`);
+        statsAtMs = nowMs;
+        forwardedCount = 0;
+        deliveredCount = 0;
+        refusedTotal = 0;
+    };
     const reportFailure = (where: string, e: unknown): void => {
         failures++;
         if (failures === 1 || failures % LogEveryN === 0)
@@ -125,6 +149,7 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
         reportPresentationOnce(displayRotation);
 
         if (writer) {
+            deliveredCount++;
             writer.write(frame)
                 .catch((e: unknown) => reportFailure('writer.write', e))
                 .finally(() => closeFrame(frame));
@@ -153,12 +178,16 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
             if (!writer && !reportFrame)
                 return;
 
+            forwardedCount++;
+            reportStats(writer ? writer.desiredSize : null);
+
             // Writer back-pressure: drop instead of buffer. The downstream
             // <video> element drains MSTG at its render cadence; if desiredSize
             // is exhausted, the renderer is stalled and queueing here only
             // delays the same drop while holding a GPU plane. A stall that
             // never clears is a dead generator, not a slow renderer.
             if (writer && writer.desiredSize !== null && writer.desiredSize <= 0) {
+                refusedTotal++;
                 noteWriterRefusal();
                 return;
             }

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder.ts
@@ -3,15 +3,9 @@ import type { RotationQuarter } from '../orientation/quantize';
 import type { PreviewFramePresentation } from '../sender/recorder-worker-contract';
 import { HAS_VF_ROTATION_INIT, wrapWithRotation } from '../video-frame-caps';
 
-const { warnLog, debugLog } = getLogs('VideoPipeline');
-// Frozen self-previews are otherwise invisible: nothing on this path logs, and
-// <video>.currentTime keeps advancing whether or not frames arrive.
-const StatsIntervalMs = 1000;
+const { warnLog } = getLogs('VideoPipeline');
 // Log first, then 1-in-N — prevents flooding when a device-level failure drops every clone.
 const LogEveryN = 30;
-// WebKit's VideoTrackGenerator can stop draining for good — a new <video> on the
-// same track stays frozen too, so only a fresh generator clears it.
-const JamThresholdMs = 1000;
 
 export interface PreviewSinkOptions {
     // iOS Safari's <video> auto-orients a generated (VTG) track to upright on
@@ -24,8 +18,6 @@ export interface PreviewSinkOptions {
     getWriter: () => WritableStreamDefaultWriter<VideoFrame> | null;
     reportFrame?: (frame: VideoFrame) => void | Promise<void>;
     reportPresentation?: (presentation: PreviewFramePresentation) => void;
-    // Writer refused every frame for JamThresholdMs; host should rebuild it.
-    onWriterJam?: () => void;
 }
 
 // The self-preview tap. `forward` takes a clone of the normalized ceiling
@@ -55,58 +47,13 @@ export interface PreviewSink {
 }
 
 export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
-    const { isIos, getWriter, reportFrame, reportPresentation, onWriterJam } = opts;
+    const { isIos, getWriter, reportFrame, reportPresentation } = opts;
     let failures = 0;
     let lastReportedRotation: number | null = null;
-    let refusedCount = 0;
-    let firstRefusalAtMs = 0;
-    let statsAtMs = 0;
-    let forwardedCount = 0;
-    let deliveredCount = 0;
-    let refusedTotal = 0;
-    const reportStats = (desiredSize: number | null): void => {
-        const nowMs = performance.now();
-        if (statsAtMs === 0)
-            statsAtMs = nowMs;
-
-        if (nowMs - statsAtMs < StatsIntervalMs)
-            return;
-
-        debugLog?.log(
-            `previewSink: forwarded=${forwardedCount} delivered=${deliveredCount} ` +
-            `refused=${refusedTotal} desiredSize=${desiredSize} over ` +
-            `${Math.round(nowMs - statsAtMs)}ms`);
-        statsAtMs = nowMs;
-        forwardedCount = 0;
-        deliveredCount = 0;
-        refusedTotal = 0;
-    };
     const reportFailure = (where: string, e: unknown): void => {
         failures++;
         if (failures === 1 || failures % LogEveryN === 0)
             warnLog?.log(`previewSink: ${where} failed (#${failures}):`, e);
-    };
-    // Re-arms itself: the window restarts after each report, so a generator that
-    // stays dead re-reports once per JamThresholdMs instead of once ever.
-    const noteWriterRefusal = (): void => {
-        const nowMs = performance.now();
-        if (refusedCount === 0)
-            firstRefusalAtMs = nowMs;
-
-        refusedCount++;
-        const elapsedMs = nowMs - firstRefusalAtMs;
-        if (elapsedMs < JamThresholdMs)
-            return;
-
-        warnLog?.log(
-            `previewSink: writer jammed — ${refusedCount} frames refused over ` +
-            `${Math.round(elapsedMs)}ms; asking the host for a fresh generator`);
-        refusedCount = 0;
-        try {
-            onWriterJam?.();
-        } catch (e) {
-            reportFailure('onWriterJam', e);
-        }
     };
     const reportPresentationOnce = (rotation: number): void => {
         if (!reportPresentation || lastReportedRotation === rotation)
@@ -149,7 +96,6 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
         reportPresentationOnce(displayRotation);
 
         if (writer) {
-            deliveredCount++;
             writer.write(frame)
                 .catch((e: unknown) => reportFailure('writer.write', e))
                 .finally(() => closeFrame(frame));
@@ -178,21 +124,14 @@ export function createPreviewSink(opts: PreviewSinkOptions): PreviewSink {
             if (!writer && !reportFrame)
                 return;
 
-            forwardedCount++;
-            reportStats(writer ? writer.desiredSize : null);
 
             // Writer back-pressure: drop instead of buffer. The downstream
             // <video> element drains MSTG at its render cadence; if desiredSize
             // is exhausted, the renderer is stalled and queueing here only
-            // delays the same drop while holding a GPU plane. A stall that
-            // never clears is a dead generator, not a slow renderer.
-            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0) {
-                refusedTotal++;
-                noteWriterRefusal();
+            // delays the same drop while holding a GPU plane.
+            if (writer && writer.desiredSize !== null && writer.desiredSize <= 0)
                 return;
-            }
 
-            refusedCount = 0;
             let clone: VideoFrame;
             try {
                 clone = source.clone();

--- a/src/dotnet/UI.Blazor.App/Services/Video/preview-backend-override.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/preview-backend-override.ts
@@ -1,0 +1,40 @@
+// Which surface paints the self-preview. WebKit gets the canvas painter: it
+// measured ~6.5 points cheaper on an iPhone 13 Pro (painting moves into
+// WebKit.GPU, but backboardd no longer composites a video layer) and it
+// sidesteps WebKit bug 230922. See docs/ui/components.md.
+//
+// `video.debug.previewCanvas`: '1' forces canvas, '0' forces the generated
+// track, absent uses the default.
+
+import { DeviceInfo } from 'device-info';
+
+const KEY = 'video.debug.previewCanvas';
+
+export function isPreviewCanvasPreferred(): boolean {
+    return readOverride() ?? DeviceInfo.isWebKit;
+}
+
+export function setPreviewCanvasOverride(isCanvas: boolean | null): void {
+    try {
+        if (isCanvas === null)
+            globalThis.localStorage.removeItem(KEY);
+        else
+            globalThis.localStorage.setItem(KEY, isCanvas ? '1' : '0');
+    } catch { /* ignore */ }
+}
+
+// Private methods
+
+function readOverride(): boolean | null {
+    try {
+        const raw = globalThis.localStorage.getItem(KEY);
+        if (raw === '1')
+            return true;
+        if (raw === '0')
+            return false;
+
+        return null;
+    } catch {
+        return null;
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-contract.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-contract.ts
@@ -127,12 +127,6 @@ export interface RecorderWorker extends SharedSettingsWorker {
     // Demand-driven target fps for temporal pacing. <=0 drops every frame
     // (idle: stop encoding, keep camera warm). Hot-applied, no restart.
     setTargetFps(fps: number, noWait?: RpcNoWait): Promise<void>;
-    // Opens the preview writable only once main has the track on a <video>.
-    // Writing into a worker-built generator that nothing reads yet leaves WebKit
-    // resolving every write while the track emits nothing.
-    setPreviewAttached(isAttached: boolean): Promise<void>;
-    // Discards a generator whose track stopped emitting and ships a fresh one.
-    rebuildPreviewGenerator(): Promise<void>;
     getStats(): Promise<RecorderStats>;
     getPreviewTrace(): Promise<PreviewTrace>;
     stop(): Promise<void>;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-contract.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker-contract.ts
@@ -59,6 +59,25 @@ export interface PreviewFramePresentation {
     rotation: number;
 }
 
+// Per-stage tally of the preview tap, pulled to main because the inspector
+// exposes no worker target — anything logged in this realm is unreadable.
+// Counters are cumulative; timestamps are worker `performance.now()`, so only
+// their deltas are meaningful on main.
+export interface PreviewTrace {
+    forwarded: number;
+    noConsumer: number;
+    refused: number;
+    cloneFailed: number;
+    writeCalled: number;
+    writeResolved: number;
+    writeRejected: number;
+    reported: number;
+    lastForwardedAtMs: number;
+    lastWriteResolvedAtMs: number;
+    lastDesiredSize: number | null;
+    lastError: string;
+}
+
 // Structural subset of `AppConstants` — anything assignable to AppConstants fits.
 export interface AppConstantsLike { readonly appName: string; readonly prodHost: string; readonly video: unknown; readonly audio: unknown }
 
@@ -108,7 +127,14 @@ export interface RecorderWorker extends SharedSettingsWorker {
     // Demand-driven target fps for temporal pacing. <=0 drops every frame
     // (idle: stop encoding, keep camera warm). Hot-applied, no restart.
     setTargetFps(fps: number, noWait?: RpcNoWait): Promise<void>;
+    // Opens the preview writable only once main has the track on a <video>.
+    // Writing into a worker-built generator that nothing reads yet leaves WebKit
+    // resolving every write while the track emits nothing.
+    setPreviewAttached(isAttached: boolean): Promise<void>;
+    // Discards a generator whose track stopped emitting and ships a fresh one.
+    rebuildPreviewGenerator(): Promise<void>;
     getStats(): Promise<RecorderStats>;
+    getPreviewTrace(): Promise<PreviewTrace>;
     stop(): Promise<void>;
 
     // No-op today — the new pipeline lazy-creates the peer per stream and the

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -105,10 +105,6 @@ export function initRecorderWorker(deps: RecorderWorkerDeps): void {
     const session = (deps.createSession ?? (() => new SenderSession()))();
     session.setPreviewFrameReporter(deps.reportPreviewFrame);
     session.setPreviewFramePresentationReporter(deps.reportPreviewFramePresentation);
-    session.setPreviewWriterJamHandler(() => {
-        if (state)
-            recreateWorkerPreviewGenerator(state);
-    });
     state = {
         session,
         recorder: new Recorder(session),
@@ -117,6 +113,20 @@ export function initRecorderWorker(deps: RecorderWorkerDeps): void {
         workerPreviewGenerator: null,
         workerSourceTrack: null,
     };
+}
+
+// Keeps a live generator across a restart so the preview <video> never has to
+// re-attach; builds a new one only when there isn't a usable one.
+function reuseOrInstallWorkerPreviewGenerator(s: WorkerState): void {
+    const generator = s.workerPreviewGenerator;
+    if (generator?.track.readyState === 'live') {
+        s.session.setPreviewGenerator({ writable: generator.writable });
+        s.deps.reportPreviewTrack?.(generator.track);
+        return;
+    }
+
+    disposeWorkerPreviewGenerator(s);
+    installWorkerPreviewGenerator(s);
 }
 
 // Stops the worker-created preview generator's track (if any) and clears the
@@ -139,18 +149,6 @@ function installWorkerPreviewGenerator(s: WorkerState): void {
     s.workerPreviewGenerator = generator;
     s.session.setPreviewGenerator(generator ? { writable: generator.writable } : undefined);
     s.deps.reportPreviewTrack?.(generator?.track ?? null);
-}
-
-// A jammed writer means WebKit's generator stopped draining for good — the
-// pipeline keeps producing, but nothing reaches the <video> again. Swapping in a
-// fresh generator is the only recovery, and it costs no capture/encoder restart.
-// Only Tier 1 (worker-built) generators are ours to replace.
-function recreateWorkerPreviewGenerator(s: WorkerState): void {
-    if (!s.workerPreviewGenerator)
-        return;
-
-    disposeWorkerPreviewGenerator(s);
-    installWorkerPreviewGenerator(s);
 }
 
 // Stops the worker-owned capture track (transferred clone) feeding a worker-side
@@ -281,16 +279,22 @@ export const recorderWorkerImpl: RecorderWorker = {
 
         const { config } = opts;
         const { deps, recorder, session } = s;
-        disposeWorkerPreviewGenerator(s);
         if (previewWritable) {
             // Tier 2: main built the generator (Chromium) and transferred only
             // the writable.
+            disposeWorkerPreviewGenerator(s);
             session.setPreviewGenerator({ writable: previewWritable });
         } else if (opts.createPreviewInWorker) {
             // Tier 1: main couldn't build a generator (Safari) — create it here
             // and ship the track back. Writable stays in this realm.
-            installWorkerPreviewGenerator(s);
+            //
+            // Reused across runs while its track is still live. The generator is
+            // independent of which camera feeds it, and on iOS a generator built
+            // during a camera switch delivers its first frame and then stops for
+            // good, while one carried over from warmup keeps working.
+            reuseOrInstallWorkerPreviewGenerator(s);
         } else {
+            disposeWorkerPreviewGenerator(s);
             session.setPreviewGenerator(undefined);
         }
         // Streaming context must land before the pipeline starts so
@@ -385,8 +389,9 @@ export const recorderWorkerImpl: RecorderWorker = {
                 catch (reportError) { errorLog?.log('reportStreamEnded failed:', reportError); }
             },
         ).finally(() => {
+            // Releases the writer lock but leaves a worker-owned generator alive
+            // for the next run to reuse; disposeRecorderWorker still stops it.
             session.setPreviewGenerator(undefined);
-            disposeWorkerPreviewGenerator(s);
             disposeWorkerSourceTrack(s);
             if (s.whenDone === whenDone)
                 s.whenDone = null;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -133,7 +133,9 @@ function disposeWorkerPreviewGenerator(s: WorkerState): void {
 function installWorkerPreviewGenerator(s: WorkerState): void {
     const generator = createWorkerVideoTrackGenerator();
     s.workerPreviewGenerator = generator;
-    s.session.setPreviewGenerator(generator ? { writable: generator.writable } : undefined);
+    // Writable stays closed until setPreviewAttached(true); until then the sink
+    // sees no writer and the generator is never written to unread.
+    s.session.setPreviewGenerator(undefined);
     s.deps.reportPreviewTrack?.(generator?.track ?? null);
 }
 
@@ -411,6 +413,29 @@ export const recorderWorkerImpl: RecorderWorker = {
         const s = requireState();
         s.recorder.setTargetFps(fps);
         await Promise.resolve();
+    },
+
+    getPreviewTrace(): Promise<import('./recorder-worker-contract').PreviewTrace> {
+        const s = requireState();
+        return Promise.resolve({ ...s.session.previewTrace });
+    },
+
+    setPreviewAttached(isAttached: boolean): Promise<void> {
+        const s = requireState();
+        const generator = s.workerPreviewGenerator;
+        s.session.setPreviewGenerator(
+            isAttached && generator ? { writable: generator.writable } : undefined);
+        return Promise.resolve();
+    },
+
+    rebuildPreviewGenerator(): Promise<void> {
+        const s = requireState();
+        if (!s.workerPreviewGenerator)
+            return Promise.resolve();
+
+        disposeWorkerPreviewGenerator(s);
+        installWorkerPreviewGenerator(s);
+        return Promise.resolve();
     },
 
     getStats(): Promise<RecorderStats> {

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -105,6 +105,10 @@ export function initRecorderWorker(deps: RecorderWorkerDeps): void {
     const session = (deps.createSession ?? (() => new SenderSession()))();
     session.setPreviewFrameReporter(deps.reportPreviewFrame);
     session.setPreviewFramePresentationReporter(deps.reportPreviewFramePresentation);
+    session.setPreviewWriterJamHandler(() => {
+        if (state)
+            recreateWorkerPreviewGenerator(state);
+    });
     state = {
         session,
         recorder: new Recorder(session),
@@ -125,6 +129,28 @@ function disposeWorkerPreviewGenerator(s: WorkerState): void {
 
     s.workerPreviewGenerator = null;
     try { generator.track.stop(); } catch { /* ignore */ }
+}
+
+// Builds the worker-side generator, hands its writable to the session and ships
+// the track to main. `reportPreviewTrack(null)` puts the preview on the canvas
+// fallback when the platform has no generator at all.
+function installWorkerPreviewGenerator(s: WorkerState): void {
+    const generator = createWorkerVideoTrackGenerator();
+    s.workerPreviewGenerator = generator;
+    s.session.setPreviewGenerator(generator ? { writable: generator.writable } : undefined);
+    s.deps.reportPreviewTrack?.(generator?.track ?? null);
+}
+
+// A jammed writer means WebKit's generator stopped draining for good — the
+// pipeline keeps producing, but nothing reaches the <video> again. Swapping in a
+// fresh generator is the only recovery, and it costs no capture/encoder restart.
+// Only Tier 1 (worker-built) generators are ours to replace.
+function recreateWorkerPreviewGenerator(s: WorkerState): void {
+    if (!s.workerPreviewGenerator)
+        return;
+
+    disposeWorkerPreviewGenerator(s);
+    installWorkerPreviewGenerator(s);
 }
 
 // Stops the worker-owned capture track (transferred clone) feeding a worker-side
@@ -263,15 +289,7 @@ export const recorderWorkerImpl: RecorderWorker = {
         } else if (opts.createPreviewInWorker) {
             // Tier 1: main couldn't build a generator (Safari) — create it here
             // and ship the track back. Writable stays in this realm.
-            const generator = createWorkerVideoTrackGenerator();
-            if (generator) {
-                s.workerPreviewGenerator = generator;
-                session.setPreviewGenerator({ writable: generator.writable });
-                deps.reportPreviewTrack?.(generator.track);
-            } else {
-                session.setPreviewGenerator(undefined);
-                deps.reportPreviewTrack?.(null);
-            }
+            installWorkerPreviewGenerator(s);
         } else {
             session.setPreviewGenerator(undefined);
         }

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -133,9 +133,7 @@ function disposeWorkerPreviewGenerator(s: WorkerState): void {
 function installWorkerPreviewGenerator(s: WorkerState): void {
     const generator = createWorkerVideoTrackGenerator();
     s.workerPreviewGenerator = generator;
-    // Writable stays closed until setPreviewAttached(true); until then the sink
-    // sees no writer and the generator is never written to unread.
-    s.session.setPreviewGenerator(undefined);
+    s.session.setPreviewGenerator(generator ? { writable: generator.writable } : undefined);
     s.deps.reportPreviewTrack?.(generator?.track ?? null);
 }
 
@@ -418,24 +416,6 @@ export const recorderWorkerImpl: RecorderWorker = {
     getPreviewTrace(): Promise<import('./recorder-worker-contract').PreviewTrace> {
         const s = requireState();
         return Promise.resolve({ ...s.session.previewTrace });
-    },
-
-    setPreviewAttached(isAttached: boolean): Promise<void> {
-        const s = requireState();
-        const generator = s.workerPreviewGenerator;
-        s.session.setPreviewGenerator(
-            isAttached && generator ? { writable: generator.writable } : undefined);
-        return Promise.resolve();
-    },
-
-    rebuildPreviewGenerator(): Promise<void> {
-        const s = requireState();
-        if (!s.workerPreviewGenerator)
-            return Promise.resolve();
-
-        disposeWorkerPreviewGenerator(s);
-        installWorkerPreviewGenerator(s);
-        return Promise.resolve();
     },
 
     getStats(): Promise<RecorderStats> {

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder-worker.ts
@@ -115,20 +115,6 @@ export function initRecorderWorker(deps: RecorderWorkerDeps): void {
     };
 }
 
-// Keeps a live generator across a restart so the preview <video> never has to
-// re-attach; builds a new one only when there isn't a usable one.
-function reuseOrInstallWorkerPreviewGenerator(s: WorkerState): void {
-    const generator = s.workerPreviewGenerator;
-    if (generator?.track.readyState === 'live') {
-        s.session.setPreviewGenerator({ writable: generator.writable });
-        s.deps.reportPreviewTrack?.(generator.track);
-        return;
-    }
-
-    disposeWorkerPreviewGenerator(s);
-    installWorkerPreviewGenerator(s);
-}
-
 // Stops the worker-created preview generator's track (if any) and clears the
 // ref. The track was transferred to main, but stopping it here closes the
 // underlying source so the generator's writable can be released.
@@ -279,22 +265,16 @@ export const recorderWorkerImpl: RecorderWorker = {
 
         const { config } = opts;
         const { deps, recorder, session } = s;
+        disposeWorkerPreviewGenerator(s);
         if (previewWritable) {
             // Tier 2: main built the generator (Chromium) and transferred only
             // the writable.
-            disposeWorkerPreviewGenerator(s);
             session.setPreviewGenerator({ writable: previewWritable });
         } else if (opts.createPreviewInWorker) {
             // Tier 1: main couldn't build a generator (Safari) — create it here
             // and ship the track back. Writable stays in this realm.
-            //
-            // Reused across runs while its track is still live. The generator is
-            // independent of which camera feeds it, and on iOS a generator built
-            // during a camera switch delivers its first frame and then stops for
-            // good, while one carried over from warmup keeps working.
-            reuseOrInstallWorkerPreviewGenerator(s);
+            installWorkerPreviewGenerator(s);
         } else {
-            disposeWorkerPreviewGenerator(s);
             session.setPreviewGenerator(undefined);
         }
         // Streaming context must land before the pipeline starts so
@@ -389,9 +369,8 @@ export const recorderWorkerImpl: RecorderWorker = {
                 catch (reportError) { errorLog?.log('reportStreamEnded failed:', reportError); }
             },
         ).finally(() => {
-            // Releases the writer lock but leaves a worker-owned generator alive
-            // for the next run to reuse; disposeRecorderWorker still stops it.
             session.setPreviewGenerator(undefined);
+            disposeWorkerPreviewGenerator(s);
             disposeWorkerSourceTrack(s);
             if (s.whenDone === whenDone)
                 s.whenDone = null;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
@@ -139,6 +139,7 @@ export class Recorder {
             getWriter: () => this.session.getPreviewWriter(),
             reportFrame: frame => this.session.reportPreviewFrame(frame),
             reportPresentation: p => this.session.reportPreviewFramePresentation(p),
+            onWriterJam: () => this.session.reportPreviewWriterJam(),
         });
 
         // Two pipes only because pipe()'s typed overload tops out at 10 ops;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
@@ -16,7 +16,7 @@ import { mstpSource } from '../operators/capture';
 import { stampCaptureTime } from '../operators/stamp-capture-time';
 import { attachSourceDims } from '../operators/attach-source-dims';
 import { normalizeDownscale, type DownscalerMode } from '../operators/downscale';
-import { createPreviewSink } from '../operators/preview-forwarder';
+import { createPreviewSink, isPreviewTraceEnabled } from '../operators/preview-forwarder';
 import { applyKeyframePolicy } from '../operators/apply-keyframe-policy';
 import { encode, type EncoderConfigPerLayer, type EncoderFactory } from '../operators/encode';
 import { FloodGate, floodGate } from '../operators/flood-gate';
@@ -139,6 +139,7 @@ export class Recorder {
             getWriter: () => this.session.getPreviewWriter(),
             reportFrame: frame => this.session.reportPreviewFrame(frame),
             reportPresentation: p => this.session.reportPreviewFramePresentation(p),
+            trace: isPreviewTraceEnabled() ? this.session.previewTrace : undefined,
         });
 
         // Two pipes only because pipe()'s typed overload tops out at 10 ops;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
@@ -139,7 +139,6 @@ export class Recorder {
             getWriter: () => this.session.getPreviewWriter(),
             reportFrame: frame => this.session.reportPreviewFrame(frame),
             reportPresentation: p => this.session.reportPreviewFramePresentation(p),
-            onWriterJam: () => this.session.reportPreviewWriterJam(),
         });
 
         // Two pipes only because pipe()'s typed overload tops out at 10 ops;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
@@ -19,7 +19,6 @@ export interface SenderSessionOptions {
     previewGenerator?: PreviewGeneratorLike;
     onPreviewFrame?: (frame: VideoFrame) => void | Promise<void>;
     onPreviewFramePresentation?: (presentation: PreviewFramePresentation) => void;
-    onPreviewWriterJam?: () => void;
     createCaptureClock?: () => MonotonicClock;
 }
 
@@ -29,7 +28,6 @@ export class SenderSession {
     private previewWriter: WritableStreamDefaultWriter<VideoFrame> | null = null;
     private onPreviewFrame: ((frame: VideoFrame) => void | Promise<void>) | null = null;
     private onPreviewFramePresentation: ((presentation: PreviewFramePresentation) => void) | null = null;
-    private onPreviewWriterJam: (() => void) | null = null;
 
     private disposed = false;
     private lastPreviewFramePresentation: PreviewFramePresentation | null = null;
@@ -41,7 +39,6 @@ export class SenderSession {
         this.encoderPool = new EncoderPool();
         this.onPreviewFrame = opts.onPreviewFrame ?? null;
         this.onPreviewFramePresentation = opts.onPreviewFramePresentation ?? null;
-        this.onPreviewWriterJam = opts.onPreviewWriterJam ?? null;
         this.setPreviewGenerator(opts.previewGenerator);
     }
 
@@ -57,14 +54,6 @@ export class SenderSession {
 
         this.lastPreviewFramePresentation = presentation;
         this.onPreviewFramePresentation?.(presentation);
-    }
-
-    reportPreviewWriterJam(): void {
-        this.onPreviewWriterJam?.();
-    }
-
-    setPreviewWriterJamHandler(handler: (() => void) | undefined): void {
-        this.onPreviewWriterJam = handler ?? null;
     }
 
     setPreviewGenerator(generator: PreviewGeneratorLike | undefined): void {

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
@@ -9,7 +9,7 @@
 
 import { MonotonicClock } from 'clocks';
 import { EncoderPool } from './encoder-pool';
-import type { PreviewFramePresentation } from './recorder-worker-contract';
+import type { PreviewFramePresentation, PreviewTrace } from './recorder-worker-contract';
 
 export interface PreviewGeneratorLike {
     writable: WritableStream<VideoFrame>;
@@ -22,9 +22,20 @@ export interface SenderSessionOptions {
     createCaptureClock?: () => MonotonicClock;
 }
 
+export function createEmptyPreviewTrace(): PreviewTrace {
+    return {
+        forwarded: 0, noConsumer: 0, refused: 0, cloneFailed: 0,
+        writeCalled: 0, writeResolved: 0, writeRejected: 0, reported: 0,
+        lastForwardedAtMs: 0, lastWriteResolvedAtMs: 0,
+        lastDesiredSize: null, lastError: '',
+    };
+}
+
 export class SenderSession {
     readonly captureClock: MonotonicClock;
     readonly encoderPool: EncoderPool;
+    // Survives runs so a restart's trace is comparable with the run before it.
+    readonly previewTrace: PreviewTrace = createEmptyPreviewTrace();
     private previewWriter: WritableStreamDefaultWriter<VideoFrame> | null = null;
     private onPreviewFrame: ((frame: VideoFrame) => void | Promise<void>) | null = null;
     private onPreviewFramePresentation: ((presentation: PreviewFramePresentation) => void) | null = null;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/session.ts
@@ -19,6 +19,7 @@ export interface SenderSessionOptions {
     previewGenerator?: PreviewGeneratorLike;
     onPreviewFrame?: (frame: VideoFrame) => void | Promise<void>;
     onPreviewFramePresentation?: (presentation: PreviewFramePresentation) => void;
+    onPreviewWriterJam?: () => void;
     createCaptureClock?: () => MonotonicClock;
 }
 
@@ -28,6 +29,7 @@ export class SenderSession {
     private previewWriter: WritableStreamDefaultWriter<VideoFrame> | null = null;
     private onPreviewFrame: ((frame: VideoFrame) => void | Promise<void>) | null = null;
     private onPreviewFramePresentation: ((presentation: PreviewFramePresentation) => void) | null = null;
+    private onPreviewWriterJam: (() => void) | null = null;
 
     private disposed = false;
     private lastPreviewFramePresentation: PreviewFramePresentation | null = null;
@@ -39,6 +41,7 @@ export class SenderSession {
         this.encoderPool = new EncoderPool();
         this.onPreviewFrame = opts.onPreviewFrame ?? null;
         this.onPreviewFramePresentation = opts.onPreviewFramePresentation ?? null;
+        this.onPreviewWriterJam = opts.onPreviewWriterJam ?? null;
         this.setPreviewGenerator(opts.previewGenerator);
     }
 
@@ -54,6 +57,14 @@ export class SenderSession {
 
         this.lastPreviewFramePresentation = presentation;
         this.onPreviewFramePresentation?.(presentation);
+    }
+
+    reportPreviewWriterJam(): void {
+        this.onPreviewWriterJam?.();
+    }
+
+    setPreviewWriterJamHandler(handler: (() => void) | undefined): void {
+        this.onPreviewWriterJam = handler ?? null;
     }
 
     setPreviewGenerator(generator: PreviewGeneratorLike | undefined): void {

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -1,7 +1,7 @@
 // Follows the currently active VideoRecorder and renders its preview to either
 // a caller-supplied <video srcObject> (generated track) or the paired canvas
 // fallback. Multiple UI surfaces can attach independently.
-// Caller-specific UI state (.starting, .has-video) is signalled via the
+// Caller-specific UI state (data-starting, data-has-video) is signalled via the
 // onAttach/onDetach/onFirstFrame hooks — this class doesn't touch CSS.
 
 import { getLogs } from 'logging';
@@ -92,7 +92,9 @@ export class RecorderPreviewView {
 
         // Reconcile immediately — recorder may already be registered before this view exists.
         this.unsubscribeRegistry = addActiveRecorderListener((_recorder, kind) => {
-            if (!this.sourceKinds.includes(kind)) return;
+            if (!this.sourceKinds.includes(kind))
+                return;
+
             this.followRecorder(this.pickRecorder());
         });
         this.followRecorder(this.pickRecorder());
@@ -119,7 +121,9 @@ export class RecorderPreviewView {
     }
 
     private applyRotationAndFit(): void {
-        if (this.disposed) return;
+        if (this.disposed)
+            return;
+
         const videoEl = this.options.videoEl;
         const parent = videoEl.parentElement;
         const currentDelta = normalizeRotationQuarter(DeviceOrientation.quarter - ScreenOrientation.quarter);
@@ -142,7 +146,8 @@ export class RecorderPreviewView {
                 : rotation;
             applyRotationLayout(this.options.bgCanvas, bgRotation);
         }
-        if (!parent) return;
+        if (!parent)
+            return;
 
         const swap = (rotation & 1) === 1;
         const sourceW = videoEl.videoWidth || this.lastFrameWidth || 0;
@@ -174,7 +179,8 @@ export class RecorderPreviewView {
     private pickRecorder(): VideoRecorder | null {
         for (const k of this.sourceKinds) {
             const r = getActiveRecorder(k);
-            if (r) return r;
+            if (r)
+                return r;
         }
         return null;
     }
@@ -190,13 +196,17 @@ export class RecorderPreviewView {
     }
 
     public set paused(value: boolean) {
-        if (this._paused === value) return;
+        if (this._paused === value)
+            return;
+
         this._paused = value;
         this.syncAttachment();
     }
 
     public dispose(): void {
-        if (this.disposed) return;
+        if (this.disposed)
+            return;
+
         this.disposed = true;
         if (this.unsubscribeRegistry) {
             this.unsubscribeRegistry();
@@ -242,7 +252,9 @@ export class RecorderPreviewView {
     }
 
     private syncAttachment(): void {
-        if (this.disposed) return;
+        if (this.disposed)
+            return;
+
         const recorder = this.followedRecorder;
         const paused = this._paused;
 
@@ -314,15 +326,21 @@ export class RecorderPreviewView {
             videoEl.srcObject = null;
         }
         const parent = videoEl.parentElement;
-        parent?.classList.toggle('preview-backend-canvas', track === null);
-        parent?.classList.toggle('preview-backend-mstg', track !== null);
+        // An attribute, not a class: Blazor owns `class` and drops whatever JS put
+        // there on its next re-render. See docs/development/ui-components.md.
+        parent?.setAttribute('data-preview-backend', track === null ? 'canvas' : 'mstg');
         if (track && this.bgCanvasTarget) {
             this.bgPumpHandle = window.setInterval(() => {
-                if (this._paused) return;
+                if (this._paused)
+                    return;
+
                 // When blur is on, the blur listener already paints the bg from the
                 // blurred canvas — sourcing from raw video here would overwrite it.
-                if (this.attachedRecorder?.isBlurActive()) return;
-                if (videoEl.videoWidth === 0 || videoEl.videoHeight === 0) return;
+                if (this.attachedRecorder?.isBlurActive())
+                    return;
+                if (videoEl.videoWidth === 0 || videoEl.videoHeight === 0)
+                    return;
+
                 this.drawBgFrameFromVideo(videoEl);
             }, BG_DRAW_INTERVAL_MS);
         }
@@ -343,7 +361,8 @@ export class RecorderPreviewView {
     }
 
     private detach(): void {
-        if (!this.attachedRecorder) return;
+        if (!this.attachedRecorder)
+            return;
 
         infoLog?.log('Detached from recorder');
 
@@ -365,7 +384,7 @@ export class RecorderPreviewView {
             this.bgPumpHandle = null;
         }
         const parent = videoEl.parentElement;
-        parent?.classList.remove('preview-backend-canvas', 'preview-backend-mstg');
+        parent?.removeAttribute('data-preview-backend');
 
         // Wipe stale frames so a failed re-attach doesn't leave the last good
         // frame on-screen while the new pipeline spins up.
@@ -382,7 +401,9 @@ export class RecorderPreviewView {
     }
 
     private fireFirstFrame(): void {
-        if (this.firstFrameFired) return;
+        if (this.firstFrameFired)
+            return;
+
         this.firstFrameFired = true;
         if (this.lastStarting) {
             this.lastStarting = false;
@@ -397,12 +418,19 @@ export class RecorderPreviewView {
     }
 
     private drawBgFrame(width: number, height: number): void {
-        if (!this.bgCanvasTarget) return;
-        if (!this.bgContainer?.classList.contains('item-focused')) return;
+        if (!this.bgCanvasTarget)
+            return;
+        if (!this.bgContainer?.classList.contains('item-focused'))
+            return;
+
         // Match the receiver: only paint the backdrop when contain is active.
-        if (this.currentFit !== 'contain') return;
+        if (this.currentFit !== 'contain')
+            return;
+
         const now = performance.now();
-        if (now - this.lastBgDrawTime < BG_DRAW_INTERVAL_MS - BG_DRAW_GATE_TOLERANCE_MS) return;
+        if (now - this.lastBgDrawTime < BG_DRAW_INTERVAL_MS - BG_DRAW_GATE_TOLERANCE_MS)
+            return;
+
         this.lastBgDrawTime = now;
 
         const bgW = BG_CANVAS_WIDTH;
@@ -414,11 +442,17 @@ export class RecorderPreviewView {
 
     // Sourced from <video> because the main canvas is empty in the generated-track path.
     private drawBgFrameFromVideo(videoEl: HTMLVideoElement): void {
-        if (!this.bgCanvasTarget) return;
-        if (!this.bgContainer?.classList.contains('item-focused')) return;
-        if (this.currentFit !== 'contain') return;
+        if (!this.bgCanvasTarget)
+            return;
+        if (!this.bgContainer?.classList.contains('item-focused'))
+            return;
+        if (this.currentFit !== 'contain')
+            return;
+
         const now = performance.now();
-        if (now - this.lastBgDrawTime < BG_DRAW_INTERVAL_MS - BG_DRAW_GATE_TOLERANCE_MS) return;
+        if (now - this.lastBgDrawTime < BG_DRAW_INTERVAL_MS - BG_DRAW_GATE_TOLERANCE_MS)
+            return;
+
         this.lastBgDrawTime = now;
 
         const w = videoEl.videoWidth;

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -5,6 +5,7 @@
 // onAttach/onDetach/onFirstFrame hooks — this class doesn't touch CSS.
 
 import { getLogs } from 'logging';
+import { DeviceInfo } from 'device-info';
 import { DeviceOrientation, ScreenOrientation, normalizeRotationQuarter } from 'orientation';
 import type { Subscription } from 'rxjs';
 import { merge } from 'rxjs';
@@ -24,6 +25,16 @@ import { applyRotationLayout, chooseFit, updateCollapsedIslandAspect } from './t
 
 const { infoLog, warnLog } = getLogs('VideoRecorder');
 const BG_DRAW_GATE_TOLERANCE_MS = 20;
+// Preview stall detection. WebKit bug 230922: a <video> fed by a MediaStream can
+// freeze on a single frame while every write into the generator still resolves.
+// Neither currentTime nor requestVideoFrameCallback notices - both keep advancing
+// on a frozen element - so the only honest signal is the pixels.
+const STALL_TICK_MS = 250;
+const STALL_TICKS_BEFORE_REPAIR = 4;
+// Cost is the video->canvas readback, not the pixel count: 8px and 32px both
+// measured ~0.7ms on an iPhone 13 Pro, so ~2.8ms/s at this cadence.
+const STALL_HASH_SIZE = 8;
+const CAMERA_SOURCE_KIND = 0;
 
 export interface RecorderPreviewViewOptions {
     // Blur overlay only — raw track always goes to videoEl.
@@ -37,6 +48,30 @@ export interface RecorderPreviewViewOptions {
     onFirstFrame?: () => void;
     onStartingChange?: (starting: boolean) => void;
     onBlurChange?: (blurActive: boolean) => void;
+}
+
+// Forces WebKit to recomposite a <video> that decodes but never paints.
+//
+// WebKit bug 230922 (open since iOS 15, still reproducing on 26): a <video> fed
+// by a MediaStream can hold a live, advancing stream and show nothing. Measured
+// here on a re-attached self-preview - display:block, visibility:visible,
+// paused:false, readyState:4, right size, right track, and drawImage(videoEl)
+// returning FRESH pixels every frame - while the screen stayed empty. The
+// element is fine; its GraphicsLayer never repaints.
+//
+// The trigger is compositing: `.video-track-player` is `contain: strict` and the
+// surfaces inside carry `will-change: transform` (plus scaleX(-1) when
+// mirrored). Both are load-bearing - see the contain/will-change notes in
+// video-panel.css - so the layer gets nudged instead of unpromoted. Toggling
+// display forces a fresh compositing pass and the frame appears instantly;
+// every workaround in the upstream thread is a reset of this kind (background
+// the app, split-view, reload, picture-in-picture).
+//
+// https://bugs.webkit.org/show_bug.cgi?id=230922, docs/ui/components.md.
+function forceRecomposite(videoEl: HTMLVideoElement): void {
+    videoEl.style.setProperty('display', 'none', 'important');
+    void videoEl.offsetHeight;
+    videoEl.style.removeProperty('display');
 }
 
 // A pending play() rejects with AbortError whenever a re-attach swaps srcObject
@@ -88,6 +123,11 @@ export class RecorderPreviewView {
     // handles it. Non-zero only when one of the two channels diverges
     // from the start (e.g. screen-lock-on + device physically rotated).
     private initialDeviceScreenDelta: number | null = null;
+    private stallTimer: number | null = null;
+    private stallHashCanvas: HTMLCanvasElement | null = null;
+    private lastPixelHash: number | null = null;
+    private stallTicks = 0;
+    private repairAttempts = 0;
 
     static create(options: RecorderPreviewViewOptions): RecorderPreviewView {
         return new RecorderPreviewView(options);
@@ -239,6 +279,7 @@ export class RecorderPreviewView {
             try { this.options.videoEl.removeEventListener('resize', this.videoResizeListener); } catch { /* ignore */ }
             this.videoResizeListener = null;
         }
+        this.stopStallWatch();
         this.detach();
         this.bgCanvasTarget?.dispose();
     }
@@ -331,7 +372,12 @@ export class RecorderPreviewView {
         if (track) {
             videoEl.srcObject = new MediaStream([track]);
             playPreview(videoEl);
-            this.videoLoadedDataListener = () => this.fireFirstFrame();
+            recorder.notifyPreviewAttached(true);
+            this.startStallWatch();
+            this.videoLoadedDataListener = () => {
+                forceRecomposite(videoEl);
+                this.fireFirstFrame();
+            };
             videoEl.addEventListener('loadeddata', this.videoLoadedDataListener);
         } else {
             videoEl.pause();
@@ -372,6 +418,117 @@ export class RecorderPreviewView {
         this.options.onAttach?.(recorder);
     }
 
+    // WebKit-wide, not iOS-only: bug 230922 is reported on macOS Safari too, and
+    // Mac Catalyst is the same engine. Camera only - a static screencast legitimately
+    // repeats frames (keepAlive re-emits the last one), so an unchanged image there
+    // means nothing is wrong.
+    private get isStallWatchApplicable(): boolean {
+        return DeviceInfo.isWebKit
+            && this.sourceKinds.length === 1
+            && this.sourceKinds[0] === CAMERA_SOURCE_KIND;
+    }
+
+    private startStallWatch(): void {
+        this.stopStallWatch();
+        if (!this.isStallWatchApplicable)
+            return;
+
+        this.lastPixelHash = null;
+        this.stallTicks = 0;
+        this.stallTimer = window.setInterval(() => this.checkForStall(), STALL_TICK_MS);
+    }
+
+    private stopStallWatch(): void {
+        if (this.stallTimer === null)
+            return;
+
+        window.clearInterval(this.stallTimer);
+        this.stallTimer = null;
+    }
+
+    // Sensor noise moves at least one of 64 samples on any live camera, so an
+    // unchanged hash means the element stopped updating, not a still scene.
+    private samplePixelHash(): number | null {
+        const videoEl = this.options.videoEl;
+        if (videoEl.videoWidth === 0 || videoEl.videoHeight === 0)
+            return null;
+
+        this.stallHashCanvas ??= document.createElement('canvas');
+        const canvas = this.stallHashCanvas;
+        canvas.width = STALL_HASH_SIZE;
+        canvas.height = STALL_HASH_SIZE;
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
+        if (!ctx)
+            return null;
+
+        try {
+            ctx.clearRect(0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE);
+            ctx.drawImage(videoEl, 0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE);
+            const data = ctx.getImageData(0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE).data;
+            let hash = 0;
+            for (let i = 0; i < data.length; i += 3)
+                hash = (hash * 31 + data[i]) >>> 0;
+
+            return hash;
+        } catch {
+            return null;
+        }
+    }
+
+    private checkForStall(): void {
+        const recorder = this.attachedRecorder;
+        if (this.disposed || this._paused || !this.attachedTrack || !recorder)
+            return;
+        if (recorder.recordingState !== 'recording')
+            return;
+
+        const hash = this.samplePixelHash();
+        if (hash === null)
+            return;
+
+        const previous = this.lastPixelHash;
+        this.lastPixelHash = hash;
+        if (previous === null || hash !== previous) {
+            this.stallTicks = 0;
+            this.repairAttempts = 0;
+            return;
+        }
+
+        this.stallTicks++;
+        if (this.stallTicks < STALL_TICKS_BEFORE_REPAIR)
+            return;
+
+        this.stallTicks = 0;
+        this.repairStalledPreview(recorder);
+    }
+
+    // WebKit 230922 has no code-level fix, only pipeline resets — so escalate
+    // through the cheap ones and land on the canvas painter if they all fail.
+    private repairStalledPreview(recorder: VideoRecorder): void {
+        const attempt = this.repairAttempts++;
+        const videoEl = this.options.videoEl;
+        if (attempt === 0) {
+            warnLog?.log('previewStall: re-attaching the generated track');
+            const track = this.attachedTrack;
+            if (track) {
+                videoEl.srcObject = new MediaStream([track]);
+                playPreview(videoEl);
+            }
+            forceRecomposite(videoEl);
+            return;
+        }
+
+        if (attempt === 1) {
+            warnLog?.log('previewStall: rebuilding the preview generator');
+            recorder.rebuildPreviewGenerator();
+            return;
+        }
+
+        warnLog?.log(`previewStall: ${attempt + 1} attempts failed — switching to the canvas painter`);
+        this.stopStallWatch();
+        recorder.forcePreviewCanvasFallback();
+    }
+
     private detach(): void {
         if (!this.attachedRecorder)
             return;
@@ -382,6 +539,10 @@ export class RecorderPreviewView {
             this.unsubscribeFrames();
             this.unsubscribeFrames = null;
         }
+        this.stopStallWatch();
+        if (this.attachedTrack)
+            this.attachedRecorder.notifyPreviewAttached(false);
+
         this.attachedRecorder = null;
         this.attachedTrack = null;
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -5,7 +5,6 @@
 // onAttach/onDetach/onFirstFrame hooks — this class doesn't touch CSS.
 
 import { getLogs } from 'logging';
-import { DeviceInfo } from 'device-info';
 import { DeviceOrientation, ScreenOrientation, normalizeRotationQuarter } from 'orientation';
 import type { Subscription } from 'rxjs';
 import { merge } from 'rxjs';
@@ -25,16 +24,6 @@ import { applyRotationLayout, chooseFit, updateCollapsedIslandAspect } from './t
 
 const { infoLog, warnLog } = getLogs('VideoRecorder');
 const BG_DRAW_GATE_TOLERANCE_MS = 20;
-// Preview stall detection. WebKit bug 230922: a <video> fed by a MediaStream can
-// freeze on a single frame while every write into the generator still resolves.
-// Neither currentTime nor requestVideoFrameCallback notices - both keep advancing
-// on a frozen element - so the only honest signal is the pixels.
-const STALL_TICK_MS = 250;
-const STALL_TICKS_BEFORE_REPAIR = 4;
-// Cost is the video->canvas readback, not the pixel count: 8px and 32px both
-// measured ~0.7ms on an iPhone 13 Pro, so ~2.8ms/s at this cadence.
-const STALL_HASH_SIZE = 8;
-const CAMERA_SOURCE_KIND = 0;
 
 export interface RecorderPreviewViewOptions {
     // Blur overlay only — raw track always goes to videoEl.
@@ -123,11 +112,6 @@ export class RecorderPreviewView {
     // handles it. Non-zero only when one of the two channels diverges
     // from the start (e.g. screen-lock-on + device physically rotated).
     private initialDeviceScreenDelta: number | null = null;
-    private stallTimer: number | null = null;
-    private stallHashCanvas: HTMLCanvasElement | null = null;
-    private lastPixelHash: number | null = null;
-    private stallTicks = 0;
-    private repairAttempts = 0;
 
     static create(options: RecorderPreviewViewOptions): RecorderPreviewView {
         return new RecorderPreviewView(options);
@@ -279,7 +263,6 @@ export class RecorderPreviewView {
             try { this.options.videoEl.removeEventListener('resize', this.videoResizeListener); } catch { /* ignore */ }
             this.videoResizeListener = null;
         }
-        this.stopStallWatch();
         this.detach();
         this.bgCanvasTarget?.dispose();
     }
@@ -372,8 +355,6 @@ export class RecorderPreviewView {
         if (track) {
             videoEl.srcObject = new MediaStream([track]);
             playPreview(videoEl);
-            recorder.notifyPreviewAttached(true);
-            this.startStallWatch();
             this.videoLoadedDataListener = () => {
                 forceRecomposite(videoEl);
                 this.fireFirstFrame();
@@ -385,7 +366,7 @@ export class RecorderPreviewView {
         }
         const parent = videoEl.parentElement;
         // An attribute, not a class: Blazor owns `class` and drops whatever JS put
-        // there on its next re-render. See docs/development/ui-components.md.
+        // there on its next re-render. See docs/ui/components.md.
         parent?.setAttribute('data-preview-backend', track === null ? 'canvas' : 'mstg');
         if (track && this.bgCanvasTarget) {
             this.bgPumpHandle = window.setInterval(() => {
@@ -418,117 +399,6 @@ export class RecorderPreviewView {
         this.options.onAttach?.(recorder);
     }
 
-    // WebKit-wide, not iOS-only: bug 230922 is reported on macOS Safari too, and
-    // Mac Catalyst is the same engine. Camera only - a static screencast legitimately
-    // repeats frames (keepAlive re-emits the last one), so an unchanged image there
-    // means nothing is wrong.
-    private get isStallWatchApplicable(): boolean {
-        return DeviceInfo.isWebKit
-            && this.sourceKinds.length === 1
-            && this.sourceKinds[0] === CAMERA_SOURCE_KIND;
-    }
-
-    private startStallWatch(): void {
-        this.stopStallWatch();
-        if (!this.isStallWatchApplicable)
-            return;
-
-        this.lastPixelHash = null;
-        this.stallTicks = 0;
-        this.stallTimer = window.setInterval(() => this.checkForStall(), STALL_TICK_MS);
-    }
-
-    private stopStallWatch(): void {
-        if (this.stallTimer === null)
-            return;
-
-        window.clearInterval(this.stallTimer);
-        this.stallTimer = null;
-    }
-
-    // Sensor noise moves at least one of 64 samples on any live camera, so an
-    // unchanged hash means the element stopped updating, not a still scene.
-    private samplePixelHash(): number | null {
-        const videoEl = this.options.videoEl;
-        if (videoEl.videoWidth === 0 || videoEl.videoHeight === 0)
-            return null;
-
-        this.stallHashCanvas ??= document.createElement('canvas');
-        const canvas = this.stallHashCanvas;
-        canvas.width = STALL_HASH_SIZE;
-        canvas.height = STALL_HASH_SIZE;
-        const ctx = canvas.getContext('2d', { willReadFrequently: true });
-        if (!ctx)
-            return null;
-
-        try {
-            ctx.clearRect(0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE);
-            ctx.drawImage(videoEl, 0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE);
-            const data = ctx.getImageData(0, 0, STALL_HASH_SIZE, STALL_HASH_SIZE).data;
-            let hash = 0;
-            for (let i = 0; i < data.length; i += 3)
-                hash = (hash * 31 + data[i]) >>> 0;
-
-            return hash;
-        } catch {
-            return null;
-        }
-    }
-
-    private checkForStall(): void {
-        const recorder = this.attachedRecorder;
-        if (this.disposed || this._paused || !this.attachedTrack || !recorder)
-            return;
-        if (recorder.recordingState !== 'recording')
-            return;
-
-        const hash = this.samplePixelHash();
-        if (hash === null)
-            return;
-
-        const previous = this.lastPixelHash;
-        this.lastPixelHash = hash;
-        if (previous === null || hash !== previous) {
-            this.stallTicks = 0;
-            this.repairAttempts = 0;
-            return;
-        }
-
-        this.stallTicks++;
-        if (this.stallTicks < STALL_TICKS_BEFORE_REPAIR)
-            return;
-
-        this.stallTicks = 0;
-        this.repairStalledPreview(recorder);
-    }
-
-    // WebKit 230922 has no code-level fix, only pipeline resets — so escalate
-    // through the cheap ones and land on the canvas painter if they all fail.
-    private repairStalledPreview(recorder: VideoRecorder): void {
-        const attempt = this.repairAttempts++;
-        const videoEl = this.options.videoEl;
-        if (attempt === 0) {
-            warnLog?.log('previewStall: re-attaching the generated track');
-            const track = this.attachedTrack;
-            if (track) {
-                videoEl.srcObject = new MediaStream([track]);
-                playPreview(videoEl);
-            }
-            forceRecomposite(videoEl);
-            return;
-        }
-
-        if (attempt === 1) {
-            warnLog?.log('previewStall: rebuilding the preview generator');
-            recorder.rebuildPreviewGenerator();
-            return;
-        }
-
-        warnLog?.log(`previewStall: ${attempt + 1} attempts failed — switching to the canvas painter`);
-        this.stopStallWatch();
-        recorder.forcePreviewCanvasFallback();
-    }
-
     private detach(): void {
         if (!this.attachedRecorder)
             return;
@@ -539,10 +409,6 @@ export class RecorderPreviewView {
             this.unsubscribeFrames();
             this.unsubscribeFrames = null;
         }
-        this.stopStallWatch();
-        if (this.attachedTrack)
-            this.attachedRecorder.notifyPreviewAttached(false);
-
         this.attachedRecorder = null;
         this.attachedTrack = null;
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -22,7 +22,7 @@ import {
 } from './bg-canvas';
 import { applyRotationLayout, chooseFit, updateCollapsedIslandAspect } from './tile-fit';
 
-const { infoLog } = getLogs('VideoRecorder');
+const { infoLog, warnLog } = getLogs('VideoRecorder');
 const BG_DRAW_GATE_TOLERANCE_MS = 20;
 
 export interface RecorderPreviewViewOptions {
@@ -37,6 +37,18 @@ export interface RecorderPreviewViewOptions {
     onFirstFrame?: () => void;
     onStartingChange?: (starting: boolean) => void;
     onBlurChange?: (blurActive: boolean) => void;
+}
+
+// A pending play() rejects with AbortError whenever a re-attach swaps srcObject
+// underneath it - routine during recorder startup, and noise that used to reach
+// the console as an unhandled rejection. Anything else is worth seeing.
+function playPreview(videoEl: HTMLVideoElement): void {
+    videoEl.play().catch((e: unknown) => {
+        if (e instanceof DOMException && e.name === 'AbortError')
+            return;
+
+        warnLog?.log('playPreview: play() failed:', e);
+    });
 }
 
 export class RecorderPreviewView {
@@ -288,7 +300,7 @@ export class RecorderPreviewView {
                 videoEl.pause();
             } else {
                 videoEl.srcObject ??= new MediaStream([this.attachedTrack]);
-                void videoEl.play();
+                playPreview(videoEl);
             }
         }
 
@@ -318,7 +330,7 @@ export class RecorderPreviewView {
         const videoEl = this.options.videoEl;
         if (track) {
             videoEl.srcObject = new MediaStream([track]);
-            void videoEl.play();
+            playPreview(videoEl);
             this.videoLoadedDataListener = () => this.fireFirstFrame();
             videoEl.addEventListener('loadeddata', this.videoLoadedDataListener);
         } else {

--- a/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
+++ b/src/dotnet/UI.Blazor/Components/MapView/map-view.ts
@@ -127,7 +127,7 @@ export class MapView {
     }
 
     private onMoveEnd(): void {
-        this.element.classList.remove('moving');
+        this.element.toggleAttribute('data-moving', false);
         const map = this.map;
         if (map == null || this.blazorRef == null)
             return;
@@ -152,7 +152,7 @@ export class MapView {
         this.map.on('webglcontextlost', () => this.onContextLost());
         // An accuracy circle is a metric radius, so its pixel size changes with zoom.
         this.map.on('move', () => this.applyAccuracyCircles(this.lastMarkers));
-        this.map.on('movestart', () => this.element.classList.add('moving'));
+        this.map.on('movestart', () => this.element.toggleAttribute('data-moving', true));
         this.map.on('moveend', () => this.onMoveEnd());
         this.applyMarkers(this.lastMarkers);
     }
@@ -163,7 +163,7 @@ export class MapView {
             return;
 
         this.map = null;
-        this.element.classList.remove('moving');
+        this.element.toggleAttribute('data-moving', false);
         // Keep the user's pan/zoom, so the map reappears where they left it.
         const center = map.getCenter();
         this.options.centerLatitude = center.lat;

--- a/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
+++ b/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
@@ -24,14 +24,14 @@ body.device-ios .side-nav {
     @apply has-viewport-height;
 }
 
-.side-nav.animated {
+.side-nav[data-animated] {
     @apply duration-250 ease-out;
     transition-property: transform, -webkit-transform, width;
 }
-.side-nav.animated > *:first-child {
+.side-nav[data-animated] > *:first-child {
     @apply transition-opacity duration-200 ease-out;
 }
-.side-nav.animated.pulling > *:first-child {
+.side-nav[data-animated][data-pulling] > *:first-child {
     @apply transition-none;
 }
 

--- a/src/dotnet/UI.Blazor/Components/SideNav/side-nav.ts
+++ b/src/dotnet/UI.Blazor/Components/SideNav/side-nav.ts
@@ -54,7 +54,7 @@ export class SideNav extends DisposableBag {
     public get isPulling() { return this._isPulling; }
     public set isPulling(value: boolean) {
         this._isPulling = value;
-        this.element.classList.toggle('pulling', value);
+        this.element.toggleAttribute('data-pulling', value);
         if (value)
             ScrollController.cancelMomentumAll();
     }
@@ -100,7 +100,7 @@ export class SideNav extends DisposableBag {
         void delayAsync(250).then(async () => {
             // No transitions immediately after the first render
             await fastWriteRafAsync();
-            this.element.classList.add('animated');
+            this.element.toggleAttribute('data-animated', true);
         });
     }
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -1006,8 +1006,8 @@ export class InfiniteList extends VirtualList {
         const wasPinned = this.pinnedEdge;
         this.pinnedEdge = edge;
         const isStickyEnd = edge === VirtualListEdge.End;
-        if (isStickyEnd !== this.ref.classList.contains('sticky-end'))
-            this.ref.classList.toggle('sticky-end', isStickyEnd);
+        if (isStickyEnd !== this.ref.hasAttribute('data-sticky-end'))
+            this.ref.toggleAttribute('data-sticky-end', isStickyEnd);
         if (wasPinned !== edge)
             this.repinChainAnchor(wasPinned);
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -98,6 +98,21 @@ const MaxOverscrollScreens = 3;
 // Past twice the allowance the blank is not something scrolling can produce - the view and its chain
 // have come apart, and only a re-pin brings them back.
 const StrandedGapFactor = 2;
+// Every other correction the list makes runs off an event - a render, a settle, a scroll - and a
+// blank viewport gives the user nothing to scroll with to produce one. This is the clock the standing
+// check runs on instead.
+const PositionGuardIntervalMs = 1000;
+// How many consecutive checks a fault has to survive to be one. Nothing legitimate holds the position
+// outside the band for a whole interval, but a correction booked for a frame that has not run yet can
+// be seen out there once.
+const PositionGuardChecks = 2;
+// A crossing this small is the model and the DOM disagreeing about a fraction of a pixel.
+const PositionGuardEpsilon = 4;
+// How long after an excursion the position is still the gesture's own rather than something to fix.
+const PositionGuardOverscrollQuietMs = 500;
+// A viewport with no content on it is legal while a query can still fill it - that is how reading
+// further back starts - so the blank is a fault only once this many checks have gone by without one.
+const OffContentChecks = 3;
 const DriftWarnThresholdPx = 8;
 const ContentOverflowThresholdPx = 2;
 const DefaultItemHeight = 48;
@@ -182,6 +197,7 @@ export class InfiniteList extends VirtualList {
     private readonly stability = new StabilityTracker();
     private readonly heights: ItemHeightController | null;
     private readonly visibleKeys = new Set<string>();
+    private readonly positionGuardTimer: ReturnType<typeof setInterval>;
 
     private items = new Array<InfiniteListItem>();
     private indexByKey = new Map<string, number>();
@@ -208,12 +224,21 @@ export class InfiniteList extends VirtualList {
     private isEndSkeletonShown = false;
     private revealedAt = 0;
     private interactiveAnchor: { key: string; at: number } | null = null;
-    // An element the caller has promised to render again under the same id, whose position on screen
-    // must survive the next render. Recorded as rendered rather than modelled, which is the whole
-    // point of it: a stuck sticky element is not where the model puts it, and an element inside a
-    // group has no modelled position at all.
-    private screenAnchor:
-        { id: string; top: number; at: number; isPlaced: boolean; corrected: number } | null = null;
+    // An element whose position on screen must survive the next render, recorded as rendered rather
+    // than modelled - a stuck sticky element is not where the model puts it, and an element inside a
+    // group has no modelled position at all. Addressed by data-vl-anchor id, or by item key for a
+    // data-anchor="below" hold; a key-addressed anchor also records the content key above it, and is
+    // placed only by the render that changes that - the one that actually inserts the revealed rows -
+    // so the unrelated renders a live chat streams in the meantime pass through without spending it.
+    private screenAnchor: {
+        id: string | null;
+        key: string | null;
+        aboveKey: string | null;
+        top: number;
+        at: number;
+        isPlaced: boolean;
+        corrected: number;
+    } | null = null;
     private isWatchingScreenAnchor = false;
     private stickyShift = 0;
     // Keys that left a recent render, with the height they had, so an item that comes straight back is
@@ -235,6 +260,8 @@ export class InfiniteList extends VirtualList {
     private mustRecentre = false;
     private lastWrapperSize = 0;
     private handledScrollToKey: string | null = null;
+    private outOfBandChecks = 0;
+    private offContentChecks = 0;
 
     public static create(
         ref: HTMLElement,
@@ -323,6 +350,7 @@ export class InfiniteList extends VirtualList {
         this.skeletonObserver.observe(this.spacerRef);
         this.skeletonObserver.observe(this.endSpacerRef);
 
+        this.positionGuardTimer = setInterval(() => this.checkPosition(), PositionGuardIntervalMs);
         InfiniteList.instances.add(this);
         (globalThis as unknown as { InfiniteList: typeof InfiniteList }).InfiniteList = InfiniteList;
         this.start();
@@ -333,6 +361,7 @@ export class InfiniteList extends VirtualList {
         super.dispose();
         InfiniteList.setPageLock(this, false);
         InfiniteList.instances.delete(this);
+        clearInterval(this.positionGuardTimer);
         this.stability.dispose();
         this.heights?.dispose();
         this.scrollController.dispose();
@@ -489,9 +518,13 @@ export class InfiniteList extends VirtualList {
             && !oldKeys.some(key => this.indexByKey.has(key));
         if (isFullReplacement) {
             // Nothing on screen survives, so no animation can be interrupted and nothing needs holding
-            // in place: whatever was animating is gone, and the list is stable by construction.
+            // in place: whatever was animating is gone, and the list is stable by construction. A
+            // key-addressed anchor's item went with everything else, and reanchor - the path that
+            // releases a vanished one - is skipped for a full replacement.
             this.heights?.applyAllInstantly();
             this.stability.releaseAllAnimations();
+            if (this.screenAnchor?.key != null)
+                this.releaseScreenAnchor();
         }
         if (!sameKeys(oldKeys, this.items))
             this.lastSentQuery = null;
@@ -726,8 +759,11 @@ export class InfiniteList extends VirtualList {
         // single row - so keeping the raw offset into that gap drops the view clean past the row, onto
         // whatever happens to sit that far below. Landing at the top of the gap puts the collapsed
         // block where the user was already looking.
+        // With nothing surviving after it the gap is the rest of the chain, which is the same fall
+        // with nothing at all to land on: the live conversation at the end of the chat folding into
+        // its summary, and the newest message shrinking under a view parked at its tail.
         const gap = after < 0
-            ? Number.POSITIVE_INFINITY
+            ? this.chainSize - this.offsets[newBefore]
             : this.offsets[this.indexByKey.get(oldKeys[after])!] - this.offsets[newBefore];
         this.chainStart = oldChainStart + oldOffsets[before] - this.offsets[newBefore]
             + (offset > gap ? offset : 0);
@@ -797,13 +833,20 @@ export class InfiniteList extends VirtualList {
         // follow stays as the fallback for the frames this one may not write.
         if (this.pinnedEdge != null && this.canCorrectPosition)
             this.applyFollow(this.measureFollow(), 'layout');
-        // Clamping needs the real sizes, and mid-animation the DOM does not have them yet; onceStable
-        // re-runs it with the content where it will actually be.
         // Skipped entirely while pinned, because a pinned list is about to correct itself by re-pinning
         // and the clamp would get there first with a scroll write - which is the one thing the re-pin
         // exists to avoid. The re-pin lands inside the band by construction, and the settled pass
         // clamps behind it either way.
-        if (!this.stability.isAnimating && this.pinnedEdge == null)
+        if (this.pinnedEdge != null)
+            return;
+
+        // Clamping needs the real sizes, and mid-animation the DOM does not have them yet, so it waits
+        // for the settled pass instead - which an unpinned list has to book for itself. Left to the
+        // pinned path alone, a block that collapses under a view that is not at an edge got no clamp
+        // at all: the render skipped it for the animation, and nothing re-ran it afterwards.
+        if (this.stability.isAnimating)
+            this.repinWhenStable();
+        else
             this.scrollController.clampToLimits();
     }
 
@@ -1712,6 +1755,8 @@ export class InfiniteList extends VirtualList {
             this.interactiveAnchor = null;
             this.screenAnchor = {
                 id: anchorId,
+                key: null,
+                aboveKey: null,
                 top: anchorRef.getBoundingClientRect().top - this.ref.getBoundingClientRect().top,
                 at: performance.now(),
                 isPlaced: false,
@@ -1726,11 +1771,30 @@ export class InfiniteList extends VirtualList {
 
         this.setPinnedEdge(null);
         // A control marked data-anchor="below" reveals rows ABOVE itself, so the item below it is what
-        // must keep its screen position - otherwise the revealed rows push everything downward.
-        const anchorKey = target.closest('[data-anchor="below"]') != null
-            ? this.getFirstContentKeyBelow(key) ?? key
-            : key;
-        this.interactiveAnchor = { key: anchorKey, at: performance.now() };
+        // must keep its screen position - otherwise the revealed rows push everything downward. It is
+        // held as a key-addressed screen anchor rather than an interactive one: the render it waits
+        // for can be seconds away on WASM, and the rows it inserts then grow in from zero - the
+        // pending TTL covers the first, watchScreenAnchor the second, and the interactive anchor's
+        // model-level hold covers neither.
+        const belowKey = target.closest('[data-anchor="below"]') != null
+            ? this.getFirstContentKeyBelow(key)
+            : null;
+        if (belowKey != null) {
+            const belowRef = this.items[this.indexByKey.get(belowKey)!].ref;
+            this.interactiveAnchor = null;
+            this.screenAnchor = {
+                id: null,
+                key: belowKey,
+                aboveKey: this.getFirstContentKeyAbove(belowKey),
+                top: belowRef.getBoundingClientRect().top - this.ref.getBoundingClientRect().top,
+                at: performance.now(),
+                isPlaced: false,
+                corrected: 0,
+            };
+            return;
+        }
+
+        this.interactiveAnchor = { key, at: performance.now() };
     };
 
     // Puts the anchored element back where it was on screen. Both readings are rendered positions,
@@ -1746,10 +1810,17 @@ export class InfiniteList extends VirtualList {
             return false;
         }
 
-        const anchorRef = this.containerRef
-            .querySelector<HTMLElement>(`:scope [data-vl-anchor="${CSS.escape(anchor.id)}"]`);
-        if (anchorRef == null)
+        const anchorRef = this.getScreenAnchorRef(anchor);
+        if (anchorRef == null) {
+            // An id names an element its owner promises to render again, so its absence is worth
+            // waiting out. A key names a list item, and an item that has left the set has nothing to
+            // come back as - the live block folding away is the case, and a hold left standing there
+            // keeps checkPosition from fixing the very view the fold stranded.
+            if (anchor.key != null)
+                this.releaseScreenAnchor();
+
             return false;
+        }
 
         // Placed once, on the render the interaction caused. Re-placing it on every render that
         // follows drags the view further off each time, because those renders are the ones growing the
@@ -1759,6 +1830,13 @@ export class InfiniteList extends VirtualList {
             this.watchScreenAnchor();
             return false;
         }
+
+        // A key-addressed anchor is spent on the render that inserts content directly above its item -
+        // that is what data-anchor="below" reveals. A live chat keeps rendering while that one is
+        // still seconds away, and placing on whichever render lands first would start (and retire) the
+        // watch before there is anything to hold.
+        if (anchor.key != null && this.getFirstContentKeyAbove(anchor.key) === anchor.aboveKey)
+            return false;
 
         anchor.isPlaced = true;
         anchor.at = performance.now();
@@ -1816,8 +1894,9 @@ export class InfiniteList extends VirtualList {
 
             // A frame the list may not write is not the element standing still: counting it would
             // release the hold with the correction still owing - twelve frames of a resting finger is
-            // all it takes.
-            const isDeferred = !this.canCorrectPosition;
+            // all it takes. An anchor still waiting on its render has nothing to correct yet either -
+            // and correctScreenAnchor's own 2s deadline would retire it mid-wait if it were asked.
+            const isDeferred = !this.canCorrectPosition || !anchor.isPlaced;
             const moved = isDeferred ? false : this.correctScreenAnchor();
             if (moved == null) {
                 this.releaseScreenAnchor();
@@ -1851,10 +1930,9 @@ export class InfiniteList extends VirtualList {
         if (anchor == null || this.isDisposed || performance.now() - anchor.at > InteractiveAnchorTtlMs)
             return null;
 
-        const anchorRef = this.containerRef
-            .querySelector<HTMLElement>(`:scope [data-vl-anchor="${CSS.escape(anchor.id)}"]`);
+        const anchorRef = this.getScreenAnchorRef(anchor);
         if (anchorRef == null)
-            return false;
+            return anchor.key != null ? null : false;
 
         // Rendered, not flow: this holds what is on screen against content moving under it. An element
         // the viewport edge has stuck is already still and reads a delta of zero, which is right for it.
@@ -1878,6 +1956,13 @@ export class InfiniteList extends VirtualList {
         // bound at all within about thirty of them.
         anchor.corrected += applied;
         return Math.abs(anchor.corrected) > this.maxOverscroll ? null : true;
+    }
+
+    private getScreenAnchorRef(anchor: { id: string | null; key: string | null }): HTMLElement | null {
+        const selector = anchor.key != null
+            ? `:scope .item[data-key="${CSS.escape(anchor.key)}"]`
+            : `:scope [data-vl-anchor="${CSS.escape(anchor.id ?? '')}"]`;
+        return this.containerRef.querySelector<HTMLElement>(selector);
     }
 
     private hasFreshScreenAnchor(): boolean {
@@ -1911,6 +1996,18 @@ export class InfiniteList extends VirtualList {
             return null;
 
         for (let i = index + 1; i < this.items.length; i++)
+            if (!this.items[i].mustSkipKey)
+                return this.items[i].key;
+
+        return null;
+    }
+
+    private getFirstContentKeyAbove(key: string): string | null {
+        const index = this.indexByKey.get(key);
+        if (index == null)
+            return null;
+
+        for (let i = index - 1; i >= 0; i--)
             if (!this.items[i].mustSkipKey)
                 return this.items[i].key;
 
@@ -2100,6 +2197,74 @@ export class InfiniteList extends VirtualList {
             priority: JumpPriority.stranded,
             reason: 'stranded',
         });
+    }
+
+    // The standing check on where the view actually is. Every other correction runs off an event -
+    // a render, a settle, a scroll - and the case none of them covers is a block collapsing under an
+    // unpinned view: the render's clamp waits for the settled sizes, the settle it waits for is a
+    // pinned list's, and what the user is left looking at is blank, which gives them nothing to scroll
+    // with to raise the scroll event that would fix it. So this asks on its own clock instead.
+    private checkPosition(): void {
+        if (this.isDisposed || this.items.length === 0 || !this.isInitiallyPlaced)
+            return;
+        // A finger, a fling, a bounce or a correction already booked all own the position, and a
+        // fresh anchor means a click of the user's is deliberately holding it somewhere.
+        if (!this.canCorrectPosition
+            || this.scrollController.isOverscrollRecent(PositionGuardOverscrollQuietMs)
+            || this.pendingJump != null
+            || this.isFollowScheduled
+            || this.hasFreshScreenAnchor()
+            || this.getFreshInteractiveAnchorKey() != null)
+            return;
+
+        const clientHeight = this.ref.clientHeight;
+        if (clientHeight <= 0)
+            return;
+
+        // Not gated on the height animations the render's own clamp waits for: what the limits are
+        // built from is the model, which carries settled heights, so this reads the same numbers the
+        // settled pass would. Persistence is what separates a fault from a frame in transit.
+        const limits = this.scrollController.getEffectiveScrollLimits();
+        const scrollTop = this.ref.scrollTop;
+        const outOfBand = Math.max(limits.min - scrollTop, scrollTop - limits.max);
+        if (outOfBand > PositionGuardEpsilon) {
+            this.offContentChecks = 0;
+            if (++this.outOfBandChecks < PositionGuardChecks)
+                return;
+
+            // Exactly what the first scroll event out here would have found, so answer it the same
+            // way: clampToLimits is the snap that event's own handler performs.
+            this.outOfBandChecks = 0;
+            warnLog?.log(`[${this.identity}] checkPosition: ${outOfBand.toFixed(0)}px out of band, snapping back`);
+            this.scrollController.clampToLimits();
+            return;
+        }
+
+        this.outOfBandChecks = 0;
+        const scrollOffset = this.scrollOffset;
+        const isOffContent = scrollOffset + clientHeight <= this.chainStart
+            || scrollOffset >= this.chainEnd + this.endAnchorSize;
+        if (!isOffContent || this.isRequestingData) {
+            this.offContentChecks = 0;
+            return;
+        }
+
+        // Legal, but with nothing on screen: the band grants three screens past what is loaded because
+        // that is how reading further back starts, so the first answer is the query that space is for.
+        if (++this.offContentChecks < OffContentChecks) {
+            this.updateViewportThrottled();
+            return;
+        }
+
+        // Nothing came, so there is nothing out here to come back to. Back to the near end of the
+        // chain rather than to the default edge - this is the position the user scrolled to, and the
+        // nearest place it puts content on screen is where scrolling itself would have stopped.
+        this.offContentChecks = 0;
+        const atChainStart = this.chainStart;
+        const atChainEnd = this.chainEnd + this.endAnchorSize - clientHeight;
+        const target = clamp(scrollOffset, Math.min(atChainStart, atChainEnd), Math.max(atChainStart, atChainEnd));
+        warnLog?.log(`[${this.identity}] checkPosition: off content, moving by ${(target - scrollOffset).toFixed(0)}`);
+        this.setScrollOffset(target);
     }
 
     // The wrapper stays CSS-hidden until the chain is positioned, so the user never sees the frames

--- a/tests/ts/unit/operators/preview-forwarder.test.ts
+++ b/tests/ts/unit/operators/preview-forwarder.test.ts
@@ -1,10 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createPreviewSink } from '../../../../src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder';
-
-// The jam detector measures elapsed time, so the clock has to be steerable.
-let nowMs = 0;
-vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
-beforeEach(() => { nowMs = 0; });
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -137,66 +132,6 @@ describe('createPreviewSink', () => {
 
         expect(frames.map(f => f.clones.length)).toEqual([0, 0]);
         expect(writer.written).toEqual([]);
-    });
-
-    it('does not report a jam while backpressure clears inside the threshold', () => {
-        const writer = new FakeWriter();
-        writer.desiredSize = 0;
-        let jams = 0;
-        const sink = makeSink(
-            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
-            { onWriterJam: () => { jams++; } });
-
-        nowMs = 1000;
-        forwardFrames(sink, 1);
-        nowMs = 1900;
-        forwardFrames(sink, 1);
-
-        expect(jams).toBe(0);
-    });
-
-    it('reports a jam once per threshold of unbroken backpressure', () => {
-        const writer = new FakeWriter();
-        writer.desiredSize = 0;
-        let jams = 0;
-        const sink = makeSink(
-            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
-            { onWriterJam: () => { jams++; } });
-
-        nowMs = 1000;
-        forwardFrames(sink, 1);
-        nowMs = 2100;
-        forwardFrames(sink, 1);
-        expect(jams).toBe(1);
-
-        // Window restarts, so a generator that stays dead re-reports rather than
-        // going quiet after the first call.
-        nowMs = 2200;
-        forwardFrames(sink, 1);
-        expect(jams).toBe(1);
-        nowMs = 3300;
-        forwardFrames(sink, 1);
-        expect(jams).toBe(2);
-    });
-
-    it('a delivered frame resets the jam window', () => {
-        const writer = new FakeWriter();
-        writer.desiredSize = 0;
-        let jams = 0;
-        const sink = makeSink(
-            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
-            { onWriterJam: () => { jams++; } });
-
-        nowMs = 1000;
-        forwardFrames(sink, 1);
-        writer.desiredSize = 1;
-        nowMs = 1500;
-        forwardFrames(sink, 1);
-        writer.desiredSize = 0;
-        nowMs = 2100;
-        forwardFrames(sink, 1);
-
-        expect(jams).toBe(0);
     });
 
     it('reports frames to the canvas fallback when no writer is available', async () => {

--- a/tests/ts/unit/operators/preview-forwarder.test.ts
+++ b/tests/ts/unit/operators/preview-forwarder.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPreviewSink } from '../../../../src/dotnet/UI.Blazor.App/Services/Video/operators/preview-forwarder';
+
+// The jam detector measures elapsed time, so the clock has to be steerable.
+let nowMs = 0;
+vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+beforeEach(() => { nowMs = 0; });
 
 // ---- Mocks ----------------------------------------------------------------
 
@@ -21,7 +26,9 @@ class FakeWriter {
     public desiredSize: number | null = 1;
     async write(frame: VideoFrame): Promise<void> {
         await Promise.resolve();
-        if (this.writeShouldThrow) throw this.writeShouldThrow;
+        if (this.writeShouldThrow)
+            throw this.writeShouldThrow;
+
         this.written.push(frame);
     }
 }
@@ -130,6 +137,66 @@ describe('createPreviewSink', () => {
 
         expect(frames.map(f => f.clones.length)).toEqual([0, 0]);
         expect(writer.written).toEqual([]);
+    });
+
+    it('does not report a jam while backpressure clears inside the threshold', () => {
+        const writer = new FakeWriter();
+        writer.desiredSize = 0;
+        let jams = 0;
+        const sink = makeSink(
+            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
+            { onWriterJam: () => { jams++; } });
+
+        nowMs = 1000;
+        forwardFrames(sink, 1);
+        nowMs = 1900;
+        forwardFrames(sink, 1);
+
+        expect(jams).toBe(0);
+    });
+
+    it('reports a jam once per threshold of unbroken backpressure', () => {
+        const writer = new FakeWriter();
+        writer.desiredSize = 0;
+        let jams = 0;
+        const sink = makeSink(
+            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
+            { onWriterJam: () => { jams++; } });
+
+        nowMs = 1000;
+        forwardFrames(sink, 1);
+        nowMs = 2100;
+        forwardFrames(sink, 1);
+        expect(jams).toBe(1);
+
+        // Window restarts, so a generator that stays dead re-reports rather than
+        // going quiet after the first call.
+        nowMs = 2200;
+        forwardFrames(sink, 1);
+        expect(jams).toBe(1);
+        nowMs = 3300;
+        forwardFrames(sink, 1);
+        expect(jams).toBe(2);
+    });
+
+    it('a delivered frame resets the jam window', () => {
+        const writer = new FakeWriter();
+        writer.desiredSize = 0;
+        let jams = 0;
+        const sink = makeSink(
+            () => writer as unknown as WritableStreamDefaultWriter<VideoFrame>,
+            { onWriterJam: () => { jams++; } });
+
+        nowMs = 1000;
+        forwardFrames(sink, 1);
+        writer.desiredSize = 1;
+        nowMs = 1500;
+        forwardFrames(sink, 1);
+        writer.desiredSize = 0;
+        nowMs = 2100;
+        forwardFrames(sink, 1);
+
+        expect(jams).toBe(0);
     });
 
     it('reports frames to the canvas fallback when no writer is available', async () => {


### PR DESCRIPTION
**Review-only.** Every commit here is already on `dev`; this branch exists so the day's video work can be read as one diff. Every file it touches is byte-identical to `dev`, so merging it is a no-op.

Branched from `4dec4658ff` — the commit immediately before the first video change.

## What the day was

The iOS own-camera preview froze after a camera switch, two distinct ways: sometimes on a single frame, sometimes live-but-invisible. Capture, encoding and the outbound stream were healthy at 24fps throughout. Six hypotheses were tested and killed by measurement before instrumentation localised it; two of those became commits that are reverted here.

Both faults are [WebKit bug 230922](https://bugs.webkit.org/show_bug.cgi?id=230922) — open since iOS 15, still reproducing on 26, no code-level fix upstream.

## What actually ships

| | |
|---|---|
| `f03ee9c5e8` | Blazor's class-attribute diff was wiping JS-set classes. JS-owned render state moves to `data-*`. **A real, separately-verified bug.** |
| `fec8c4a267` | WebKit paints the self-preview on canvas instead of a `VideoTrackGenerator` track — avoids the bug and measured cheaper |
| `79cdb5c8a3` | Rotation for the join-modal preview, which the canvas painter needs and the generated track didn't |
| `f2a858fdb7` | Removes the stall detector and repair ladder |

Plus `forceRecomposite` (one `display` toggle on `loadeddata`) and preview instrumentation behind `isPreviewTraceEnabled()`, off by default.

## Dead ends, kept in history

`bc6eecf6d3` (writer-jam detector) and `e9bec8d1c6` (generator reuse) were both reverted — the first never fired, the second could not fire because `switchCamera` tears the worker down. They're here because the reverts are part of the story.

## CPU measurement

30s Activity Monitor captures on an iPhone 13 Pro, two runs per arm:

| process | MSTG | canvas |
|---|---|---|
| `WebKit.GPU` | 12.3% | 19.4% |
| `backboardd` | 22.0% | 12.8% |
| `WebKit.WebContent` | 31.0% | 28.9% |
| `ActualChat` | 8.6% | 6.6% |
| **subtotal** | **75.8%** | **69.3%** |

Painting moves into the GPU process, but the compositor stops handling a dedicated video layer and gives back more.

**Caveat:** the ladder was collapsed to 320×184 with no viewer subscribed, so canvas was measured at a quarter of the pixels a real call paints. Unverified at 640×360.

## Worth a look

- Whether canvas should stay the WebKit default given that caveat
- `forceRecomposite` — kept deliberately, though with WebKit on canvas it only matters under `video.debug.previewCanvas='0'`
- The instrumentation — dormant, but it's what made the diagnosis possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJtnveuFUHm2pcpWChoJhn