### PR TITLE
feat(ui): prefetch chat data on pointer down

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,6 +57,10 @@
   <PropertyGroup>
     <UseMemoryPack Condition="'$(UseMemoryPack)' == ''">true</UseMemoryPack>
     <DefineConstants Condition="$(UseMemoryPack)">$(DefineConstants);USE_MEMORYPACK</DefineConstants>
+    <!-- Compiles in ChatSwitchTracer's calls - see its EnableSymbol. Off by default; turn on with
+         `dotnet build -p:EnableChatSwitchTracer=true` or `b app build windows -p:...`. -->
+    <EnableChatSwitchTracer Condition="'$(EnableChatSwitchTracer)' == ''">false</EnableChatSwitchTracer>
+    <DefineConstants Condition="$(EnableChatSwitchTracer)">$(DefineConstants);CHAT_SWITCH_TRACER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
@@ -30,6 +30,7 @@
     Class="@navbarItemCls"
     data-menu="@(MenuRef.New<ChatMenu>(chat.Id.Value, listKind.Format()).ToString())"
     data-menu-placement="@(FloatingPosition.BottomStart.ToPositionString())"
+    data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(chat.Id.Value).ToString())"
     @attributes="@attributes">
     <ChildContent>
         <div class="c-container">

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundGroupListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundGroupListItem.razor
@@ -13,7 +13,9 @@
     var chat = m.ChatState.Chat;
 }
 
-<NavbarItem Class="found-result chat" IsSelected="@m.IsSelected" Url="@m.Link" @onclick="@(() => SearchUI.Select(m.Item))">
+<NavbarItem Class="found-result chat" IsSelected="@m.IsSelected" Url="@m.Link"
+            data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(chat.Id.Value).ToString())"
+            @onclick="@(() => SearchUI.Select(m.Item))">
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chat"/>

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundUserListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundUserListItem.razor
@@ -14,7 +14,9 @@
     var chat = chatState.Chat;
 }
 
-<NavbarItem Class="found-result contact" IsSelected="@m.IsSelected" Url="@m.Link" @onclick="@(() => SearchUI.Select(m.Item))">
+<NavbarItem Class="found-result contact" IsSelected="@m.IsSelected" Url="@m.Link"
+            data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(chat.Id.Value).ToString())"
+            @onclick="@(() => SearchUI.Select(m.Item))">
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chat"/>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -4,6 +4,7 @@ using ActualChat.Pooling;
 using ActualChat.UI.Blazor.App.Events;
 using ActualChat.UI.Blazor.App.Module;
 using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.Diagnostics;
 using ActualChat.UI.Blazor.Services;
 using ActualLab.Diagnostics;
 using Microsoft.Extensions.Localization;
@@ -90,6 +91,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     protected override async Task OnInitializedAsync()
     {
         Log.LogDebug("Created for chat #{ChatId}", Chat.Id);
+        ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: entered", Chat.Id);
         Nav.LocationChanged += OnLocationChanged;
         try {
             var type = GetType();
@@ -102,13 +104,18 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _shownReadEntryLid = StateFactory.NewMutable(
                 0L,
                 StateCategories.Get(type, nameof(ShownReadEntryLid)));
+            ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: LeaseReadPositionState -> in");
             _readPositionLease = await ChatUI.LeaseReadPositionState(Chat.Id, DisposeToken);
+            ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: LeaseReadPositionState <- out");
             _viewPositionLease = await ChatUI.LeaseViewPositionState(Chat.Id, DisposeToken);
+            ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: LeaseViewPositionState <- out");
             var readPosition = _readPositionLease.Resource.Value;
             _shownReadEntryLid.Value = readPosition.EntryLid;
             if (_viewPositionLease.Resource.Value.EntryLid is 0 && readPosition.EntryLid > 0)
                 _viewPositionLease.Resource.Value = readPosition;
             _whenInitializedSource.TrySetResult();
+            ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: WhenInitialized SET",
+                $"readEntryLid={readPosition.EntryLid}");
             _updateReadStateTask = AsyncChain.From(UpdateReadState)
                 .Log(LogLevel.Debug, Log)
                 .RetryForever(RetryDelaySeq.Exp(0.5, 3), Log)
@@ -149,6 +156,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (_disposeTokenSource.IsCancellationRequested)
             return;
 
+        ChatSwitchTracer.Mark("ChatView.Dispose (outgoing view)", Chat.Id);
         _disposeTokenSource.CancelAndDisposeSilently();
         _whenInitializedSource.TrySetCanceled();
         _readPositionLease.DisposeSilently();
@@ -217,6 +225,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         await WhenInitialized;
         if (updateReadPosition)
             _shownReadEntryLid.Value = UpdateReadPosition(entryLid);
+        ChatSwitchTracer.Mark("ChatView.NavigateTo: nav set", $"entryLid={entryLid}, highlight={highlight}");
         _nextNavigation.Value = new ChatViewNavigation(entryLid, highlight, KeepConversationsCollapsed: keepConversationsCollapsed);
     }
 
@@ -237,6 +246,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (!localUrl.IsChat(out _, out long entryId) || entryId <= 0)
             return;
 
+        ChatSwitchTracer.Mark("ChatView.NavigateToUrlFragment: entry nav", $"entryLid={entryId}");
         var cts = new CancellationTokenSource();
         var cancellationToken = cts.Token;
         _ = History
@@ -398,10 +408,16 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     {
         var chatId = Chat.Id;
         var startedAt = CpuTimestamp.Now;
+        var isFirstGetData = renderedData.IsNone && query.IsNone;
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: entered", chatId);
         await WhenInitialized;
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: WhenInitialized awaited");
 
         var isChatViewVisible = RegionVisibility.IsVisible;
         if (!isChatViewVisible.Value) {
+            ChatSwitchTracer.Mark("ChatView.GetData: SUSPENDED - region not visible", chatId);
             // Chat is invisible now, let's suspend & await for it to become visible
             ChatUI.ResetItemVisibility(chatId);
             using (Computed.BeginIsolation())
@@ -411,6 +427,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _itemVisibility.Value = ChatViewItemVisibility.Empty;
             // A report from the pre-suspend rendering may have landed while we awaited visibility
             ChatUI.ResetItemVisibility(chatId);
+            ChatSwitchTracer.Mark("ChatView.GetData: RESUMED - region visible", chatId);
         }
 
         // Update delay: we want to collect as many dependencies as possible here,
@@ -444,11 +461,15 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             nav = null;
 
         var mustScrollToEntry = nav != null && ItemVisibility.Value.IsScrollRequired(nav.EntryLid);
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: nav resolved", $"nav={nav?.EntryLid}");
         Computed<Range<long>> cChatIdRange;
         using (Computed.BeginIsolation())
             cChatIdRange = await Computed.Capture(
                 () => Chats.GetIdRange(Session, chatId, cancellationToken),
                 cancellationToken);
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: GetIdRange done");
         // Rethrows via Use() to register the dependency - an isolated failure has nothing to recover on,
         // so the view would stay stale for Fusion's 30s error horizon rather than until access returns.
         if (cChatIdRange.HasError)
@@ -484,7 +505,11 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (chat == null)
             return VirtualListData<ChatMessage>.None;
 
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: GetChatItems -> in", dataQuery);
         var (items, hasBefore, hasAfter) = await ChatUI.GetChatItems(chatId, dataQuery, readEntryLid, cancellationToken).ConfigureAwait(false);
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: GetChatItems <- out", $"{items.Count} items");
         if (items.Count == 0) {
             var isEmpty = await ChatUI.IsEmpty(chatId, cancellationToken);
             if (isEmpty)
@@ -605,6 +630,10 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             Metadata = new ChatViewMetadata(chat.IsSummarized ?? false),
         };
 
+        if (isFirstGetData)
+            ChatSwitchTracer.Mark("ChatView.GetData#1: exit - data built",
+                $"{items.Count} items, build={buildMs}ms, scrollToKey={scrollToKey}");
+
         // do not return new instance if data is the same to prevent re-renders
         return !mustScrollToEntry && result.IsSimilarTo(renderedData)
             ? renderedData
@@ -617,6 +646,8 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         ChatViewNavigation? navigation,
         Range<long> chatLidRange)
     {
+        // NOTE: Changing the ranges this produces? Review ChatUI.Prefetch - it guesses this query's load zone
+        // in advance, and only helps while the guess still lands on the same tiles.
         var firstLayer = ChatUI.IdTileStack.FirstLayer;
         var secondLayer = ChatUI.IdTileStack.LastLayer;
         var itemVisibility = ItemVisibility.Value;
@@ -687,6 +718,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         DebugLog?.LogDebug(
             "GetChatDataQuery: case={Case}, result={DataQuery}, chatIdRange={IdRange}",
             caseName, dataQuery.Format(), chatLidRange.Format());
+        ChatSwitchTracer.Mark($"ChatView.GetChatDataQuery: case={caseName}", dataQuery);
 
         return dataQuery;
     }

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/RecentlyContactedUser.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/RecentlyContactedUser.razor
@@ -1,6 +1,7 @@
 @namespace ActualChat.UI.Blazor.App.Components
 
-<div class="recently-contacted-user" data-href="@($"/chat/{Chat.Id}")">
+<div class="recently-contacted-user" data-href="@($"/chat/{Chat.Id}")"
+     data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(Chat.Id.Value).ToString())">
     <div class="c-contact">
         <ChatIcon Chat="@Chat" HideTitle="true"/>
         <div class="c-name">@Chat.Title</div>

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
@@ -7,7 +7,9 @@
     _renderedModel = m;
 }
 
-<div class="thread-list-item" role="option" tabindex="0" @onclick="OnItemClicked">
+@* data-prefetch tracks OnItemClicked's target - Chat.Id, not the model's chat *@
+<div class="thread-list-item" role="option" tabindex="0" @onclick="OnItemClicked"
+     data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(Chat.Id.Value).ToString())">
     <div class="c-description">
         <div class="c-top">
             <span class="c-chat-title">

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
@@ -88,6 +88,7 @@ public sealed class BlazorUIAppModule(IServiceProvider moduleServices)
         services.AddScoped<IActivitySource>(c => c.GetRequiredService<LocationActivitySource>());
         fusion.AddService<UploadActivitySource>(ServiceLifetime.Scoped);
         services.AddScoped<IActivitySource>(c => c.GetRequiredService<UploadActivitySource>());
+        services.AddScoped(c => new ChatPrefetcher(c.AppUIHub()));
         services.AddScoped(c => new SelectionUI(c.AppUIHub()));
         services.AddScoped(c => new ChatPinsUI(c.AppUIHub()));
         services.AddScoped(c => new ActiveChatsUI(c.AppUIHub()));

--- a/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
@@ -4,8 +4,10 @@
 @using ActualChat.Hosting
 @using ActualChat.Contacts
 @using RightPanel = ActualChat.UI.Blazor.App.Components.RightPanel
+@using ActualChat.UI.Blazor.Diagnostics
 @inherits ComputedStateComponent<AppUIHub, ChatPage.Model?>
 @{
+    ChatSwitchTracer.Mark("ChatPage: render");
     var m = Rendered = State.Value;
     if (_isVeryFirstLoad && !PanelsUI.Middle.IsVisible.Value)
         return;
@@ -68,8 +70,7 @@
 </RenderIntoSlot>
 
 <ContentSwap LayerKey="@swapKey" Class="chat-view-swap"
-             Effect="@ContentSwapEffect.None"
-             MaxDisplayDelay="@SwapMaxDisplayDelay">
+             Effect="@ContentSwapEffect.None">
     <ChildContent>
         @if (m is null) {
             <chat-view-skeleton count="15" class="chat-view-skeleton-list no-scrollbar"/>
@@ -95,9 +96,6 @@
     protected static TimeSpan VeryFirstLoadDelay = TimeSpan.FromSeconds(1.5);
     protected static TimeSpan LoadTimeout = TimeSpan.FromSeconds(1);
     protected static TimeSpan LoadTimeoutToReloadDelay = TimeSpan.FromSeconds(2);
-    // Only the backstop for a chat that never says it is there: a cold InfiniteList regularly needs
-    // longer than the 0.333s default, and a skeleton flash reads worse than a slightly longer hold
-    protected static TimeSpan SwapMaxDisplayDelay = TimeSpan.FromSeconds(0.5);
     private static bool _isVeryFirstLoad = true;
 
     private MutableState<RouteState> _routeState = null!;
@@ -133,20 +131,26 @@
            || State.Value != Rendered;
 
     protected override async Task<Model?> ComputeState(CancellationToken cancellationToken) {
+        ChatSwitchTracer.Mark("ChatPage.ComputeState: entered");
         var lastState = State.ValueOrDefault;
         var hostInfo = HostInfo;
         var routeState = await _routeState.Use(cancellationToken).ConfigureAwait(false);
         var parsedRoute = routeState.Parsed;
         var fixedRoute = routeState.Fixed;
-        if (fixedRoute is null)
+        if (fixedRoute is null) {
+            ChatSwitchTracer.Mark("ChatPage.ComputeState: exit - no fixed route (synchronizing)");
             return lastState; // Synchronizing
+        }
 
         if (!ChatUI.WhenReady.IsCompleted)
             await ChatUI.WhenReady.WaitAsync(cancellationToken).ConfigureAwait(false);
         var chatId = await ChatUI.SelectedChatId.Use(cancellationToken).ConfigureAwait(false);
+        ChatSwitchTracer.Mark("ChatPage.ComputeState: SelectedChatId used", chatId);
 
-        if (chatId != fixedRoute.ChatId)
+        if (chatId != fixedRoute.ChatId) {
+            ChatSwitchTracer.Mark("ChatPage.ComputeState: exit - chatId != route (synchronizing)");
             return lastState; // Synchronizing
+        }
 
         if (_isVeryFirstLoad) {
             _isVeryFirstLoad = false;
@@ -158,6 +162,7 @@
         }
 
         var account = await AccountUI.OwnAccount.Use(cancellationToken).ConfigureAwait(false);
+        ChatSwitchTracer.Mark("ChatPage.ComputeState: OwnAccount used");
         if (chatId is null)
             return Model.NewUnavailable(account, fixedRoute, false);
 
@@ -179,6 +184,7 @@
                 .Get(Session, chatId, cancellationToken)
                 .WaitAsync(LoadTimeout, cancellationToken)
                 .ConfigureAwait(false);
+            ChatSwitchTracer.Mark("ChatPage.ComputeState: Chats.Get done", chat is null ? "null" : "ok");
             var chatContext = chat is not null
                 ? new ChatContext(Hub, chat)
                 : null;
@@ -195,7 +201,9 @@
                 }
             }
             var footerModel = await GetFooterModel(chat, account, cancellationToken).ConfigureAwait(false);
+            ChatSwitchTracer.Mark("ChatPage.ComputeState: GetFooterModel done");
             var enableIncompleteUI = await enableIncompleteUITask.ConfigureAwait(false);
+            ChatSwitchTracer.Mark("ChatPage.ComputeState: exit - new Model");
             return new(account, fixedRoute, chatContext, footerModel, canSendJoinPlaceRequest, enableIncompleteUI);
         }
         catch (TimeoutException) {
@@ -270,6 +278,7 @@
     }
 
     protected async Task SetRoute(string? route) {
+        ChatSwitchTracer.Mark("ChatPage.SetRoute: entered", route);
         _routeState.Value = new RouteState(null, null);
         ChatId? chatId;
 
@@ -310,7 +319,9 @@
 
         var fixedRoute = chatId is null ? parsedRoute : new RouteResult(chatId);
         _routeState.Value = new RouteState(parsedRoute, fixedRoute);
+        ChatSwitchTracer.Mark("ChatPage.SetRoute: route state set", chatId);
         ChatUI.SelectChatOnNavigation(chatId);
+        ChatSwitchTracer.Mark("ChatPage.SetRoute: SelectChatOnNavigation done");
     }
 
     protected async ValueTask<RouteResult> ResolveAliasRoute(string? route) {

--- a/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
+++ b/src/dotnet/UI.Blazor.App/Services/AppScopedServiceStarter.cs
@@ -95,6 +95,11 @@ public sealed class AppScopedServiceStarter
                 // Ensure that the right panel state is preloaded.
                 await rightPanelStoredState.WhenRead.ConfigureAwait(false);
             _ = Hub.PanelsUI; // Touch
+            var prefetchUI = Hub.Services.GetRequiredService<PrefetchUI>();
+            _ = BackgroundTask.Run(prefetchUI.Initialize,
+                    Log,
+                    $"{nameof(PrefetchUI)}.{nameof(PrefetchUI.Initialize)} failed")
+                .SuppressExceptions();
             if (url.IsChat() && browserInfo.ScreenSize.Value.IsNarrow()) {
                 // We have to open chat root first - to make sure "Back" leads to it
                 await History.Initialize(Links.Chats).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatPrefetcher.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatPrefetcher.cs
@@ -1,0 +1,19 @@
+using ActualChat.UI.Blazor.Components;
+
+namespace ActualChat.UI.Blazor.App.Services;
+
+/// <summary>
+/// The <see cref="IPrefetcher"/> behind <c>data-prefetch</c> on anything that opens a chat.
+/// Its single argument is the chat id.
+/// </summary>
+public sealed class ChatPrefetcher(AppUIHub hub) : IPrefetcher
+{
+    private ChatUI ChatUI => hub.ChatUI;
+    public Task Prefetch(string[] arguments, CancellationToken cancellationToken)
+    {
+        if (arguments.Length != 1 || !ChatId.TryParse(arguments[0], out var chatId))
+            return Task.CompletedTask;
+
+        return ChatUI.Prefetch(chatId, cancellationToken);
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using ActualChat.Diagnostics;
+using ActualChat.UI.Blazor.Diagnostics;
 using CommunityToolkit.HighPerformance;
 
 namespace ActualChat.UI.Blazor.App.Services;
@@ -144,6 +145,102 @@ public partial class ChatUI
         }
     }
 
+    public async Task Prefetch(ChatId chatId, CancellationToken cancellationToken)
+    {
+        // NOTE: Has to stay in sync with GetChatItemsInternal and GetChatDataQuery: Fusion dedupes on
+        // ComputedInput, so an argument that drifts by one tile boundary warms a different entry and
+        // buys nothing - silently, with no failing test to catch it, just a slower switch.
+        // The load zone is guessed rather than derived: the real one needs range meta, and waiting for
+        // that is the serialized round trip this exists to overlap.
+        ChatSwitchTracer.TryStart(Links.Chat(chatId).Value, "ChatUI.Prefetch (pointer down)");
+        ChatSwitchTracer.Mark("ChatUI.Prefetch: entered", chatId);
+        // Everything GetChatItemsInternal issues before its first await, in the same order
+        var chatTask = Chats.Get(Session, chatId, cancellationToken);
+        var liveConversationTask = Hub.LiveSessionUI.GetConversation(chatId, cancellationToken);
+        var rawLiveTask = Hub.LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken);
+        var blockStateTask = Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken);
+        var chatLidRangeTask = Chats.GetIdRange(Session, chatId, cancellationToken);
+        var readPositionTask = ChatPositions.GetOwn(Session, chatId, ChatPositionKind.Read, cancellationToken);
+        var pending = new List<Task> {
+            chatTask, liveConversationTask, rawLiveTask, blockStateTask, chatLidRangeTask, readPositionTask,
+        };
+        try {
+            // The anchor is read from the cached ChatInfo rather than awaited, because on a cold chat
+            // awaiting GetIdRange + GetOwn is a round trip of its own - and it measured 77-81ms there,
+            // which pushed the warm requests past the click they were meant to arrive before.
+            var (lidRange, readEntryLid, showConversations) = GetPrefetchAnchor(chatId);
+            if (lidRange is null) {
+                var chat = await chatTask.ConfigureAwait(false);
+                if (chat == null)
+                    return;
+
+                lidRange = await chatLidRangeTask.ConfigureAwait(false);
+                readEntryLid = (await readPositionTask.ConfigureAwait(false)).EntryLid;
+                showConversations = chat.IsSummarized ?? false;
+                ChatSwitchTracer.Mark("ChatUI.Prefetch: anchor awaited (ChatInfo miss)", $"lid={readEntryLid}");
+            }
+            else
+                ChatSwitchTracer.Mark("ChatUI.Prefetch: anchor from ChatInfo (no await)", $"lid={readEntryLid}");
+
+            // NOTE: Issued only after the peek above - calling it first would register a still-Computing
+            // computed that GetExisting then returns, and reading such a computed's Output throws.
+            // It runs whether or not the peek hit, so a ChatInfo that needs recomputing gets it in advance.
+            var chatInfoTask = Get(chatId, cancellationToken);
+            pending.Add(chatInfoTask);
+
+            var range = lidRange.Value;
+            if (range.End <= range.Start)
+                return;
+
+            // Mirrors GetChatDataQuery: a chat opens at its read position when there is a usable one, and
+            // at the tail otherwise - the two cases centre on different tiles and split the zone differently
+            var initialLoadLimit = InitialLoadLimit;
+            var firstTileSize = IdTileStack.FirstLayer.TileSize;
+            var hasViewEntry = readEntryLid > 0 && readEntryLid < range.End;
+            var anchorLid = hasViewEntry
+                ? readEntryLid
+                : Math.Max(range.Start, range.End - firstTileSize);
+            var anchorTile = IdTileStack.LastLayer.GetTile(anchorLid).Range;
+            var startOffset = hasViewEntry ? initialLoadLimit / 3 : initialLoadLimit / 2;
+            var endOffset = hasViewEntry ? initialLoadLimit * 2 / 3 : initialLoadLimit / 2;
+            // Clamped to the chat: the real query never asks past the end, so warming there is pure waste
+            var loadZone = new Range<long>(
+                Math.Max(range.Start, anchorTile.Start - startOffset),
+                Math.Min(range.End, anchorTile.End + endOffset));
+            if (loadZone.End <= loadZone.Start)
+                return;
+
+            var idTiles = IdTileStack.LastLayer
+                .GetCoveringTiles(loadZone)
+                .Select(t => t.Range)
+                .Where(r => r.Start >= 0)
+                .ToList();
+            var metaIdTiles = ServerIdTileStack.LastLayer
+                .GetCoveringTiles(loadZone.Expand(LoadLimit))
+                .Where(t => t.Start >= 0)
+                .ToList();
+            var metaTask = metaIdTiles
+                .Select(t => Chats.GetChatRangeMeta(Session, chatId, t.Range.Start, cancellationToken))
+                .Collect(ApiConstants.Concurrency.High, cancellationToken);
+            var conversationTilesTask = metaIdTiles
+                .Select(t => Conversations.GetTile(Session, chatId, t.Range, cancellationToken))
+                .Collect(ApiConstants.Concurrency.High, cancellationToken);
+            var loadZoneTask = PrefetchLoadZone(chatId, idTiles, showConversations, cancellationToken);
+            pending.Add(metaTask);
+            pending.Add(conversationTilesTask);
+            pending.Add(loadZoneTask);
+            ChatSwitchTracer.Mark("ChatUI.Prefetch: warm requests issued",
+                $"{idTiles.Count} idTiles, {metaIdTiles.Count} metaTiles, anchor={anchorLid}");
+            await Task.WhenAll(metaTask, conversationTilesTask, loadZoneTask).ConfigureAwait(false);
+            ChatSwitchTracer.Mark("ChatUI.Prefetch: done");
+        }
+        finally {
+            // NOTE: Every task above is observed on every exit path, including the early returns - an
+            // unobserved fault here would surface as an UnobservedTaskException per pointer down.
+            await Task.WhenAll(pending).SilentAwait(false);
+        }
+    }
+
     public Task<ChatItems> GetChatItems(
         ChatId chatId,
         ChatDataQuery dataQuery,
@@ -167,6 +264,8 @@ public partial class ChatUI
         CancellationToken cancellationToken)
     {
         // DebugLog?.LogDebug("GetTiles: {ChatId} {IdRange} {ShownReadyEntryLid}", chatId, dataQuery, shownReadyEntryLid);
+        // NOTE: Changing what this requests? Review Prefetch - it warms these same calls in advance, and only
+        // helps while its arguments still match the ones below.
         var startedAt = CpuTimestamp.Now;
         // Captured to detect a background stretch inside this build: GetData gates on visibility before
         // calling us, but the app can background AFTER that gate, and the in-flight RPCs below then don't
@@ -607,6 +706,9 @@ public partial class ChatUI
             }
             // The log carries the split because nothing else does on a device: the Meter has no exporter
             // there, and Sentry drops Activity tags (it stores no AC.* span attribute at all).
+            ChatSwitchTracer.Mark("ChatUI.GetChatItems: phases",
+                $"total={totalMs} (live={liveMs} [chat={chatMs} conv={conversationMs} amInLive={amInLiveMs} "
+                + $"snapshot={snapshotMs} blockState={blockStateMs}], meta={metaMs}, load={loadMs}, build={buildMs})");
             if (totalMs > SlowBuildMs && !wasBackgrounded)
                 Log.LogWarning(
                     "GetChatItems: {ChatId} took {TotalMs}ms (live {LiveMs} = chat {ChatMs} "
@@ -1350,6 +1452,25 @@ public partial class ChatUI
 
     private static void RecordPhase(long elapsedMs, string phase)
         => GetChatItemsDuration.Record(elapsedMs, new KeyValuePair<string, object?>("phase", phase));
+
+    private (Range<long>? LidRange, long ReadEntryLid, bool ShowConversations) GetPrefetchAnchor(ChatId chatId)
+    {
+        // NOTE: GetExisting rather than a call - this must not start a computation it would then await.
+        // Computing is the one state to reject, because reading its Output throws; an invalidated value
+        // is still fine to aim a load zone with. The registry never hands out an invalidated computed,
+        // but the one it hands out can be invalidated right after - and since ConsistencyState only
+        // moves forward, observing "not Computing" here stays true for the reads below.
+        var cChatInfo = Computed.GetExisting(() => Get(chatId, default));
+        if (cChatInfo is null
+            || cChatInfo.IsComputing()
+            || !cChatInfo.IsValue(out var chatInfo)
+            || chatInfo?.News is not { } news)
+            return (null, 0, false);
+
+        // A single-author chat reports long.MaxValue as "fully read"; the tail branch handles it
+        var readEntryLid = chatInfo.ReadEntryLid == long.MaxValue ? 0 : chatInfo.ReadEntryLid;
+        return (news.TextEntryLidRange, readEntryLid, chatInfo.Chat.IsSummarized ?? false);
+    }
 
     private Task PrefetchLoadZone(
         ChatId chatId,

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -3,6 +3,7 @@ using ActualChat.Kvas;
 using ActualChat.Localization;
 using ActualChat.Pooling;
 using ActualChat.UI.Blazor.App.Events;
+using ActualChat.UI.Blazor.Diagnostics;
 using ActualChat.UI.Blazor.Services;
 using ActualLab.Interception;
 using MathExt = ActualLab.Mathematics.MathExt;
@@ -521,10 +522,14 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         ChatId chatId,
         CancellationToken cancellationToken)
     {
+        ChatSwitchTracer.Mark("ChatUI.LeaseReadPositionState: Rent -> in", chatId);
         var lease = await _readPositionStates.Rent(chatId, cancellationToken).ConfigureAwait(false);
         try {
             var state = lease.Resource;
+            ChatSwitchTracer.Mark("ChatUI.LeaseReadPositionState: Rent <- out",
+                state.WhenFirstTimeRead.IsCompleted ? "already read (pool hit)" : "first read pending");
             await state.WhenFirstTimeRead.WaitAsync(cancellationToken).ConfigureAwait(false);
+            ChatSwitchTracer.Mark("ChatUI.LeaseReadPositionState: WhenFirstTimeRead awaited");
             InvokeReadPositionUpdated(state);
             state.Updated += (s, stateEventKind) => {
                 if (stateEventKind == StateEventKind.Updated)
@@ -672,7 +677,9 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             TimeSpan.FromSeconds(1),
             command => Commander.Run(command, CancellationToken.None));
 
+        ChatSwitchTracer.Mark("ChatUI.CreateReadPositionState: Chats.Get -> in", chatId);
         var chat = await Chats.Get(Session, chatId, cancellationToken).ConfigureAwait(false);
+        ChatSwitchTracer.Mark("ChatUI.CreateReadPositionState: Chats.Get <- out");
         var hasSingleAuthor = chat?.HasSingleAuthor == true;
         return StateFactory.NewCustomSynced<ReadPosition>(
             new (
@@ -681,8 +688,10 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
                     if (hasSingleAuthor) // Notes chat should always appear as fully read
                         return ReadPosition.NewFullyRead(chatId);
 
+                    ChatSwitchTracer.Mark("ChatUI.ReadPosition.Read: ChatPositions.GetOwn -> in (SYNCHRONIZED)");
                     using var _ = ComputedSynchronizer.Default.Activate();
                     var (entryLid, origin) = await ChatPositions.GetOwn(Session, chatId, ChatPositionKind.Read, ct).ConfigureAwait(false);
+                    ChatSwitchTracer.Mark("ChatUI.ReadPosition.Read: ChatPositions.GetOwn <- out", $"lid={entryLid}");
                     return new ReadPosition(chatId, entryLid, origin);
                 },
                 // Writer

--- a/src/dotnet/UI.Blazor/Components/ContentSwap/ContentSwap.razor
+++ b/src/dotnet/UI.Blazor/Components/ContentSwap/ContentSwap.razor
@@ -1,4 +1,5 @@
 @namespace ActualChat.UI.Blazor.Components
+@using ActualChat.UI.Blazor.Diagnostics
 @using ActualChat.UI.Blazor.Module
 @using System.Diagnostics.CodeAnalysis
 @inherits ComponentBase<UIHub>
@@ -37,6 +38,7 @@
     private IJSObjectReference _jsRef = null!;
     private DotNetObjectReference<ContentSwap> _blazorRef = null!;
 
+    private string TraceName => _name ?? Class.NullIfEmpty() ?? "?";
     [CascadingParameter] private ContentSwapContext? ParentContext { get; set; }
     [Parameter] public object? LayerKey { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
@@ -72,6 +74,8 @@
 
     [JSInvokable]
     public void OnDisplayed() {
+        ChatSwitchTracer.Mark($"ContentSwap[{TraceName}].OnDisplayed",
+            _holdToken is null ? "not holding" : "hold dropped by JS");
         if (_holdToken is null)
             return;
 
@@ -161,9 +165,12 @@
         _holdToken = _swapIndex.Format();
         _animator ??= new ComponentAnimator(this, Duration);
         _animator.BeginAnimation(MaxDisplayDelay);
+        ChatSwitchTracer.Mark($"ContentSwap[{TraceName}].StartSwap - HOLD STARTS",
+            $"key={LayerKey}, max={MaxDisplayDelay.TotalMilliseconds}ms");
     }
 
     private void Display() {
+        ChatSwitchTracer.Mark($"ContentSwap[{TraceName}].Display - CONTENT SWAPPED");
         _holdToken = null;
         _outgoingLayer!.Context.SetState(ContentSwapLayerState.Replaced);
         _currentLayer.Context.SetState(ContentSwapLayerState.Displayed);
@@ -171,6 +178,7 @@
     }
 
     private void EndSwap() {
+        ChatSwitchTracer.Mark($"ContentSwap[{TraceName}].EndSwap - outgoing layer dropped");
         _outgoingLayer!.Context.Detach();
         _outgoingLayer = null;
         _currentLayer.CssClass = "";

--- a/src/dotnet/UI.Blazor/Components/Prefetch/IPrefetcher.cs
+++ b/src/dotnet/UI.Blazor/Components/Prefetch/IPrefetcher.cs
@@ -1,0 +1,11 @@
+namespace ActualChat.UI.Blazor.Components;
+
+/// <summary>
+/// Warms whatever a <see cref="PrefetchRef"/> points at. Implementations are resolved from DI by
+/// type and must be cheap to call repeatedly: the same target is prefetched again on every pointer
+/// down, and deduplication is left to the compute methods they touch.
+/// </summary>
+public interface IPrefetcher
+{
+    Task Prefetch(string[] arguments, CancellationToken cancellationToken);
+}

--- a/src/dotnet/UI.Blazor/Components/Prefetch/PrefetchRef.cs
+++ b/src/dotnet/UI.Blazor/Components/Prefetch/PrefetchRef.cs
@@ -1,0 +1,69 @@
+namespace ActualChat.UI.Blazor.Components;
+
+/// <summary>
+/// What a <c>data-prefetch</c> attribute carries: the <see cref="IPrefetcher"/> to run and its
+/// arguments. Rendered into markup, read back by the document-level pointer-down handler.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly struct PrefetchRef(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type prefetcherType,
+    params string[] arguments)
+{
+    private const char Delimiter = '|';
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public Type PrefetcherType { get; } = prefetcherType;
+    public string[] Arguments { get; } = arguments;
+
+    public static PrefetchRef New<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TPrefetcher>(params string[] arguments)
+        where TPrefetcher : IPrefetcher
+        => new (typeof(TPrefetcher), arguments);
+
+    public override string ToString()
+    {
+        var bufferLength = Arguments.Length + 1;
+        var buffer = new RefArrayPoolBuffer<string>(ArrayPools.SharedStringPool, bufferLength, mustClear: true);
+        var span = buffer.Array.AsSpan(0, bufferLength);
+        try {
+            span[0] = PrefetchRegistry.GetTypeId(PrefetcherType);
+            for (var i = 0; i < Arguments.Length; i++)
+                span[i + 1] = Arguments[i].ToBase64();
+            return string.Join(Delimiter, span);
+        }
+        finally {
+            buffer.Release();
+        }
+    }
+
+    // Parse & TryParse
+
+    public static PrefetchRef Parse(string value)
+        => TryParse(value, out var result) ? result : throw StandardError.Format<PrefetchRef>();
+
+    public static bool TryParse(string value, out PrefetchRef result)
+    {
+        var parts = value.Split(Delimiter);
+        if (parts.Length == 0 || parts[0].IsNullOrEmpty()) {
+            result = default;
+            return false;
+        }
+
+        if (PrefetchRegistry.TryGetType(parts[0]) is not { } prefetcherType) {
+            result = default;
+            return false;
+        }
+
+        try {
+            for (var i = 1; i < parts.Length; i++)
+                parts[i] = parts[i].FromBase64();
+        }
+        catch (FormatException) {
+            result = default;
+            return false;
+        }
+
+        result = new PrefetchRef(prefetcherType, parts[1..]);
+        return true;
+    }
+}

--- a/src/dotnet/UI.Blazor/Components/Prefetch/PrefetchRegistry.cs
+++ b/src/dotnet/UI.Blazor/Components/Prefetch/PrefetchRegistry.cs
@@ -1,0 +1,33 @@
+namespace ActualChat.UI.Blazor.Components;
+
+public static class PrefetchRegistry
+{
+    private static readonly ConcurrentDictionary<Type, string> TypeToId = new();
+    private static readonly ConcurrentDictionary<string, Type> IdToType = new();
+    private static int _lastPrefetcherId;
+
+    public static string GetTypeId([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+        => TypeToId.GetOrAdd(type, static type1 => {
+            if (!type1.IsAssignableTo(typeof(IPrefetcher)))
+                throw new ArgumentOutOfRangeException(nameof(type));
+
+            var prefetcherId = Interlocked.Increment(ref _lastPrefetcherId);
+            var typeId = $"{type1.Name}-{prefetcherId}";
+            IdToType.GetOrAdd(typeId, type1);
+            return typeId;
+        });
+
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073:ReturnValueDoesNotMatchAnnotation",
+        Justification = "All possible results already have annotation.")]
+    public static Type GetType(string typeId)
+        => TryGetType(typeId)
+            ?? throw new KeyNotFoundException(typeId);
+
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073:ReturnValueDoesNotMatchAnnotation",
+        Justification = "All possible results already have annotation.")]
+    public static Type? TryGetType(string typeId)
+        // An unregistered id means "no prefetcher" - markup can outlive the build that rendered it
+        => IdToType.GetValueOrDefault(typeId);
+}

--- a/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
@@ -1,11 +1,14 @@
 @namespace ActualChat.UI.Blazor.Components
 @typeparam TItem
 @using ActualChat.UI.Blazor.Components.Internal
+@using ActualChat.UI.Blazor.Diagnostics
 @inherits VirtualList<TItem>
 @{
 #pragma warning disable IL2026
 
     var renderIndex = RenderIndex++;
+    ChatSwitchTracer.Mark($"InfiniteList: render #{renderIndex}",
+        $"{Identity}, {Data.Count} items, scrollToKey={Data.ScrollToKey}");
 
     // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
     // We are unable to scroll to the right location until JS client part of the Virtual List created

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -1,4 +1,5 @@
 using ActualChat.UI.Blazor.Components.Internal;
+using ActualChat.UI.Blazor.Diagnostics;
 using ActualChat.UI.Blazor.Services;
 using ActualLab.Fusion.Internal;
 
@@ -74,6 +75,7 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     [JSInvokable]
     public async Task RequestData(VirtualListDataQuery query)
     {
+        ChatSwitchTracer.Mark("VirtualList.RequestData (from JS)", Identity);
         Query = query;
         while (State == null)
             await Task.Delay(100);
@@ -104,10 +106,13 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
         // so we can't use Hub.IsPrerendering here. RendererInfo is set before SetParametersAsync and is
         // per-circuit: IsInteractive is false during prerender SSR, true once the list is interactive.
         var shouldSetInitialData = RendererInfo.IsInteractive && RenderIndex == 0;
-        if (shouldSetInitialData)
+        if (shouldSetInitialData) {
+            ChatSwitchTracer.Mark("VirtualList: initial GetData -> in (BLOCKS FIRST RENDER)", Identity);
             _initialData = await DataSource.GetData(VirtualListDataQuery.None,
                 VirtualListData<TItem>.None,
                 CancellationToken.None);
+            ChatSwitchTracer.Mark("VirtualList: initial GetData <- out", Identity);
+        }
         else
             _initialData = null;
 
@@ -139,8 +144,10 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
             return;
 
         if (firstRender) {
+            ChatSwitchTracer.Mark("VirtualList: first render done, creating JS side", Identity);
             BlazorRef = DotNetObjectReference.Create<IVirtualListBackend>(this);
             JSRef = await CreateJSRef();
+            ChatSwitchTracer.Mark("VirtualList: JS side created", Identity);
         }
     }
 

--- a/src/dotnet/UI.Blazor/Diagnostics/ChatSwitchTracer.cs
+++ b/src/dotnet/UI.Blazor/Diagnostics/ChatSwitchTracer.cs
@@ -1,0 +1,66 @@
+namespace ActualChat.UI.Blazor.Diagnostics;
+
+/// <summary>
+/// Chat-switch instrumentation, compiled out unless <see cref="EnableSymbol"/> is defined.
+/// <see cref="TryStart"/> opens a trace per navigation to a chat URL, and every <see cref="Mark(string)"/>
+/// until <see cref="Window"/> expires is logged with its offset from that start, so one switch reads
+/// as a single ordered timeline.
+/// </summary>
+public static class ChatSwitchTracer
+{
+    // NOTE: [Conditional] is evaluated in the caller's compilation, so defining this in a source file would
+    // only cover that file - build with -p:EnableChatSwitchTracer=true to turn it on everywhere.
+    private const string EnableSymbol = "CHAT_SWITCH_TRACER";
+    public static readonly TimeSpan Window = TimeSpan.FromSeconds(15);
+    private static readonly Lock Lock = new();
+    private static CpuTimestamp _startedAt;
+    private static string _chatSid = "";
+    private static int _index;
+    private static ILogger Log => field ??= StaticLog.For(typeof(ChatSwitchTracer));
+
+    [Conditional(EnableSymbol)]
+    public static void TryStart(string url, string source)
+    {
+        var localUrl = new LocalUrl(url);
+        if (!localUrl.IsChat(out var chatId))
+            return;
+
+        var chatSid = chatId.Value;
+        int index;
+        lock (Lock) {
+            if (chatSid == _chatSid && _startedAt.Elapsed < TimeSpan.FromSeconds(1))
+                return; // A re-navigation to the same chat within one switch isn't a new switch
+
+            index = ++_index;
+            _startedAt = CpuTimestamp.Now;
+            _chatSid = chatSid;
+        }
+
+        Log.LogInformation("CST#{Index} +   0.0ms START ({Source}) -> #{ChatId}", index, source, chatSid);
+    }
+
+    [Conditional(EnableSymbol)]
+    public static void Mark(string stage)
+        => Mark(stage, null);
+
+    [Conditional(EnableSymbol)]
+    public static void Mark(string stage, object? detail)
+    {
+        int index;
+        double elapsedMs;
+        lock (Lock) {
+            if (_index == 0)
+                return;
+
+            var elapsed = _startedAt.Elapsed;
+            if (elapsed > Window)
+                return;
+
+            index = _index;
+            elapsedMs = elapsed.TotalMilliseconds;
+        }
+
+        Log.LogInformation("CST#{Index} +{Elapsed}ms {Stage} {Detail}",
+            index, elapsedMs.ToString("F1").PadLeft(6), stage, detail);
+    }
+}

--- a/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
+++ b/src/dotnet/UI.Blazor/Module/BlazorUICoreModule.cs
@@ -51,6 +51,7 @@ public sealed class BlazorUICoreModule(IServiceProvider moduleServices)
         services.AddScoped(c => new BrowserInfo(c.UIHub()));
         services.AddScoped(c => new WebShareInfo(c.UIHub()));
         services.AddScoped(c => new FileDownloadUI(c.UIHub()));
+        services.AddScoped(c => new PrefetchUI(c.UIHub()));
         services.AddScoped(_ => new ComponentIdGenerator());
         services.AddScoped(_ => new RenderVars());
 

--- a/src/dotnet/UI.Blazor/Services/History/History.LocationChange.cs
+++ b/src/dotnet/UI.Blazor/Services/History/History.LocationChange.cs
@@ -1,4 +1,5 @@
 using ActualChat.Concurrency;
+using ActualChat.UI.Blazor.Diagnostics;
 using ActualChat.UI.Blazor.Services.Internal;
 
 namespace ActualChat.UI.Blazor.Services;
@@ -18,10 +19,12 @@ public partial class History
             eventArgs.IsNavigationIntercepted ? "intercepted" : "internal",
             eventArgs.Location, parsedHistoryEntryState?.Format() ?? "null", historyEntryState);
 
+        ChatSwitchTracer.Mark("History.LocationChange: entered", eventArgs.Location);
         Action? exitAction = null;
         try {
             // Saving the current state
             Save();
+            ChatSwitchTracer.Mark("History.LocationChange: Save() done");
 
             var url = _url = Nav.GetLocalUrl().Value;
             var lastItem = _currentItem;
@@ -71,11 +74,13 @@ public partial class History
                 // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
                 $"LocationChange: transition #{lastItem.Id} -> #{CurrentItem.Id}, {transition}");
             Transition(transition);
+            ChatSwitchTracer.Mark("History.LocationChange: Transition() done");
         }
         finally {
             _state.Value = _currentItem;
             try {
                 LocationChanged?.Invoke(this, eventArgs);
+                ChatSwitchTracer.Mark("History.LocationChange: LocationChanged handlers done");
             }
             catch (Exception e) {
                 Log.LogError(e, "LocationChange: One of LocationChanged handlers failed");

--- a/src/dotnet/UI.Blazor/Services/History/History.Navigation.cs
+++ b/src/dotnet/UI.Blazor/Services/History/History.Navigation.cs
@@ -1,3 +1,5 @@
+using ActualChat.UI.Blazor.Diagnostics;
+
 namespace ActualChat.UI.Blazor.Services;
 
 public partial class History
@@ -27,10 +29,19 @@ public partial class History
     }
 
     [JSInvokable]
-    public async Task NavigateTo(string url, bool mustReplace = false, bool force = false, bool addInFront = false)
+    public async Task NavigateTo(
+        string url,
+        bool mustReplace = false,
+        bool force = false,
+        bool addInFront = false,
+        double clickToInvokeMs = -1)
     {
         Dispatcher.AssertAccess();
+        ChatSwitchTracer.TryStart(url, "History.NavigateTo");
+        ChatSwitchTracer.Mark("History.NavigateTo: entered",
+            $"{url} (JS click -> navigateTo: {clickToInvokeMs:F1}ms)");
         await WhenNavigationCompletedOrTimeout().ConfigureAwait(true);
+        ChatSwitchTracer.Mark("History.NavigateTo: nav queue drained");
 
         var localUrl = new LocalUrl(url);
         var fixedUriLogLevel = LogLevel.Warning;
@@ -57,14 +68,17 @@ public partial class History
 
             DebugLog?.LogDebug("{Entry}", title);
             var itemId = mustReplace ? _currentItem.Id : NewItemId();
+            ChatSwitchTracer.Mark("History.NavigateTo: Nav.NavigateTo -> in");
             Nav.NavigateTo(url, new NavigationOptions() {
                 ForceLoad = force,
                 ReplaceHistoryEntry = mustReplace,
                 HistoryEntryState = ItemIdFormatter.Format(itemId),
             });
+            ChatSwitchTracer.Mark("History.NavigateTo: Nav.NavigateTo <- out");
             return itemId;
         });
         await entry.WhenCompleted.ConfigureAwait(false);
+        ChatSwitchTracer.Mark("History.NavigateTo: queue entry completed");
     }
 
     public bool TryGetStepBackUrl(out string backUrl)
@@ -102,6 +116,7 @@ public partial class History
             backItem = currentItem.GenerateBackItem();
             if (backItem == null)
                 return false; // No way to step back: can't neither get nor generate the back step
+
             backItem = backItem with { Id = NewItemId() }; // Change Id to prevent endless loop
         }
 
@@ -139,7 +154,7 @@ public partial class History
     }
 
     private Task AddHistoryEntry(HistoryItem item, bool addInFront = false)
-        => NavigationQueue.Enqueue(addInFront,  $"AddHistoryEntry: {item}", () => {
+        => NavigationQueue.Enqueue(addInFront, $"AddHistoryEntry: {item}", () => {
             Nav.NavigateTo(item.Url,
                 new NavigationOptions {
                     ForceLoad = false,

--- a/src/dotnet/UI.Blazor/Services/History/history.ts
+++ b/src/dotnet/UI.Blazor/Services/History/history.ts
@@ -10,6 +10,9 @@ export class History {
 
     public static navigationManager: any
     public static whenReady: PromiseSource<void> = new PromiseSource<void>();
+    // Temporary chat-switch instrumentation: the gap from the originating click to navigateTo, plus
+    // the round trip, are the only parts of a switch that .NET can't time from its own side.
+    public static lastClickAt = -1;
 
     public static init(
         backendRef1: DotNet.DotNetObject,
@@ -36,7 +39,11 @@ export class History {
     ): Promise<void> {
         infoLog?.log(`navigateTo:`, url, mustReplace, force, addInFront);
         await this.whenReady;
-        await this.backendRef.invokeMethodAsync('NavigateTo', url, mustReplace, force, addInFront);
+        const clickAt = this.lastClickAt;
+        this.lastClickAt = -1;
+        const clickToInvokeMs = clickAt >= 0 ? performance.now() - clickAt : -1;
+        await this.backendRef.invokeMethodAsync(
+            'NavigateTo', url, mustReplace, force, addInFront, clickToInvokeMs);
     };
 
     public static async forceReload(url: string, mustReplace: boolean, historyEntryState: string) {

--- a/src/dotnet/UI.Blazor/Services/PanelsUI/PanelsUI.cs
+++ b/src/dotnet/UI.Blazor/Services/PanelsUI/PanelsUI.cs
@@ -1,3 +1,4 @@
+using ActualChat.UI.Blazor.Diagnostics;
 using ActualChat.UI.Blazor.Services.Internal;
 
 namespace ActualChat.UI.Blazor.Services;
@@ -39,6 +40,7 @@ public partial class PanelsUI : UIWorkerBase<UIHub>
         if (IsWide())
             return;
 
+        ChatSwitchTracer.Mark("PanelsUI.HidePanels");
         Left.SetIsVisible(false);
         Right.SetIsVisible(false);
     }

--- a/src/dotnet/UI.Blazor/Services/PrefetchUI/PrefetchUI.cs
+++ b/src/dotnet/UI.Blazor/Services/PrefetchUI/PrefetchUI.cs
@@ -1,0 +1,83 @@
+using ActualChat.UI.Blazor.Components;
+using ActualChat.UI.Blazor.Module;
+
+namespace ActualChat.UI.Blazor.Services;
+
+/// <summary>
+/// Runs the <see cref="IPrefetcher"/> named by a <c>data-prefetch</c> attribute when the pointer goes
+/// down on the element carrying it, so the round trips the follow-up click needs are already in flight
+/// by the time it lands. Everything here is best-effort: a failed prefetch only costs the warm-up.
+/// </summary>
+public sealed class PrefetchUI : UIServiceBase<UIHub>, IDisposable
+{
+    private static readonly string JSInitMethod = $"{BlazorUICoreModule.ImportName}.PrefetchUI.init";
+    // A pointer down repeated on the same target within this window is the same intent, not a new one
+    private static readonly TimeSpan RepeatWindow = TimeSpan.FromSeconds(1);
+
+    private readonly DotNetObjectReference<PrefetchUI> _blazorRef;
+    private readonly Lock _lock = new();
+    private string _lastRef = "";
+    private CpuTimestamp _lastRefAt;
+
+    public PrefetchUI(UIHub hub) : base(hub)
+        => _blazorRef = DotNetObjectReference.Create(this);
+
+    public void Dispose()
+        => _blazorRef.DisposeSilently();
+
+    public Task Initialize()
+        => JS.InvokeVoidAsync(JSInitMethod, _blazorRef).AsTask();
+
+    [JSInvokable]
+    public void OnPrefetchRequest(string sPrefetchRef)
+    {
+        // NOTE: Nothing here may throw - a prefetch is pure speculation, so its worst outcome has to be a log
+        // entry. Throwing would reject the JS-side promise and fault the pointer-down handler instead.
+        try {
+            if (sPrefetchRef.IsNullOrEmpty() || IsRepeat(sPrefetchRef))
+                return;
+
+            if (!PrefetchRef.TryParse(sPrefetchRef, out var prefetchRef)) {
+                Log.LogWarning("OnPrefetchRequest: can't parse '{PrefetchRef}'", sPrefetchRef);
+                return;
+            }
+
+            // Fire-and-forget on purpose: the pointer-down handler must not wait for any of this.
+            // NOTE: SuppressExceptions because BackgroundTask.Run's error handler logs and rethrows, and
+            // nothing awaits the task it returns - the fault would surface as an unobserved one.
+            _ = BackgroundTask.Run(
+                    () => Prefetch(prefetchRef),
+                    Log,
+                    $"Prefetch failed for '{sPrefetchRef}'.",
+                    Hub.StopToken)
+                .SuppressExceptions();
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "OnPrefetchRequest failed for '{PrefetchRef}'", sPrefetchRef);
+        }
+    }
+
+    // Private methods
+
+    private Task Prefetch(PrefetchRef prefetchRef)
+    {
+        if (Services.GetService(prefetchRef.PrefetcherType) is not IPrefetcher prefetcher) {
+            Log.LogWarning("Prefetch: {PrefetcherType} isn't registered", prefetchRef.PrefetcherType);
+            return Task.CompletedTask;
+        }
+
+        return prefetcher.Prefetch(prefetchRef.Arguments, Hub.StopToken);
+    }
+
+    private bool IsRepeat(string sPrefetchRef)
+    {
+        lock (_lock) {
+            if (sPrefetchRef == _lastRef && _lastRefAt.Elapsed < RepeatWindow)
+                return true;
+
+            _lastRef = sPrefetchRef;
+            _lastRefAt = CpuTimestamp.Now;
+            return false;
+        }
+    }
+}

--- a/src/dotnet/UI.Blazor/Services/PrefetchUI/prefetch-ui.ts
+++ b/src/dotnet/UI.Blazor/Services/PrefetchUI/prefetch-ui.ts
@@ -1,0 +1,22 @@
+import { getLogs } from 'logging';
+
+const { debugLog, warnLog } = getLogs('PrefetchUI');
+
+// The JS half of PrefetchUI.
+export class PrefetchUI {
+    private static backendRef: DotNet.DotNetObject | null = null;
+
+    public static init(backendRef1: DotNet.DotNetObject): void {
+        this.backendRef = backendRef1;
+    }
+
+    // NOTE: a failed prefetch is logged and nothing else - never an unhandled rejection
+    public static request(prefetchRef: string): void {
+        if (this.backendRef === null)
+            return;
+
+        debugLog?.log(`request:`, prefetchRef);
+        this.backendRef.invokeMethodAsync('OnPrefetchRequest', prefetchRef)
+            .catch(e => warnLog?.log(`request: failed`, e));
+    }
+}

--- a/src/dotnet/UI.Blazor/exports.ts
+++ b/src/dotnet/UI.Blazor/exports.ts
@@ -19,6 +19,7 @@ export * from './Services/FileUploads/stream-file-upload';
 export * from './Services/FileUploads/web-uploads';
 export * from './Services/FocusUI/focus-ui';
 export * from './Services/History/history';
+export * from './Services/PrefetchUI/prefetch-ui';
 export * from './Services/InteractiveUI/interactive-ui';
 export * from './Services/KeepAwakeUI/keep-awake-ui';
 export * from './Services/KeyboardUI/keyboard-ui';

--- a/src/nodejs/src/gestures.ts
+++ b/src/nodejs/src/gestures.ts
@@ -12,6 +12,7 @@ import { Tune, TuneName, TuneUI } from '../../dotnet/UI.Blazor/Services/TuneUI/t
 import { Vector2D } from 'math';
 import { getLogs } from 'logging';
 import { BrowserInfo } from '../../dotnet/UI.Blazor/Services/BrowserInfo/browser-info';
+import { PrefetchUI } from '../../dotnet/UI.Blazor/Services/PrefetchUI/prefetch-ui';
 
 const { debugLog } = getLogs('Gestures');
 
@@ -24,6 +25,7 @@ export class Gestures {
     public static init(): void {
         // Used gestures
         DataHrefGesture.use();
+        DataPrefetchGesture.use();
         SuppressDefaultContextMenuGesture.use();
         ContextMenuGesture.use();
         DismissKeyboardOnDragGesture.use();
@@ -141,8 +143,29 @@ class DataHrefGesture extends Gesture {
                     mustReplace = !except || path !== except;
                 }
             }
+            History.lastClickAt = event.timeStamp;
             void History.navigateTo(href, mustReplace); // Internal URL
         }
+    }
+}
+
+// Warms whatever `data-prefetch` names as soon as the pointer goes down on it, so the round trips the
+// click needs are already in flight when it lands. Passive and fire-and-forget: it never affects the
+// click that follows, and a pointer down that turns out to be a scroll only costs the warm-up.
+class DataPrefetchGesture extends Gesture {
+    public static use(): void {
+        debugLog?.log(`DataPrefetchGesture.use`);
+
+        DocumentEvents.passive.pointerDown$.subscribe((event: PointerEvent) => {
+            if (event.button !== 0) // Only primary button
+                return;
+
+            const [, prefetchRef] = getOrInheritData(event.target, 'prefetch');
+            if (prefetchRef === null)
+                return;
+
+            PrefetchUI.request(prefetchRef);
+        });
     }
 }
 

--- a/src/nodejs/src/logging.ts
+++ b/src/nodejs/src/logging.ts
@@ -58,6 +58,7 @@ export type LogScope =
     | 'MainThreadDiagnostics'
     | 'MenuHost'
     | 'ModalHost'
+    | 'PrefetchUI'
     | 'OnDeviceAwake'
     | 'promises'
     | 'ResilientStream'
@@ -174,6 +175,7 @@ const defaults: Record<LogScope, LogLevel> = {
     MainThreadDiagnostics: LogLevel.Info,
     MenuHost: LogLevel.Warn,
     ModalHost: LogLevel.Warn,
+    PrefetchUI: LogLevel.Warn,
     OnDeviceAwake: LogLevel.Warn,
     promises: LogLevel.Warn,
     ResilientStream: LogLevel.Warn,


### PR DESCRIPTION
## Why

Switching chats cost **2–3 serialized RPC round trips** before anything could render.
`GetChatItemsInternal` issues its `live` + `meta` calls in parallel, but the id-tiles to load can
only be derived *from* the range meta — so the tile fetch always started a round trip late.

Measured on the Windows app against dev.voxt.ai (RTT ≈ 70 ms), **before** this change:

| case | click → content swap | `GetChatItems` |
|---|---|---|
| warm | 68–110 ms | 0–15 ms |
| first visit to a chat | 136–260 ms | 80–152 ms (`live.conversation` = 69–79 ms, always) |
| cold | **506 ms** | **644 ms** (live 79 + meta 87 + load 476) |

The cold case blew past `ContentSwap`'s 500 ms `MaxDisplayDelay`, so the swap fired on the backstop
and showed an **empty** chat view, filling in ~200 ms later.

## What

A generic prefetch mechanism modelled on `MenuRef`:

- `PrefetchRef` / `PrefetchRegistry` / `IPrefetcher` — an element carries `data-prefetch="<PrefetchRef>"`.
- `DataPrefetchGesture` — one **passive** document-level `pointerdown` handler resolves the nearest
  `data-prefetch` and hands it to `PrefetchUI`.
- `PrefetchUI` — parses the ref, resolves the `IPrefetcher` from DI, runs it fire-and-forget, with a
  1 s same-target repeat guard.

Because Fusion dedupes by `ComputedInput`, the calls the real switch makes a moment later land on the
computations the prefetch already put in flight.

`ChatUI.Prefetch` warms everything opening a chat needs in one parallel burst. Two details matter:

- **The load zone is guessed from the read position, not derived from the meta** — waiting for the meta
  is precisely the serialized round trip this exists to overlap. A miss costs a few extra tile fetches.
- **The anchor is read from the chat list's already-cached `ChatInfo` via `Computed.GetExisting`**, so
  the warms go out with zero awaits. This only matters in the cold case, and it was measured: across 17
  switches on the await path, 15 resolved the anchor in 0.3–0.8 ms (cached — awaiting cost nothing),
  while the 2 genuinely cold chats spent 76.7 ms and 80.7 ms in `GetIdRange`, pushing the warm requests
  *past* the click they were meant to precede. `Get(chatId)` is still issued unconditionally, so a stale
  `ChatInfo` is revalidated in advance rather than left for whoever needs it next.

Nothing on the existing path was reordered: `ChatUI.Tiles.cs` is **+93 / −0**, and the tile fetches were
already unbounded-parallel (`ApiConstants.Concurrency.High == 0`).

Wired onto `ChatListItem` for now; anything else that opens a chat only needs the attribute.

## Results

Re-measured on the Windows app with the **Kvasar computed cache deleted** — a strictly harder starting
state than the "before" numbers above, where the on-disk cache was partly warm.

| | before | after (cold cache) |
|---|---|---|
| worst | **506 ms** | **232 ms** |
| ≥237 ms | 4 of 12 | 0 of 8 |

**`meta = 0` and `live = 0` in all 8 traces.** Both round trips the prefetch targets are fully hidden
even from an empty cache — including the guaranteed 69–79 ms `GetConversation` RTT
(`CacheMode.NoCache`, so it can never be served from cache). Only `load` partially remains (63–82 ms on
5 of 8): the tile burst is issued at ~1.6 ms but takes longer than the available lead.

Where the remaining time goes (means across the 8 cold switches):

| data | render | interop | place | total |
|---|---|---|---|---|
| 56.6 ms | 29.4 ms | 36.6 ms | 8.1 ms | **130.8 ms** |

**Render + `InfiniteList.create` interop is now 66 ms — 50% of the mean — and prefetching cannot touch
any of it.** On revisits, data drops to 8.6 ms and the total is still 74–111 ms, entirely render and
interop. Data has stopped being the bottleneck; that's the next thing to look at, separately.

The prefetch's ceiling is the pointerdown→click gap (52–159 ms observed) — `ChatUI.Prefetch: done` fires
at ~345 ms on a cold chat, i.e. after the swap. More lead time (`pointerover`) would help on desktop but
does nothing for touch.

## Tracing

`ChatSwitchTracer` and its call sites are kept, but every method is `[Conditional("CHAT_SWITCH_TRACER")]`
and the symbol is **off by default**, so the calls and their argument evaluation are compiled out
entirely. Turn it on with `-p:EnableChatSwitchTracer=true` (see `Directory.Build.props`).

## Test plan

- [x] Plumbing verified on Blazor Server — pointerdown → `PrefetchUI` → `ChatPrefetcher` → `ChatUI.Prefetch`.
- [x] Windows app against dev.voxt.ai, warm cache.
- [x] Windows app with the Kvasar cache deleted — every chat genuinely cold.
- [x] Cold-chat worst case down from 506 ms to 232 ms, below the 500 ms `MaxDisplayDelay` cliff; no more
      empty-view swaps.
- [x] Builds clean with the tracer both off and on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jzFJyQ1c8EoUWWdiocQ8E

## Also

`ChatPage`'s 0.5 s `MaxDisplayDelay` override is dropped back to the 0.333 s `ContentSwap` default. It
existed because "a cold InfiniteList regularly needs longer than the 0.333s default" — no longer true
now that the prefetch lands the data first; the worst observed hold is ~218 ms.

## Review follow-ups

A Fusion-grounded review of this branch found one real bug and several sharp edges, all fixed here:

- **`GetPrefetchAnchor` could throw.** `Computed.GetExisting` captures unconditionally
  (`ComputedImpl.Helpers.cs`, no state check), so it can return a **`Computing`** computed — and
  `Computed.Output` calls `AssertConsistencyStateIsNot(Computing)`, a real throw. Issuing
  `Get(chatId)` *before* the peek was itself registering that computed. Fixed by peeking first
  **and** gating on `!IsComputing()`; ordering alone doesn't cover a concurrent recompute driven by
  `ChatListItem`. The gate rejects only `Computing` — an invalidated value still aims a load zone
  fine, and since `ConsistencyState` only moves forward, observing "not Computing" stays true.
- **Notes / single-author chats warmed nothing.** `ReadEntryLid == long.MaxValue` made
  `GetTile(long.MaxValue)` overflow to a negative end, and `GetCoveringTiles` silently yielded zero
  tiles. Normalised to the tail branch.
- **Never-read chats mirrored the wrong branch.** `GetChatDataQuery` uses the tail case
  (anchor `tile20(End-5)`, ±limit/2) with no view entry; the prefetch always mirrored the navigation
  case (`tile20(End-1)`, -1/3/+2/3), a different anchor tile ~20% of the time. Now branches alike.
- **Warming past the chat end** — the zone is clamped to the chat's lid range, dropping ~20 empty
  tile RPCs per pointer down.
- **Unobserved task faults** on every early return — all tasks are now observed in a `finally`.
- `PrefetchRef.TryParse` no longer throws on malformed base64; `PrefetchUI.Initialize()` is no longer
  a discarded fire-and-forget.

Known remaining gap: the load-zone offsets are applied as raw lid arithmetic, while `GetIdWithOffset`
walks them as positions along merged entry ranges (gaps skipped, a collapsed conversation counting as
one). These coincide in dense chats but diverge in summarized ones, which is consistent with `load`
staying at 63-82ms in the cold traces. Closing that needs the range meta — the very round trip this
overlaps — so it's left for a follow-up.

## Final measurement (cold Kvasar cache, 22 switches)

Re-measured after the review fixes, with the cache deleted again:

| | before prefetch | after (this branch) |
|---|---|---|
| median click→swap | — | **93 ms** (was 125 ms pre-fix) |
| worst | 506 ms | 340 ms (a chat with `load=400`) |

`load = 0` in over half the traces — it was non-zero in *every* trace before the end-clamping and
tail-branch fixes. The residual is now mostly `meta` (4–40 ms).

### Search → message (`?n={entryLid}`) is deliberately not prefetched

Measured separately: 5 of 7 such navigations land at a flat **341–354 ms regardless of data** — one
with `GetChatItems total=0` took 341 ms, one with `total=982` took 345 ms. That flat cost is
`ContentSwap`'s 333 ms `MaxDisplayDelay` backstop: those traces get **zero** `OnDisplayed` calls, so
the swap fires on the timer because the chat view never reports its content as placed.

A `?n=` prefetch path would therefore buy nothing here. The trace points at two separate defects in
`ChatView`'s navigation handling instead — the navigation is applied twice (`OnParametersSetAsync`
and `OnLocationChanged` both call `NavigateToUrlFragment`), and the follow-up query drops
`Navigation` and re-anchors elsewhere (`{181020,181040}` → `{6853,7115}`). Those are being tracked
separately.

Incidentally, because this path is backstop-bound, dropping `MaxDisplayDelay` to 0.333 s made
search→message ~167 ms faster.
