### PR TITLE
feat(l10n): localize the iOS share extension

### DIFF
--- a/docs/api-index-full.md
+++ b/docs/api-index-full.md
@@ -1194,6 +1194,7 @@ Standalone iOS share extension app and views.
 - `UploadProgressView` - Upload progress view.
 - `IStatefulView`, `IStatefulView<T>`, `StatefulView`, `StatefulView<T>` - Stateful view abstractions.
 - `ComputedStateView`, `ComputedStateView<T>`, `ComputedStateViewState<T>`, `CreateDefaultStateOptionsFactory<T>` - Computed-state view helpers.
+- `AppStrings` (static class) - The extension's `IStringLocalizer`, resolved against the language the app mirrors into the App Group.
 - `NSId`, `NSId<TId>`, `NSHasId<T, TId>` - NSObject ID wrappers.
 - `FusionBuilderExt`, `ServiceProviderExt`, `UICollectionViewCellRegistrationExt`, `UIKitExt`, `NSItemProviderExt` (static classes) - DI/UIKit/Fusion extensions.
 

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -400,6 +400,7 @@ Standalone iOS share-extension app:
 - `IosHub`, `IosShareExtensionModule`, `SessionInitializer` — DI / session
 - `ShareView`, `SignInView`, `ContactSelectionView`, `UploadProgressView`, etc. — extension UI
 - `IStatefulView<T>`, `ComputedStateView<T>` — Fusion-style stateful UIKit views
+- `AppStrings` — the extension's `IStringLocalizer`, language from the App Group
 
 
 ## MAUI Application (`ActualChat.App.Maui`)

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -50,7 +50,7 @@ remaining work; this one carries the rules.
 Two embedded JSON catalogs per language live in
 `src/dotnet/Localization/Resources/`:
 
-- **`Strings.<iso>.json`** — ordinary UI text, addressed by key. 1289 keys.
+- **`Strings.<iso>.json`** — ordinary UI text, addressed by key. 1304 keys.
 - **`Messages.<iso>.json`** — server errors and validation messages, reverse-indexed
   by `MessageIndex` so an English message produced at runtime can be matched back
   to its key. 103 keys.
@@ -84,7 +84,7 @@ rather than from ICU.
 | Localizer | Where | Language from |
 |---|---|---|
 | `AppStringLocalizer` (`src/dotnet/UI.Blazor.App/Services/`) | the app, scoped to the Blazor circuit | `LocalizationUI.Language`, read per lookup |
-| `LanguageStringLocalizer` (`src/dotnet/Localization/Resources/`) | server-side code composing text *for* a user | an explicit `Language`, passed in; cached per language |
+| `LanguageStringLocalizer` (`src/dotnet/Localization/Resources/`) | server-side code composing text *for* a user, and the iOS share extension | an explicit `Language`, passed in; cached per language |
 
 **Server code composing text for a user must resolve
 `UILanguage ?? DetectedUILanguage ?? Languages.Main`** — the account's explicit
@@ -399,7 +399,7 @@ See `LocalizingUIActionFailureTracker` for the pattern.
 
 ## Terminology
 
-Product terms must be translated consistently across all 1289 keys, and in
+Product terms must be translated consistently across all 1304 keys, and in
 languages that have case, marked as terms by **capitalizing them mid-sentence**
 so they don't read as a generic noun.
 
@@ -643,9 +643,12 @@ Do not confuse any of this with the *spoken*/transcription languages —
 `Primary`/`Secondary`/`Tertiary` on the same record, and `GetChatLanguage` for
 the per-chat override. Same service, two unrelated concepts.
 
-**What is still English regardless:** the iOS share extension, Android permission
-dialogs and every OS prompt. Push notification text is *not* on that list any
-more — it is composed on the server in the recipient's language (#4125), which
-also covers the in-app notification list, since both render the same
-`Notification.Text`. See §3 and §4 of
+**What is still English regardless:** Android permission dialogs and every OS
+prompt. Push notification text is *not* on that list any more — it is composed on
+the server in the recipient's language (#4125), which also covers the in-app
+notification list, since both render the same `Notification.Text`. Neither is the
+iOS share extension (#4261): it runs in its own process, so the app mirrors the
+language it renders in into the App Group as `MauiPreferences.UILanguage`, and
+`AppStrings.L` reads it there, falling back to `NSLocale.PreferredLanguages` until
+the app has run once. See §3 and §4 of
 [what's left](plans/localization-remaining.md).

--- a/docs/plans/localization-remaining.md
+++ b/docs/plans/localization-remaining.md
@@ -7,7 +7,7 @@ validation messages and dates. This plan is the remaining work, ordered so that
 each item's prerequisite comes before it.
 
 ## Where things stand
-`Strings.<lang>.json` holds 1289 keys × 22 languages (plus the derived `Max`),
+`Strings.<lang>.json` holds 1304 keys × 22 languages (plus the derived `Max`),
 `Messages.<lang>.json` holds 103; both are guarded by `AppLocalizationTest` (key/member correspondence,
 per-language completeness, placeholder preservation) and
 `ServerErrorLocalizationTest`. Consuming code goes through the typed members in
@@ -305,7 +305,7 @@ that loads that assembly can already read it:
 |---|---|---|---|---|
 | Android dialogs | 9 strings, 3 files | main app | **yes** | plain C#; no `strings.xml` needed |
 | Local notifications / Live Activity | ~6 strings | main app | **yes** | plain C# in `App.Maui` |
-| iOS share extension (`App.Maui.IosShareExt/Components/*`) | ~18 strings | separate appex | **yes, since #4125** — it can reference `ActualChat.Localization` | needs only the language, see below |
+| iOS share extension (`App.Maui.IosShareExt/Components/*`) | ~18 strings | separate appex | **yes, since #4125** — it references `ActualChat.Localization` | **done (#4261)** — `AppStrings.L`, language from the App Group |
 | `Info.plist` usage descriptions | 6 iOS + 5 MacCatalyst | OS reads them, app not running | **no** | `InfoPlist.strings` per language — genuinely native |
 
 Android dialog sites: `AndroidWebChromeClient.cs:267-270`,
@@ -321,10 +321,10 @@ So for the in-process two-thirds the strings are not the blocker — the
 circuit, while this code runs on the native side (foreground service, FCM
 receiver, permission dialogs, Live Activity), where no such scope exists.
 
-### One question left, one answered
+### Both questions answered
 
 The catalog question that used to gate this section — and §3 with it — was
-answered by #4125. What remains is the language:
+answered by #4125; the language question, by #4261:
 
 1. **Where the catalog lives — answered by #4125.** `ActualChat.Localization`
    exists: dependency-free (`Api` + `Microsoft.Extensions.Localization`), it owns
@@ -334,14 +334,15 @@ answered by #4125. What remains is the language:
    spent their effort avoiding. The namespace was `ActualChat.UI.Blazor.Resources`
    until it was renamed to `ActualChat.Localization` to match the
    assembly.
-2. **How native-side code reads the current UI language.** Options: have
-   `LanguageUI` publish it to a process-wide accessor on change (one owner,
-   synchronous reads); read `LocalSettings` at each call site; or pass it down
-   from the Blazor side, which doesn't help the sites the OS invokes directly.
-
-Crossing the process boundary is already solved here: the share extension reads
-the session id from `AppleSharedSecureStorage` (`SessionInitializer.cs:35`), so
-the same shared keychain / app group can carry a language.
+2. **How native-side code reads the current UI language — answered for iOS by
+   #4261.** `MauiBrowserInfo.OnInitialized` mirrors `BrowserInfo.UILanguage` into
+   `MauiPreferences.UILanguage`, which on iOS is the App Group container the app
+   and its extensions share — the same crossing the session id already makes
+   through `AppleSharedSecureStorage` (`SessionInitializer.cs:35`). The share
+   extension reads it back through `AppStrings.L` and falls back to
+   `NSLocale.PreferredLanguages` until the app has run once. The in-process sites
+   (Android dialogs, local notifications, Live Activity) can read the same
+   accessor rather than reaching for the Blazor circuit.
 
 `Info.plist` is the one part that is settled — `InfoPlist.strings` per language,
 independent of everything above, and doable at any time.
@@ -518,11 +519,10 @@ why #3721 dropped the keys instead of relocating them. Now:
    the 5 templates, using the same `LanguageStringLocalizer`.
 2. §4's `Info.plist` strings — settled and independent, doable any time.
 3. §4's in-process subset (Android dialogs, local notifications, Live Activity)
-   — needs only a native-side language accessor, no new mechanism.
-4. §4's iOS share extension — the catalog question is answered; it needs the
-   language, which is §4's remaining open item.
-5. §6's video error codes — the branch `wip/l10n-video-error-codes` is
+   — the native-side accessor now exists (`MauiPreferences.UILanguage`, written on
+   every platform), so this is catalog lookups at the call sites and nothing else.
+4. §6's video error codes — the branch `wip/l10n-video-error-codes` is
    ready to cherry-pick; then web-auth's popup alert.
-6. §5, independently and on its own schedule — the marketing half needs SEO
+5. §5, independently and on its own schedule — the marketing half needs SEO
    routing before translation pays off, and the legal half needs a liability
    decision. Neither holds up anything else.

--- a/scripts/l10n/derive-bcms.py
+++ b/scripts/l10n/derive-bcms.py
@@ -100,6 +100,9 @@ CROATIAN = [
     ("neko ", "netko "), ("Neko", "Netko"),
     ("svako ", "svatko "),
     ("ko otvori", "tko otvori"), ("ko je još", "tko je još"),
+    # Before the noun swap below: "prijenos" is masculine where "otpremanje" is neuter,
+    # so a predicate agreeing with it has to be rewritten whole.
+    ("Otpremanje nije uspjelo", "Prijenos nije uspio"),
     ("Otpremi", "Prenesi"), ("otpremanje", "prijenos"), ("Otpremanje", "Prijenos"),
     ("otpremite", "prenesite"), ("Otpremite", "Prenesite"),
     ("otpremljeno", "preneseno"), ("Otpremljeno", "Preneseno"),
@@ -124,6 +127,7 @@ EKAVIAN = [
     ("srijed", "sred"), ("|sri|", "|sre|"),
     ("rješ", "reš"), ("Rješ", "Reš"), ("riješ", "reš"), ("Riješ", "Reš"),
     ("uspješ", "uspeš"), ("Uspješ", "Uspeš"),
+    ("uspjelo", "uspelo"), ("Uspjelo", "Uspelo"),
     ("svijetl", "svetl"), ("Svijetl", "Svetl"),
     ("vjeru", "veru"), ("Vjeru", "Veru"),
     ("vjerovatn", "verovatn"), ("Vjerovatn", "Verovatn"),

--- a/scripts/l10n/derive-bcms.py
+++ b/scripts/l10n/derive-bcms.py
@@ -100,9 +100,8 @@ CROATIAN = [
     ("neko ", "netko "), ("Neko", "Netko"),
     ("svako ", "svatko "),
     ("ko otvori", "tko otvori"), ("ko je još", "tko je još"),
-    # Before the noun swap below: "prijenos" is masculine where "otpremanje" is neuter,
-    # so a predicate agreeing with it has to be rewritten whole.
-    ("Otpremanje nije uspjelo", "Prijenos nije uspio"),
+    # "prijenos" is masculine where "otpremanje" is neuter, so a predicate agreeing with it
+    # needs its own whole-phrase entry above this line rather than a word swap.
     ("Otpremi", "Prenesi"), ("otpremanje", "prijenos"), ("Otpremanje", "Prijenos"),
     ("otpremite", "prenesite"), ("Otpremite", "Prenesite"),
     ("otpremljeno", "preneseno"), ("Otpremljeno", "Preneseno"),

--- a/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
+++ b/src/dotnet/App.Maui.IosShareExt/App.Maui.IosShareExt.csproj
@@ -97,6 +97,7 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <ProjectReference Include="..\Api.Contracts\Api.Contracts.csproj" />
+    <ProjectReference Include="..\Localization\Localization.csproj" />
     <ProjectReference Include="..\Maui\Maui.csproj" />
   </ItemGroup>
 

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
@@ -1,5 +1,4 @@
 using ActualChat.App.Maui.IosShareExt.Services;
-using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 using ActualChat.Localization;
 using ActualChat.Maui;
@@ -31,7 +30,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var titleLabel = new UILabel
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Text = AppStrings.L.ShareExt_ShareWith,
+            Text = L.ShareExt_ShareWith,
             Font = UIFont.SystemFontOfSize(17, UIFontWeight.Semibold)!,
             TextColor = AppColors.Text01,
             TextAlignment = UITextAlignment.Center
@@ -41,7 +40,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         // Send button
         _sendButton = new UIButton(UIButtonType.System);
         _sendButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        _sendButton.SetTitle(AppStrings.L.Common_Send, UIControlState.Normal);
+        _sendButton.SetTitle(L.Common_Send, UIControlState.Normal);
         _sendButton.TitleLabel.Font = UIFont.SystemFontOfSize(17, UIFontWeight.Semibold)!;
         _sendButton.TintColor = AppColors.Primary;
         _sendButton.TouchUpInside += Safe(() => ShareUI.StartSending());
@@ -56,7 +55,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var searchField = new UITextField
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Placeholder = AppStrings.L.Share_WhoToShareWith,
+            Placeholder = L.Share_WhoToShareWith,
             Font = UIFont.SystemFontOfSize(17),
             TextColor = AppColors.Text01,
             BackgroundColor = AppColors.Input,
@@ -94,7 +93,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var commentField = new UITextField
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Placeholder = AppStrings.L.Share_AddComment,
+            Placeholder = L.Share_AddComment,
             Font = UIFont.SystemFontOfSize(17),
             TextColor = AppColors.Text01,
             BackgroundColor = AppColors.Input,

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
@@ -1,5 +1,7 @@
 using ActualChat.App.Maui.IosShareExt.Services;
+using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
@@ -29,7 +31,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var titleLabel = new UILabel
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Text = "Share with",
+            Text = AppStrings.L.ShareExt_ShareWith,
             Font = UIFont.SystemFontOfSize(17, UIFontWeight.Semibold)!,
             TextColor = AppColors.Text01,
             TextAlignment = UITextAlignment.Center
@@ -39,7 +41,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         // Send button
         _sendButton = new UIButton(UIButtonType.System);
         _sendButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        _sendButton.SetTitle("Send", UIControlState.Normal);
+        _sendButton.SetTitle(AppStrings.L.Common_Send, UIControlState.Normal);
         _sendButton.TitleLabel.Font = UIFont.SystemFontOfSize(17, UIFontWeight.Semibold)!;
         _sendButton.TintColor = AppColors.Primary;
         _sendButton.TouchUpInside += Safe(() => ShareUI.StartSending());
@@ -54,7 +56,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var searchField = new UITextField
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Placeholder = "Who would you like to share with",
+            Placeholder = AppStrings.L.Share_WhoToShareWith,
             Font = UIFont.SystemFontOfSize(17),
             TextColor = AppColors.Text01,
             BackgroundColor = AppColors.Input,
@@ -92,7 +94,7 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         var commentField = new UITextField
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            Placeholder = "Add your comment (optional)",
+            Placeholder = AppStrings.L.Share_AddComment,
             Font = UIFont.SystemFontOfSize(17),
             TextColor = AppColors.Text01,
             BackgroundColor = AppColors.Input,

--- a/src/dotnet/App.Maui.IosShareExt/Components/ErrorContentView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ErrorContentView.cs
@@ -1,4 +1,5 @@
 using ActualChat.App.Maui.IosShareExt.UI;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
@@ -27,7 +28,7 @@ public sealed class ErrorContentView : UIView
         };
         var closeButton = UIButton.FromType(UIButtonType.System);
         closeButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        closeButton.SetTitle("Close", UIControlState.Normal);
+        closeButton.SetTitle(AppStrings.L.Common_Close, UIControlState.Normal);
         closeButton.TitleLabel.Font = UIFont.SystemFontOfSize(20, UIFontWeight.Semibold);
         closeButton.TintColor = AppColors.Primary;
         closeButton.TouchUpInside += onClose;

--- a/src/dotnet/App.Maui.IosShareExt/Components/SignInView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/SignInView.cs
@@ -1,5 +1,7 @@
 using ActualChat.App.Maui.IosShareExt.Services;
+using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
@@ -47,7 +49,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = "Sign in to Voxt to share content",
+            Text = AppStrings.L.ShareExt_SignInPrompt_Format(CoreConstants.AppName),
             Font = UIFont.SystemFontOfSize(20),
             TextColor = AppColors.Text01,
         };
@@ -55,7 +57,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         // Sign In button
         var signInButton = UIButton.FromType(UIButtonType.System);
         signInButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        signInButton.SetTitle("Sign In", UIControlState.Normal);
+        signInButton.SetTitle(AppStrings.L.SignIn_SignIn, UIControlState.Normal);
         signInButton.TitleLabel.Font = UIFont.SystemFontOfSize(18, UIFontWeight.Semibold);
         signInButton.SetTitleColor(AppColors.PrimaryTitle, UIControlState.Normal);
         signInButton.BackgroundColor = AppColors.Primary;
@@ -65,7 +67,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         // Close button
         var closeButton = UIButton.FromType(UIButtonType.System);
         closeButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        closeButton.SetTitle("Close", UIControlState.Normal);
+        closeButton.SetTitle(AppStrings.L.Common_Close, UIControlState.Normal);
         closeButton.TitleLabel.Font = UIFont.SystemFontOfSize(16);
         closeButton.TintColor = AppColors.Primary;
         closeButton.TouchUpInside += Safe(UIKitExt.CloseApp);

--- a/src/dotnet/App.Maui.IosShareExt/Components/SignInView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/SignInView.cs
@@ -1,5 +1,4 @@
 using ActualChat.App.Maui.IosShareExt.Services;
-using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 using ActualChat.Localization;
 using ActualChat.Maui;
@@ -49,7 +48,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = AppStrings.L.ShareExt_SignInPrompt_Format(CoreConstants.AppName),
+            Text = L.ShareExt_SignInPrompt_Format(CoreConstants.AppName),
             Font = UIFont.SystemFontOfSize(20),
             TextColor = AppColors.Text01,
         };
@@ -57,7 +56,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         // Sign In button
         var signInButton = UIButton.FromType(UIButtonType.System);
         signInButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        signInButton.SetTitle(AppStrings.L.SignIn_SignIn, UIControlState.Normal);
+        signInButton.SetTitle(L.SignIn_SignIn, UIControlState.Normal);
         signInButton.TitleLabel.Font = UIFont.SystemFontOfSize(18, UIFontWeight.Semibold);
         signInButton.SetTitleColor(AppColors.PrimaryTitle, UIControlState.Normal);
         signInButton.BackgroundColor = AppColors.Primary;
@@ -67,7 +66,7 @@ public class SignInView(IosHub hub) : ComputedStateView<SignInView.Model>(hub)
         // Close button
         var closeButton = UIButton.FromType(UIButtonType.System);
         closeButton.TranslatesAutoresizingMaskIntoConstraints = false;
-        closeButton.SetTitle(AppStrings.L.Common_Close, UIControlState.Normal);
+        closeButton.SetTitle(L.Common_Close, UIControlState.Normal);
         closeButton.TitleLabel.Font = UIFont.SystemFontOfSize(16);
         closeButton.TintColor = AppColors.Primary;
         closeButton.TouchUpInside += Safe(UIKitExt.CloseApp);

--- a/src/dotnet/App.Maui.IosShareExt/Components/SuccessView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/SuccessView.cs
@@ -1,5 +1,7 @@
 using ActualChat.App.Maui.IosShareExt.Services;
+using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
@@ -45,7 +47,7 @@ public class SuccessView(IosHub hub) : ComputedStateView<SuccessView.Model>(hub)
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = "Done!",
+            Text = AppStrings.L.ShareExt_Done,
             Font = UIFont.SystemFontOfSize(24, UIFontWeight.Semibold),
             TextColor = AppColors.Text01,
         };

--- a/src/dotnet/App.Maui.IosShareExt/Components/SuccessView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/SuccessView.cs
@@ -1,5 +1,4 @@
 using ActualChat.App.Maui.IosShareExt.Services;
-using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 using ActualChat.Localization;
 using ActualChat.Maui;
@@ -47,7 +46,7 @@ public class SuccessView(IosHub hub) : ComputedStateView<SuccessView.Model>(hub)
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = AppStrings.L.ShareExt_Done,
+            Text = L.ShareExt_Done,
             Font = UIFont.SystemFontOfSize(24, UIFontWeight.Semibold),
             TextColor = AppColors.Text01,
         };

--- a/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
@@ -1,6 +1,7 @@
 using ActualChat.App.Maui.IosShareExt.Services;
 using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
@@ -42,7 +43,7 @@ public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressVi
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = "Uploading...",
+            Text = AppStrings.L.ShareExt_Uploading,
             Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium)!,
             TextColor = AppColors.Text01,
         };
@@ -62,7 +63,7 @@ public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressVi
         var cancelConfiguration = UIButtonConfiguration.PlainButtonConfiguration;
         cancelConfiguration.ContentInsets = new NSDirectionalEdgeInsets(10, 24, 10, 24);
         cancelConfiguration.BaseForegroundColor = AppColors.Primary;
-        cancelConfiguration.AttributedTitle = new NSAttributedString("Cancel",
+        cancelConfiguration.AttributedTitle = new NSAttributedString(AppStrings.L.Common_Cancel,
             new UIStringAttributes { Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium) });
         var cancelButton = new UIButton {
             TranslatesAutoresizingMaskIntoConstraints = false,

--- a/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/UploadProgressView.cs
@@ -43,7 +43,7 @@ public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressVi
         var label = new UILabel {
             TranslatesAutoresizingMaskIntoConstraints = false,
             TextAlignment = UITextAlignment.Center,
-            Text = AppStrings.L.ShareExt_Uploading,
+            Text = L.ShareExt_Uploading,
             Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium)!,
             TextColor = AppColors.Text01,
         };
@@ -63,7 +63,7 @@ public class UploadProgressView(IosHub hub) : ComputedStateView<UploadProgressVi
         var cancelConfiguration = UIButtonConfiguration.PlainButtonConfiguration;
         cancelConfiguration.ContentInsets = new NSDirectionalEdgeInsets(10, 24, 10, 24);
         cancelConfiguration.BaseForegroundColor = AppColors.Primary;
-        cancelConfiguration.AttributedTitle = new NSAttributedString(AppStrings.L.Common_Cancel,
+        cancelConfiguration.AttributedTitle = new NSAttributedString(L.Common_Cancel,
             new UIStringAttributes { Font = UIFont.SystemFontOfSize(16, UIFontWeight.Medium) });
         var cancelButton = new UIButton {
             TranslatesAutoresizingMaskIntoConstraints = false,

--- a/src/dotnet/App.Maui.IosShareExt/README.md
+++ b/src/dotnet/App.Maui.IosShareExt/README.md
@@ -16,11 +16,16 @@ app's `localStorage` nor its `NSUserDefaults`. Two entitlements bridge that:
 
 - **Keychain access group** (`M287G8G83F.chat.actual[.dev].app.shared`) — the session,
   see `AppleSharedSecureStorage`.
-- **App Group** (`group.chat.actual[.dev].app.shared`) — the theme, see
-  `MauiPreferences.Theme`. The app writes it on every theme change
-  (`MauiThemeHandler.OnThemeChanged`); `ShareViewController` reads it per share and
-  applies it to `AppColors` and `OverrideUserInterfaceStyle`. Nothing written means
-  "follow the system appearance", which is what the extension did before.
+- **App Group** (`group.chat.actual[.dev].app.shared`) — the theme and the UI
+  language, see `MauiPreferences.Theme` and `MauiPreferences.UILanguage`.
+  - The app writes the theme on every theme change (`MauiThemeHandler.OnThemeChanged`);
+    `ShareViewController` reads it per share and applies it to `AppColors` and
+    `OverrideUserInterfaceStyle`. Nothing written means "follow the system
+    appearance", which is what the extension did before.
+  - The app writes the language it renders in on every launch
+    (`MauiBrowserInfo.OnInitialized`); `AppStrings.L` reads it and resolves the
+    catalog against it. Nothing written means "follow `NSLocale.PreferredLanguages`",
+    which is what a device that hasn't run the app since #4261 gets.
 
 Both entitlements have to be granted by the provisioning profile the build is signed
 with, otherwise codesign fails with `MT7140`. Adding one means registering it on the

--- a/src/dotnet/App.Maui.IosShareExt/Services/ExceptionExt.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Services/ExceptionExt.cs
@@ -1,4 +1,6 @@
 using System.Security;
+using ActualChat.App.Maui.IosShareExt.UI;
+using ActualChat.Localization;
 
 namespace ActualChat.App.Maui.IosShareExt.Services;
 
@@ -8,8 +10,8 @@ public static class ExceptionExt
     {
         public string UserFriendlyMessage => error switch
         {
-            SecurityException or UnauthorizedAccessException => "You can't send to this contact",
-            _ => "Upload failed",
+            SecurityException or UnauthorizedAccessException => AppStrings.L.ShareExt_CannotSendToContact,
+            _ => AppStrings.L.ShareExt_UploadFailed,
         };
     }
 }

--- a/src/dotnet/App.Maui.IosShareExt/Services/ExceptionExt.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Services/ExceptionExt.cs
@@ -11,7 +11,7 @@ public static class ExceptionExt
         public string UserFriendlyMessage => error switch
         {
             SecurityException or UnauthorizedAccessException => AppStrings.L.ShareExt_CannotSendToContact,
-            _ => AppStrings.L.ShareExt_UploadFailed,
+            _ => AppStrings.L.ShareExt_SharingFailed,
         };
     }
 }

--- a/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
+++ b/src/dotnet/App.Maui.IosShareExt/ShareViewController.cs
@@ -1,4 +1,6 @@
 ﻿using ActualChat.App.Maui.IosShareExt.Components;
+using ActualChat.App.Maui.IosShareExt.UI;
+using ActualChat.Localization;
 using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt;
@@ -17,7 +19,7 @@ public class ShareViewController : UIViewController
         // object"), so a failed bootstrap used to crash the extension outright - which also killed
         // the failure report Bootstrap had just started sending.
         View = _app is null
-            ? new ErrorContentView("Something went wrong. Please try again.",
+            ? new ErrorContentView(AppStrings.L.ShareExt_StartupFailed,
                 (_, _) => _ = ExtensionContext?.CompleteRequestAsync([]))
             : _app.View;
     }

--- a/src/dotnet/App.Maui.IosShareExt/UI/AppStrings.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/AppStrings.cs
@@ -1,0 +1,17 @@
+using ActualChat.Localization;
+using ActualChat.Maui;
+using Microsoft.Extensions.Localization;
+
+namespace ActualChat.App.Maui.IosShareExt.UI;
+
+/// <summary>
+/// The extension's <see cref="IStringLocalizer"/>, resolved against the language the app mirrors
+/// into the App Group (<see cref="MauiPreferences.UILanguage"/>) - or, until the app has run once
+/// since that key appeared, against the device's own language ordering.
+/// </summary>
+public static class AppStrings
+{
+    public static IStringLocalizer L => LanguageStringLocalizer.Get(UILanguage);
+    private static Language UILanguage
+        => MauiPreferences.UILanguage ?? Languages.DetectUILanguage(NSLocale.PreferredLanguages);
+}

--- a/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/StatefulView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/StatefulView.cs
@@ -1,5 +1,6 @@
 using ActualLab.Fusion.UI;
 using ActualLab.Internal;
+using Microsoft.Extensions.Localization;
 
 namespace ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 
@@ -22,6 +23,9 @@ public abstract class StatefulView : UIView, IStatefulView, IEnumerable<UIView>
     public IServiceProvider Services => Hub.Services;
     protected UICommander UICommander => Hub.UICommander;
     protected Session Session => Hub.Session;
+    // Not a hub service: the appex resolves the catalog against a process-wide language rather
+    // than scope state, so this is a shortcut over the static AppColors and AppImages sit beside.
+    protected IStringLocalizer L => AppStrings.L;
     protected State State { get; private set; } = null!;
     protected Action<State, StateEventKind> StateChanged { get; set; }
     protected ILogger Log => field ??= Hub.LogFor(GetType());

--- a/src/dotnet/App.Maui/Services/MauiBrowserInfo.cs
+++ b/src/dotnet/App.Maui/Services/MauiBrowserInfo.cs
@@ -49,6 +49,9 @@ public class MauiBrowserInfo : BrowserInfo
         Update(screenSize, initResult.IsHoverable, initResult.IsVisible);
         WindowId = initResult.WindowId;
         UpdateUILanguageInfo(initResult.UILanguageInfo);
+        // Written on every launch, not only on a change: this is also how the iOS share extension
+        // learns the language, and its App Group may still be empty from an earlier version.
+        MauiPreferences.UILanguage = UILanguage;
         // We don't want to change any other properties here
 
         WhenReadySource.TrySetResult();

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -1009,7 +1009,7 @@ public static class LocalizedStringsLocalizerExt
         public string ShareExt_Done => l["ShareExt_Done"].Value;
         public string ShareExt_StartupFailed => l["ShareExt_StartupFailed"].Value;
         public string ShareExt_CannotSendToContact => l["ShareExt_CannotSendToContact"].Value;
-        public string ShareExt_UploadFailed => l["ShareExt_UploadFailed"].Value;
+        public string ShareExt_SharingFailed => l["ShareExt_SharingFailed"].Value;
 
         public string Ptt_UseOnThisDevice => l["Ptt_UseOnThisDevice"].Value;
         public string Ptt_UseOnThisDeviceCaption => l["Ptt_UseOnThisDeviceCaption"].Value;

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -1003,6 +1003,14 @@ public static class LocalizedStringsLocalizerExt
         public string Share_AddComment => l["Share_AddComment"].Value;
         public string Share_SendToSelected => l["Share_SendToSelected"].Value;
 
+        public string ShareExt_ShareWith => l["ShareExt_ShareWith"].Value;
+        public string ShareExt_SignInPrompt_Format(object arg0) => l["ShareExt_SignInPrompt_Format", arg0].Value;
+        public string ShareExt_Uploading => l["ShareExt_Uploading"].Value;
+        public string ShareExt_Done => l["ShareExt_Done"].Value;
+        public string ShareExt_StartupFailed => l["ShareExt_StartupFailed"].Value;
+        public string ShareExt_CannotSendToContact => l["ShareExt_CannotSendToContact"].Value;
+        public string ShareExt_UploadFailed => l["ShareExt_UploadFailed"].Value;
+
         public string Ptt_UseOnThisDevice => l["Ptt_UseOnThisDevice"].Value;
         public string Ptt_UseOnThisDeviceCaption => l["Ptt_UseOnThisDeviceCaption"].Value;
         public string Ptt_DeviceEnabledToast => l["Ptt_DeviceEnabledToast"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Копирай линка",
   "Share_LinkCopied": "Линкът е копиран!",
   "Share_WhoToShareWith": "С кого искате да споделите",
-  "Share_AddComment": "Добавете коментар (по избор)",
+  "Share_AddComment": "Добавете коментар",
   "Share_SendToSelected": "Изпрати до избраните контакти",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Готово!",
   "ShareExt_StartupFailed": "Нещо се обърка. Моля, опитайте отново.",
   "ShareExt_CannotSendToContact": "Не можете да изпращате на този контакт",
-  "ShareExt_UploadFailed": "Качването е неуспешно",
+  "ShareExt_SharingFailed": "Споделянето е неуспешно",
 
   "Ptt_UseOnThisDevice": "Използвай Натисни и говори на това устройство",
   "Ptt_UseOnThisDeviceCaption": "Когато е изключено, това устройство няма да се събужда, възпроизвежда или предава глас с Натисни и говори.",

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Добавете коментар (по избор)",
   "Share_SendToSelected": "Изпрати до избраните контакти",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Споделяне",
+  "ShareExt_SignInPrompt_Format": "Влезте в {0}, за да споделяте съдържание",
+  "ShareExt_Uploading": "Качване...",
+  "ShareExt_Done": "Готово!",
+  "ShareExt_StartupFailed": "Нещо се обърка. Моля, опитайте отново.",
+  "ShareExt_CannotSendToContact": "Не можете да изпращате на този контакт",
+  "ShareExt_UploadFailed": "Качването е неуспешно",
+
   "Ptt_UseOnThisDevice": "Използвай Натисни и говори на това устройство",
   "Ptt_UseOnThisDeviceCaption": "Когато е изключено, това устройство няма да се събужда, възпроизвежда или предава глас с Натисни и говори.",
   "Ptt_DeviceEnabledToast": "Натисни и говори вече е активно на това устройство.",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopiraj link",
   "Share_LinkCopied": "Link je kopiran!",
   "Share_WhoToShareWith": "S kim želite podijeliti",
-  "Share_AddComment": "Dodajte komentar (opcionalno)",
+  "Share_AddComment": "Dodajte komentar",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Gotovo!",
   "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
   "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
-  "ShareExt_UploadFailed": "Otpremanje nije uspjelo",
+  "ShareExt_SharingFailed": "Dijeljenje nije uspjelo",
 
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Dodajte komentar (opcionalno)",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Podijeli",
+  "ShareExt_SignInPrompt_Format": "Prijavite se u {0} da biste dijelili sadržaj",
+  "ShareExt_Uploading": "Otpremanje...",
+  "ShareExt_Done": "Gotovo!",
+  "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
+  "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
+  "ShareExt_UploadFailed": "Otpremanje nije uspjelo",
+
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",
   "Ptt_DeviceEnabledToast": "Pritisni i govori je sada aktivan na ovom uređaju.",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopiraj link",
   "Share_LinkCopied": "Link je kopiran!",
   "Share_WhoToShareWith": "S kim želite podijeliti",
-  "Share_AddComment": "Dodajte komentar (opcionalno)",
+  "Share_AddComment": "Dodajte komentar",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Gotovo!",
   "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
   "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
-  "ShareExt_UploadFailed": "Otpremanje nije uspjelo",
+  "ShareExt_SharingFailed": "Dijeljenje nije uspjelo",
 
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Dodajte komentar (opcionalno)",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Podijeli",
+  "ShareExt_SignInPrompt_Format": "Prijavite se u {0} da biste dijelili sadržaj",
+  "ShareExt_Uploading": "Otpremanje...",
+  "ShareExt_Done": "Gotovo!",
+  "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
+  "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
+  "ShareExt_UploadFailed": "Otpremanje nije uspjelo",
+
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",
   "Ptt_DeviceEnabledToast": "Pritisni i govori je sada aktivan na ovom uređaju.",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Přidejte komentář (nepovinné)",
   "Share_SendToSelected": "Odeslat vybraným kontaktům",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Sdílet",
+  "ShareExt_SignInPrompt_Format": "Přihlaste se do {0} a sdílejte obsah",
+  "ShareExt_Uploading": "Nahrávání...",
+  "ShareExt_Done": "Hotovo!",
+  "ShareExt_StartupFailed": "Něco se pokazilo. Zkuste to prosím znovu.",
+  "ShareExt_CannotSendToContact": "Tomuto kontaktu nemůžete odesílat",
+  "ShareExt_UploadFailed": "Nahrávání selhalo",
+
   "Ptt_UseOnThisDevice": "Používat Stiskni a mluv na tomto zařízení",
   "Ptt_UseOnThisDeviceCaption": "Když je vypnuto, toto zařízení se nebude budit, přehrávat ani vysílat hlas přes Stiskni a mluv.",
   "Ptt_DeviceEnabledToast": "Stiskni a mluv je teď na tomto zařízení aktivní.",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopírovat odkaz",
   "Share_LinkCopied": "Odkaz zkopírován!",
   "Share_WhoToShareWith": "Komu chcete sdílet",
-  "Share_AddComment": "Přidejte komentář",
+  "Share_AddComment": "Přidat komentář",
   "Share_SendToSelected": "Odeslat vybraným kontaktům",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopírovat odkaz",
   "Share_LinkCopied": "Odkaz zkopírován!",
   "Share_WhoToShareWith": "Komu chcete sdílet",
-  "Share_AddComment": "Přidejte komentář (nepovinné)",
+  "Share_AddComment": "Přidejte komentář",
   "Share_SendToSelected": "Odeslat vybraným kontaktům",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Hotovo!",
   "ShareExt_StartupFailed": "Něco se pokazilo. Zkuste to prosím znovu.",
   "ShareExt_CannotSendToContact": "Tomuto kontaktu nemůžete odesílat",
-  "ShareExt_UploadFailed": "Nahrávání selhalo",
+  "ShareExt_SharingFailed": "Sdílení se nezdařilo",
 
   "Ptt_UseOnThisDevice": "Používat Stiskni a mluv na tomto zařízení",
   "Ptt_UseOnThisDeviceCaption": "Když je vypnuto, toto zařízení se nebude budit, přehrávat ani vysílat hlas přes Stiskni a mluv.",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Kommentar hinzufügen (optional)",
   "Share_SendToSelected": "An ausgewählte Kontakte senden",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Teilen mit",
+  "ShareExt_SignInPrompt_Format": "Melde dich bei {0} an, um Inhalte zu teilen",
+  "ShareExt_Uploading": "Wird hochgeladen...",
+  "ShareExt_Done": "Fertig!",
+  "ShareExt_StartupFailed": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+  "ShareExt_CannotSendToContact": "Du kannst an diesen Kontakt nichts senden",
+  "ShareExt_UploadFailed": "Hochladen fehlgeschlagen",
+
   "Ptt_UseOnThisDevice": "Push-to-Talk auf diesem Gerät verwenden",
   "Ptt_UseOnThisDeviceCaption": "Wenn aus, weckt dieses Gerät nicht, spielt nichts ab und überträgt keine Push-to-Talk-Sprache.",
   "Ptt_DeviceEnabledToast": "Push-to-Talk ist jetzt auf diesem Gerät aktiv.",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Link kopieren",
   "Share_LinkCopied": "Link kopiert!",
   "Share_WhoToShareWith": "Mit wem möchtest du teilen?",
-  "Share_AddComment": "Kommentar hinzufügen (optional)",
+  "Share_AddComment": "Kommentar hinzufügen",
   "Share_SendToSelected": "An ausgewählte Kontakte senden",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Fertig!",
   "ShareExt_StartupFailed": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
   "ShareExt_CannotSendToContact": "Du kannst diesem Kontakt nichts senden",
-  "ShareExt_UploadFailed": "Hochladen fehlgeschlagen",
+  "ShareExt_SharingFailed": "Teilen fehlgeschlagen",
 
   "Ptt_UseOnThisDevice": "Push-to-Talk auf diesem Gerät verwenden",
   "Ptt_UseOnThisDeviceCaption": "Wenn aus, weckt dieses Gerät nicht, spielt nichts ab und überträgt keine Push-to-Talk-Sprache.",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -976,7 +976,7 @@
   "ShareExt_Uploading": "Wird hochgeladen...",
   "ShareExt_Done": "Fertig!",
   "ShareExt_StartupFailed": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
-  "ShareExt_CannotSendToContact": "Du kannst an diesen Kontakt nichts senden",
+  "ShareExt_CannotSendToContact": "Du kannst diesem Kontakt nichts senden",
   "ShareExt_UploadFailed": "Hochladen fehlgeschlagen",
 
   "Ptt_UseOnThisDevice": "Push-to-Talk auf diesem Gerät verwenden",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Copy link",
   "Share_LinkCopied": "Link copied!",
   "Share_WhoToShareWith": "Who would you like to share with",
-  "Share_AddComment": "Add your comment (optional)",
+  "Share_AddComment": "Add a comment",
   "Share_SendToSelected": "Send to selected contacts",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Done!",
   "ShareExt_StartupFailed": "Something went wrong. Please try again.",
   "ShareExt_CannotSendToContact": "You can't send to this contact",
-  "ShareExt_UploadFailed": "Upload failed",
+  "ShareExt_SharingFailed": "Sharing failed",
 
   "Ptt_UseOnThisDevice": "Use Push-to-talk on this device",
   "Ptt_UseOnThisDeviceCaption": "When off, this device won't wake, play, or transmit Push-to-talk voice.",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Add your comment (optional)",
   "Share_SendToSelected": "Send to selected contacts",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Share with",
+  "ShareExt_SignInPrompt_Format": "Sign in to {0} to share content",
+  "ShareExt_Uploading": "Uploading...",
+  "ShareExt_Done": "Done!",
+  "ShareExt_StartupFailed": "Something went wrong. Please try again.",
+  "ShareExt_CannotSendToContact": "You can't send to this contact",
+  "ShareExt_UploadFailed": "Upload failed",
+
   "Ptt_UseOnThisDevice": "Use Push-to-talk on this device",
   "Ptt_UseOnThisDeviceCaption": "When off, this device won't wake, play, or transmit Push-to-talk voice.",
   "Ptt_DeviceEnabledToast": "Push-to-talk is now active on this device.",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Añade un comentario (opcional)",
   "Share_SendToSelected": "Enviar a los contactos seleccionados",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Compartir con",
+  "ShareExt_SignInPrompt_Format": "Inicia sesión en {0} para compartir contenido",
+  "ShareExt_Uploading": "Subiendo...",
+  "ShareExt_Done": "¡Listo!",
+  "ShareExt_StartupFailed": "Algo salió mal. Vuelve a intentarlo.",
+  "ShareExt_CannotSendToContact": "No puedes enviar a este contacto",
+  "ShareExt_UploadFailed": "Error al subir",
+
   "Ptt_UseOnThisDevice": "Usar Pulsar para hablar en este dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Si está desactivado, este dispositivo no se despertará, no reproducirá ni transmitirá voz de Pulsar para hablar.",
   "Ptt_DeviceEnabledToast": "Pulsar para hablar ya está activo en este dispositivo.",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Copiar enlace",
   "Share_LinkCopied": "¡Enlace copiado!",
   "Share_WhoToShareWith": "¿Con quién quieres compartir?",
-  "Share_AddComment": "Añade un comentario (opcional)",
+  "Share_AddComment": "Añade un comentario",
   "Share_SendToSelected": "Enviar a los contactos seleccionados",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "¡Listo!",
   "ShareExt_StartupFailed": "Algo salió mal. Vuelve a intentarlo.",
   "ShareExt_CannotSendToContact": "No puedes enviar a este contacto",
-  "ShareExt_UploadFailed": "Error al subir",
+  "ShareExt_SharingFailed": "Error al compartir",
 
   "Ptt_UseOnThisDevice": "Usar Pulsar para hablar en este dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Si está desactivado, este dispositivo no se despertará, no reproducirá ni transmitirá voz de Pulsar para hablar.",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Ajoutez un commentaire (facultatif)",
   "Share_SendToSelected": "Envoyer aux contacts sélectionnés",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Partager avec",
+  "ShareExt_SignInPrompt_Format": "Connectez-vous à {0} pour partager du contenu",
+  "ShareExt_Uploading": "Envoi en cours…",
+  "ShareExt_Done": "Terminé !",
+  "ShareExt_StartupFailed": "Une erreur s'est produite. Veuillez réessayer.",
+  "ShareExt_CannotSendToContact": "Vous ne pouvez pas envoyer à ce contact",
+  "ShareExt_UploadFailed": "Échec de l'envoi",
+
   "Ptt_UseOnThisDevice": "Utiliser le Push-to-Talk sur cet appareil",
   "Ptt_UseOnThisDeviceCaption": "Si désactivé, cet appareil ne se réveillera pas, ne lira pas et ne transmettra pas la voix Push-to-Talk.",
   "Ptt_DeviceEnabledToast": "Le Push-to-Talk est maintenant actif sur cet appareil.",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -973,7 +973,7 @@
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
   "ShareExt_ShareWith": "Partager avec",
   "ShareExt_SignInPrompt_Format": "Connectez-vous à {0} pour partager du contenu",
-  "ShareExt_Uploading": "Envoi en cours…",
+  "ShareExt_Uploading": "Envoi en cours...",
   "ShareExt_Done": "Terminé !",
   "ShareExt_StartupFailed": "Une erreur s'est produite. Veuillez réessayer.",
   "ShareExt_CannotSendToContact": "Vous ne pouvez pas envoyer à ce contact",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Copier le lien",
   "Share_LinkCopied": "Lien copié !",
   "Share_WhoToShareWith": "Avec qui souhaitez-vous partager ?",
-  "Share_AddComment": "Ajoutez un commentaire (facultatif)",
+  "Share_AddComment": "Ajoutez un commentaire",
   "Share_SendToSelected": "Envoyer aux contacts sélectionnés",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Terminé !",
   "ShareExt_StartupFailed": "Une erreur s'est produite. Veuillez réessayer.",
   "ShareExt_CannotSendToContact": "Vous ne pouvez pas envoyer à ce contact",
-  "ShareExt_UploadFailed": "Échec de l'envoi",
+  "ShareExt_SharingFailed": "Échec du partage",
 
   "Ptt_UseOnThisDevice": "Utiliser le Push-to-Talk sur cet appareil",
   "Ptt_UseOnThisDeviceCaption": "Si désactivé, cet appareil ne se réveillera pas, ne lira pas et ne transmettra pas la voix Push-to-Talk.",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -976,7 +976,7 @@
   "ShareExt_Uploading": "अपलोड हो रहा है...",
   "ShareExt_Done": "हो गया!",
   "ShareExt_StartupFailed": "कुछ गड़बड़ हो गई। कृपया पुनः प्रयास करें।",
-  "ShareExt_CannotSendToContact": "आप इस संपर्क को नहीं भेज सकते",
+  "ShareExt_CannotSendToContact": "आप इस संपर्क को संदेश नहीं भेज सकते",
   "ShareExt_UploadFailed": "अपलोड विफल",
 
   "Ptt_UseOnThisDevice": "इस डिवाइस पर पुश टू टॉक इस्तेमाल करें",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "अपनी टिप्पणी जोड़ें (वैकल्पिक)",
   "Share_SendToSelected": "चुने गए संपर्कों को भेजें",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "साझा करें",
+  "ShareExt_SignInPrompt_Format": "सामग्री साझा करने के लिए {0} में साइन इन करें",
+  "ShareExt_Uploading": "अपलोड हो रहा है...",
+  "ShareExt_Done": "हो गया!",
+  "ShareExt_StartupFailed": "कुछ गड़बड़ हो गई। कृपया पुनः प्रयास करें।",
+  "ShareExt_CannotSendToContact": "आप इस संपर्क को नहीं भेज सकते",
+  "ShareExt_UploadFailed": "अपलोड विफल",
+
   "Ptt_UseOnThisDevice": "इस डिवाइस पर पुश टू टॉक इस्तेमाल करें",
   "Ptt_UseOnThisDeviceCaption": "बंद होने पर यह डिवाइस पुश टू टॉक आवाज़ के लिए न जागेगा, न चलाएगा, न भेजेगा।",
   "Ptt_DeviceEnabledToast": "पुश टू टॉक अब इस डिवाइस पर सक्रिय है।",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "लिंक कॉपी करें",
   "Share_LinkCopied": "लिंक कॉपी हो गया!",
   "Share_WhoToShareWith": "आप किसके साथ साझा करना चाहेंगे",
-  "Share_AddComment": "अपनी टिप्पणी जोड़ें (वैकल्पिक)",
+  "Share_AddComment": "टिप्पणी जोड़ें",
   "Share_SendToSelected": "चुने गए संपर्कों को भेजें",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "हो गया!",
   "ShareExt_StartupFailed": "कुछ गड़बड़ हो गई। कृपया पुनः प्रयास करें।",
   "ShareExt_CannotSendToContact": "आप इस संपर्क को संदेश नहीं भेज सकते",
-  "ShareExt_UploadFailed": "अपलोड विफल",
+  "ShareExt_SharingFailed": "साझा नहीं किया जा सका",
 
   "Ptt_UseOnThisDevice": "इस डिवाइस पर पुश टू टॉक इस्तेमाल करें",
   "Ptt_UseOnThisDeviceCaption": "बंद होने पर यह डिवाइस पुश टू टॉक आवाज़ के लिए न जागेगा, न चलाएगा, न भेजेगा।",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Dodajte komentar (opcionalno)",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Podijeli",
+  "ShareExt_SignInPrompt_Format": "Prijavite se u {0} da biste dijelili sadržaj",
+  "ShareExt_Uploading": "Prijenos...",
+  "ShareExt_Done": "Gotovo!",
+  "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
+  "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
+  "ShareExt_UploadFailed": "Prijenos nije uspio",
+
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",
   "Ptt_DeviceEnabledToast": "Pritisni i govori je sada aktivan na ovom uređaju.",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopiraj link",
   "Share_LinkCopied": "Link je kopiran!",
   "Share_WhoToShareWith": "S kim želite podijeliti",
-  "Share_AddComment": "Dodajte komentar (opcionalno)",
+  "Share_AddComment": "Dodajte komentar",
   "Share_SendToSelected": "Pošalji odabranim kontaktima",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Gotovo!",
   "ShareExt_StartupFailed": "Nešto je pošlo naopako. Molimo pokušajte ponovo.",
   "ShareExt_CannotSendToContact": "Ne možete slati ovom kontaktu",
-  "ShareExt_UploadFailed": "Prijenos nije uspio",
+  "ShareExt_SharingFailed": "Dijeljenje nije uspjelo",
 
   "Ptt_UseOnThisDevice": "Koristi Pritisni i govori na ovom uređaju",
   "Ptt_UseOnThisDeviceCaption": "Kada je isključeno, ovaj uređaj se neće buditi, reproducirati ni slati glas putem Pritisni i govori.",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Tambahkan komentar (opsional)",
   "Share_SendToSelected": "Kirim ke kontak terpilih",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Bagikan ke",
+  "ShareExt_SignInPrompt_Format": "Masuk ke {0} untuk berbagi konten",
+  "ShareExt_Uploading": "Mengunggah...",
+  "ShareExt_Done": "Selesai!",
+  "ShareExt_StartupFailed": "Terjadi kesalahan. Silakan coba lagi.",
+  "ShareExt_CannotSendToContact": "Anda tidak dapat mengirim ke kontak ini",
+  "ShareExt_UploadFailed": "Unggahan gagal",
+
   "Ptt_UseOnThisDevice": "Gunakan Tekan untuk bicara di perangkat ini",
   "Ptt_UseOnThisDeviceCaption": "Saat mati, perangkat ini tidak akan bangun, memutar, atau mengirim suara Tekan untuk bicara.",
   "Ptt_DeviceEnabledToast": "Tekan untuk bicara kini aktif di perangkat ini.",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Salin tautan",
   "Share_LinkCopied": "Tautan disalin!",
   "Share_WhoToShareWith": "Ingin berbagi dengan siapa",
-  "Share_AddComment": "Tambahkan komentar (opsional)",
+  "Share_AddComment": "Tambahkan komentar",
   "Share_SendToSelected": "Kirim ke kontak terpilih",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Selesai!",
   "ShareExt_StartupFailed": "Terjadi kesalahan. Silakan coba lagi.",
   "ShareExt_CannotSendToContact": "Anda tidak dapat mengirim ke kontak ini",
-  "ShareExt_UploadFailed": "Unggahan gagal",
+  "ShareExt_SharingFailed": "Gagal berbagi",
 
   "Ptt_UseOnThisDevice": "Gunakan Tekan untuk bicara di perangkat ini",
   "Ptt_UseOnThisDeviceCaption": "Saat mati, perangkat ini tidak akan bangun, memutar, atau mengirim suara Tekan untuk bicara.",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Aggiungi un commento (facoltativo)",
   "Share_SendToSelected": "Invia ai contatti selezionati",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Condividi con",
+  "ShareExt_SignInPrompt_Format": "Accedi a {0} per condividere contenuti",
+  "ShareExt_Uploading": "Caricamento...",
+  "ShareExt_Done": "Fatto!",
+  "ShareExt_StartupFailed": "Si è verificato un problema. Riprova.",
+  "ShareExt_CannotSendToContact": "Non puoi inviare a questo contatto",
+  "ShareExt_UploadFailed": "Caricamento non riuscito",
+
   "Ptt_UseOnThisDevice": "Usa il Push-to-Talk su questo dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Se disattivato, questo dispositivo non si sveglierà, non riprodurrà né trasmetterà la voce Push-to-Talk.",
   "Ptt_DeviceEnabledToast": "Il Push-to-Talk è ora attivo su questo dispositivo.",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Copia link",
   "Share_LinkCopied": "Link copiato!",
   "Share_WhoToShareWith": "Con chi vuoi condividere?",
-  "Share_AddComment": "Aggiungi un commento (facoltativo)",
+  "Share_AddComment": "Aggiungi un commento",
   "Share_SendToSelected": "Invia ai contatti selezionati",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Fatto!",
   "ShareExt_StartupFailed": "Si è verificato un problema. Riprova.",
   "ShareExt_CannotSendToContact": "Non puoi inviare a questo contatto",
-  "ShareExt_UploadFailed": "Caricamento non riuscito",
+  "ShareExt_SharingFailed": "Condivisione non riuscita",
 
   "Ptt_UseOnThisDevice": "Usa il Push-to-Talk su questo dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Se disattivato, questo dispositivo non si sveglierà, non riprodurrà né trasmetterà la voce Push-to-Talk.",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "リンクをコピー",
   "Share_LinkCopied": "リンクをコピーしました!",
   "Share_WhoToShareWith": "誰と共有しますか",
-  "Share_AddComment": "コメントを追加(任意)",
+  "Share_AddComment": "コメントを追加",
   "Share_SendToSelected": "選択した連絡先に送信",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "完了!",
   "ShareExt_StartupFailed": "問題が発生しました。もう一度お試しください。",
   "ShareExt_CannotSendToContact": "この連絡先には送信できません",
-  "ShareExt_UploadFailed": "アップロードに失敗しました",
+  "ShareExt_SharingFailed": "共有に失敗しました",
 
   "Ptt_UseOnThisDevice": "この端末でプッシュ・トゥ・トークを使う",
   "Ptt_UseOnThisDeviceCaption": "オフにすると、この端末はプッシュ・トゥ・トークの音声で起動・再生・送信しません。",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "コメントを追加(任意)",
   "Share_SendToSelected": "選択した連絡先に送信",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "共有先",
+  "ShareExt_SignInPrompt_Format": "コンテンツを共有するには {0} にサインインしてください",
+  "ShareExt_Uploading": "アップロード中…",
+  "ShareExt_Done": "完了!",
+  "ShareExt_StartupFailed": "問題が発生しました。もう一度お試しください。",
+  "ShareExt_CannotSendToContact": "この連絡先には送信できません",
+  "ShareExt_UploadFailed": "アップロードに失敗しました",
+
   "Ptt_UseOnThisDevice": "この端末でプッシュ・トゥ・トークを使う",
   "Ptt_UseOnThisDeviceCaption": "オフにすると、この端末はプッシュ・トゥ・トークの音声で起動・再生・送信しません。",
   "Ptt_DeviceEnabledToast": "この端末でプッシュ・トゥ・トークが有効になりました。",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -973,7 +973,7 @@
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
   "ShareExt_ShareWith": "共有先",
   "ShareExt_SignInPrompt_Format": "コンテンツを共有するには {0} にサインインしてください",
-  "ShareExt_Uploading": "アップロード中…",
+  "ShareExt_Uploading": "アップロード中...",
   "ShareExt_Done": "完了!",
   "ShareExt_StartupFailed": "問題が発生しました。もう一度お試しください。",
   "ShareExt_CannotSendToContact": "この連絡先には送信できません",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "링크 복사",
   "Share_LinkCopied": "링크가 복사되었습니다!",
   "Share_WhoToShareWith": "누구와 공유할까요",
-  "Share_AddComment": "댓글 추가 (선택 사항)",
+  "Share_AddComment": "댓글 추가",
   "Share_SendToSelected": "선택한 연락처로 보내기",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "완료!",
   "ShareExt_StartupFailed": "문제가 발생했습니다. 다시 시도해 주세요.",
   "ShareExt_CannotSendToContact": "이 연락처로는 보낼 수 없습니다",
-  "ShareExt_UploadFailed": "업로드 실패",
+  "ShareExt_SharingFailed": "공유 실패",
 
   "Ptt_UseOnThisDevice": "이 기기에서 푸시 투 토크 사용",
   "Ptt_UseOnThisDeviceCaption": "끄면 이 기기는 푸시 투 토크 음성으로 깨어나거나 재생·전송하지 않습니다.",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "댓글 추가 (선택 사항)",
   "Share_SendToSelected": "선택한 연락처로 보내기",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "공유 대상",
+  "ShareExt_SignInPrompt_Format": "콘텐츠를 공유하려면 {0}에 로그인하세요",
+  "ShareExt_Uploading": "업로드 중...",
+  "ShareExt_Done": "완료!",
+  "ShareExt_StartupFailed": "문제가 발생했습니다. 다시 시도해 주세요.",
+  "ShareExt_CannotSendToContact": "이 연락처로는 보낼 수 없습니다",
+  "ShareExt_UploadFailed": "업로드 실패",
+
   "Ptt_UseOnThisDevice": "이 기기에서 푸시 투 토크 사용",
   "Ptt_UseOnThisDeviceCaption": "끄면 이 기기는 푸시 투 토크 음성으로 깨어나거나 재생·전송하지 않습니다.",
   "Ptt_DeviceEnabledToast": "이 기기에서 푸시 투 토크가 활성화되었습니다.",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -975,8 +975,8 @@
   "ShareExt_SignInPrompt_Format": "コンテンツを共有するには {0} にサインインしてください",
   "ShareExt_Uploading": "Wird hochgeladen...",
   "ShareExt_Done": "Tamamlandı!",
-  "ShareExt_StartupFailed": "Что-то пошло не так. Пожалуйста, попробуйте ещё раз.",
-  "ShareExt_CannotSendToContact": "Du kannst an diesen Kontakt nichts senden",
+  "ShareExt_StartupFailed": "Нешто је пошло наопако. Молимо покушајте поново.",
+  "ShareExt_CannotSendToContact": "Вы не можете отправлять этому контакту",
   "ShareExt_UploadFailed": "アップロードに失敗しました",
 
   "Ptt_UseOnThisDevice": "Використовувати Push-to-Talk на цьому пристрої",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Скопіювати посилання",
   "Share_LinkCopied": "リンクをコピーしました!",
   "Share_WhoToShareWith": "Com quem você quer compartilhar?",
-  "Share_AddComment": "Добавьте комментарий (необязательно)",
+  "Share_AddComment": "Adicione um comentário",
   "Share_SendToSelected": "Enviar a los contactos seleccionados",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Tamamlandı!",
   "ShareExt_StartupFailed": "Нешто је пошло наопако. Молимо покушајте поново.",
   "ShareExt_CannotSendToContact": "Вы не можете отправлять этому контакту",
-  "ShareExt_UploadFailed": "アップロードに失敗しました",
+  "ShareExt_SharingFailed": "Udostępnianie nie powiodło się",
 
   "Ptt_UseOnThisDevice": "Використовувати Push-to-Talk на цьому пристрої",
   "Ptt_UseOnThisDeviceCaption": "Когато е изключено, това устройство няма да се събужда, възпроизвежда или предава глас с Натисни и говори.",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Добавьте комментарий (необязательно)",
   "Share_SendToSelected": "Enviar a los contactos seleccionados",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Compartilhar com",
+  "ShareExt_SignInPrompt_Format": "コンテンツを共有するには {0} にサインインしてください",
+  "ShareExt_Uploading": "Wird hochgeladen...",
+  "ShareExt_Done": "Tamamlandı!",
+  "ShareExt_StartupFailed": "Что-то пошло не так. Пожалуйста, попробуйте ещё раз.",
+  "ShareExt_CannotSendToContact": "Du kannst an diesen Kontakt nichts senden",
+  "ShareExt_UploadFailed": "アップロードに失敗しました",
+
   "Ptt_UseOnThisDevice": "Використовувати Push-to-Talk на цьому пристрої",
   "Ptt_UseOnThisDeviceCaption": "Когато е изключено, това устройство няма да се събужда, възпроизвежда или предава глас с Натисни и говори.",
   "Ptt_DeviceEnabledToast": "この端末でプッシュ・トゥ・トークが有効になりました。",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Dodaj komentarz (opcjonalnie)",
   "Share_SendToSelected": "Wyślij do wybranych kontaktów",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Udostępnij",
+  "ShareExt_SignInPrompt_Format": "Zaloguj się w {0}, aby udostępniać treści",
+  "ShareExt_Uploading": "Przesyłanie...",
+  "ShareExt_Done": "Gotowe!",
+  "ShareExt_StartupFailed": "Coś poszło nie tak. Spróbuj ponownie.",
+  "ShareExt_CannotSendToContact": "Nie możesz wysyłać do tego kontaktu",
+  "ShareExt_UploadFailed": "Przesyłanie nie powiodło się",
+
   "Ptt_UseOnThisDevice": "Używaj Naciśnij i mów na tym urządzeniu",
   "Ptt_UseOnThisDeviceCaption": "Gdy wyłączone, to urządzenie nie będzie się budzić, odtwarzać ani nadawać głosu Naciśnij i mów.",
   "Ptt_DeviceEnabledToast": "Naciśnij i mów jest teraz aktywne na tym urządzeniu.",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Kopiuj link",
   "Share_LinkCopied": "Link skopiowany!",
   "Share_WhoToShareWith": "Komu chcesz udostępnić",
-  "Share_AddComment": "Dodaj komentarz (opcjonalnie)",
+  "Share_AddComment": "Dodaj komentarz",
   "Share_SendToSelected": "Wyślij do wybranych kontaktów",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Gotowe!",
   "ShareExt_StartupFailed": "Coś poszło nie tak. Spróbuj ponownie.",
   "ShareExt_CannotSendToContact": "Nie możesz wysyłać do tego kontaktu",
-  "ShareExt_UploadFailed": "Przesyłanie nie powiodło się",
+  "ShareExt_SharingFailed": "Udostępnianie nie powiodło się",
 
   "Ptt_UseOnThisDevice": "Używaj Naciśnij i mów na tym urządzeniu",
   "Ptt_UseOnThisDeviceCaption": "Gdy wyłączone, to urządzenie nie będzie się budzić, odtwarzać ani nadawać głosu Naciśnij i mów.",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Adicione um comentário (opcional)",
   "Share_SendToSelected": "Enviar aos contatos selecionados",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Compartilhar com",
+  "ShareExt_SignInPrompt_Format": "Entre no {0} para compartilhar conteúdo",
+  "ShareExt_Uploading": "Enviando...",
+  "ShareExt_Done": "Pronto!",
+  "ShareExt_StartupFailed": "Algo deu errado. Tente novamente.",
+  "ShareExt_CannotSendToContact": "Você não pode enviar para este contato",
+  "ShareExt_UploadFailed": "Falha no envio",
+
   "Ptt_UseOnThisDevice": "Usar Pressione para falar neste dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Quando desligado, este dispositivo não desperta, não reproduz nem transmite voz de Pressione para falar.",
   "Ptt_DeviceEnabledToast": "Pressione para falar agora está ativo neste dispositivo.",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Copiar link",
   "Share_LinkCopied": "Link copiado!",
   "Share_WhoToShareWith": "Com quem você quer compartilhar?",
-  "Share_AddComment": "Adicione um comentário (opcional)",
+  "Share_AddComment": "Adicione um comentário",
   "Share_SendToSelected": "Enviar aos contatos selecionados",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Pronto!",
   "ShareExt_StartupFailed": "Algo deu errado. Tente novamente.",
   "ShareExt_CannotSendToContact": "Você não pode enviar para este contato",
-  "ShareExt_UploadFailed": "Falha no envio",
+  "ShareExt_SharingFailed": "Falha ao compartilhar",
 
   "Ptt_UseOnThisDevice": "Usar Pressione para falar neste dispositivo",
   "Ptt_UseOnThisDeviceCaption": "Quando desligado, este dispositivo não desperta, não reproduz nem transmite voz de Pressione para falar.",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Добавьте комментарий (необязательно)",
   "Share_SendToSelected": "Отправить выбранным контактам",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Поделиться",
+  "ShareExt_SignInPrompt_Format": "Войдите в {0}, чтобы делиться контентом",
+  "ShareExt_Uploading": "Загрузка...",
+  "ShareExt_Done": "Готово!",
+  "ShareExt_StartupFailed": "Что-то пошло не так. Пожалуйста, попробуйте ещё раз.",
+  "ShareExt_CannotSendToContact": "Вы не можете отправлять этому контакту",
+  "ShareExt_UploadFailed": "Не удалось загрузить",
+
   "Ptt_UseOnThisDevice": "Использовать Push-to-Talk на этом устройстве",
   "Ptt_UseOnThisDeviceCaption": "Когда выключено, это устройство не будет просыпаться, воспроизводить и передавать голос Push-to-Talk.",
   "Ptt_DeviceEnabledToast": "Push-to-Talk теперь активен на этом устройстве.",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Скопировать ссылку",
   "Share_LinkCopied": "Ссылка скопирована!",
   "Share_WhoToShareWith": "С кем поделиться",
-  "Share_AddComment": "Добавьте комментарий",
+  "Share_AddComment": "Добавить комментарий",
   "Share_SendToSelected": "Отправить выбранным контактам",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -975,7 +975,7 @@
   "ShareExt_SignInPrompt_Format": "Войдите в {0}, чтобы делиться контентом",
   "ShareExt_Uploading": "Загрузка...",
   "ShareExt_Done": "Готово!",
-  "ShareExt_StartupFailed": "Что-то пошло не так. Пожалуйста, попробуйте ещё раз.",
+  "ShareExt_StartupFailed": "Что-то пошло не так. Попробуйте ещё раз.",
   "ShareExt_CannotSendToContact": "Вы не можете отправлять этому контакту",
   "ShareExt_UploadFailed": "Не удалось загрузить",
 

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Скопировать ссылку",
   "Share_LinkCopied": "Ссылка скопирована!",
   "Share_WhoToShareWith": "С кем поделиться",
-  "Share_AddComment": "Добавьте комментарий (необязательно)",
+  "Share_AddComment": "Добавьте комментарий",
   "Share_SendToSelected": "Отправить выбранным контактам",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Готово!",
   "ShareExt_StartupFailed": "Что-то пошло не так. Попробуйте ещё раз.",
   "ShareExt_CannotSendToContact": "Вы не можете отправлять этому контакту",
-  "ShareExt_UploadFailed": "Не удалось загрузить",
+  "ShareExt_SharingFailed": "Не удалось поделиться",
 
   "Ptt_UseOnThisDevice": "Использовать Push-to-Talk на этом устройстве",
   "Ptt_UseOnThisDeviceCaption": "Когда выключено, это устройство не будет просыпаться, воспроизводить и передавать голос Push-to-Talk.",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Копирај линк",
   "Share_LinkCopied": "Линк је копиран!",
   "Share_WhoToShareWith": "С ким желите поделити",
-  "Share_AddComment": "Додајте коментар (опционално)",
+  "Share_AddComment": "Додајте коментар",
   "Share_SendToSelected": "Пошаљи одабраним контактима",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Готово!",
   "ShareExt_StartupFailed": "Нешто је пошло наопако. Молимо покушајте поново.",
   "ShareExt_CannotSendToContact": "Не можете слати овом контакту",
-  "ShareExt_UploadFailed": "Отпремање није успело",
+  "ShareExt_SharingFailed": "Дељење није успело",
 
   "Ptt_UseOnThisDevice": "Користи Притисни и говори на овом уређају",
   "Ptt_UseOnThisDeviceCaption": "Када је искључено, овај уређај се неће будити, репродуцирати ни слати глас путем Притисни и говори.",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Додајте коментар (опционално)",
   "Share_SendToSelected": "Пошаљи одабраним контактима",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Подели",
+  "ShareExt_SignInPrompt_Format": "Пријавите се у {0} да бисте делили садржај",
+  "ShareExt_Uploading": "Отпремање...",
+  "ShareExt_Done": "Готово!",
+  "ShareExt_StartupFailed": "Нешто је пошло наопако. Молимо покушајте поново.",
+  "ShareExt_CannotSendToContact": "Не можете слати овом контакту",
+  "ShareExt_UploadFailed": "Отпремање није успело",
+
   "Ptt_UseOnThisDevice": "Користи Притисни и говори на овом уређају",
   "Ptt_UseOnThisDeviceCaption": "Када је искључено, овај уређај се неће будити, репродуцирати ни слати глас путем Притисни и говори.",
   "Ptt_DeviceEnabledToast": "Притисни и говори је сада активан на овом уређају.",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Bağlantıyı kopyala",
   "Share_LinkCopied": "Bağlantı kopyalandı!",
   "Share_WhoToShareWith": "Kiminle paylaşmak istersin",
-  "Share_AddComment": "Yorumunu ekle (isteğe bağlı)",
+  "Share_AddComment": "Yorum ekle",
   "Share_SendToSelected": "Seçili kişilere gönder",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Tamamlandı!",
   "ShareExt_StartupFailed": "Bir sorun oluştu. Lütfen tekrar dene.",
   "ShareExt_CannotSendToContact": "Bu kişiye gönderemezsin",
-  "ShareExt_UploadFailed": "Yükleme başarısız",
+  "ShareExt_SharingFailed": "Paylaşma başarısız",
 
   "Ptt_UseOnThisDevice": "Bu cihazda Bas-Konuş kullan",
   "Ptt_UseOnThisDeviceCaption": "Kapalıyken bu cihaz Bas-Konuş sesiyle uyanmaz, ses çalmaz ve iletmez.",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Yorumunu ekle (isteğe bağlı)",
   "Share_SendToSelected": "Seçili kişilere gönder",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Paylaş",
+  "ShareExt_SignInPrompt_Format": "İçerik paylaşmak için {0} uygulamasına giriş yap",
+  "ShareExt_Uploading": "Yükleniyor...",
+  "ShareExt_Done": "Tamamlandı!",
+  "ShareExt_StartupFailed": "Bir sorun oluştu. Lütfen tekrar dene.",
+  "ShareExt_CannotSendToContact": "Bu kişiye gönderemezsin",
+  "ShareExt_UploadFailed": "Yükleme başarısız",
+
   "Ptt_UseOnThisDevice": "Bu cihazda Bas-Konuş kullan",
   "Ptt_UseOnThisDeviceCaption": "Kapalıyken bu cihaz Bas-Konuş sesiyle uyanmaz, ses çalmaz ve iletmez.",
   "Ptt_DeviceEnabledToast": "Bas-Konuş artık bu cihazda etkin.",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -975,7 +975,7 @@
   "ShareExt_SignInPrompt_Format": "Увійдіть у {0}, щоб ділитися контентом",
   "ShareExt_Uploading": "Завантаження...",
   "ShareExt_Done": "Готово!",
-  "ShareExt_StartupFailed": "Щось пішло не так. Будь ласка, спробуйте ще раз.",
+  "ShareExt_StartupFailed": "Щось пішло не так. Спробуйте ще раз.",
   "ShareExt_CannotSendToContact": "Ви не можете надсилати цьому контакту",
   "ShareExt_UploadFailed": "Не вдалося завантажити",
 

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Додайте коментар (необов'язково)",
   "Share_SendToSelected": "Надіслати вибраним контактам",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Поділитися",
+  "ShareExt_SignInPrompt_Format": "Увійдіть у {0}, щоб ділитися контентом",
+  "ShareExt_Uploading": "Завантаження...",
+  "ShareExt_Done": "Готово!",
+  "ShareExt_StartupFailed": "Щось пішло не так. Будь ласка, спробуйте ще раз.",
+  "ShareExt_CannotSendToContact": "Ви не можете надсилати цьому контакту",
+  "ShareExt_UploadFailed": "Не вдалося завантажити",
+
   "Ptt_UseOnThisDevice": "Використовувати Push-to-Talk на цьому пристрої",
   "Ptt_UseOnThisDeviceCaption": "Коли вимкнено, цей пристрій не прокидатиметься, не відтворюватиме й не передаватиме голос Push-to-Talk.",
   "Ptt_DeviceEnabledToast": "Push-to-Talk тепер активний на цьому пристрої.",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Скопіювати посилання",
   "Share_LinkCopied": "Посилання скопійовано!",
   "Share_WhoToShareWith": "З ким поділитися",
-  "Share_AddComment": "Додайте коментар (необов'язково)",
+  "Share_AddComment": "Додайте коментар",
   "Share_SendToSelected": "Надіслати вибраним контактам",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Готово!",
   "ShareExt_StartupFailed": "Щось пішло не так. Спробуйте ще раз.",
   "ShareExt_CannotSendToContact": "Ви не можете надсилати цьому контакту",
-  "ShareExt_UploadFailed": "Не вдалося завантажити",
+  "ShareExt_SharingFailed": "Не вдалося поділитися",
 
   "Ptt_UseOnThisDevice": "Використовувати Push-to-Talk на цьому пристрої",
   "Ptt_UseOnThisDeviceCaption": "Коли вимкнено, цей пристрій не прокидатиметься, не відтворюватиме й не передаватиме голос Push-to-Talk.",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Скопіювати посилання",
   "Share_LinkCopied": "Посилання скопійовано!",
   "Share_WhoToShareWith": "З ким поділитися",
-  "Share_AddComment": "Додайте коментар",
+  "Share_AddComment": "Додати коментар",
   "Share_SendToSelected": "Надіслати вибраним контактам",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "Thêm bình luận (tùy chọn)",
   "Share_SendToSelected": "Gửi đến các liên hệ đã chọn",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "Chia sẻ với",
+  "ShareExt_SignInPrompt_Format": "Đăng nhập vào {0} để chia sẻ nội dung",
+  "ShareExt_Uploading": "Đang tải lên...",
+  "ShareExt_Done": "Xong!",
+  "ShareExt_StartupFailed": "Đã xảy ra lỗi. Vui lòng thử lại.",
+  "ShareExt_CannotSendToContact": "Bạn không thể gửi đến liên hệ này",
+  "ShareExt_UploadFailed": "Tải lên thất bại",
+
   "Ptt_UseOnThisDevice": "Dùng Nhấn để nói trên thiết bị này",
   "Ptt_UseOnThisDeviceCaption": "Khi tắt, thiết bị này sẽ không đánh thức, phát hay truyền giọng nói Nhấn để nói.",
   "Ptt_DeviceEnabledToast": "Nhấn để nói hiện đã hoạt động trên thiết bị này.",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "Sao chép liên kết",
   "Share_LinkCopied": "Đã sao chép liên kết!",
   "Share_WhoToShareWith": "Bạn muốn chia sẻ với ai",
-  "Share_AddComment": "Thêm bình luận (tùy chọn)",
+  "Share_AddComment": "Thêm bình luận",
   "Share_SendToSelected": "Gửi đến các liên hệ đã chọn",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "Xong!",
   "ShareExt_StartupFailed": "Đã xảy ra lỗi. Vui lòng thử lại.",
   "ShareExt_CannotSendToContact": "Bạn không thể gửi đến liên hệ này",
-  "ShareExt_UploadFailed": "Tải lên thất bại",
+  "ShareExt_SharingFailed": "Chia sẻ thất bại",
 
   "Ptt_UseOnThisDevice": "Dùng Nhấn để nói trên thiết bị này",
   "Ptt_UseOnThisDeviceCaption": "Khi tắt, thiết bị này sẽ không đánh thức, phát hay truyền giọng nói Nhấn để nói.",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -973,7 +973,7 @@
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
   "ShareExt_ShareWith": "分享给",
   "ShareExt_SignInPrompt_Format": "登录 {0} 即可分享内容",
-  "ShareExt_Uploading": "正在上传…",
+  "ShareExt_Uploading": "正在上传...",
   "ShareExt_Done": "完成！",
   "ShareExt_StartupFailed": "出错了，请重试。",
   "ShareExt_CannotSendToContact": "你无法发送给该联系人",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -967,7 +967,7 @@
   "Share_CopyLink": "复制链接",
   "Share_LinkCopied": "链接已复制！",
   "Share_WhoToShareWith": "你想与谁分享",
-  "Share_AddComment": "添加你的备注（可选）",
+  "Share_AddComment": "添加备注",
   "Share_SendToSelected": "发送给所选联系人",
 
   // The iOS share extension - native UIKit, so it renders outside the app's WebView.
@@ -977,7 +977,7 @@
   "ShareExt_Done": "完成！",
   "ShareExt_StartupFailed": "出错了，请重试。",
   "ShareExt_CannotSendToContact": "你无法发送给该联系人",
-  "ShareExt_UploadFailed": "上传失败",
+  "ShareExt_SharingFailed": "分享失败",
 
   "Ptt_UseOnThisDevice": "在此设备上使用按住说话",
   "Ptt_UseOnThisDeviceCaption": "关闭后，此设备不会因按住说话语音而唤醒、播放或发送。",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -970,6 +970,15 @@
   "Share_AddComment": "添加你的备注（可选）",
   "Share_SendToSelected": "发送给所选联系人",
 
+  // The iOS share extension - native UIKit, so it renders outside the app's WebView.
+  "ShareExt_ShareWith": "分享给",
+  "ShareExt_SignInPrompt_Format": "登录 {0} 即可分享内容",
+  "ShareExt_Uploading": "正在上传…",
+  "ShareExt_Done": "完成！",
+  "ShareExt_StartupFailed": "出错了，请重试。",
+  "ShareExt_CannotSendToContact": "你无法发送给该联系人",
+  "ShareExt_UploadFailed": "上传失败",
+
   "Ptt_UseOnThisDevice": "在此设备上使用按住说话",
   "Ptt_UseOnThisDeviceCaption": "关闭后，此设备不会因按住说话语音而唤醒、播放或发送。",
   "Ptt_DeviceEnabledToast": "按住说话已在此设备上启用。",

--- a/src/dotnet/Maui/MauiPreferences.cs
+++ b/src/dotnet/Maui/MauiPreferences.cs
@@ -17,6 +17,7 @@ public static class MauiPreferences
     private const string IsDataCollectionEnabledKey = "analytics";
     private const string ThemeKey = "Theme";
     private const string ThemeColorsKey = "ThemeColors";
+    private const string UILanguageKey = "UILanguage";
     private const string MinReportableClientVersionKey = "min_reportable_client_version";
     private const string IsPttArmedKey = "is_ptt_armed";
 
@@ -68,6 +69,13 @@ public static class MauiPreferences
     public static string ThemeColors {
         get => Get<string>(ThemeColorsKey, sharedName: SharedName) ?? "";
         set => Set(ThemeColorsKey, value, SharedName);
+    }
+
+    // The language the app renders in, resolved rather than selected; null means the app hasn't
+    // run since this key appeared, and a reader falls back to the device languages.
+    public static Language? UILanguage {
+        get => Language.TryParse(Get<string>(UILanguageKey, sharedName: SharedName), allowNull: true);
+        set => Set(UILanguageKey, value?.Value, SharedName);
     }
 
     public static string? MinReportableClientVersion {


### PR DESCRIPTION
Fixes #4261.

The share sheet you get when sharing into Voxt from another iOS app rendered
every string in English, whatever language the app was set to.

## Why it was stuck

Two halves, and only one of them was still a problem.

The **catalog** stopped being a blocker in #4125: `ActualChat.Localization` is
dependency-free (`Api` + `Microsoft.Extensions.Localization`), so the appex can
reference it without dragging in the Blazor UI assembly — the dependency #4132
and #4214 spent their effort avoiding.

The **language** was the real gap. It lives on the account and in the app's
`localStorage`, and the extension is a separate process with its own bundle id,
so it can reach neither.

## How the language crosses the process boundary

The same way the theme has since #4232 — the App Group container
(`group.chat.actual[.dev].app.shared`), which the app and its extensions both see:

- `MauiPreferences.UILanguage` is the new shared key.
- `MauiBrowserInfo.OnInitialized` writes it on every launch. It writes
  `BrowserInfo.UILanguage` — the *resolved* language, i.e. what the app actually
  renders in, not the account's nullable selection — and writes it
  unconditionally rather than on change, since the group may still be empty from
  an earlier version. That is the same reasoning
  `MauiThemeHandler.OnThemeChanged` already carries.
- `AppStrings.L` (new, `App.Maui.IosShareExt/UI/AppStrings.cs`, next to
  `AppImages`) reads it back and resolves the catalog against it through
  `LanguageStringLocalizer`, falling back to `NSLocale.PreferredLanguages` until
  the app has run once — the same "follow the device" rule `navigator.languages`
  gives the app.

The accessor is deliberately not iOS-shaped. The in-process native sites that are
still English — Android dialogs, local notifications, the Live Activity — need
exactly this value and can now read the same property instead of growing a second
one. That was §4's remaining open question in the localization plan.

## The strings

Thirteen call sites. Six already had keys, and two of those were verbatim copies
of the web share modal's placeholders that the extension had been carrying as
literals:

| Reused | |
|---|---|
| `Common_Close`, `Common_Cancel`, `Common_Send` | buttons |
| `SignIn_SignIn` | the signed-out button |
| `Share_WhoToShareWith`, `Share_AddComment` | the two field placeholders |

Seven new `ShareExt_*` keys cover the rest — the sheet title, the signed-out
prompt (`_Format`, taking `CoreConstants.AppName`), `Uploading...`, `Done!`, the
bootstrap-failure screen, and the two `ExceptionExt.UserFriendlyMessage` arms.
All 19 hand-written catalogs translated; BCMS and Max regenerated.

## One thing to look at: `derive-bcms.py`

Two lexicon entries were needed to keep the derived catalogs grammatical, and
both are gaps the new strings happened to expose rather than anything specific to
this change:

- The Croatian lexicon swaps `otpremanje → prijenos`, which changes the noun's
  **gender**, so `Otpremanje nije uspjelo` derived as `Prijenos nije uspjelo`. A
  word list can't fix agreement, so the phrase is listed whole — the script
  already carries multi-word entries (`Cijeli ekran → Ceo ekran`) for exactly
  this.
- Serbian had no ijekavian→ekavian rule for the participle `uspjelo → uspelo`.

Both `--check` runs are clean and no pre-existing derived line moved — the sr/hr
diffs are additions only.

## Verification

- `App.Maui.IosShareExt` and `App.Maui` build for `net11.0-ios`.
- `Chat.UI.Blazor.UnitTests` — 186 localization/plural tests pass, including
  `AppLocalizationTest`'s key/member correspondence and per-language completeness.
- `derive-bcms --check`, `derive-max --check`, `test_derive_max.py` — all clean.
- **On device** (iPhone 15 Pro Max): after a launch, the App Group container holds
  `"UILanguage" => "ru-RU"` alongside the theme, so the write side and the
  entitlement path are confirmed end to end. The read side — opening the sheet
  from another app and seeing it in Russian — still wants a human tap.

## Docs

`i18n.md` drops the extension from "what is still English regardless" and
describes the new path; `plans/localization-remaining.md` §4 records both of its
open questions as answered and renumbers the suggested order; the extension
`README.md` gains the language alongside the theme; both API indexes list
`AppStrings`.

## Size note

The appex gains `ActualChat.Localization.dll` — 2.4 MB uncompressed, mostly the
embedded JSON catalogs. The issue explicitly accepts the reference, but given
#4214 was about appex size, worth an eyeball on the compressed delta before this
ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
