### PR TITLE
fix(chat): entry navigation bugs + prefetch for message search results

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundMessageListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundMessageListItem.razor
@@ -15,7 +15,10 @@
         return;
 }
 
-<NavbarItem Class="found-result message" IsSelected="@m.IsSelected" Url="@m.Link" @onclick="@(() => SearchUI.Select(m.Item))">
+@* The entry lid matches m.Link's ?n= - the view opens there, so that's what the prefetch must aim at *@
+<NavbarItem Class="found-result message" IsSelected="@m.IsSelected" Url="@m.Link"
+            data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(chat.Id.Value, m.Entry.LocalId.Format()).ToString())"
+            @onclick="@(() => SearchUI.Select(m.Item))">
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chatState.Chat"/>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
@@ -72,6 +72,7 @@
         DataSource="@this"
         Identity="@Chat.Id.Value"
         IsContentSwapDependency="true"
+        SkipPreRenderGetDataCall="@HasUrlEntryLid"
         DefaultEdge="@VirtualListEdge.End"
         RenderDirection="@VirtualListRenderDirection.Reverse"
         AnimateItemHeight="true"

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -55,6 +55,12 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     private CancellationToken DisposeToken { get; }
     private ILogger Log => field ??= Hub.LogFor(GetType());
 
+    private bool HasUrlEntryLid
+        // NOTE: ?n= means NavigateToUrlFragment is about to set _nextNavigation, and it races the list's
+        // initial GetData - ComponentBase renders before OnParametersSetAsync's task completes
+        => new LocalUrl(History.Uri).IsChat(out var chatId, out long entryLid)
+            && entryLid > 0
+            && chatId == Chat.Id;
     private ILogger? DebugLog => Log.IfEnabled(LogLevel.Debug);
     private bool IsNewMessagesLineDebounceActive
         => _newMessagesLineShownAt != default

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -32,6 +32,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     private CpuTimestamp _newMessagesLineShownAt;
     private long _debouncedReadEntryLid;
     private long _lastKnownEntryLid = -1;
+    private string _lastNavigatedUri = "";
 
     private static readonly string HoverMenuJSCreateMethod = $"{BlazorUIAppModule.ImportName}.ChatHoverMenu.create";
     private readonly Dictionary<ChatEntryId, MessageHoverMenu> _hoverMenus = new();
@@ -243,9 +244,20 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
         var sUri = History.Uri;
         var localUrl = new LocalUrl(sUri);
-        if (!localUrl.IsChat(out _, out long entryId) || entryId <= 0)
+        if (!localUrl.IsChat(out var urlChatId, out long entryId) || entryId <= 0)
             return;
 
+        // NOTE: The outgoing ChatView is still alive and subscribed during a swap, so without this it
+        // scrolls itself to an entry lid belonging to the chat being switched to
+        if (urlChatId != Chat.Id)
+            return;
+
+        // NOTE: OnParametersSetAsync lands here on every ChatContext change, so one ?n= navigation
+        // otherwise repeats (measured 4x) - re-scrolling and re-highlighting each time
+        if (sUri == _lastNavigatedUri)
+            return;
+
+        _lastNavigatedUri = sUri;
         ChatSwitchTracer.Mark("ChatView.NavigateToUrlFragment: entry nav", $"entryLid={entryId}");
         var cts = new CancellationTokenSource();
         var cancellationToken = cts.Token;
@@ -324,7 +336,12 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
-        => _ = NavigateToUrlFragment();
+    {
+        // Clearing the guard here is what keeps it a per-navigation one rather than a permanent
+        // "this URL was handled once" - navigating back to the same ?n= URL has to work again
+        _lastNavigatedUri = "";
+        _ = NavigateToUrlFragment();
+    }
 
     private Task OnNavigateToChatEntry(NavigateToChatEntryEvent @event, CancellationToken cancellationToken)
     {
@@ -718,7 +735,8 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         DebugLog?.LogDebug(
             "GetChatDataQuery: case={Case}, result={DataQuery}, chatIdRange={IdRange}",
             caseName, dataQuery.Format(), chatLidRange.Format());
-        ChatSwitchTracer.Mark($"ChatView.GetChatDataQuery: case={caseName}", dataQuery);
+        ChatSwitchTracer.Mark($"ChatView.GetChatDataQuery: case={caseName}",
+            $"#{Chat.Id} {dataQuery.Format()}");
 
         return dataQuery;
     }

--- a/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
@@ -317,6 +317,10 @@
             }
         }
 
+        // Started here rather than on the route string: the chat the app restores at startup arrives as
+        // an empty route resolved from SelectedChatId, and never goes through History.NavigateTo at all
+        if (chatId is not null)
+            ChatSwitchTracer.TryStart($"/chat/{chatId.Value}", "ChatPage.SetRoute");
         var fixedRoute = chatId is null ? parsedRoute : new RouteResult(chatId);
         _routeState.Value = new RouteState(parsedRoute, fixedRoute);
         ChatSwitchTracer.Mark("ChatPage.SetRoute: route state set", chatId);

--- a/src/dotnet/UI.Blazor.App/Services/ChatPrefetcher.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatPrefetcher.cs
@@ -11,9 +11,14 @@ public sealed class ChatPrefetcher(AppUIHub hub) : IPrefetcher
     private ChatUI ChatUI => hub.ChatUI;
     public Task Prefetch(string[] arguments, CancellationToken cancellationToken)
     {
-        if (arguments.Length != 1 || !ChatId.TryParse(arguments[0], out var chatId))
+        // The optional second argument is the entry lid a /chat/{id}?n={lid} link opens at
+        if (arguments.Length is < 1 or > 2 || !ChatId.TryParse(arguments[0], out var chatId))
             return Task.CompletedTask;
 
-        return ChatUI.Prefetch(chatId, cancellationToken);
+        var entryLid = 0L;
+        if (arguments.Length == 2 && !long.TryParse(arguments[1], out entryLid))
+            return Task.CompletedTask;
+
+        return ChatUI.Prefetch(chatId, entryLid, cancellationToken);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -145,8 +145,13 @@ public partial class ChatUI
         }
     }
 
-    public async Task Prefetch(ChatId chatId, CancellationToken cancellationToken)
+    public Task Prefetch(ChatId chatId, CancellationToken cancellationToken)
+        => Prefetch(chatId, 0, cancellationToken);
+
+    public async Task Prefetch(ChatId chatId, long entryLid, CancellationToken cancellationToken)
     {
+        // entryLid > 0 aims the zone at that entry rather than the read position - what /chat/{id}?n={lid}
+        // does - and needs no lookup at all to do it, since the lid alone decides every tile.
         // NOTE: Has to stay in sync with GetChatItemsInternal and GetChatDataQuery: Fusion dedupes on
         // ComputedInput, so an argument that drifts by one tile boundary warms a different entry and
         // buys nothing - silently, with no failing test to catch it, just a slower switch.
@@ -169,7 +174,7 @@ public partial class ChatUI
             // awaiting GetIdRange + GetOwn is a round trip of its own - and it measured 77-81ms there,
             // which pushed the warm requests past the click they were meant to arrive before.
             var (lidRange, readEntryLid, showConversations) = GetPrefetchAnchor(chatId);
-            if (lidRange is null) {
+            if (lidRange is null && entryLid <= 0) {
                 var chat = await chatTask.ConfigureAwait(false);
                 if (chat == null)
                     return;
@@ -179,8 +184,16 @@ public partial class ChatUI
                 showConversations = chat.IsSummarized ?? false;
                 ChatSwitchTracer.Mark("ChatUI.Prefetch: anchor awaited (ChatInfo miss)", $"lid={readEntryLid}");
             }
+            else if (lidRange is null) {
+                // An entry-anchored prefetch skips the await entirely - a searched-for message is often in
+                // a chat the list never rendered, and the lid is all the tile maths needs. Summarization
+                // is on by default, so assuming it costs at most a few unused conversation tiles.
+                showConversations = true;
+                ChatSwitchTracer.Mark("ChatUI.Prefetch: entry anchor, no ChatInfo", $"entryLid={entryLid}");
+            }
             else
-                ChatSwitchTracer.Mark("ChatUI.Prefetch: anchor from ChatInfo (no await)", $"lid={readEntryLid}");
+                ChatSwitchTracer.Mark("ChatUI.Prefetch: anchor from ChatInfo (no await)",
+                    $"lid={readEntryLid}, entryLid={entryLid}");
 
             // NOTE: Issued only after the peek above - calling it first would register a still-Computing
             // computed that GetExisting then returns, and reading such a computed's Output throws.
@@ -188,25 +201,36 @@ public partial class ChatUI
             var chatInfoTask = Get(chatId, cancellationToken);
             pending.Add(chatInfoTask);
 
-            var range = lidRange.Value;
-            if (range.End <= range.Start)
+            var hasChatRange = lidRange.HasValue;
+            var chatRange = lidRange ?? default;
+            if (hasChatRange && chatRange.End <= chatRange.Start)
                 return;
 
-            // Mirrors GetChatDataQuery: a chat opens at its read position when there is a usable one, and
-            // at the tail otherwise - the two cases centre on different tiles and split the zone differently
+            // Mirrors GetChatDataQuery: the navigation branch when there's an entry to open at - the
+            // explicit one, or the read position - and the tail branch otherwise. They centre on
+            // different tiles and split the zone differently, so the wrong branch warms the wrong set.
             var initialLoadLimit = InitialLoadLimit;
             var firstTileSize = IdTileStack.FirstLayer.TileSize;
-            var hasViewEntry = readEntryLid > 0 && readEntryLid < range.End;
-            var anchorLid = hasViewEntry
-                ? readEntryLid
-                : Math.Max(range.Start, range.End - firstTileSize);
+            var isNavigation = entryLid > 0
+                || (readEntryLid > 0 && (!hasChatRange || readEntryLid < chatRange.End));
+            var anchorLid = entryLid > 0
+                ? entryLid
+                : readEntryLid > 0
+                    ? readEntryLid
+                    : Math.Max(chatRange.Start, chatRange.End - firstTileSize);
             var anchorTile = IdTileStack.LastLayer.GetTile(anchorLid).Range;
-            var startOffset = hasViewEntry ? initialLoadLimit / 3 : initialLoadLimit / 2;
-            var endOffset = hasViewEntry ? initialLoadLimit * 2 / 3 : initialLoadLimit / 2;
-            // Clamped to the chat: the real query never asks past the end, so warming there is pure waste
-            var loadZone = new Range<long>(
-                Math.Max(range.Start, anchorTile.Start - startOffset),
-                Math.Min(range.End, anchorTile.End + endOffset));
+            var startOffset = isNavigation ? initialLoadLimit / 3 : initialLoadLimit / 2;
+            var endOffset = isNavigation ? initialLoadLimit * 2 / 3 : initialLoadLimit / 2;
+            var zoneStart = anchorTile.Start - startOffset;
+            var zoneEnd = anchorTile.End + endOffset;
+            // Clamped to the chat when it's known: the real query never asks past either end, so warming
+            // there is pure waste. An entry-anchored prefetch may not know the range, and doesn't need to.
+            if (hasChatRange) {
+                zoneStart = Math.Max(chatRange.Start, zoneStart);
+                zoneEnd = Math.Min(chatRange.End, zoneEnd);
+            }
+
+            var loadZone = new Range<long>(Math.Max(0, zoneStart), zoneEnd);
             if (loadZone.End <= loadZone.Start)
                 return;
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -13,6 +13,10 @@ namespace ActualChat.UI.Blazor.Components;
 public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, VirtualListData<TItem>>, IVirtualListBackend
     where TItem : class, IVirtualListItem
 {
+    // Long enough that a warm first load always uses it (1.5-8ms measured), short enough that a cold one
+    // (1114ms at app start) falls back to skeletons instead of holding the whole list blank
+    private static readonly TimeSpan InitialDataTimeout = TimeSpan.FromSeconds(0.3);
+
     private VirtualListData<TItem>? _initialData;
 
     private ILogger Log => field ??= Hub.LogFor(GetType());
@@ -108,10 +112,20 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
         var shouldSetInitialData = RendererInfo.IsInteractive && RenderIndex == 0;
         if (shouldSetInitialData) {
             ChatSwitchTracer.Mark("VirtualList: initial GetData -> in (BLOCKS FIRST RENDER)", Identity);
-            _initialData = await DataSource.GetData(VirtualListDataQuery.None,
-                VirtualListData<TItem>.None,
-                CancellationToken.None);
-            ChatSwitchTracer.Mark("VirtualList: initial GetData <- out", Identity);
+            try {
+                _initialData = await DataSource.GetData(VirtualListDataQuery.None,
+                        VirtualListData<TItem>.None,
+                        CancellationToken.None)
+                    .WaitAsync(InitialDataTimeout);
+                ChatSwitchTracer.Mark("VirtualList: initial GetData <- out", Identity);
+            }
+            catch (TimeoutException) {
+                // NOTE: The abandoned call is left running rather than cancelled - it warms exactly what
+                // the follow-up GetData needs, so what it costs from here is the item building, not the
+                // round trips. Rendering skeletons now beats holding the list blank until it lands.
+                _initialData = null;
+                ChatSwitchTracer.Mark("VirtualList: initial GetData TIMED OUT - skeletons", Identity);
+            }
         }
         else
             _initialData = null;

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -47,6 +47,9 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     // Opt-in: most lists sit in no swap area at all. Set it where the enclosing area should hold
     // until this list has its content placed - see ContentSwap and virtual-list.ts.
     [Parameter] public bool IsContentSwapDependency { get; set; }
+    // NOTE: Only its value at the first SetParametersAsync matters - set it when a pending navigation
+    // will issue the first query anyway, so the pre-render one would be superseded before it's rendered
+    [Parameter] public bool SkipPreRenderGetDataCall { get; set; }
     [Parameter] public double ExpandMultiplier { get; set; } = 2;
     // This event is intentionally Action vs EventCallback, coz normally it shouldn't
     // trigger StateHasChanged on parent component.
@@ -109,7 +112,7 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
         // NOTE: Hub (and other injected services) aren't available yet in the first SetParametersAsync,
         // so we can't use Hub.IsPrerendering here. RendererInfo is set before SetParametersAsync and is
         // per-circuit: IsInteractive is false during prerender SSR, true once the list is interactive.
-        var shouldSetInitialData = RendererInfo.IsInteractive && RenderIndex == 0;
+        var shouldSetInitialData = RendererInfo.IsInteractive && RenderIndex == 0 && !SkipPreRenderGetDataCall;
         if (shouldSetInitialData) {
             ChatSwitchTracer.Mark("VirtualList: initial GetData -> in (BLOCKS FIRST RENDER)", Identity);
             try {

--- a/src/dotnet/UI.Blazor/Services/PrefetchUI/prefetch-ui.ts
+++ b/src/dotnet/UI.Blazor/Services/PrefetchUI/prefetch-ui.ts
@@ -17,6 +17,6 @@ export class PrefetchUI {
 
         debugLog?.log(`request:`, prefetchRef);
         this.backendRef.invokeMethodAsync('OnPrefetchRequest', prefetchRef)
-            .catch(e => warnLog?.log(`request: failed`, e));
+            .catch((e: unknown) => warnLog?.log(`request: failed`, e));
     }
 }


### PR DESCRIPTION
Follow-up to #4277. Two navigation bugs found while tracing the search→message path, the prefetch
support that path needs, and two `VirtualList` first-render fixes that came out of the same traces.

## 1. Two `ChatView` navigation bugs

Navigating to `/chat/{id}?n={entryLid}` — what clicking a message search result does — ran
`NavigateToUrlFragment` **four times per navigation**, each time re-scrolling, re-highlighting and
starting another 3 s URL-strip timer. Two independent causes:

**The outgoing `ChatView` cross-applied the incoming chat's entry navigation.**
`NavigateToUrlFragment` discarded the URL's chat id (`out _`), and the outgoing view is still alive
and subscribed to `LocationChanged` during a swap — so it scrolled *itself* to an entry lid belonging
to the chat being switched to, and fetched tiles for it. It now bails when the URL isn't for its own
chat.

**The navigation repeated on every `ChatPage` recompute.** `OnParametersSetAsync` lands in the same
method and re-runs whenever `ChatContext` changes. Guarded by the last handled URI, which
`OnLocationChanged` clears so navigating back to the same `?n=` URL still works.

Both were needed: the URI guard took it 4 → 2, the chat-id guard 2 → 1.

## 2. Entry-lid prefetch

`ChatUI.Prefetch` takes an optional `entryLid`, and `ChatPrefetcher` an optional second argument
carrying it, so `FoundMessageListItem` can prefetch what the click is about to load. It was the one
chat-opening surface still without a prefetch, because the read-position anchor would have warmed the
wrong tiles for it.

The entry path mirrors `GetChatDataQuery`'s navigation branch (anchor tile `GetTile(entryLid)`,
`-limit/3 .. +2*limit/3`) and is the cheaper case: **the lid alone decides every tile, so it needs no
lookup at all before issuing the warms.** A searched-for message is often in a chat the list never
rendered, so `ChatInfo` is frequently absent there — the read-position path would have to await
`GetIdRange` + `GetOwn`, exactly the round trip that pushes warms past the click.

## 3. A bounded wait for the first `VirtualList` render

`SetParametersAsync` awaited the first `GetData` before rendering anything — not even skeletons — so
whatever that call cost was time the list spent blank:

| case | first `GetData` |
|---|---|
| warm | 1.5–8 ms |
| cold chat, cold cache | 200–600 ms |
| chat restored at app start | **1114 ms** |

The await is now capped at **0.3 s**. Under it nothing changes and the no-flash behaviour is kept;
over it the list renders skeletons and fills in when the data lands. The abandoned call is left
running and uncancelled on purpose — it warms exactly what the follow-up `GetData` needs, so what it
still costs is the item building, not the round trips.

## 4. Skipping the pre-render `GetData` when a navigation is pending

Opening `?n=` sets `_nextNavigation` from `ChatView.OnParametersSetAsync`, but `ComponentBase` renders
*before* that task completes — so the child list's pre-render `GetData` races it. Winning the race is
what makes that query anchor on the target entry; losing it anchors on the read position and produces
a result superseded before anyone sees it, having blocked the first render to compute it.

`VirtualList.SkipPreRenderGetDataCall` (read only at the first `SetParametersAsync`, since that's the
only render it can affect) lets `ChatView` opt out whenever the URL still carries `?n=` for its chat.
The first query then comes from the navigation that was always going to issue it.

## 5. A lint fix for #4277

`prefetch-ui.ts`'s `.catch(e => …)` violated `@typescript-eslint/use-unknown-in-catch-callback-variable`,
which runs in `build:Release` (the Docker image build) but not in the loop's `build:Debug` — so dev CI
has been red since #4277 merged. **If this PR won't land promptly, `7f5c62bebf` is worth
cherry-picking to dev on its own.**

## Measured

Search result → message, local server:

| | before | after |
|---|---|---|
| entry navigations per click | 4 | **1** |
| warm requests issued | — | **0.2 ms**, `anchor=4329`, 6 id-tiles |
| real query | — | `{4320,4340}@[-24,+49]`, inside the warmed zone |
| `GetChatItems` | — | **`total=0`** |
| chat-view swap | 333 ms backstop, no `OnDisplayed` | **real `OnDisplayed`** |

Windows app, cold Kvasar cache, 41 switches: the 0.3 s fallback fired 4 times, each rendering
skeletons at the point it would previously have shown nothing, with real items arriving ~275 ms later.

## Not yet verified

- **`SkipPreRenderGetDataCall` has not been exercised on a device** — the Windows run predates it. The
  case to watch is a search→message click; the failure mode to look for is a list that stays on
  skeletons rather than one that is merely slower.
- Median swap time in the last cold Windows run was 169 ms across 35 switches, versus 93 ms in an
  earlier 22-switch run. That is **not** presented as a regression — different chats, cold cache, and
  rapid clicking that leaves the prefetch almost no lead — but neither can these changes be claimed to
  have improved the median. What is solid: the fallback produced skeletons instead of blanks, and
  `entry nav` went 4 → 1.

## Also

`ChatSwitchTracer` now starts from `ChatPage.SetRoute`, and the `GetChatDataQuery` trace carries its
chat id. The chat the app restores at startup arrives as an empty route resolved from `SelectedChatId`
and never calls `History.NavigateTo`, so it previously traced nothing — which is why the startup path
was invisible. The chat id matters because without it the outgoing view's queries look like the
incoming one re-anchoring somewhere unrelated, which is exactly how bug 1 hid and led me to misdiagnose
it at first. Both are `[Conditional]` and compiled out by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jzFJyQ1c8EoUWWdiocQ8E
