### PR TITLE
feat(ios): show chat icons in push notifications

### DIFF
--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -629,6 +629,20 @@ jobs:
         with:
           base64: ${{ secrets.PROVISIONING_PROFILE_WIDGET_PROD_BASE64 }}
 
+      - name: Install Provisioning Profile (Notification service extension) for DEV
+        id: notification-profile-dev
+        uses: ./.github/actions/install-provisioning-profile
+        if: ${{env.IS_DEV_MAUI == 'true'}}
+        with:
+          base64: ${{ secrets.PROVISIONING_PROFILE_NOTIFICATION_DEV_BASE64 }}
+
+      - name: Install Provisioning Profile (Notification service extension) for PROD
+        id: notification-profile-prod
+        uses: ./.github/actions/install-provisioning-profile
+        if: ${{env.IS_DEV_MAUI == 'false'}}
+        with:
+          base64: ${{ secrets.PROVISIONING_PROFILE_NOTIFICATION_PROD_BASE64 }}
+
       - name: Install the Apple distribution certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{secrets.APPLE_DISTRIBUTION_CERT_BASE64}}
@@ -662,8 +676,8 @@ jobs:
       - name: Install workloads (pinned to the .NET 11 preview 7 workload band — see #3839)
         run: dotnet workload install maui ios maui-ios --from-rollback-file ${{github.workspace}}/.github/workloads-net11-p7.json
 
-      # VoxtActivities.xcodeproj is generated from project.yml, not committed - the iOS build
-      # (src/swift/VoxtActivities/build.sh) fails without xcodegen.
+      # The Xcode projects under src/swift/ are generated from their project.yml, not
+      # committed - each one's build.sh, invoked by the iOS build, fails without xcodegen.
       - name: Install xcodegen
         run: brew install xcodegen
 
@@ -737,6 +751,9 @@ jobs:
           VoxtActivitiesTeamId: M287G8G83F
           VoxtActivitiesIdentity: Apple Distribution
           VoxtActivitiesProfile: ${{ env.IS_DEV_MAUI == 'true' && steps.widget-profile-dev.outputs.name || steps.widget-profile-prod.outputs.name }}
+          VoxtNotificationServiceTeamId: M287G8G83F
+          VoxtNotificationServiceIdentity: Apple Distribution
+          VoxtNotificationServiceProfile: ${{ env.IS_DEV_MAUI == 'true' && steps.notification-profile-dev.outputs.name || steps.notification-profile-prod.outputs.name }}
         run: |-
           ./run-build.cmd publish-ios --configuration Release --is-dev-maui "${{env.IS_DEV_MAUI}}" --use-native-aot "${{ github.event.inputs.useNativeAot || 'false' }}"
           pushd artifacts/publish/App.Maui/release_net11.0-ios_ios-arm64
@@ -751,6 +768,7 @@ jobs:
           for appex in Payload/ActualChat.app/PlugIns/*; do
             case "$(basename "$appex")" in
               VoxtActivitiesWidget.appex) entitlements=${{github.workspace}}/src/swift/VoxtActivities/${{env.ENTITLEMENTS_FILE}} ;;
+              VoxtNotificationService.appex) entitlements=${{github.workspace}}/src/swift/VoxtNotificationService/${{env.ENTITLEMENTS_FILE}} ;;
               *) entitlements=${{github.workspace}}/src/dotnet/App.Maui.IosShareExt/${{env.ENTITLEMENTS_FILE}} ;;
             esac
             codesign -f -s "Apple Distribution: Actual Chat Inc. (M287G8G83F)" --entitlements "$entitlements" "$appex"

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -68,6 +68,14 @@ way. Clients render every banner themselves — no `webpush.notification`, no
   and the bell panel, and are deliberately a different calculation. `ListActive`
   drives the app-icon badge and the OS-level surfaces. Two concepts, one source of
   truth each — not two sources for one thing.
+- **Banner rendering** — Android builds its own banner from the data message
+  (`Platforms/Android/Notifications/NotificationHelper.cs`, `MessagingStyle` with
+  the avatar as the sender's icon). iOS renders `aps.alert` itself, and
+  `src/swift/VoxtNotificationService` (a `UNNotificationServiceExtension`, Swift
+  because of its 24 MB memory limit) rewrites it into a *communication
+  notification* so the chat avatar replaces the app icon. Its
+  `conversationIdentifier` must stay equal to the thread id the dismissal path
+  matches on — see that project's README.
 - **App-icon badge** — `AppIconBadgeUpdater.cs` (single source of truth) plus
   native `AppIconBadge` on iOS (`App.Maui/MaciOS/AppIconBadge.cs`) and Windows
   (`Platforms/Windows/WindowsAppIconBadge.cs`). On iOS the badge of a
@@ -83,3 +91,4 @@ way. Clients render every banner themselves — no `webpush.notification`, no
 | Notification lingers after read | clear-on-read → silent dismissal push; `NotificationReconciler` prune |
 | Duplicate / noisy pushes | soft-buffer coalescing + throttle window in `NotificationsBackend` |
 | Active set looks wrong | `/test/notifications` — dumps `INotifications.ListActive` as JSON |
+| iOS banner shows the app icon, not the chat avatar | is `VoxtNotificationService.appex` in the bundle's `PlugIns/`, and does the build have the `com.apple.developer.usernotifications.communication` entitlement on both the app and the extension? |

--- a/src/dotnet/App.Maui/App.Maui.csproj
+++ b/src/dotnet/App.Maui/App.Maui.csproj
@@ -918,6 +918,52 @@
     </AdditionalAppExtensions>
   </ItemGroup>
 
+  <!-- iOS notification service extension. src/swift/VoxtNotificationService turns chat pushes
+       into communication notifications (chat avatar in place of the app icon). Swift, not .NET,
+       because a UNNotificationServiceExtension gets a hard 24MB memory limit - well under what
+       the managed runtime needs. Everything below mirrors the VoxtActivities block above; see
+       it for why each knob exists. -->
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('osx')) and $(TargetFramework.Contains('-ios'))">
+    <VoxtNotificationServiceDir>$(MSBuildThisFileDirectory)..\..\swift\VoxtNotificationService\</VoxtNotificationServiceDir>
+    <VoxtNotificationServiceSdk>iphoneos</VoxtNotificationServiceSdk>
+    <VoxtNotificationServiceSdk Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</VoxtNotificationServiceSdk>
+    <VoxtNotificationServiceOutDir>build/$(Configuration)-$(VoxtNotificationServiceSdk)</VoxtNotificationServiceOutDir>
+    <VoxtNotificationServiceId>$(ApplicationId).notification</VoxtNotificationServiceId>
+    <VoxtNotificationServiceTeamId Condition="'$(VoxtNotificationServiceTeamId)' == ''">$(CodesignTeamId)</VoxtNotificationServiceTeamId>
+    <VoxtNotificationServiceIdentity Condition="'$(VoxtNotificationServiceIdentity)' == ''"></VoxtNotificationServiceIdentity>
+    <VoxtNotificationServiceProfile Condition="'$(VoxtNotificationServiceProfile)' == ''"></VoxtNotificationServiceProfile>
+    <!-- A device build has to give the appex its own embedded.mobileprovision: its
+         application-identifier isn't the app's, so the app's profile can't authorize it, and the
+         SDK never provisions an AdditionalAppExtensions appex. CI passes all three explicitly;
+         these Debug defaults are what make a local device build work, and they mirror the
+         CodesignProvision/CodesignKey pair in the Debug|net11.0-ios block above. -->
+    <VoxtNotificationServiceTeamId Condition="'$(VoxtNotificationServiceTeamId)' == '' and '$(VoxtNotificationServiceSdk)' == 'iphoneos' and '$(Configuration)' == 'Debug'">M287G8G83F</VoxtNotificationServiceTeamId>
+    <VoxtNotificationServiceIdentity Condition="'$(VoxtNotificationServiceIdentity)' == '' and '$(VoxtNotificationServiceSdk)' == 'iphoneos' and '$(Configuration)' == 'Debug'">Apple Development</VoxtNotificationServiceIdentity>
+    <VoxtNotificationServiceProfile Condition="'$(VoxtNotificationServiceProfile)' == '' and '$(VoxtNotificationServiceSdk)' == 'iphoneos' and '$(Configuration)' == 'Debug'">chat.actual.dev.app.notification</VoxtNotificationServiceProfile>
+    <!-- Unlike the widget's, these carry a real capability - com.apple.developer.usernotifications.communication -
+         so the App ID behind the profile must have Communication Notifications enabled. -->
+    <VoxtNotificationServiceEntitlements Condition="'$(VoxtNotificationServiceEntitlements)' == '' and '$(IsDevMaui)' == 'true'">Entitlements.dev.plist</VoxtNotificationServiceEntitlements>
+    <VoxtNotificationServiceEntitlements Condition="'$(VoxtNotificationServiceEntitlements)' == ''">Entitlements.prod.plist</VoxtNotificationServiceEntitlements>
+    <MaciOSPrepareForBuildDependsOn>BuildVoxtNotificationService;$(MaciOSPrepareForBuildDependsOn)</MaciOSPrepareForBuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="BuildVoxtNotificationService" BeforeTargets="_ExtendAppExtensionReferences"
+          Condition="$([MSBuild]::IsOSPlatform('osx')) and $(TargetFramework.Contains('-ios'))">
+    <Exec Command="sh &quot;$(VoxtNotificationServiceDir)build.sh&quot; &quot;$(Configuration)&quot; &quot;$(VoxtNotificationServiceSdk)&quot; &quot;$(VoxtNotificationServiceId)&quot; &quot;$(ApplicationDisplayVersion)&quot; &quot;$(ApplicationVersion)&quot; &quot;$(VoxtNotificationServiceTeamId)&quot; &quot;$(VoxtNotificationServiceIdentity)&quot; &quot;$(VoxtNotificationServiceProfile)&quot; &quot;$(VoxtNotificationServiceEntitlements)&quot;" />
+  </Target>
+
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('osx')) and $(TargetFramework.Contains('-ios'))">
+    <AdditionalAppExtensions Include="$(VoxtNotificationServiceDir)">
+      <Name>VoxtNotificationService</Name>
+      <BuildOutput>$(VoxtNotificationServiceOutDir)</BuildOutput>
+      <!-- The SDK re-signs every embedded appex, and without this it does so with no
+           entitlements at all - which strips the capability and makes updating(from:) fail at
+           runtime while the build stays green. The widget needs no entitlements, so it gets
+           away without it; this one does not. -->
+      <CodesignEntitlements>$(VoxtNotificationServiceDir)$(VoxtNotificationServiceEntitlements)</CodesignEntitlements>
+    </AdditionalAppExtensions>
+  </ItemGroup>
+
   <!-- Native AOT — single source of truth, and the only runtime alternative to CoreCLR:
        the per-platform Release blocks above describe the default CoreCLR + ReadyToRun
        behavior and run regardless of UseNativeAot. This block then overrides what

--- a/src/dotnet/App.Maui/Platforms/iOS/Entitlements.dev.plist
+++ b/src/dotnet/App.Maui/Platforms/iOS/Entitlements.dev.plist
@@ -23,5 +23,7 @@
 	<array>
 		<string>group.chat.actual.dev.app.shared</string>
 	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 </dict>
 </plist>

--- a/src/dotnet/App.Maui/Platforms/iOS/Entitlements.prod.plist
+++ b/src/dotnet/App.Maui/Platforms/iOS/Entitlements.prod.plist
@@ -21,5 +21,7 @@
 	<array>
 		<string>group.chat.actual.app.shared</string>
 	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 </dict>
 </plist>

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -30,7 +30,8 @@ public static class NotificationHelper
         };
 
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
-        => urlMapper.IconUrl(chat.GetIconQuery(author));
+        => urlMapper.IconUrl(chat.GetIconQuery(author, renderAvatarTitle: true));
+
     public static string GetVoiceChatStartedText(IReadOnlyList<string> authorNames, IStringLocalizer l)
     {
         var shown = authorNames.Take(Constants.Notification.MaxSummaryAuthors).ToList();

--- a/src/swift/VoxtActivities/README.md
+++ b/src/swift/VoxtActivities/README.md
@@ -42,6 +42,9 @@ host app (ITMS-90473). The target therefore depends on `NBGV_SetVersionForMauiIO
 NBGV target that fills `ApplicationDisplayVersion` / `ApplicationVersion` — because it
 otherwise runs before it and would pass empty strings.
 
+`build.sh` is a thin wrapper: the xcodegen and signing plumbing lives in `../appex-build.sh`,
+shared with `../VoxtNotificationService`, which is also where that empty-version check lives.
+
 Manually:
 
 ```sh

--- a/src/swift/VoxtActivities/build.sh
+++ b/src/swift/VoxtActivities/build.sh
@@ -3,85 +3,27 @@
 #   libVoxtActivityKitShim.a  - linked into the app via NativeReference
 #   VoxtActivitiesWidget.appex - embedded via AdditionalAppExtensions
 # Invoked from App.Maui.csproj (macOS + iOS only) and by hand during development.
+# ../appex-build.sh holds the xcodegen and signing plumbing, and documents the APPEX_* vars.
 set -e
 cd "$(dirname "$0")"
 
-CONFIG=${1:-Release}
-SDK=${2:-iphoneos}
-BUNDLE_ID=${3:-chat.actual.dev.app.widget}
-# ${4-} / ${5-}, not ${4:-}: an empty argument must NOT fall back to the placeholder, or a
-# caller whose version properties aren't computed yet silently ships an appex whose
-# CFBundleShortVersionString / CFBundleVersion don't match the app - which is an App Store
-# Connect ITMS-90473 rejection. The defaults are for hand runs that pass no version at all.
-SHORT_VERSION=${4-1.0}
-BUILD_VERSION=${5-1}
-DEV_TEAM=${6:-${VOXT_ACTIVITIES_TEAM:-}}
-# "Apple Development" for local device builds; pass "Apple Distribution" for TestFlight.
-IDENTITY=${7:-${VOXT_ACTIVITIES_IDENTITY:-Apple Development}}
-# A profile name switches signing from automatic to manual - see the comment below.
-PROFILE=${8:-${VOXT_ACTIVITIES_PROFILE:-}}
-# Relative to this folder. Xcode derives one from the profile when it's omitted, but CI
-# re-signs the embedded appex afterwards and needs the same file to sign it with.
-ENTITLEMENTS=${9:-${VOXT_ACTIVITIES_ENTITLEMENTS:-}}
+APPEX_PROJECT=VoxtActivities
+APPEX_CONFIG=${1:-Release}
+APPEX_SDK=${2:-iphoneos}
+APPEX_BUNDLE_ID=${3:-chat.actual.dev.app.widget}
+# ${4-} / ${5-}, not ${4:-}: an empty argument must NOT fall back to the placeholder - see the
+# ITMS-90473 check in ../appex-build.sh. The defaults are for hand runs that pass no version.
+APPEX_SHORT_VERSION=${4-1.0}
+APPEX_BUILD_VERSION=${5-1}
+APPEX_TEAM=${6:-${VOXT_ACTIVITIES_TEAM:-}}
+APPEX_IDENTITY=${7:-${VOXT_ACTIVITIES_IDENTITY:-Apple Development}}
+APPEX_PROFILE=${8:-${VOXT_ACTIVITIES_PROFILE:-}}
+APPEX_ENTITLEMENTS=${9:-${VOXT_ACTIVITIES_ENTITLEMENTS:-}}
 
-if [ -z "$SHORT_VERSION" ] || [ -z "$BUILD_VERSION" ]; then
-    echo "build.sh: empty version (short='$SHORT_VERSION', build='$BUILD_VERSION')." >&2
-    echo "The .appex must carry the app's versions - see ITMS-90473." >&2
-    exit 1
-fi
+. ../appex-build.sh
 
-if [ ! -d VoxtActivities.xcodeproj ] || [ project.yml -nt VoxtActivities.xcodeproj/project.pbxproj ]; then
-    if ! command -v xcodegen >/dev/null 2>&1; then
-        echo "VoxtActivities.xcodeproj is missing or stale and xcodegen isn't installed." >&2
-        echo "Run 'brew install xcodegen', or regenerate it on a Mac that has it." >&2
-        exit 1
-    fi
-    xcodegen generate
-fi
-
-# The .NET SDK re-signs the .appex it embeds, but it never gives it an
-# embedded.mobileprovision - only the app bundle gets one. So a device or TestFlight build
-# needs Xcode to sign the appex here, which takes a team id. Without one we build unsigned,
-# which is all the simulator and a headless CI compile need.
-build_target() {
-    TARGET=$1
-    shift
-    xcodebuild -project VoxtActivities.xcodeproj -target "$TARGET" \
-        -configuration "$CONFIG" -sdk "$SDK" \
-        SYMROOT=build OBJROOT=build/obj \
-        PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-        MARKETING_VERSION="$SHORT_VERSION" \
-        CURRENT_PROJECT_VERSION="$BUILD_VERSION" \
-        "$@" \
-        build
-}
-
-# CODE_SIGN_IDENTITY is load-bearing: project.yml pins it to "" for the unsigned default, an
-# empty identity means "skip CodeSign entirely", and a project-level setting outranks automatic
-# signing - so without this override a signed build reports success and silently ships an
-# unsigned appex. Command-line settings beat project-level ones, which is what makes it work.
-# CODE_SIGNING_REQUIRED=YES then turns any future silent skip into a hard failure.
-# Automatic signing only ever picks a development identity: combining it with "Apple
-# Distribution" makes Xcode fail with "conflicting provisioning settings". So distribution
-# builds must go manual, which in turn requires naming the profile explicitly - hence PROFILE
-# selecting between the two modes rather than a second identity knob.
-if [ -n "$DEV_TEAM" ] && [ -n "$PROFILE" ]; then
-    set -- CODE_SIGN_STYLE=Manual "DEVELOPMENT_TEAM=$DEV_TEAM" \
-        "CODE_SIGN_IDENTITY=$IDENTITY" "PROVISIONING_PROFILE_SPECIFIER=$PROFILE" \
-        CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES
-elif [ -n "$DEV_TEAM" ]; then
-    set -- CODE_SIGN_STYLE=Automatic "DEVELOPMENT_TEAM=$DEV_TEAM" \
-        "CODE_SIGN_IDENTITY=$IDENTITY" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES \
-        -allowProvisioningUpdates
-else
-    set -- CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=
-fi
-
-if [ -n "$DEV_TEAM" ] && [ -n "$ENTITLEMENTS" ]; then
-    set -- "$@" "CODE_SIGN_ENTITLEMENTS=$ENTITLEMENTS"
-fi
-
+appex_generate_project
 # A static archive is not a signable artifact - CodeSign fails outright on one - so the shim
 # builds unsigned whatever the team. Only the widget takes the signing settings.
-build_target VoxtActivityKitShim CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=
-build_target VoxtActivitiesWidget "$@"
+appex_build_target VoxtActivityKitShim unsigned
+appex_build_target VoxtActivitiesWidget signed

--- a/src/swift/VoxtNotificationService/.gitignore
+++ b/src/swift/VoxtNotificationService/.gitignore
@@ -1,0 +1,4 @@
+build/
+VoxtNotificationService.xcodeproj/
+*.xcuserdatad/
+xcuserdata/

--- a/src/swift/VoxtNotificationService/Entitlements.dev.plist
+++ b/src/swift/VoxtNotificationService/Entitlements.dev.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>application-identifier</key>
+    <string>M287G8G83F.chat.actual.dev.app.notification</string>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
+</dict>
+</plist>

--- a/src/swift/VoxtNotificationService/Entitlements.prod.plist
+++ b/src/swift/VoxtNotificationService/Entitlements.prod.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>application-identifier</key>
+    <string>M287G8G83F.chat.actual.app.notification</string>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
+</dict>
+</plist>

--- a/src/swift/VoxtNotificationService/README.md
+++ b/src/swift/VoxtNotificationService/README.md
@@ -1,0 +1,142 @@
+# VoxtNotificationService — iOS chat icons in push notifications
+
+A `UNNotificationServiceExtension` (`.appex`) that rewrites every chat push into an iOS
+**communication notification**: the chat or author avatar replaces the app icon on the banner,
+the sender's name becomes the title and the chat name the subtitle — the same shape Messages,
+Telegram and WhatsApp use.
+
+## Why the extension has to exist
+
+The server has always sent everything needed for this: `FirebaseMessagingClient` sets
+`aps.mutable-content = 1`, puts the absolute icon URL in the `icon` data key, and also passes
+it as `fcm_options.image`. But `mutable-content` only means *"an extension is allowed to
+rewrite this notification"* — with no service extension in the bundle, nothing downloads the
+image and iOS renders the plain app-icon banner. That was issue #4184.
+
+## Why Swift and not .NET
+
+Unlike the share extension (`src/dotnet/App.Maui.IosShareExt`), a notification service
+extension runs under a hard **24 MB** memory limit — well below what the managed runtime
+needs — and the whole job is ~150 lines of `URLSession` plus `Intents`. So it follows
+`../VoxtActivities` instead: an xcodegen-generated Xcode project, built by `build.sh` from
+`App.Maui.csproj` and embedded via `AdditionalAppExtensions`.
+
+## What it does, per push
+
+1. Reads the `icon` data key. No icon → deliver the push untouched.
+2. Downloads it (5s timeout, 512 KB cap, HTTP cache honoured — the extension process is
+   reused, so a chatty conversation's avatar is normally already cached).
+3. Splits `content.title` on `" @ "` — that's the shape `NotificationHelper.GetTitle`
+   composes for group chats, and the same split Android's `NotificationHelper` does.
+4. Builds an `INSendMessageIntent` whose sender carries the avatar as an `INImage`, donates
+   the interaction (so Focus can allow-list the sender), and returns
+   `content.updating(from: intent)`.
+
+**`conversationIdentifier` must equal `content.threadIdentifier`.** `updating(from:)` rewrites
+the thread id from the conversation id, and `AppDelegate.RemoveDeliveredNotifications` matches
+delivered banners on their thread id when a silent dismissal push arrives — so a different
+value would silently break dismissal and per-chat grouping.
+
+If `updating(from:)` fails — which is what a missing entitlement looks like — the banner is
+delivered with the sender/chat split applied to title and subtitle, but no avatar. That's the
+pre-#4184 behavior, not a crash.
+
+## Prerequisites
+
+- macOS with Xcode (iOS 16.4+ SDK).
+- `brew install xcodegen`.
+
+`VoxtNotificationService.xcodeproj` is generated from `project.yml` and gitignored; `build.sh`
+regenerates it whenever it's missing or stale.
+
+## Building
+
+The MAUI iOS build does it: `App.Maui.csproj` runs `BuildVoxtNotificationService` (hooked via
+`MaciOSPrepareForBuildDependsOn`, macOS + `-ios` only), which invokes `build.sh`. The product
+is consumed as an `AdditionalAppExtensions` item.
+
+```sh
+./build.sh [CONFIG] [SDK] [BUNDLE_ID] [SHORT_VERSION] [BUILD_VERSION] [DEVELOPMENT_TEAM] \
+           [IDENTITY] [PROFILE] [ENTITLEMENTS]
+./build.sh                        # Release / iphoneos / dev bundle id, unsigned
+./build.sh Debug iphonesimulator
+```
+
+Output: `build/$CONFIG-$SDK/VoxtNotificationService.appex`.
+
+Signing works as for the widget — see `../appex-build.sh`, which both projects share, and
+`../VoxtActivities/README.md#signing` for the reasoning. Short version: unsigned by default; a
+device or TestFlight build needs a team id here, because the .NET SDK re-signs the embedded
+appex but never gives it an `embedded.mobileprovision`.
+
+Two things differ from the widget, both because this appex actually carries an entitlement:
+
+- **The SDK's re-sign drops entitlements unless you ask it not to.** An
+  `AdditionalAppExtensions` item is re-signed with whatever `CodesignEntitlements` metadata it
+  has — with none, the appex ships with an empty entitlement set, the build stays green, and
+  `updating(from:)` fails at runtime. `App.Maui.csproj` sets that metadata to the
+  flavor-appropriate plist. The symptom if it regresses is the middle row of the table below.
+- **A device build needs the appex's own profile embedded**, since its `application-identifier`
+  is `…app.notification`, which the app's profile doesn't cover. `App.Maui.csproj` defaults the
+  team/identity/profile for Debug `iphoneos` builds so `/ios-run` works with no extra
+  arguments; CI passes its own via the `VoxtNotificationService*` properties.
+
+## Apple Developer portal setup
+
+Unlike the widget, this extension carries a real capability —
+`com.apple.developer.usernotifications.communication` — and it has to be enabled on the App ID
+behind every profile that signs the appex *and* on the host app's App ID. Set up on
+2026-08-27:
+
+| What | Dev | Prod |
+|---|---|---|
+| Extension App ID | `chat.actual.dev.app.notification` | `chat.actual.app.notification` |
+| App Store profile | `App Store Notification Dev` | `App Store Notification` |
+| Development profile | `chat.actual.dev.app.notification` | — (nobody builds prod-flavor Debug) |
+
+Nothing on the app side needed changing: `chat.actual.dev.app` and `chat.actual.app` already
+had Communication Notifications enabled, and `App Store Dev`, `App Store 2` and the
+`chat.actual.dev.app` development profile already carried the entitlement.
+
+The two App Store profiles are what the repo secrets
+`PROVISIONING_PROFILE_NOTIFICATION_DEV_BASE64` / `PROVISIONING_PROFILE_NOTIFICATION_PROD_BASE64`
+hold, base64 of the `.mobileprovision`.
+
+Registering an App ID takes an **Admin**-role App Store Connect API key — an App Manager key
+can create profiles but gets a 403 on `POST /v1/bundleIds`, so new App IDs are a web-UI job.
+
+If the entitlement ever goes missing, banners keep arriving without an avatar rather than
+failing.
+
+## Testing it
+
+**This can only be tested on a device.** Two independent reasons:
+
+- `xcrun simctl push` never runs a service extension. It hands the payload straight to
+  SpringBoard, which adds the notification request as-is — the log shows the banner delivered
+  with its original `thread-id` and `Notification serviced by the communication context
+  service: 0`, and no extension process is ever spawned.
+- A simulator build is ad-hoc signed with an empty entitlement set, so
+  `updating(from:)` would fail there even if the extension did run.
+
+So: build to a device (`/ios-run`), background the app, and send yourself a message from
+another account — a second browser session on dev.voxt.ai is the quickest. Verified working on
+device 2026-08-27.
+
+**If a simulator build came first, wipe `artifacts/out` before building to a device.** Every
+iOS TFM shares that one flat obj dir, so the simulator run leaves a simulator-arch
+`r2r_modules.o` behind and the device link dies with `ld: building for 'iOS', but linking in
+object file ... built for 'iOS-simulator'`. `rm -rf artifacts/out
+artifacts/bin/App.Maui/debug_net11.0-ios_ios-arm64` and rebuild.
+
+What to look for:
+
+| Result | Meaning |
+|---|---|
+| Circular chat avatar in place of the app icon | working |
+| App icon, but title/subtitle split into sender and chat name | the extension ran; `updating(from:)` failed — check the entitlement on **both** the app and the appex |
+| App icon and a `"<sender> @ <chat>"` title | the extension didn't run at all — check `PlugIns/VoxtNotificationService.appex` exists and is signed |
+
+The extension is a separate process, so the app's debugger session won't stop in it — attach
+to `VoxtNotificationService` explicitly, or read its `os_log` output with
+`xcrun devicectl` / Console.app filtered on the process name.

--- a/src/swift/VoxtNotificationService/Service/Info.plist
+++ b/src/swift/VoxtNotificationService/Service/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Voxt</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>XPC!</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>MinimumOSVersion</key>
+  <string>$(IPHONEOS_DEPLOYMENT_TARGET)</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.usernotifications.service</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+  </dict>
+</dict>
+</plist>

--- a/src/swift/VoxtNotificationService/Service/NotificationService.swift
+++ b/src/swift/VoxtNotificationService/Service/NotificationService.swift
@@ -1,0 +1,175 @@
+import Intents
+import os
+import UserNotifications
+
+// Rewrites Voxt's chat pushes into iOS communication notifications, so the banner shows the
+// chat or author avatar in place of the app icon. `mutable-content` is inert without an
+// extension like this one, which is the only reason the target exists.
+final class NotificationService: UNNotificationServiceExtension {
+    // The FCM data keys `FirebaseMessagingClient` sends alongside `aps`.
+    private static let iconKey = "icon"
+    private static let chatIdKey = "chatId"
+    // `NotificationHelper.GetTitle` composes group-chat titles as "<author> @ <chat>".
+    private static let titleSeparator = " @ "
+    // The system allows 30s, but a banner that lands seconds late is worse than an iconless
+    // one - and these are 128px avatars, so a slow fetch means the network is gone anyway.
+    private static let downloadTimeout: TimeInterval = 5
+    private static let maxIconBytes = 512 * 1024
+
+    // The only way to see what this extension did: it is a separate process, and the failure
+    // modes (no entitlement, unreachable icon host) are invisible from the banner alone.
+    private static let log = Logger(subsystem: "ai.voxt.notification-service", category: "push")
+
+    private let lock = NSLock()
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttempt: UNMutableNotificationContent?
+    private var downloadTask: URLSessionDataTask?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        guard let content = request.content.mutableCopy() as? UNMutableNotificationContent else {
+            contentHandler(request.content)
+            return
+        }
+        lock.lock()
+        self.contentHandler = contentHandler
+        bestAttempt = content
+        lock.unlock()
+
+        guard let iconUrl = Self.iconUrl(of: content) else {
+            deliver(content)
+            return
+        }
+        downloadTask = Self.session.dataTask(with: iconUrl) { [weak self] data, response, error in
+            guard let self else { return }
+            if let error {
+                Self.log.error("Icon download failed: \(error.localizedDescription, privacy: .public)")
+            }
+            self.deliver(Self.applyIcon(Self.imageData(data, response), to: content))
+        }
+        downloadTask?.resume()
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        downloadTask?.cancel()
+        lock.lock()
+        let content = bestAttempt
+        lock.unlock()
+        if let content {
+            deliver(content)
+        }
+    }
+
+    // Private members
+
+    private static let session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = downloadTimeout
+        configuration.timeoutIntervalForResource = downloadTimeout
+        // The extension process is reused across pushes, so a chatty conversation's avatar is
+        // normally served from cache - the icon URLs go through the image proxy, and honouring
+        // its cache headers is enough to get that for free.
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+        return URLSession(configuration: configuration)
+    }()
+
+    private func deliver(_ content: UNNotificationContent) {
+        lock.lock()
+        let handler = contentHandler
+        contentHandler = nil
+        bestAttempt = nil
+        lock.unlock()
+        handler?(content)
+    }
+
+    private static func iconUrl(of content: UNMutableNotificationContent) -> URL? {
+        guard let icon = content.userInfo[iconKey] as? String, !icon.isEmpty else { return nil }
+        return URL(string: icon)
+    }
+
+    private static func imageData(_ data: Data?, _ response: URLResponse?) -> Data? {
+        guard let data, !data.isEmpty, data.count <= maxIconBytes else { return nil }
+        // INImage rasterizes at display time and iOS drops the whole notification if it can't:
+        // the marble avatar endpoint answers SVG unless a format is asked for. The server does
+        // ask - IconQuery.Create pins PNG - so SVG here means a server old enough to predate it.
+        return response?.mimeType == "image/svg+xml" ? nil : data
+    }
+
+    private static func applyIcon(
+        _ iconData: Data?,
+        to content: UNMutableNotificationContent
+    ) -> UNNotificationContent {
+        let (senderName, groupName) = splitTitle(content.title)
+        guard let iconData,
+              let intent = makeIntent(senderName: senderName, groupName: groupName, content: content, iconData: iconData)
+        else { return content }
+
+        // Titling the banner ourselves keeps the sender/chat split readable even when the
+        // update below fails - which it does when the communication entitlement is missing.
+        content.title = senderName
+        content.subtitle = groupName ?? ""
+        let updated: UNNotificationContent
+        do {
+            updated = try content.updating(from: intent)
+        }
+        catch {
+            // Overwhelmingly means the communication entitlement is missing from this build.
+            log.error("Communication notification update failed: \(error.localizedDescription, privacy: .public)")
+            return content
+        }
+
+        // Makes the sender addressable by Focus ("Allow notifications from") and Siri.
+        let interaction = INInteraction(intent: intent, response: nil)
+        interaction.direction = .incoming
+        interaction.donate(completion: nil)
+        return updated
+    }
+
+    private static func makeIntent(
+        senderName: String,
+        groupName: String?,
+        content: UNMutableNotificationContent,
+        iconData: Data
+    ) -> INSendMessageIntent? {
+        guard !senderName.isEmpty else { return nil }
+        // The thread id is the chat tag the server groups banners under, and AppDelegate's
+        // dismissal path matches delivered notifications on it. updating(from:) rewrites the
+        // thread id from the conversation id, so these two must be the same string.
+        let conversationId = content.threadIdentifier.isEmpty
+            ? (content.userInfo[chatIdKey] as? String ?? "")
+            : content.threadIdentifier
+        guard !conversationId.isEmpty else { return nil }
+
+        let image = INImage(imageData: iconData)
+        let sender = INPerson(
+            personHandle: INPersonHandle(value: conversationId, type: .unknown),
+            nameComponents: nil,
+            displayName: senderName,
+            image: image,
+            contactIdentifier: nil,
+            customIdentifier: conversationId)
+        let intent = INSendMessageIntent(
+            recipients: nil,
+            outgoingMessageType: .outgoingMessageText,
+            content: nil,
+            speakableGroupName: groupName.map { INSpeakableString(spokenPhrase: $0) },
+            conversationIdentifier: conversationId,
+            serviceName: nil,
+            sender: sender,
+            attachments: nil)
+        // For a group or place chat the server's icon is the chat's own picture, not the
+        // author's, so it belongs on the group rather than only on the sender.
+        if groupName != nil {
+            intent.setImage(image, forParameterNamed: \.speakableGroupName)
+        }
+        return intent
+    }
+
+    private static func splitTitle(_ title: String) -> (senderName: String, groupName: String?) {
+        guard let range = title.range(of: titleSeparator) else { return (title, nil) }
+        let groupName = String(title[range.upperBound...])
+        return (String(title[..<range.lowerBound]), groupName.isEmpty ? nil : groupName)
+    }
+}

--- a/src/swift/VoxtNotificationService/build.sh
+++ b/src/swift/VoxtNotificationService/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Builds VoxtNotificationService.appex into build/$CONFIG-$SDK/ - embedded into the app via
+# AdditionalAppExtensions from App.Maui.csproj (macOS + iOS only) and buildable by hand.
+# ../appex-build.sh holds the xcodegen and signing plumbing, and documents the APPEX_* vars.
+set -e
+cd "$(dirname "$0")"
+
+APPEX_PROJECT=VoxtNotificationService
+APPEX_CONFIG=${1:-Release}
+APPEX_SDK=${2:-iphoneos}
+APPEX_BUNDLE_ID=${3:-chat.actual.dev.app.notification}
+# ${4-} / ${5-}, not ${4:-}: an empty argument must NOT fall back to the placeholder - see the
+# ITMS-90473 check in ../appex-build.sh. The defaults are for hand runs that pass no version.
+APPEX_SHORT_VERSION=${4-1.0}
+APPEX_BUILD_VERSION=${5-1}
+APPEX_TEAM=${6:-${VOXT_NOTIFICATION_SERVICE_TEAM:-}}
+APPEX_IDENTITY=${7:-${VOXT_NOTIFICATION_SERVICE_IDENTITY:-Apple Development}}
+APPEX_PROFILE=${8:-${VOXT_NOTIFICATION_SERVICE_PROFILE:-}}
+APPEX_ENTITLEMENTS=${9:-${VOXT_NOTIFICATION_SERVICE_ENTITLEMENTS:-}}
+
+. ../appex-build.sh
+
+appex_generate_project
+appex_build_target VoxtNotificationService signed

--- a/src/swift/VoxtNotificationService/project.yml
+++ b/src/swift/VoxtNotificationService/project.yml
@@ -1,0 +1,40 @@
+name: VoxtNotificationService
+
+options:
+  bundleIdPrefix: chat.actual
+  createIntermediateGroups: true
+  minimumXcodeGenVersion: "2.38.0"
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    # Unsigned on purpose: build.sh overrides these when a team id is supplied, and the
+    # .NET iOS SDK re-signs the .appex when it embeds it.
+    CODE_SIGN_STYLE: Manual
+    CODE_SIGN_IDENTITY: ""
+    DEVELOPMENT_TEAM: ""
+    MARKETING_VERSION: "1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    ENABLE_USER_SCRIPT_SANDBOXING: NO
+
+targets:
+  VoxtNotificationService:
+    type: app-extension
+    platform: iOS
+    # Matches App.Maui's SupportedOSPlatformVersion; communication notifications need 15.0.
+    deploymentTarget: "16.4"
+    sources:
+      - path: Service
+        excludes: [Info.plist]
+      - path: Service/Info.plist
+        buildPhase: none
+    settings:
+      base:
+        # PRODUCT_NAME drives the .appex name and must stay in step with the
+        # AdditionalAppExtensions Name metadata; the bundle id is independent of it.
+        PRODUCT_NAME: VoxtNotificationService
+        # Overridden per flavor from build.sh; the app's own id + ".notification".
+        PRODUCT_BUNDLE_IDENTIFIER: chat.actual.dev.app.notification
+        INFOPLIST_FILE: Service/Info.plist
+        SKIP_INSTALL: YES
+        LD_RUNPATH_SEARCH_PATHS: [$(inherited), "@executable_path/Frameworks", "@executable_path/../../Frameworks"]

--- a/src/swift/appex-build.sh
+++ b/src/swift/appex-build.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Shared xcodegen + signing plumbing for the Xcode projects under src/swift/.
+# Sourced - never executed - by each project's build.sh, which first sets:
+#
+#   APPEX_PROJECT          <name>.xcodeproj, generated next to the sourcing script
+#   APPEX_CONFIG           Debug | Release
+#   APPEX_SDK              iphoneos | iphonesimulator
+#   APPEX_BUNDLE_ID        overrides PRODUCT_BUNDLE_IDENTIFIER (the app is flavor-conditional)
+#   APPEX_SHORT_VERSION    MARKETING_VERSION
+#   APPEX_BUILD_VERSION    CURRENT_PROJECT_VERSION
+#   APPEX_TEAM             empty = build unsigned, which is all CI and the simulator need
+#   APPEX_IDENTITY         "Apple Development" locally, "Apple Distribution" for TestFlight
+#   APPEX_PROFILE          naming one switches Xcode from automatic to manual signing
+#   APPEX_ENTITLEMENTS     relative to the project dir; only used on the signed path
+#
+# and then calls appex_generate_project once, followed by appex_build_target per target.
+
+# An empty version is a hard error rather than something to paper over with a default: App
+# Store Connect rejects an upload whose extension's CFBundleShortVersionString /
+# CFBundleVersion disagree with the host app (ITMS-90473), and a build.sh can be invoked
+# before NBGV has filled the version properties in.
+if [ -z "$APPEX_SHORT_VERSION" ] || [ -z "$APPEX_BUILD_VERSION" ]; then
+    echo "$APPEX_PROJECT/build.sh: empty version (short='$APPEX_SHORT_VERSION', build='$APPEX_BUILD_VERSION')." >&2
+    echo "The .appex must carry the app's versions - see ITMS-90473." >&2
+    exit 1
+fi
+
+appex_generate_project() {
+    if [ -d "$APPEX_PROJECT.xcodeproj" ] && [ ! project.yml -nt "$APPEX_PROJECT.xcodeproj/project.pbxproj" ]; then
+        return
+    fi
+    if ! command -v xcodegen >/dev/null 2>&1; then
+        echo "$APPEX_PROJECT.xcodeproj is missing or stale and xcodegen isn't installed." >&2
+        echo "Run 'brew install xcodegen', or regenerate it on a Mac that has it." >&2
+        exit 1
+    fi
+    xcodegen generate
+}
+
+# appex_build_target <target> signed|unsigned
+#
+# The .NET iOS SDK re-signs the .appex it embeds, but it never gives it an
+# embedded.mobileprovision - only the app bundle gets one - so a device or TestFlight build
+# needs Xcode to sign the appex here, which takes a team id.
+#
+# CODE_SIGN_IDENTITY is load-bearing: every project.yml pins it to "" for the unsigned
+# default, an empty identity means "skip CodeSign entirely", and a project-level setting
+# outranks automatic signing - so without overriding it on the command line a signed build
+# reports success and silently ships an unsigned appex. CODE_SIGNING_REQUIRED=YES then turns
+# any future silent skip into a hard failure.
+#
+# Automatic signing only ever picks a development identity: combining it with "Apple
+# Distribution" makes Xcode fail with "conflicting provisioning settings". So distribution
+# builds must go manual, which in turn requires naming the profile explicitly - hence
+# APPEX_PROFILE selecting between the two modes rather than a second identity knob.
+appex_build_target() {
+    _target=$1
+    _mode=$2
+
+    if [ "$_mode" != signed ] || [ -z "$APPEX_TEAM" ]; then
+        set -- CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=
+    elif [ -n "$APPEX_PROFILE" ]; then
+        set -- CODE_SIGN_STYLE=Manual "DEVELOPMENT_TEAM=$APPEX_TEAM" \
+            "CODE_SIGN_IDENTITY=$APPEX_IDENTITY" "PROVISIONING_PROFILE_SPECIFIER=$APPEX_PROFILE" \
+            CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES
+    else
+        set -- CODE_SIGN_STYLE=Automatic "DEVELOPMENT_TEAM=$APPEX_TEAM" \
+            "CODE_SIGN_IDENTITY=$APPEX_IDENTITY" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES \
+            -allowProvisioningUpdates
+    fi
+    # Xcode derives an entitlements file from the profile on its own, but CI re-signs the
+    # embedded appex afterwards and must use the same file - so the signed path names it.
+    if [ "$_mode" = signed ] && [ -n "$APPEX_TEAM" ] && [ -n "$APPEX_ENTITLEMENTS" ]; then
+        set -- "$@" "CODE_SIGN_ENTITLEMENTS=$APPEX_ENTITLEMENTS"
+    fi
+
+    xcodebuild -project "$APPEX_PROJECT.xcodeproj" -target "$_target" \
+        -configuration "$APPEX_CONFIG" -sdk "$APPEX_SDK" \
+        SYMROOT=build OBJROOT=build/obj \
+        PRODUCT_BUNDLE_IDENTIFIER="$APPEX_BUNDLE_ID" \
+        MARKETING_VERSION="$APPEX_SHORT_VERSION" \
+        CURRENT_PROJECT_VERSION="$APPEX_BUILD_VERSION" \
+        "$@" \
+        build
+}


### PR DESCRIPTION
Closes #4184.

iOS drew every chat push with the app icon. The server side was already complete — `FirebaseMessagingClient` sets `aps.mutable-content` and puts the icon URL in the data payload — but `mutable-content` only *permits* a service extension to rewrite the notification, and the bundle had none, so nothing ever downloaded the image.

`src/swift/VoxtNotificationService` is that extension. Per push it downloads the icon, builds an `INSendMessageIntent` carrying it as the sender's `INImage`, donates the interaction so Focus can allow-list the sender, and returns `content.updating(from:)` — which is what makes iOS render a *communication notification*: chat avatar in place of the app icon, sender as title, chat as subtitle. Swift rather than .NET because a `UNNotificationServiceExtension` has a hard 24 MB memory limit, well under what the managed runtime needs.

`conversationIdentifier` is pinned to `threadIdentifier`: `updating(from:)` rewrites the thread id from the conversation id, and `AppDelegate.RemoveDeliveredNotifications` matches delivered banners on their thread id when a silent dismissal push arrives — any other value would quietly break dismissal and per-chat grouping.

The commits are meant to be read in order:

| | |
|---|---|
| `349589e` | Extracts the xcodegen + signing plumbing out of `VoxtActivities/build.sh` into the shared `src/swift/appex-build.sh`, so the two Swift appexes can't drift apart. No behavior change. |
| `199e75f` | The extension itself, plus its build/signing/CI wiring. |
| `6d34135` | Group chats showed a blank marble avatar — see below. |

### Group-chat avatars

A group or place chat with no picture falls back to a Marble avatar, and `Chat.GetIconQuery` renders the chat's initial into it only when `renderAvatarTitle: true` — which `NotificationHelper.GetIconUrl` never passed. Peer chats use a Beam avatar and carry no letter, so only group chats were affected. **This one also fixes Android**, whose `MessagingStyle` banner reads the same icon URL, and it needs a deploy rather than a client release.

### Two signing traps worth a reviewer's eye

Both fail silently — green build, broken at runtime — and are documented in the extension's README:

1. The SDK re-signs an `AdditionalAppExtensions` appex with an **empty entitlement set** unless the item carries `CodesignEntitlements` metadata. Without it `updating(from:)` fails on device while everything looks fine.
2. A device build needs the appex's **own** `embedded.mobileprovision`, since its `application-identifier` isn't the app's and the SDK never provisions these. `App.Maui.csproj` defaults team/identity/profile for local Debug device builds so `/ios-run` works unchanged; CI passes its own.

### Portal / CI prerequisites — already done

- App IDs `chat.actual.dev.app.notification` / `chat.actual.app.notification`, both with Communication Notifications.
- Profiles `App Store Notification Dev`, `App Store Notification`, and the development profile `chat.actual.dev.app.notification`.
- Repo secrets `PROVISIONING_PROFILE_NOTIFICATION_{DEV,PROD}_BASE64` are set. The workflow installs them unconditionally on iOS builds, so they must stay.
- The app App IDs and their profiles already carried the entitlement, so nothing there was regenerated.

### Testing

Verified on device (iPhone 15 Pro Max, dev flavor): avatars render on the banner. It **cannot** be tested in the simulator — `xcrun simctl push` never spawns a service extension, and a simulator build is ad-hoc signed with no entitlements.

Note for anyone building this locally: a prior simulator build poisons the shared `artifacts/out`, and the device link then fails with `ld: building for 'iOS', but linking in object file ... built for 'iOS-simulator'`. Wipe it and rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
