### PR TITLE
fix(maui): only MainActivity decides whether the app is backgrounded

### DIFF
--- a/src/dotnet/App.Maui/MauiProgram.Android.cs
+++ b/src/dotnet/App.Maui/MauiProgram.Android.cs
@@ -56,14 +56,21 @@ public static partial class MauiProgram
             android.OnCreate(OnCreate);
             android.OnPostCreate(OnPostCreate);
             android.OnResume(_ => MauiWebView.LogResume());
-            android.OnStart(_ => {
+            // These fire for every activity in the process, and only MainActivity hosts the WebView.
+            android.OnStart(activity => {
+                if (activity is not MainActivity)
+                    return;
+
                 Android.Util.Log.Info(MauiDiagnostics.LogTag, "OnBecameForeground");
                 MauiStartupBreadcrumbs.Add("Became foreground");
                 SetBackgroundState(false);
                 if (MainPage.Current is { Content: null } mainPage)
                     BeginDispatchToMainThread(() => mainPage.RecreateWebView());
             });
-            android.OnStop(_ => {
+            android.OnStop(activity => {
+                if (activity is not MainActivity)
+                    return;
+
                 Android.Util.Log.Info(MauiDiagnostics.LogTag, "OnBecameBackground");
                 MauiStartupBreadcrumbs.Add("Became background");
                 SetBackgroundState(true);

--- a/src/dotnet/App.Maui/MauiProgram.Android.cs
+++ b/src/dotnet/App.Maui/MauiProgram.Android.cs
@@ -56,9 +56,10 @@ public static partial class MauiProgram
             android.OnCreate(OnCreate);
             android.OnPostCreate(OnPostCreate);
             android.OnResume(_ => MauiWebView.LogResume());
-            // These fire for every activity in the process, and only MainActivity hosts the WebView.
+            // These fire for every activity in the process, and only the live MainActivity hosts
+            // the WebView.
             android.OnStart(activity => {
-                if (activity is not MainActivity)
+                if (!MainActivity.IsCurrent(activity))
                     return;
 
                 Android.Util.Log.Info(MauiDiagnostics.LogTag, "OnBecameForeground");
@@ -68,7 +69,7 @@ public static partial class MauiProgram
                     BeginDispatchToMainThread(() => mainPage.RecreateWebView());
             });
             android.OnStop(activity => {
-                if (activity is not MainActivity)
+                if (!MainActivity.IsCurrent(activity))
                     return;
 
                 Android.Util.Log.Info(MauiDiagnostics.LogTag, "OnBecameBackground");

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -55,6 +55,10 @@ public partial class MainActivity : MauiAppCompatActivity
 
     public static MainActivity Current => _current
         ?? throw StandardError.Internal($"{nameof(MainActivity)} isn't created yet.");
+    // A recreated MainActivity can start before the one it replaces stops, so lifecycle callbacks
+    // have to tell the live instance from the outgoing one rather than just matching the type.
+    internal static bool IsCurrent(Android.App.Activity activity)
+        => ReferenceEquals(activity, _current);
     // Whether an activity has run in THIS process, which is what decides if the foreground service
     // could ever have earned the microphone: Android grants it only to a service started while the
     // app is visible, and the grant then outlives the activity. Unlike Current, this never reverts.

--- a/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
+++ b/src/dotnet/UI.Blazor/BaseTypes/RenderGate.cs
@@ -8,10 +8,17 @@ public sealed class RenderGate : WorkerBase
     // Elsewhere the render batch transport is in-process, so nothing can be lost and postponing
     // would only add latency.
     public const bool IsEnabledOnMauiApp = true;
+    private static readonly TimeSpan WatchdogPeriod = TimeSpan.FromSeconds(2);
+    // Long enough that a resume racing a render never trips it, short enough that a lost one
+    // doesn't read as a frozen app.
+    private static readonly TimeSpan MaxForegroundPostponeDuration = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan StuckReportPeriod = TimeSpan.FromMinutes(1);
 
     private readonly BackgroundStateTracker? _backgroundStateTracker;
     private readonly HashSet<ComponentBase> _postponed = new();
     private readonly Lock _lock = new();
+    private CpuTimestamp _postponedAt;
+    private CpuTimestamp _reportedStuckAt;
 
     private ILogger Log { get; }
     public bool IsEnabled => _backgroundStateTracker != null;
@@ -37,14 +44,32 @@ public sealed class RenderGate : WorkerBase
         if (computed.HasError || !computed.Value)
             return false;
 
-        lock (_lock)
+        lock (_lock) {
+            if (_postponed.Count == 0)
+                _postponedAt = CpuTimestamp.Now;
             _postponed.Add(renderer);
+        }
+
         return true;
     }
 
     // Protected methods
 
-    protected override async Task OnRun(CancellationToken cancellationToken)
+    protected override Task OnRun(CancellationToken cancellationToken)
+    {
+        var baseChains = new[] {
+            AsyncChain.From(ResumeWhenForeground),
+            AsyncChain.From(WatchPostponed),
+        };
+        var retryDelays = RetryDelaySeq.Exp(0.1, 1);
+        return baseChains
+            .Select(chain => chain.Log(LogLevel.Debug, Log).RetryForever(retryDelays, Log))
+            .RunIsolated(cancellationToken);
+    }
+
+    // Private methods
+
+    private async Task ResumeWhenForeground(CancellationToken cancellationToken)
     {
         var isBackgroundState = _backgroundStateTracker!.IsBackground;
         var cIsBackground = await Computed
@@ -62,7 +87,45 @@ public sealed class RenderGate : WorkerBase
         }
     }
 
-    // Private methods
+    private async Task WatchPostponed(CancellationToken cancellationToken)
+    {
+        // The gate has exactly one way out - a background -> foreground transition - so a resume
+        // that never arrives leaves the UI frozen with nothing to say so. Resuming is only safe
+        // while the app reports itself foreground; a genuinely backgrounded WebView still must not
+        // be handed batches it would drop, so a stuck background flag is reported rather than
+        // overridden.
+        var isBackgroundState = _backgroundStateTracker!.IsBackground;
+        while (true) {
+            await Task.Delay(WatchdogPeriod, cancellationToken).ConfigureAwait(false);
+            var computed = isBackgroundState.Computed;
+            var isBackground = !computed.HasError && computed.Value;
+            int count;
+            TimeSpan duration;
+            lock (_lock) {
+                count = _postponed.Count;
+                duration = count == 0 ? TimeSpan.Zero : _postponedAt.Elapsed;
+            }
+
+            if (count == 0)
+                continue;
+
+            if (!isBackground) {
+                if (duration >= MaxForegroundPostponeDuration) {
+                    Log.LogWarning("{Count} render(s) postponed for {Duration} while foreground - resuming",
+                        count, duration.ToShortString());
+                    Resume();
+                }
+                continue;
+            }
+
+            if (duration < StuckReportPeriod || _reportedStuckAt.Elapsed < StuckReportPeriod)
+                continue;
+
+            _reportedStuckAt = CpuTimestamp.Now;
+            Log.LogWarning("{Count} render(s) postponed for {Duration} - the app still reports it is backgrounded",
+                count, duration.ToShortString());
+        }
+    }
 
     private void Resume()
     {


### PR DESCRIPTION
## Symptom

Sign in with Google on Android, and the app stays on the sign-in page — while being fully signed in. A second attempt "works", because the state was already good.

Measured on a device:

```
17:47:53.004  MainActivity:     OnResume            ← visible
17:47:53.009  FragmentActivity: OnStop
17:47:53.010  OnBecameBackground                    ← wrong
17:47:54.048  Account is changed to … Status = Active
17:47:54.454  NotificationUI: Register command has been executed   ← authenticated session
      … 302 seconds …
17:52:56.248  AutoNavigationUI  * NavigateTo(/chat, SignIn)
17:52:57.828  RenderGate: Resuming 92 postponed render(s)
```

## Cause

`android.OnStart`/`OnStop` fire for **every activity in the process**, and `SetBackgroundState` was wired to them as if only ours existed — the `Activity` argument was discarded (`_ =>`). Android guarantees the two activities overlap, so on the return leg the departing activity's `OnStop` is the last event.

It's worse than a missed event: the GMS sign-in activity is translucent (`ExcludeFromRecents`, and `MainActivity` never got `OnStop`), so **there was no background transition to record** — and no later `OnStart` to correct it with. The flag stayed wrong until the user manually backgrounded and reopened the app.

Harmless until `411bdcf8f5` attached `RenderGate` to that flag. Now a wrong value freezes every component. `SignInModal` closes itself only by rendering (`if (!State.Value.IsGuestOrNull()) Modal.Close(true)`), and `PostponeOnSignedInWorkflow` waits on that close — so nothing navigates.

## Blast radius beyond sign-in

The same flag feeds `ActivitiesUI.ComputeState`, so a visible app reports `AppActivityState.BackgroundIdle`:

- **`RpcEndpointMonitor`** blocks on `When(x => x != BackgroundIdle)` before selecting an endpoint, and won't demote a dead one — endpoint failover silently stops.
- **`VideoQualityUI`** pauses inbound video and forces a decoder restart on "resume".
- **`RpcSwitchingClient.IsBackgroundGetter`**, **`PttReplyUI`** hot windows, **`GestureUI`**, **`AppIconBadgeUpdater`**, **`AudioInitializer`**.

Triggered by anything that starts an activity: Google/Apple sign-in, the photo picker, camera, share sheet. Android only — iOS uses app-level `AppDelegate` callbacks, Windows uses `OnVisibilityChanged`.

## Fix

**`MainActivity` gates the state**, rather than a count of started activities. It hosts the WebView, which is what `RenderGate` protects; counting would call an opaque picker "foreground" while our WebView is stopped — the exact desync the gate exists to prevent. `OnStart`/`OnStop` rather than `OnResume`/`OnPause`, because a translucent activity pauses us without hiding us (`MainActivity` *did* get `OnPause` in the trace above). The same check now also gates the `RecreateWebView()` call a foreign activity could previously trigger.

**`RenderGate` gains a watchdog** for the other half: the gate has exactly one way out — a background → foreground transition — so a resume that never arrives leaves the UI frozen with nothing to say so.

It resumes **only while the app reports itself foreground** (postponed ≥ 2 s), which covers a *lost* resume — a stalled `Changes` stream, a dead worker, a missed transition — without ever handing batches to a WebView that really is stopped. A stuck background flag is **reported once a minute instead of overridden**: forcing renders through on a genuinely backgrounded WebView recreates the permanent renderer desync the gate prevents. I looked at cross-checking `BrowserInfo.IsVisible`, but can't establish that Android's WebView reports `visibilityState: hidden` when the activity stops, so that check could green-light renders during a real background.

## Verified on device

Same flow, build `2.17.213-alpha-g0edc33d973`:

```
19:26:43.252  SignInHubActivity: OnCreate, Intent: 'com.google.android.gms.auth.GOOGLE_SIGN_IN'
19:26:45.995  MainActivity:      OnResume
19:26:47.307  Account is changed to … Active
19:26:47.324  * NavigateTo(/chat, SignIn)          ← 17 ms
```

No `OnBecameBackground` during sign-in, zero postponed renders, both watchdog chains running, no watchdog warnings across normal foreground/background cycles.

**Not covered:** the watchdog's corrective path is untested — with the first fix in place, nothing produces the state that triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhHJcVHwxZEy7QminjJs8h