### PR TITLE
fix(ui): stop walk-through bubbles from rendering twice

### DIFF
--- a/src/dotnet/UI.Blazor/Components/Bubble/BubbleHost.razor
+++ b/src/dotnet/UI.Blazor/Components/Bubble/BubbleHost.razor
@@ -2,7 +2,6 @@
 @using ActualChat.UI.Blazor.Module
 @using ActualChat.UI.Blazor.Services
 @using ActualChat.Users
-@using ActualLab.Generators
 @using System.Diagnostics.CodeAnalysis
 @implements IAsyncDisposable
 @attribute [UnconditionalSuppressMessage("Trimming", "IL2110", Justification = "UI types are expected to be untrimmed.")]
@@ -23,7 +22,6 @@
 
 @code {
     private static readonly string JSCreateMethod = $"{BlazorUICoreModule.ImportName}.BubbleHost.create";
-    private static RandomStringGenerator IdGenerator { get; } = new(3, Alphabet.AlphaNumeric);
 
     private BubbleModel? _bubble;
     private IJSObjectReference _jsRef = null!;
@@ -33,6 +31,7 @@
     private AccountUI AccountUI => Hub.AccountUI;
     private BubbleUI BubbleUI => field ??= Hub.BubbleUI;
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
+    private ComponentIdGenerator ComponentIdGenerator => Hub.ComponentIdGenerator;
     private IJSRuntime JS => field ??= Hub.JS;
     private ILogger Log => field ??= Hub.LogFor(GetType());
 
@@ -54,10 +53,15 @@
 
     [JSInvokable]
     public Task OnShow(string bubbleRef, bool isLastVisible, int index, int total) {
-        var id = IdGenerator.Next();
+        // Reusing the Id keeps @key - and thus the element - stable, so a repeated
+        // OnShow for the same bubble updates it in place instead of blinking.
+        var parsedRef = BubbleRef.Parse(bubbleRef);
+        var id = _bubble is { } oldBubble && oldBubble.Ref.BubbleType == parsedRef.BubbleType
+            ? oldBubble.Id
+            : ComponentIdGenerator.Next("bubble");
         _bubble = new BubbleModel(
             id,
-            BubbleRef.Parse(bubbleRef),
+            parsedRef,
             new Dictionary<string, object> {
                 { nameof(IBubble.Id), id },
                 { nameof(IBubble.IsLastVisible), isLastVisible },

--- a/src/dotnet/UI.Blazor/Components/Bubble/bubble-host.ts
+++ b/src/dotnet/UI.Blazor/Components/Bubble/bubble-host.ts
@@ -13,6 +13,7 @@ interface BubbleModel {
     isInViewport: boolean;
     isTopElement: boolean;
     isRead: boolean;
+    // Set when the show is requested, not when the bubble element appears - see show()
     isShown: boolean;
     priority: number;
     index?: number;
@@ -127,8 +128,12 @@ export class BubbleHost {
         debugLog?.log(`readBubble:`, bubbleRef);
 
         const bubble = this._bubbles.find(x => x.bubbleRef === bubbleRef);
-        if (bubble)
+        if (bubble) {
             bubble.isRead = true;
+            bubble.isShown = false;
+            bubble.bubbleElement = undefined;
+        }
+
         this.clearAutoUpdate();
         this.showNextBubble();
     }
@@ -145,8 +150,12 @@ export class BubbleHost {
 
         this.readBubbles.push(...readBubbles);
 
+        this.clearAutoUpdate();
+        // isShown is cleared too: every caller of this method drops the rendered bubble on the Blazor side
         this._bubbles.forEach(x => {
             x.isRead = this.readBubbles.includes(x.bubbleRef);
+            x.isShown = false;
+            x.bubbleElement = undefined;
             x.index = undefined;
             x.total = undefined;
         });
@@ -169,6 +178,7 @@ export class BubbleHost {
         const bubbleElement = document.getElementById(id);
         if (!bubbleElement) {
             warnLog?.log(`Bubble element not found:`, id);
+            bubble.isShown = false;
             return;
         }
 
@@ -321,6 +331,9 @@ export class BubbleHost {
     private show(bubble: BubbleModel, isLastVisible: boolean): void {
         debugLog?.log(`show:`, bubble.bubbleRef);
 
+        // Marked here rather than in showBubble(): the round trip can outlast the DOM
+        // debounce above, and re-requesting the same bubble meanwhile makes it blink
+        bubble.isShown = true;
         void this.blazorRef.invokeMethodAsync(
             'OnShow',
             bubble.bubbleRef,


### PR DESCRIPTION
Fixes #4265.

A walk-through bubble rendered, vanished, then rendered again. It showed up on a
loaded CPU — including a CPU loaded by `server-loop` rebuilding — and in
server-side rendering, which is the tell.

## Why

`bubble-host.ts` only learns a bubble is on screen when the `showBubble()`
interop callback comes back from Blazor. Meanwhile its own `MutationObserver`
(on `#app`, debounced 500ms) sees the bubble's DOM insert and re-runs
`showNextBubble()`. If the round trip hasn't returned by then, `isShown` is still
`false`, so the same bubble is requested a second time — `OnShow` minted a fresh
random element id, `@key` changed, and Blazor removed the node and inserted a new
one, which starts hidden (`.ac-bubble` is `@apply hidden`) until the next
callback arrives.

Only the SSB round trip is slow enough to cross the 500ms debounce; WASM never
is. Trace with the round trip held at 800ms (element ids are the old random ones,
this is pre-fix):

```
30455 show: ChatListTabsBubble     ← 1st request
30462 ADD u2A                      ← element rendered, still hidden
30963 showNextBubble → show:       ← debounce fired, isShown still false
30965 ADD 7kt + REMOVE u2A         ← node swapped = the blink
31262 showBubble: u2A → "Bubble element not found"
31767 showBubble: 7kt → display=block
```

## The fix

- A bubble is marked `isShown` when its show is **requested**, not when the
  element materializes. `showNextBubble()`'s existing
  `shownBubble === bubbleToShow` check then covers the in-flight window: the
  question it asks is "is this already the current bubble?", and the answer is
  yes from the moment we ask Blazor for it.
- `OnShow` reuses the current Id when the same `BubbleRef` is re-shown, so `@key`
  stays stable and the element is updated in place. The Id only has to be unique
  in the DOM — one `.ac-bubble` exists at a time — and it still changes when the
  bubble itself changes, which is the only case where the
  `_bubble?.Id != bubble.Id` guard has work to do.
- That Id now comes from `ComponentIdGenerator` — readable, counter-based ids like
  `bubble-3` — instead of a component-local `RandomStringGenerator(3, AlphaNumeric)`,
  whose ~238k values were shared by every circuit in the server process.

Also fixes the mirror desync found while testing: `resetBubbles()` and
`readBubble()` now clear `isShown`/`bubbleElement`, since every Blazor-side path
that calls them drops `_bubble`. Before this, `debugUI.resetBubbles(true)` (and
the login/logout reset) removed the bubble while JS still believed it was shown,
leaving nothing on screen until a reload.

## Verification

Driven against the local server with Playwright, with the round trip held at
800ms — the delay that reproduced the blink before the fix:

- one `show`, one element added, none removed, bubble ends `display: block`;
  same with no artificial delay
- full chain still walks: `bubble-3` → `bubble-6`, "1 of 4" → "4 of 4", ending
  with no bubble left
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

