### PR TITLE
feat(settings): show every RPC endpoint with status and mean RTT

### DIFF
--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -80,6 +80,7 @@ public static class LocalizedStringsLocalizerExt
         public string YourAccount_ShareYourContact => l["YourAccount_ShareYourContact"].Value;
         public string YourAccount_MyAvatars => l["YourAccount_MyAvatars"].Value;
 
+        public string AppSettings_Connection => l["AppSettings_Connection"].Value;
         public string AppSettings_TelemetryDataCollection => l["AppSettings_TelemetryDataCollection"].Value;
         public string AppSettings_AllowTelemetry => l["AppSettings_AllowTelemetry"].Value;
         public string AppSettings_TelemetryAllowed => l["AppSettings_TelemetryAllowed"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Споделете своя контакт",
   "YourAccount_MyAvatars": "Моите аватари",
 
+  "AppSettings_Connection": "Връзка",
   "AppSettings_TelemetryDataCollection": "Събиране на телеметрични данни",
   "AppSettings_AllowTelemetry": "Разрешете събирането на телеметрични данни",
   "AppSettings_TelemetryAllowed": "Събирането на телеметрични данни е разрешено.",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Podijelite svoj kontakt",
   "YourAccount_MyAvatars": "Moji avatari",
 
+  "AppSettings_Connection": "Veza",
   "AppSettings_TelemetryDataCollection": "Prikupljanje telemetrijskih podataka",
   "AppSettings_AllowTelemetry": "Dozvolite prikupljanje telemetrijskih podataka",
   "AppSettings_TelemetryAllowed": "Prikupljanje telemetrijskih podataka je dozvoljeno.",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Podijelite svoj kontakt",
   "YourAccount_MyAvatars": "Moji avatari",
 
+  "AppSettings_Connection": "Veza",
   "AppSettings_TelemetryDataCollection": "Prikupljanje telemetrijskih podataka",
   "AppSettings_AllowTelemetry": "Dozvolite prikupljanje telemetrijskih podataka",
   "AppSettings_TelemetryAllowed": "Prikupljanje telemetrijskih podataka je dozvoljeno.",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Sdílet svůj kontakt",
   "YourAccount_MyAvatars": "Moje avatary",
 
+  "AppSettings_Connection": "Připojení",
   "AppSettings_TelemetryDataCollection": "Sběr telemetrických dat",
   "AppSettings_AllowTelemetry": "Povolit sběr telemetrických dat",
   "AppSettings_TelemetryAllowed": "Sběr telemetrických dat je povolen.",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Kontakt teilen",
   "YourAccount_MyAvatars": "Meine Avatare",
 
+  "AppSettings_Connection": "Verbindung",
   "AppSettings_TelemetryDataCollection": "Telemetriedatenerfassung",
   "AppSettings_AllowTelemetry": "Telemetriedatenerfassung erlauben",
   "AppSettings_TelemetryAllowed": "Telemetriedatenerfassung ist erlaubt.",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Share your contact",
   "YourAccount_MyAvatars": "My avatars",
 
+  "AppSettings_Connection": "Connection",
   "AppSettings_TelemetryDataCollection": "Telemetry Data Collection",
   "AppSettings_AllowTelemetry": "Allow Telemetry Data Collection",
   "AppSettings_TelemetryAllowed": "Telemetry data collection is allowed.",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Comparte tu contacto",
   "YourAccount_MyAvatars": "Mis avatares",
 
+  "AppSettings_Connection": "Conexión",
   "AppSettings_TelemetryDataCollection": "Recopilación de datos de telemetría",
   "AppSettings_AllowTelemetry": "Permitir recopilación de datos de telemetría",
   "AppSettings_TelemetryAllowed": "La recopilación de datos de telemetría está permitida.",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Partager votre contact",
   "YourAccount_MyAvatars": "Mes avatars",
 
+  "AppSettings_Connection": "Connexion",
   "AppSettings_TelemetryDataCollection": "Collecte de données de télémétrie",
   "AppSettings_AllowTelemetry": "Autoriser la collecte de données de télémétrie",
   "AppSettings_TelemetryAllowed": "La collecte de données de télémétrie est autorisée.",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "अपना संपर्क साझा करें",
   "YourAccount_MyAvatars": "मेरे अवतार",
 
+  "AppSettings_Connection": "कनेक्शन",
   "AppSettings_TelemetryDataCollection": "टेलीमेट्री डेटा संग्रह",
   "AppSettings_AllowTelemetry": "टेलीमेट्री डेटा संग्रह की अनुमति दें",
   "AppSettings_TelemetryAllowed": "टेलीमेट्री डेटा संग्रह की अनुमति है।",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Podijelite svoj kontakt",
   "YourAccount_MyAvatars": "Moji avatari",
 
+  "AppSettings_Connection": "Veza",
   "AppSettings_TelemetryDataCollection": "Prikupljanje telemetrijskih podataka",
   "AppSettings_AllowTelemetry": "Dozvolite prikupljanje telemetrijskih podataka",
   "AppSettings_TelemetryAllowed": "Prikupljanje telemetrijskih podataka je dozvoljeno.",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Bagikan kontak Anda",
   "YourAccount_MyAvatars": "Avatar saya",
 
+  "AppSettings_Connection": "Koneksi",
   "AppSettings_TelemetryDataCollection": "Pengumpulan data telemetri",
   "AppSettings_AllowTelemetry": "Izinkan pengumpulan data telemetri",
   "AppSettings_TelemetryAllowed": "Pengumpulan data telemetri diizinkan.",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Condividi il tuo contatto",
   "YourAccount_MyAvatars": "I miei avatar",
 
+  "AppSettings_Connection": "Connessione",
   "AppSettings_TelemetryDataCollection": "Raccolta dati di telemetria",
   "AppSettings_AllowTelemetry": "Consenti raccolta dati di telemetria",
   "AppSettings_TelemetryAllowed": "La raccolta dati di telemetria è consentita.",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "連絡先を共有",
   "YourAccount_MyAvatars": "マイアバター",
 
+  "AppSettings_Connection": "接続",
   "AppSettings_TelemetryDataCollection": "テレメトリデータの収集",
   "AppSettings_AllowTelemetry": "テレメトリデータの収集を許可",
   "AppSettings_TelemetryAllowed": "テレメトリデータの収集が許可されています。",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "연락처 공유",
   "YourAccount_MyAvatars": "내 아바타",
 
+  "AppSettings_Connection": "연결",
   "AppSettings_TelemetryDataCollection": "원격 측정 데이터 수집",
   "AppSettings_AllowTelemetry": "원격 측정 데이터 수집 허용",
   "AppSettings_TelemetryAllowed": "원격 측정 데이터 수집이 허용되어 있습니다.",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Compartilhar seu contato",
   "YourAccount_MyAvatars": "Ảnh đại diện của tôi",
 
+  "AppSettings_Connection": "Соединение",
   "AppSettings_TelemetryDataCollection": "Прикупљање телеметријских података",
   "AppSettings_AllowTelemetry": "Дозволите прикупљање телеметријских података",
   "AppSettings_TelemetryAllowed": "Прикупљање телеметријских података је дозвољено.",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Udostępnij swój kontakt",
   "YourAccount_MyAvatars": "Moje awatary",
 
+  "AppSettings_Connection": "Połączenie",
   "AppSettings_TelemetryDataCollection": "Zbieranie danych telemetrycznych",
   "AppSettings_AllowTelemetry": "Zezwól na zbieranie danych telemetrycznych",
   "AppSettings_TelemetryAllowed": "Zbieranie danych telemetrycznych jest dozwolone.",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Compartilhar seu contato",
   "YourAccount_MyAvatars": "Meus avatares",
 
+  "AppSettings_Connection": "Conexão",
   "AppSettings_TelemetryDataCollection": "Coleta de dados de telemetria",
   "AppSettings_AllowTelemetry": "Permitir coleta de dados de telemetria",
   "AppSettings_TelemetryAllowed": "A coleta de dados de telemetria está permitida.",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Поделиться контактом",
   "YourAccount_MyAvatars": "Мои аватары",
 
+  "AppSettings_Connection": "Соединение",
   "AppSettings_TelemetryDataCollection": "Сбор данных телеметрии",
   "AppSettings_AllowTelemetry": "Разрешить сбор данных телеметрии",
   "AppSettings_TelemetryAllowed": "Сбор данных телеметрии разрешён.",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Поделите свој контакт",
   "YourAccount_MyAvatars": "Моји аватари",
 
+  "AppSettings_Connection": "Веза",
   "AppSettings_TelemetryDataCollection": "Прикупљање телеметријских података",
   "AppSettings_AllowTelemetry": "Дозволите прикупљање телеметријских података",
   "AppSettings_TelemetryAllowed": "Прикупљање телеметријских података је дозвољено.",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Kişi bilginizi paylaşın",
   "YourAccount_MyAvatars": "Avatarlarım",
 
+  "AppSettings_Connection": "Bağlantı",
   "AppSettings_TelemetryDataCollection": "Telemetri Veri Toplama",
   "AppSettings_AllowTelemetry": "Telemetri veri toplamaya izin ver",
   "AppSettings_TelemetryAllowed": "Telemetri veri toplamaya izin verildi.",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Поділитися контактом",
   "YourAccount_MyAvatars": "Мої аватари",
 
+  "AppSettings_Connection": "З'єднання",
   "AppSettings_TelemetryDataCollection": "Збір даних телеметрії",
   "AppSettings_AllowTelemetry": "Дозволити збір даних телеметрії",
   "AppSettings_TelemetryAllowed": "Збір даних телеметрії дозволено.",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "Chia sẻ liên hệ của bạn",
   "YourAccount_MyAvatars": "Ảnh đại diện của tôi",
 
+  "AppSettings_Connection": "Kết nối",
   "AppSettings_TelemetryDataCollection": "Thu thập dữ liệu đo lường",
   "AppSettings_AllowTelemetry": "Cho phép thu thập dữ liệu đo lường",
   "AppSettings_TelemetryAllowed": "Đã cho phép thu thập dữ liệu đo lường.",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -65,6 +65,7 @@
   "YourAccount_ShareYourContact": "分享你的联系方式",
   "YourAccount_MyAvatars": "我的头像",
 
+  "AppSettings_Connection": "连接",
   "AppSettings_TelemetryDataCollection": "遥测数据收集",
   "AppSettings_AllowTelemetry": "允许遥测数据收集",
   "AppSettings_TelemetryAllowed": "已允许遥测数据收集。",

--- a/src/dotnet/UI.Blazor.App/Components/Settings/AppSettings.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/AppSettings.razor
@@ -13,6 +13,7 @@
 @if (HostInfo.HostKind != HostKind.MauiApp) {
     <RenderModeSelector/>
 }
+<RpcEndpoints/>
 <TileTopic Topic="@L.AppSettings_TelemetryDataCollection"/>
 <Tile Class="data-collection-consent">
     <TileItem Click="@OnEnableTelemetryClick">

--- a/src/dotnet/UI.Blazor.App/Components/Settings/DeveloperTools.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/DeveloperTools.razor
@@ -1,4 +1,3 @@
-@using ActualChat.Rpc
 @using ActualChat.UI.App.Services
 @inherits ComputedStateComponent<AppUIHub, DeveloperTools.Model>
 @{
@@ -16,12 +15,6 @@
         <TileTopic Topic="@L.DevTools_Host"/>
         <Tile Class="host-switcher-tile">
             <ServerInstanceSelector Selector="@ServerInstanceSelector" />
-            @if (m.RpcEndpoint.Length != 0) {
-                <TileItem>
-                    <Content>RPC endpoint</Content>
-                    <Caption>@m.RpcEndpoint</Caption>
-                </TileItem>
-            }
         </Tile>
     }
 
@@ -115,8 +108,7 @@
             account.IsAdmin,
             appSettings.IsLogViewerEnabledOrDefault,
             isVideoDiagnosticsEnabled,
-            isAudioDiagnosticsEnabled,
-            RpcEndpointSelector.Instance?.Current ?? "");
+            isAudioDiagnosticsEnabled);
     }
 
     private Task OnExperimentalFeatureEnabledClick()
@@ -157,9 +149,8 @@
         bool IsAdmin,
         bool IsLogUIEnabled,
         bool IsVideoDiagnosticsEnabled,
-        bool IsAudioDiagnosticsEnabled,
-        string RpcEndpoint)
+        bool IsAudioDiagnosticsEnabled)
     {
-        public static readonly Model None = new(false, false, false, false, false, false, "");
+        public static readonly Model None = new(false, false, false, false, false, false);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/Settings/RpcEndpoints.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/RpcEndpoints.razor
@@ -1,0 +1,75 @@
+@inherits ComputedStateComponent<AppUIHub, ImmutableArray<RpcEndpointMonitor.EndpointInfo>>
+@{
+    var endpoints = State.Value;
+}
+
+@if (endpoints.Length != 0) {
+    <TileTopic Topic="@L.AppSettings_Connection"/>
+    <Tile Class="rpc-endpoints">
+        @foreach (var endpoint in endpoints) {
+            <TileItem>
+                <Icon>
+                    <div class="c-status @GetStatusClass(endpoint)"></div>
+                </Icon>
+                <Content>@endpoint.Host</Content>
+                <Caption>@GetRoundTripText(endpoint)</Caption>
+                <Right>
+                    <i class="@(endpoint.IsSelected ? "icon-checkmark-simple" : "icon-checkmark-simple invisible")"></i>
+                </Right>
+            </TileItem>
+        }
+    </Tile>
+}
+
+@code {
+    private static readonly TimeSpan RefreshPeriod = TimeSpan.FromSeconds(5);
+
+    private CancellationTokenSource? _measureCts;
+    private RpcEndpointMonitor Monitor => field ??= Services.GetRequiredService<RpcEndpointMonitor>();
+    private ILogger Log => field ??= Services.LogFor(GetType());
+
+    protected override void OnInitialized() {
+        base.OnInitialized();
+        // Measuring costs traffic on every client, so it runs only while this panel is open.
+        _measureCts = new CancellationTokenSource();
+        _ = MeasureLoop(_measureCts.Token);
+    }
+
+    public override async ValueTask DisposeAsync() {
+        _measureCts.CancelAndDisposeSilently();
+        _measureCts = null;
+        await base.DisposeAsync().ConfigureAwait(true);
+    }
+
+    protected override ComputedState<ImmutableArray<RpcEndpointMonitor.EndpointInfo>>.Options GetStateOptions()
+        => new() { InitialValue = Monitor.Endpoints.Value };
+
+    protected override async Task<ImmutableArray<RpcEndpointMonitor.EndpointInfo>> ComputeState(
+        CancellationToken cancellationToken)
+        => await Monitor.Endpoints.Use(cancellationToken).ConfigureAwait(false);
+
+    private async Task MeasureLoop(CancellationToken cancellationToken) {
+        while (!cancellationToken.IsCancellationRequested) {
+            try {
+                await Monitor.MeasureEndpoints(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (!cancellationToken.IsCancellationRequested) {
+                Log.LogWarning(e, "Failed to measure RPC endpoints");
+            }
+            await Clocks.CpuClock.Delay(RefreshPeriod, cancellationToken).SilentAwait(false);
+        }
+    }
+
+    private static string GetStatusClass(RpcEndpointMonitor.EndpointInfo endpoint)
+        => endpoint.IsReachable switch {
+            true => "on",
+            false => "off",
+            _ => "",
+        };
+
+    private static string GetRoundTripText(RpcEndpointMonitor.EndpointInfo endpoint)
+        // Values, not prose: the dot carries reachability, so no language has to be picked here.
+        => endpoint.MeanRoundTrip is { } roundTrip
+            ? $"{roundTrip.TotalMilliseconds:F0} ms"
+            : endpoint.IsReachable is null ? "…" : "—";
+}

--- a/src/dotnet/UI.Blazor.App/Components/Settings/settings-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/settings-modal.css
@@ -104,6 +104,23 @@ body.narrow .close-settings-btn {
     @apply text-02;
 }
 
+/* ── Connection endpoints ── */
+
+/* An unmeasured endpoint takes the icon slot's own text color: --background-03 is
+   the tile background in the dark theme, so a dot painted with it is invisible. */
+.rpc-endpoints .c-status {
+    @apply self-center;
+    @apply w-2 h-2;
+    @apply rounded-full;
+    background-color: currentColor;
+}
+.rpc-endpoints .c-status.on {
+    @apply bg-success;
+}
+.rpc-endpoints .c-status.off {
+    @apply bg-danger;
+}
+
 /* ── Host Switcher ── */
 
 .host-switcher-tile .form-block.with-input-radio .tile-item {

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/RpcEndpointMonitor.cs
@@ -51,8 +51,12 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     private static readonly string JSSetRpcBaseUriMethod
         = $"{BlazorUICoreModule.ImportName}.BrowserInit.setRpcBaseUri";
     private static readonly TimeSpan PushToJSTimeout = TimeSpan.FromSeconds(2);
+    // Enough to smooth a single unlucky sample without making the reading lag a real change.
+    private const int MeanRoundTripSampleCount = 3;
+    private readonly Dictionary<string, EndpointMeasurement> _measurements = new(StringComparer.OrdinalIgnoreCase);
     private int _selectedVersion = -1;
     private int _verifiedVersion = -1;
+    private int _measuredVersion = -1;
     private string _pushedEndpoint = "";
     private RpcEndpointReport? _pendingReport;
     private Moment _selectedAt;
@@ -65,6 +69,36 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
     private ServerTimeSync? TimeSync => field ??= Services.GetService<ServerTimeSync>();
     private RpcClientPeer? Peer => Hub.RpcHub.GetClientPeer(RpcRef.Default);
     private bool IsBackgroundIdle => ActivityState.State.Value == AppActivityState.BackgroundIdle;
+    private MutableState<ImmutableArray<EndpointInfo>> MutableEndpoints
+        => field ??= StateFactory.NewMutable(GetEndpoints());
+    public IState<ImmutableArray<EndpointInfo>> Endpoints => MutableEndpoints;
+
+    public async Task MeasureEndpoints(CancellationToken cancellationToken)
+    {
+        // The unsized probe is 2 bytes, so this times distance rather than throughput - the
+        // reading stays meaningful on a link too slow to carry the app.
+        if (RpcEndpointSelector.Instance is not { } selector)
+            return;
+
+        var candidates = selector.Candidates;
+        var roundTripTasks = candidates
+            .Select(x => ServerProbe.MeasureRoundTrip(x, RoundTripTimeout, cancellationToken))
+            .ToArray();
+        var roundTrips = await Task.WhenAll(roundTripTasks).ConfigureAwait(false);
+        var current = selector.Current;
+        ImmutableArray<EndpointInfo> endpoints;
+        lock (_measurements) {
+            DropStaleMeasurements(selector);
+            for (var i = 0; i < candidates.Count; i++) {
+                var measurement = GetMeasurement(candidates[i]);
+                measurement.IsReachable = roundTrips[i] is not null;
+                if (roundTrips[i] is { } roundTrip)
+                    measurement.RoundTrip.AppendSample(roundTrip.TotalMilliseconds);
+            }
+            endpoints = [..candidates.Select(x => ToEndpointInfo(x, current))];
+        }
+        MutableEndpoints.Value = endpoints;
+    }
 
     // Protected/internal methods
 
@@ -390,10 +424,71 @@ public sealed class RpcEndpointMonitor(UIHub hub) : UIWorkerBase<UIHub>(hub)
         ReconnectUI.ResetReconnectDelays();
     }
 
+    private ImmutableArray<EndpointInfo> GetEndpoints()
+    {
+        if (RpcEndpointSelector.Instance is not { } selector)
+            return [];
+
+        var current = selector.Current;
+        lock (_measurements) {
+            DropStaleMeasurements(selector);
+            return [..selector.Candidates.Select(x => ToEndpointInfo(x, current))];
+        }
+    }
+
+    private void DropStaleMeasurements(RpcEndpointSelector selector)
+    {
+        // A new network makes every earlier reading meaningless: the same host is a
+        // different distance away once the route out changes.
+        var version = selector.Version;
+        if (version == _measuredVersion)
+            return;
+
+        _measuredVersion = version;
+        _measurements.Clear();
+    }
+
+    private EndpointMeasurement GetMeasurement(string host)
+    {
+        if (!_measurements.TryGetValue(host, out var measurement))
+            _measurements[host] = measurement = new EndpointMeasurement();
+
+        return measurement;
+    }
+
+    private EndpointInfo ToEndpointInfo(string host, string current)
+    {
+        var measurement = _measurements.GetValueOrDefault(host);
+        var meanRoundTrip = measurement is { RoundTrip.SampleCount: > 0 }
+            ? TimeSpan.FromMilliseconds(measurement.RoundTrip.Value)
+            : (TimeSpan?)null;
+        return new EndpointInfo(host,
+            string.Equals(host, current, StringComparison.OrdinalIgnoreCase),
+            measurement?.IsReachable,
+            meanRoundTrip);
+    }
+
     private static double ToMilliseconds(TimeSpan? elapsed)
         => elapsed?.TotalMilliseconds ?? -1;
 
     // Nested types
+
+    /// <summary>
+    /// One RPC endpoint as a support readout: is it the one in use, does it
+    /// answer, and how far away it is.
+    /// </summary>
+    public sealed record EndpointInfo(
+        string Host,
+        bool IsSelected,
+        // Null rather than false until measured, so "not asked yet" doesn't read as "down".
+        bool? IsReachable,
+        TimeSpan? MeanRoundTrip);
+
+    private sealed class EndpointMeasurement
+    {
+        public RunningEma RoundTrip { get; } = new(0, MeanRoundTripSampleCount);
+        public bool? IsReachable { get; set; }
+    }
 
     private sealed record Selection(string Endpoint, TimeSpan? OriginElapsed, TimeSpan? EndpointElapsed);
 


### PR DESCRIPTION
## Why

When a user complains that the app is slow, support needs to know which RPC endpoint they are actually on. Until now that was a caption inside the **admin-only** Developer tools tile — invisible to exactly the people who hit a bad path.

**Settings → Application** now lists every candidate endpoint for every user:

```
Соединение
● dev.voxt.ai              180 ms
● kz1.edge.dev.voxt.ai     350 ms   ✓
```

Green dot = answered the last probe, red = didn't, grey = not measured yet. The checkmark marks the endpoint in use — the one to ask a user to read out. Verified on an Android device on RU cellular, where the client had failed over to the edge (screenshot values above are real).

## How

- **Distance, not throughput.** Measured with the *unsized* `/rpc/check` reply (2 bytes), reusing `RpcServerProbe.MeasureRoundTrip` — the same call `RpcEndpointMonitor.ShortlistRelays` already makes. The reading stays meaningful on a link too slow to carry the app.
- **No new service.** Per `CODING_STYLE.md` rule 14, the measurements live on `RpcEndpointMonitor`, which already owns which endpoints exist, which is selected, and how they measure. Mean is a `RunningEma` over 3 samples, kept per host so values survive reopening the panel.
- **Readings are dropped when `RpcEndpointSelector.Version` changes** — a new network makes the same host a different distance away, so an old number would lie.
- **Probing stops when the panel closes.** It costs traffic on every client now, so the 5 s loop is owned by the component and cancelled in `DisposeAsync`.
- **Results are published through a `MutableState`**, not a self-invalidating compute. `ComputedStateComponent.ShouldRender()` returns `false` for an inconsistent computed unless `RenderInconsistentState` is set, so a state that invalidates itself inside its own computation measures correctly and never renders what it measured — that bug is fixed here, found on device.
- **One new localization key** (`AppSettings_Connection`), all 19 hand-written catalogs plus regenerated BCMS/Max. Hostnames and `180 ms` are data and the dot carries reachability, so nothing else needs a language — the reasoning `i18n.md` applies to diagnostics readouts.

## Scope

The section renders where `RpcEndpointSelector.Instance` exists, which is **MAUI**. The web has one candidate and no failover, so there is nothing to choose between.

## Two bugs worth knowing about

- **`icon-checkmark` is unusable.** Its SVG is a filled disc with a *stroke-drawn* tick, and the icon-font generator drops stroke geometry (documented in `docs/ui/components.md`), so the glyph renders as a solid blob. Everything else in the codebase uses `icon-checkmark-simple`; this now does too.
- **`bg-03` is invisible on a tile in the dark theme** — `--background-03` and `--tile` both resolve to `--ash-22`. The status dot uses `currentColor` instead.

## Verified

`dotnet build` clean · `AppLocalizationTest` 16/16 · `UI.Blazor.UnitTests` 55/55 · `Core.UnitTests` RPC filter 21/21 · `derive-bcms --check` / `derive-max --check` in sync · CSS compiles · installed and confirmed on an Android device.

Note: `npm run build:Verify` is already red on `dev` (`prefetch-ui.ts:20`, `use-unknown-in-catch-callback-variable`), unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhHJcVHwxZEy7QminjJs8h