### PR TITLE
perf(android): keep the main looper free during startup

### DIFF
--- a/docs/android-specific.md
+++ b/docs/android-specific.md
@@ -13,6 +13,217 @@ that makes up the app packages.
 partial-R2R configuration and the measured numbers live. This page covers CPU profiling:
 where time goes at startup, and how to read the traces without being misled.
 
+## Startup: what runs where
+
+Startup is shaped by one constraint: an ANR is caused by the length of a **single
+uninterrupted main-thread block**, not by total work. So the goal is to keep the main
+looper free to dispatch, even when the same work still happens. Everything below follows
+from that.
+
+### Two kinds of start
+
+[`MauiStart`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/MauiStartKind.cs)
+reads `RunningAppProcessInfo.Importance` through
+[`AndroidUtils.GetProcessInfo`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs)
+and splits the process into two:
+
+| Kind | How it starts | Importance |
+|------|---------------|------------|
+| Interactive | User taps the launcher or a notification | `Foreground` — AMS marks the process top-bound at bind time, before any Activity exists |
+| Headless | An FCM broadcast or a PTT wake starts the process for a *service* | receiver / cached |
+
+::: tip
+Detection is fail-safe: an unknown importance takes the full interactive path, so a broken
+check costs startup time rather than correctness.
+:::
+
+### Interactive cold start
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as Main thread (looper)
+    participant Pool as Thread pool
+
+    Note over Main: Application.onCreate
+    Main->>Main: MauiDiagnostics, exception handlers,<br/>runtime settings, ClientStartup.Initialize
+    Main->>Main: MauiApp.CreateBuilder + ConfigureMauiApp + Build
+    Main->>Main: BlazorWebViewApp.Initialize<br/>stores a factory, does not build
+    Note over Main,Pool: StartInteractiveServices — everything below is offloaded
+    Main-)Pool: WarmupStaticServices<br/>serializers, markup parser
+    Main-)Pool: EnsureStarted<br/>builds the Blazor DI container
+    Main-)Pool: WarmUpWebView<br/>loads the Chromium provider
+    Main-)Pool: BlazorViewAppPostBuildRoutine
+    Note over Main: CreateMauiApp returns — 35 ms
+
+    Note over Main: MainActivity.OnCreate
+    Main->>Main: MarkInteractive, PromoteToInteractive<br/>already done, no-op
+    Main->>Main: base.OnCreate — 31 ms<br/>builds Window, MainPage, fragment
+    Main->>Main: MainPage sets Content = null<br/>splash-coloured background stands in
+    Main-)Pool: AttachWebViewWhenReady
+    Note over Main: OnCreate returns — 41 ms<br/>looper free, window draws and takes focus
+
+    Pool->>Pool: await container AND Chromium warm-up
+    Note over Pool: BlazorWebViewApp ready
+    Pool--)Main: BeginDispatchToMainThread(RecreateWebView)
+    Main->>Main: MauiWebView #1 created — 231 ms
+    Main->>Main: first WebView paint — 640 ms
+    Note over Main: splash removed — 1103 ms
+```
+
+The two things that used to block the main thread and no longer do:
+
+- **The Blazor DI container.** `EnsureStarted` now runs at the end of `CreateMauiApp`, so
+  the container builds on the pool *alongside* MAUI's own startup and is typically ready
+  before `MainActivity.OnCreate` finishes.
+- **The Chromium provider.** Constructing `BlazorAndroidWebView` loads it on whatever
+  thread constructs the view and blocks on Chromium's provider lock. `MainPage` therefore
+  does not construct it until the warm-up has already taken that lock.
+
+::: warning
+Nothing may block the main thread on the warm-up task. Chromium posts its native init back
+to the main thread, so waiting there deadlocks — see the comment on
+[`AndroidUtils.WarmUpWebView`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs).
+:::
+
+### Headless (push-woken) start
+
+A push starts the process for the FCM service. There is no Activity, no Window and no UI,
+so `CreateMauiApp` does the minimum and returns.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as Main thread (looper)
+    participant Fcm as FCM dispatch thread
+
+    Note over Main: Application.onCreate
+    Main->>Main: MauiDiagnostics, exception handlers,<br/>runtime settings, ClientStartup.Initialize
+    Main->>Main: MauiApp.CreateBuilder + Build
+    Main->>Main: BlazorWebViewApp.Initialize<br/>factory only — a notification tap needs it
+    Note over Main: MauiStart.Kind = Headless<br/>StartInteractiveServices is SKIPPED
+    Note over Main: CreateMauiApp returns — 36 ms<br/>broadcast dispatches well inside the deadline
+
+    Fcm->>Fcm: FirebaseMessagingService.OnMessageReceived
+    alt kind = Message / Attention / DismissedTags
+        Fcm->>Fcm: Android notification APIs only<br/>no DI container needed
+    else kind = SpeechStarted (PTT wake)
+        Fcm->>Fcm: PttWakeHandler calls EnsureStarted itself
+        Fcm->>Fcm: HeadlessBlazorScope.GetOrCreate
+    end
+
+    opt User taps the notification
+        Note over Main: MainActivity.OnCreate
+        Main->>Main: MarkInteractive
+        Main->>Main: PromoteToInteractive<br/>runs exactly what the start skipped
+    end
+```
+
+What the headless path skips is only ever *work*, never a prerequisite:
+`WarmupStaticServices`, `BlazorViewAppPostBuildRoutine`, `LoadingUI.MarkAppBuilt`,
+`EnsureStarted` and the Chromium warm-up. None of it serves the FCM handler, and the
+ThreadPool spin-up alone competes with the broadcast the process was started to deliver.
+
+::: info
+The skip is safe because the container is already built **on demand by whoever needs it** —
+[`PttWakeHandler`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/Android/Audio/PttWakeHandler.cs)
+calls `BlazorWebViewApp.EnsureStarted()` before touching the scope, and `PttSession` awaits
+`WhenAppReady`. Ordinary notification display touches Android APIs only.
+:::
+
+### What is awaited, and where
+
+| Work | Started on | Awaited by | Blocks the main thread? |
+|------|-----------|------------|--------------------------|
+| Blazor DI container (`EnsureStarted`) | pool | `MainPage.AttachWebViewWhenReady` | no — awaited off-thread |
+| Chromium provider (`WarmUpWebView`) | pool | `MainPage.AttachWebViewWhenReady` | no — awaited off-thread |
+| `WarmupStaticServices` | pool | nothing | no — fire and forget |
+| `BlazorViewAppPostBuildRoutine` | pool | nothing | no — fire and forget |
+
+The one remaining main-thread wait is in
+[`CustomBlazorWebViewHandler.SetMauiContext`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/CustomBlazorWebViewHandler.cs),
+and it is reached only via `MainPage.MaxAttachDelay` (10 s) — the safety valve for a
+container build that never completes. It blocks rather than spins: the old
+`while (!IsCompleted) Thread.Sleep(5)` poll burned the core that would have finished the
+very build it was waiting on. When it does wait, it warn-logs
+`Awaiting BlazorWebViewApp readiness blocked the UI thread for …`; that line appearing in
+logcat means the deferral failed and is worth investigating.
+
+### Measured on device
+
+Samsung `SM-S948U1` (`m3q`), Android 16, Release + composite ReadyToRun, from
+[`MauiStartupBreadcrumbs`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/Maui/MauiStartupBreadcrumbs.cs)
+and `@trace` marks.
+
+**Main-thread block durations.** Each region below is synchronous on the main thread, so
+nothing else dispatches while it runs.
+
+| Region | Interactive | Headless | Headless + notification tap |
+|--------|-------------|----------|------------------------------|
+| `CreateMauiApp` | 35 ms | 36 ms | 36 ms |
+| `base.OnCreate` | 31 ms | — | 30 ms |
+| `MainActivity.OnCreate` (total) | 41 ms | — | 33 ms |
+
+**Elapsed since process start** — timestamps, not durations.
+
+| Milestone | Interactive | Headless + notification tap |
+|-----------|-------------|------------------------------|
+| WebView constructed | 231 ms | 128 ms after promote |
+| Splash removed | 1103 ms | 794 ms after promote |
+| `SetMauiContext` had to wait | no | no |
+
+::: tip
+The last row is a single point check, not a sampled one: `SetMauiContext` tests
+`WhenAppReady.IsCompleted` **once**, on the one call per `RecreateWebView`, and warn-logs a
+duration only if it then has to block. "No" means the container was already built at that
+moment. For actual block durations, see below.
+:::
+
+### Longest main-thread block
+
+Measured with `MauiSettings.Diagnostics.EnableMainThreadMonitor` on and its threshold at
+30 ms, three runs each, same device and build.
+
+| Block | Interactive (launcher tap) | Headless (push) |
+|-------|---------------------------|-----------------|
+| `Application.onCreate` | 51–53 ms | **46–48 ms** |
+| Activity launch transaction (`ActivityThread$H … 159`) | 64–86 ms | — |
+| Posted C# action (`android.os.Handler … RunnableImplementor`) | 123–139 ms | — |
+| MAUI dispatcher (`PlatformDispatcher … RunnableImplementor`) | 34–53 ms | — |
+| First WebView raster frame (`Choreographer$FrameHandler`) | **224–285 ms** | — |
+| **Longest single block** | **285 ms** | **48 ms** |
+| Blocks over 30 ms, per run | 7–9 | **1** |
+
+Two things this says:
+
+- **On the push path, `Application.onCreate` is the only main-thread block over 30 ms at
+  all** — the FCM handler itself runs on an FCM dispatch thread, and nothing the headless
+  start does reaches the looper. 48 ms against a broadcast deadline measured in seconds.
+- **On the launch path the longest block is the first WebView raster frame**, not our
+  startup code. That corroborates the note on `SplashExitAnimator`: a long WebView frame
+  starves the splash animation. The largest block we actually control is the ~130 ms posted
+  C# action, which is the same shape as the `mono.java.lang.RunnableImplementor.n_run`
+  cluster in Play Vitals.
+
+::: warning
+`AndroidMainThreadMonitor` cannot see the dispatch that contains `Application.onCreate`:
+`Activate()` runs from inside `CreateMauiApp`, i.e. inside that very looper message, so the
+`>>>>>` it would pair with has already gone by and the `<<<<<` is dropped. That row comes
+from an explicit `CpuTimestamp` in
+[`MainApplication`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs)
+instead, logged with the same wording so one grep finds both.
+
+The monitor also perturbs what it measures — any `Looper` printer makes `loopOnce` build two
+strings per main-thread message and adds two JNI upcalls — so treat these as upper bounds.
+It is off by default for that reason.
+:::
+
+Exactly one `MauiWebView` is created per launch (`Current = #1`). The foreground handler in
+[`MauiProgram.Android.cs`](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/MauiProgram.Android.cs)
+recreates the WebView when it finds `Content: null`, which is also the state during the
+initial attach — so it checks `MainPage.IsWebViewAttachPending` to tell "not attached yet"
+from "went away while backgrounded" and leave the first attach alone.
+
 ## Recording a CPU profile
 
 ### 1. Build a tracing-enabled APK

--- a/src/dotnet/App.Maui/CustomBlazorWebViewHandler.cs
+++ b/src/dotnet/App.Maui/CustomBlazorWebViewHandler.cs
@@ -5,23 +5,22 @@ namespace ActualChat.App.Maui;
 /// <summary>
 /// Custom Blazor WebView handler that ensures the app services are ready before configuring the MAUI context.
 /// </summary>
-public partial class CustomBlazorWebViewHandler : BlazorWebViewHandler
+public sealed partial class CustomBlazorWebViewHandler : BlazorWebViewHandler
 {
-    private ILogger Log => field ??= StaticLog.For<CustomBlazorWebViewHandler>();
+    private ILogger Log => field ??= StaticLog.For(GetType());
 
     public override void SetMauiContext(IMauiContext mauiContext)
     {
         BlazorWebViewApp.EnsureStarted();
 
-        // Await blazor app is ready
+        // MainPage attaches the WebView only once the app is ready, so this normally doesn't wait
+        // at all; it still can via MainPage.MaxAttachDelay. Blocking rather than spinning matters
+        // there - the old poll burned the core that finishes the build it was waiting for.
         if (!BlazorWebViewApp.WhenAppReady.IsCompleted) {
-            var sw = Stopwatch.GetTimestamp();
-            while (!BlazorWebViewApp.WhenAppReady.IsCompleted)
-                Thread.Sleep(5);
-            var elapsed = Stopwatch.GetElapsedTime(sw);
-
-            var log = StaticLog.Factory.CreateLogger<CustomBlazorWebViewHandler>();
-            log.LogDebug("Awaiting BlazorWebViewApp readiness took {Elapsed}ms", (int)elapsed.TotalMilliseconds);
+            var startedAt = CpuTimestamp.Now;
+            BlazorWebViewApp.WhenAppReady.Wait();
+            Log.LogWarning("Awaiting BlazorWebViewApp readiness blocked the UI thread for {Elapsed}",
+                (CpuTimestamp.Now - startedAt).ToShortString());
         }
 
         var services = BlazorWebViewApp.Current.Services;

--- a/src/dotnet/App.Maui/MainPage.Android.cs
+++ b/src/dotnet/App.Maui/MainPage.Android.cs
@@ -6,4 +6,9 @@ public partial class MainPage
     {
         // Safe areas handled by CSS via viewport-fit=cover and env(safe-area-inset-*)
     }
+
+    private partial Task WhenPlatformWebViewReady()
+        // Chromium's provider lock is what the BlazorWebView ctor would otherwise block the UI
+        // thread on, so the WebView is attached only once this warm-up has taken it.
+        => AndroidUtils.WarmUpWebView();
 }

--- a/src/dotnet/App.Maui/MainPage.MaciOS.cs
+++ b/src/dotnet/App.Maui/MainPage.MaciOS.cs
@@ -7,4 +7,8 @@ public partial class MainPage
         // .NET 10: ContentPage defaults to SafeAreaEdges.None (edge-to-edge).
         // Safe areas are handled by CSS via viewport-fit=cover and env(safe-area-inset-*).
     }
+
+    private partial Task WhenPlatformWebViewReady()
+        // WKWebView has no provider load to wait for.
+        => Task.CompletedTask;
 }

--- a/src/dotnet/App.Maui/MainPage.Windows.cs
+++ b/src/dotnet/App.Maui/MainPage.Windows.cs
@@ -4,4 +4,8 @@ public partial class MainPage
 {
     private partial void OnLoaded_Platform()
     { }
+
+    private partial Task WhenPlatformWebViewReady()
+        // WebView2 has no provider load to wait for.
+        => Task.CompletedTask;
 }

--- a/src/dotnet/App.Maui/MainPage.cs
+++ b/src/dotnet/App.Maui/MainPage.cs
@@ -1,10 +1,16 @@
 namespace ActualChat.App.Maui;
 
-public partial class MainPage : ContentPage
+public sealed partial class MainPage : ContentPage
 {
-    private static volatile MainPage _current = null!;
-
-    public static MainPage Current => _current;
+    // Past this the WebView waits for the container itself - the old behaviour - rather than
+    // leaving a blank splash on screen forever.
+    private static readonly TimeSpan MaxAttachDelay = TimeSpan.FromSeconds(10);
+    private static MainPage _current = null!;
+    private int _isWebViewAttachPending = 1;
+    public static MainPage Current => Volatile.Read(ref _current);
+    public bool IsWebViewAttachPending
+        // Tells "no WebView yet, still starting up" from "it went away while backgrounded".
+        => Volatile.Read(ref _isWebViewAttachPending) != 0;
 
     public MainPage()
     {
@@ -12,7 +18,7 @@ public partial class MainPage : ContentPage
 
         // Safe areas handled by CSS via viewport-fit=cover and env(safe-area-inset-*)
         BackgroundColor = MauiSettings.SplashBackgroundColor;
-        RecreateWebView();
+        _ = AttachWebViewWhenReady();
 
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
@@ -39,6 +45,8 @@ public partial class MainPage : ContentPage
     public void Unload()
         => Content = null;
 
+    // Private methods
+
     private void OnLoaded(object? sender, EventArgs e)
         => OnLoaded_Platform();
 
@@ -48,5 +56,19 @@ public partial class MainPage : ContentPage
         Unloaded -= OnUnloaded;
     }
 
+    private async Task AttachWebViewWhenReady()
+    {
+        // Off the UI thread on purpose: the BlazorWebView ctor blocks it on Chromium's provider
+        // lock, and the handler then waits there for the container. The background stands in.
+        var whenReady = Task.WhenAll(BlazorWebViewApp.WhenAppReady, WhenPlatformWebViewReady());
+        await whenReady.WaitAsync(MaxAttachDelay).SilentAwait(false);
+        Volatile.Write(ref _isWebViewAttachPending, 0);
+        if (!ReferenceEquals(Volatile.Read(ref _current), this))
+            return; // A newer MainPage took over while we were waiting
+
+        BeginDispatchToMainThread(RecreateWebView);
+    }
+
     private partial void OnLoaded_Platform();
+    private partial Task WhenPlatformWebViewReady();
 }

--- a/src/dotnet/App.Maui/MauiProgram.Android.cs
+++ b/src/dotnet/App.Maui/MauiProgram.Android.cs
@@ -65,7 +65,7 @@ public static partial class MauiProgram
                 Android.Util.Log.Info(MauiDiagnostics.LogTag, "OnBecameForeground");
                 MauiStartupBreadcrumbs.Add("Became foreground");
                 SetBackgroundState(false);
-                if (MainPage.Current is { Content: null } mainPage)
+                if (MainPage.Current is { Content: null, IsWebViewAttachPending: false } mainPage)
                     BeginDispatchToMainThread(() => mainPage.RecreateWebView());
             });
             android.OnStop(activity => {

--- a/src/dotnet/App.Maui/MauiProgram.cs
+++ b/src/dotnet/App.Maui/MauiProgram.cs
@@ -139,6 +139,12 @@ public static partial class MauiProgram
         MauiStartupBreadcrumbs.Add("Static services warmed up");
         SetupBlazorViewAppPostBuildRoutine();
         LoadingUI.MarkAppBuilt();
+        // MainPage waits for both before it attaches the WebView, so they start here - alongside
+        // MAUI's own startup - instead of when the Activity is already asking for them.
+        BlazorWebViewApp.EnsureStarted();
+#if ANDROID
+        _ = AndroidUtils.WarmUpWebView();
+#endif
     }
 
     private static HostInfo CreateHostInfo(IConfiguration configuration)

--- a/src/dotnet/App.Maui/MauiProgram.cs
+++ b/src/dotnet/App.Maui/MauiProgram.cs
@@ -26,6 +26,7 @@ namespace ActualChat.App.Maui;
 
 public static partial class MauiProgram
 {
+    private static int _areInteractiveServicesStarted;
     private static HostInfo HostInfo => Constants.HostInfo;
     private static ILogger Log => field ??= StaticLog.For(typeof(MauiProgram));
     private static Tracer Tracer => field ??= Tracer.Default[nameof(MauiProgram)];
@@ -103,17 +104,15 @@ public static partial class MauiProgram
             MauiStartupBreadcrumbs.Add("MauiApp built");
             StaticLog.Factory = app.Services.LoggerFactory();
 
-            AppNonScopedServiceStarter.WarmupStaticServices(HostInfo);
-            MauiStartupBreadcrumbs.Add("Static services warmed up");
-
+            // Registering the factory is just storing a lambda, and a notification tap on a
+            // headless process needs it, so it happens on both paths.
 #pragma warning disable CA2025
             BlazorWebViewApp.Initialize(() => BuildBlazorViewAppInternal(app));
 #pragma warning restore CA2025
 
-            SetupBlazorViewAppPostBuildRoutine();
-
-            LoadingUI.MarkAppBuilt();
-            MauiStartupBreadcrumbs.Add("CreateMauiApp completed");
+            if (!MauiStart.IsHeadless)
+                StartInteractiveServices();
+            MauiStartupBreadcrumbs.Add($"CreateMauiApp completed ({MauiStart.Kind})");
 
             return app;
         }
@@ -121,6 +120,25 @@ public static partial class MauiProgram
             Log.LogCritical(ex, "Failed to build MAUI app");
             throw;
         }
+    }
+
+    public static void PromoteToInteractive()
+        // An Activity reached a process that started headless - a notification tap. Idempotent,
+        // so the ordinary interactive start, which already ran this, pays nothing for the call.
+        => StartInteractiveServices();
+
+    private static void StartInteractiveServices()
+    {
+        // None of this serves the FCM handler, and a push-woken process runs inside the deadline
+        // Android gives Application.onCreate - where the ThreadPool spin-up alone competes with
+        // the broadcast it was started to deliver.
+        if (Interlocked.Exchange(ref _areInteractiveServicesStarted, 1) != 0)
+            return;
+
+        AppNonScopedServiceStarter.WarmupStaticServices(HostInfo);
+        MauiStartupBreadcrumbs.Add("Static services warmed up");
+        SetupBlazorViewAppPostBuildRoutine();
+        LoadingUI.MarkAppBuilt();
     }
 
     private static HostInfo CreateHostInfo(IConfiguration configuration)
@@ -256,11 +274,13 @@ public static partial class MauiProgram
             Log.LogWarning("Can't add SafeJSRuntime: IJSRuntime registration is not found");
             return;
         }
+
         var webViewJSRuntimeType = jsRuntimeRegistration.ImplementationType;
         if (webViewJSRuntimeType == null) {
             Log.LogWarning("Can't add SafeJSRuntime: IJSRuntime registration has no ImplementationType");
             return;
         }
+
         services.Remove(jsRuntimeRegistration);
         services.Add(new ServiceDescriptor(
             typeof(SafeJSRuntime),
@@ -337,6 +357,7 @@ public static partial class MauiProgram
             if (e.Message == "Timeout while waiting for RPC keep-alive.")
                 return true;
         }
+
         return false;
     }
 #endif

--- a/src/dotnet/App.Maui/MauiStartKind.cs
+++ b/src/dotnet/App.Maui/MauiStartKind.cs
@@ -1,0 +1,44 @@
+namespace ActualChat.App.Maui;
+
+/// <summary>
+/// Whether this process was started to show UI, or to service a background wake
+/// (an FCM broadcast, a PTT wake) that may never reach an <c>Activity</c>.
+/// </summary>
+public enum MauiStartKind { Interactive = 0, Headless }
+
+public static class MauiStart
+{
+    private static int _kind = -1;
+    public static MauiStartKind Kind {
+        get {
+            var kind = Volatile.Read(ref _kind);
+            if (kind < 0) {
+                kind = (int)Detect();
+                Interlocked.CompareExchange(ref _kind, kind, -1);
+                kind = Volatile.Read(ref _kind);
+            }
+            return (MauiStartKind)kind;
+        }
+    }
+    public static bool IsHeadless => Kind == MauiStartKind.Headless;
+    public static void MarkInteractive()
+        // An Activity means UI is coming: a headless process that gets one - a notification
+        // tap - must run everything its start skipped, and skip nothing from here on.
+        => Volatile.Write(ref _kind, (int)MauiStartKind.Interactive);
+
+    // Private methods
+
+    private static MauiStartKind Detect()
+    {
+#if ANDROID
+        // An FCM wake reads as a receiver/cached importance, a user launch as Foreground; unknown
+        // takes the interactive path, so a broken check costs startup time, not correctness.
+        var importance = AndroidUtils.GetProcessInfo()?.Importance;
+        return importance is not null && importance != Android.App.Importance.Foreground
+            ? MauiStartKind.Headless
+            : MauiStartKind.Interactive;
+#else
+        return MauiStartKind.Interactive;
+#endif
+    }
+}

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidMainThreadMonitor.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidMainThreadMonitor.cs
@@ -11,7 +11,7 @@ namespace ActualChat.App.Maui;
 public sealed class AndroidMainThreadMonitor : Java.Lang.Object, IPrinter
 {
     private const int MaxMessageLength = 300;
-    private static readonly TimeSpan Threshold = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan Threshold = MauiSettings.Diagnostics.MainThreadBlockThreshold;
 
     private CpuTimestamp _startedAt;
     private string? _message;

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
@@ -17,6 +17,8 @@ public static class AndroidUtils
     private const int ImageDownloadTimeoutSeconds = 5;
     private const string Tag = Firebase.Messaging.Constants.Tag;
     private const string ThreadNetworkIo = "Firebase-Messaging-Network-Io";
+    private static readonly Lock WebViewWarmUpLock = new();
+    private static Task? _whenWebViewWarm;
 
     public static bool? IsAppForeground()
     {
@@ -62,6 +64,35 @@ public static class AndroidUtils
         return processInfo is null
             ? "Unknown"
             : $"{processInfo.Importance}/{processInfo.ImportanceReasonCode}";
+    }
+
+    public static Task WarmUpWebView()
+    {
+        // Takes Chromium's provider lock off the UI thread, which BlazorAndroidWebView's ctor
+        // would otherwise take on it. Never block the UI thread on the result: Chromium posts
+        // its native init back there, so waiting would deadlock.
+        // Volatile pair: the lock's release does not publish to a reader that skips the lock.
+        var whenWarm = Volatile.Read(ref _whenWebViewWarm);
+        if (whenWarm is not null)
+            return whenWarm;
+
+        lock (WebViewWarmUpLock) {
+            whenWarm = _whenWebViewWarm;
+            if (whenWarm is not null)
+                return whenWarm;
+
+            // Started inside the lock, so a lost race cannot leave a second provider load running.
+            whenWarm = Task.Run(() => {
+                try {
+                    _ = Android.Webkit.WebSettings.GetDefaultUserAgent(Application.Context);
+                }
+                catch (System.Exception e) {
+                    Android.Util.Log.Warn(MauiDiagnostics.LogTag, $"WebView warm-up failed: {e.Message}");
+                }
+            });
+            Volatile.Write(ref _whenWebViewWarm, whenWarm);
+            return whenWarm;
+        }
     }
 
     public static bool IsMainThread()

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidUtils.cs
@@ -32,7 +32,7 @@ public static class AndroidUtils
 
         // Screen is on and unlocked, now check if the process is in the foreground
 
-        int pid = Android.OS.Process.MyPid();
+        var pid = Android.OS.Process.MyPid();
         var appProcesses = activityManager.RunningAppProcesses;
         if (appProcesses != null) {
             foreach (var process in appProcesses) {
@@ -40,22 +40,28 @@ public static class AndroidUtils
                     return process.Importance == Importance.Foreground;
             }
         }
+
         return false;
+    }
+
+    public static ActivityManager.RunningAppProcessInfo? GetProcessInfo()
+    {
+        try {
+            var processInfo = new ActivityManager.RunningAppProcessInfo();
+            ActivityManager.GetMyMemoryState(processInfo);
+            return processInfo;
+        }
+        catch (System.Exception) {
+            return null;
+        }
     }
 
     public static string GetProcessStartReason()
     {
-        // Importance separates a broadcast-started process from a user launch: an FCM wake reads
-        // as a receiver/cached importance, a user launch as Foreground (AMS marks the process
-        // top-bound at bind time, before any activity exists).
-        try {
-            var processInfo = new ActivityManager.RunningAppProcessInfo();
-            ActivityManager.GetMyMemoryState(processInfo);
-            return $"{processInfo.Importance}/{processInfo.ImportanceReasonCode}";
-        }
-        catch (System.Exception e) {
-            return e.GetType().Name;
-        }
+        var processInfo = GetProcessInfo();
+        return processInfo is null
+            ? "Unknown"
+            : $"{processInfo.Importance}/{processInfo.ImportanceReasonCode}";
     }
 
     public static bool IsMainThread()
@@ -84,6 +90,7 @@ public static class AndroidUtils
             var networkIoExecutor = NewNetworkIoExecutor();
             imageDownload.Start(networkIoExecutor);
         }
+
         return imageDownload;
     }
 
@@ -125,6 +132,7 @@ public static class AndroidUtils
              * when it is updated.
              */
         }
+
         return null;
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -36,7 +36,7 @@ namespace ActualChat.App.Maui;
     ConfigurationChanges =
         ConfigChanges.UiMode |
         ConfigChanges.Density | ConfigChanges.FontScale | ConfigChanges.FontWeightAdjustment |
-        ConfigChanges.ScreenSize |  ConfigChanges.SmallestScreenSize | ConfigChanges.ScreenLayout |
+        ConfigChanges.ScreenSize | ConfigChanges.SmallestScreenSize | ConfigChanges.ScreenLayout |
         ConfigChanges.Orientation | ConfigChanges.LayoutDirection |
         ConfigChanges.Touchscreen | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden
     )]
@@ -79,6 +79,10 @@ public partial class MainActivity : MauiAppCompatActivity
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
+        // Before anything that reads MauiStart: an Activity means this process shows UI even if it
+        // started headless for a push, so PromoteToInteractive runs whatever that start skipped.
+        MauiStart.MarkInteractive();
+        MauiProgram.PromoteToInteractive();
         WarmUpWebView();
 
         // Before base.OnCreate, which calls setContentView - the listener has to be registered
@@ -117,7 +121,7 @@ public partial class MainActivity : MauiAppCompatActivity
         _isFirstTime = false;
 
         // ReSharper disable once ExplicitCallerInfoArgument
-        using(Tracer.Region("Calling base.OnCreate"))
+        using (Tracer.Region("Calling base.OnCreate"))
             base.OnCreate(Bundle.Empty);
 
         // base.OnCreate call hides native splash screen. Set NavigationBar color the same as web splash screen
@@ -136,7 +140,8 @@ public partial class MainActivity : MauiAppCompatActivity
         // https://github.com/firebase/quickstart-android/issues/368#issuecomment-683151061
         // seems it does not help
         var componentName = new ComponentName(this, Java.Lang.Class.FromType(typeof(FirebaseMessagingService)));
-        PackageManager?.SetComponentEnabledSetting(componentName, ComponentEnabledState.Enabled, ComponentEnableOption.DontKillApp);
+        PackageManager?.SetComponentEnabledSetting(
+            componentName, ComponentEnabledState.Enabled, ComponentEnableOption.DontKillApp);
 
         // Create launcher to request permissions
         _permissionRequestLauncher = RegisterForActivityResult(
@@ -242,28 +247,6 @@ public partial class MainActivity : MauiAppCompatActivity
         keyguardManager.RequestDismissKeyguard(this, new CallKeyguardDismissCallback(this, onResult));
     }
 
-    private sealed class CallKeyguardDismissCallback(MainActivity activity, Action<bool> onResult)
-        : KeyguardManager.KeyguardDismissCallback
-    {
-        public override void OnDismissSucceeded()
-        {
-            activity.DisableShowWhenLocked();
-            onResult(true);
-        }
-
-        public override void OnDismissError()
-        {
-            activity.DisableShowWhenLocked();
-            onResult(false);
-        }
-
-        public override void OnDismissCancelled()
-        {
-            activity.DisableShowWhenLocked();
-            onResult(false);
-        }
-    }
-
     public override void OnTrimMemory(TrimMemory level)
     {
         Log.LogInformation("OnTrimMemory, Level: {Level}", level);
@@ -299,7 +282,7 @@ public partial class MainActivity : MauiAppCompatActivity
 
     public void PickVisualMedia(PickVisualMediaKind kind, Action<Uri[]> onReceiveResult)
     {
-        _onReceivePickVisualMedialResult?.Invoke(Array.Empty<Uri>());
+        _onReceivePickVisualMedialResult?.Invoke([]);
         _onReceivePickVisualMedialResult = onReceiveResult;
 
         ActivityResultContracts.PickVisualMedia.IVisualMediaType visualMediaType = kind switch {
@@ -312,6 +295,8 @@ public partial class MainActivity : MauiAppCompatActivity
              .Build();
         _pickVisualMediaLauncher.Launch(pickVisualMediaRequest);
     }
+
+    // Private methods
 
     private static void WarmUpWebView()
     {
@@ -353,7 +338,8 @@ public partial class MainActivity : MauiAppCompatActivity
             Log.LogInformation("MemoryClass: {MemoryClass}", memoryClass);
             var memoryInfo = new ActivityManager.MemoryInfo();
             activityManager.GetMemoryInfo(memoryInfo);
-            Log.LogInformation("MemoryInfo: AvailMem={AvailMem}, TotalMem={TotalMem}, LowMemory={LowMemory}, Threshold={Threshold}",
+            Log.LogInformation(
+                "MemoryInfo: AvailMem={AvailMem}, TotalMem={TotalMem}, LowMemory={LowMemory}, Threshold={Threshold}",
                 memoryInfo.AvailMem,
                 memoryInfo.TotalMem,
                 memoryInfo.LowMemory,
@@ -361,7 +347,8 @@ public partial class MainActivity : MauiAppCompatActivity
             var processInfo = new ActivityManager.RunningAppProcessInfo();
             ActivityManager.GetMyMemoryState(processInfo);
             Log.LogInformation(
-                "MyMemoryState: Pid={Pid}, LastTrimLevel={LastTrimLevel}, Lru={Lru}, Importance={Importance}, ImportanceReasonCode={ImportanceReasonCode}",
+                "MyMemoryState: Pid={Pid}, LastTrimLevel={LastTrimLevel}, Lru={Lru}"
+                + ", Importance={Importance}, ImportanceReasonCode={ImportanceReasonCode}",
                 processInfo.Pid,
                 processInfo.LastTrimLevel,
                 processInfo.Lru,
@@ -370,6 +357,30 @@ public partial class MainActivity : MauiAppCompatActivity
         }
         catch (Exception e) {
             Log.LogWarning(e, "DumpMemoryInfo failed");
+        }
+    }
+
+    // Nested types
+
+    private sealed class CallKeyguardDismissCallback(MainActivity activity, Action<bool> onResult)
+        : KeyguardManager.KeyguardDismissCallback
+    {
+        public override void OnDismissSucceeded()
+        {
+            activity.DisableShowWhenLocked();
+            onResult(true);
+        }
+
+        public override void OnDismissError()
+        {
+            activity.DisableShowWhenLocked();
+            onResult(false);
+        }
+
+        public override void OnDismissCancelled()
+        {
+            activity.DisableShowWhenLocked();
+            onResult(false);
         }
     }
 
@@ -391,7 +402,7 @@ public partial class MainActivity : MauiAppCompatActivity
         }
     }
 
-    private class SplashDelayer(AView contentView) : JObject, ViewTreeObserver.IOnPreDrawListener
+    private sealed class SplashDelayer(AView contentView) : JObject, ViewTreeObserver.IOnPreDrawListener
     {
         // Cap the pre-draw hold: if the WebView callback never arrives, holding forever starves
         // input dispatch and Android reports a "no focused window" ANR.

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -83,7 +83,6 @@ public partial class MainActivity : MauiAppCompatActivity
         // started headless for a push, so PromoteToInteractive runs whatever that start skipped.
         MauiStart.MarkInteractive();
         MauiProgram.PromoteToInteractive();
-        WarmUpWebView();
 
         // Before base.OnCreate, which calls setContentView - the listener has to be registered
         // before that for the dismissal logic to see it.
@@ -297,26 +296,6 @@ public partial class MainActivity : MauiAppCompatActivity
     }
 
     // Private methods
-
-    private static void WarmUpWebView()
-    {
-        // Without this the WebView provider is loaded on the UI thread inside performStart, right
-        // before BlazorAndroidWebView is constructed. GetDefaultUserAgent forces the same load and
-        // is safe off the UI thread, moving ~10ms off the critical path. Here rather than in
-        // MainApplication.OnCreate: a push-started process has no WebView coming, and the eager
-        // ThreadPool spin-up + JNI type-load only added lock contention to the FCM cold start.
-        // Nothing waits on this: Chromium's own provider lock already makes WebView construction
-        // block until the load finishes, and it posts its native init back to the UI thread - so
-        // blocking the UI thread on this task instead would deadlock.
-        _ = Task.Run(() => {
-            try {
-                _ = Android.Webkit.WebSettings.GetDefaultUserAgent(Platform.AppContext);
-            }
-            catch (Exception e) {
-                Android.Util.Log.Warn(MauiDiagnostics.LogTag, $"WebView warm-up failed: {e.Message}");
-            }
-        });
-    }
 
     private void CloseHeadlessScope()
     {

--- a/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainApplication.cs
@@ -9,9 +9,13 @@ namespace ActualChat.App.Maui;
 [Application]
 public sealed class MainApplication : MauiApplication, AndroidX.Work.Configuration.IProvider
 {
+    private static CpuTimestamp _startedAt;
     public MainApplication(IntPtr handle, JniHandleOwnership ownership)
         : base(handle, ownership)
-        => Android.Util.Log.Info(MauiDiagnostics.LogTag, "---- Started ----");
+    {
+        _startedAt = CpuTimestamp.Now;
+        Android.Util.Log.Info(MauiDiagnostics.LogTag, "---- Started ----");
+    }
 
     public override void OnCreate()
     {
@@ -19,6 +23,12 @@ public sealed class MainApplication : MauiApplication, AndroidX.Work.Configurati
         // The moment the main looper is free to dispatch the broadcast that may have started us;
         // the delta from "CreateMauiApp completed" is pure MAUI framework overhead.
         MauiStartupBreadcrumbs.Add("Application.OnCreate completed");
+        // AndroidMainThreadMonitor is blind to this dispatch - it is installed from inside it, so
+        // the ">>>>>" it would pair with has already gone by. Same wording, so one grep finds both.
+        if (MauiSettings.Diagnostics.EnableMainThreadMonitor)
+            Android.Util.Log.Warn(MauiDiagnostics.LogTag,
+                $"Main thread was blocked for {(CpuTimestamp.Now - _startedAt).ToShortString()}"
+                + $" by: Application.onCreate ({MauiStart.Kind})");
         // Any process start, not only a user launch. A message push starts us with no MainActivity
         // and no Blazor scope, so nothing else raises the armed service - leaving no PTT badge and
         // no media session for the headset button. Android 12+ bans foreground-service starts from

--- a/src/dotnet/App.Maui/_Profiling/android-notif.mibc
+++ b/src/dotnet/App.Maui/_Profiling/android-notif.mibc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56513584c5409c7e88fddc13f8c49b74be2eab1f69fb8184a3cbeb30949691d3
-size 106349
+oid sha256:5110dac3b60f245924bf9fb1d9db6b80ae205f32b1bf3f444e7afdcfcac8bfc2
+size 76956

--- a/src/dotnet/App.Maui/_Profiling/android.mibc
+++ b/src/dotnet/App.Maui/_Profiling/android.mibc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:220e00a5e3579a1e91103422895c2ebf0456d58a0f05af9db6a520d3acbadf5e
-size 565841
+oid sha256:5da9f8033728182dd4206742f3a932aee26cc5f142cd0d56efd816c047ee2ee0
+size 557232

--- a/src/dotnet/App.Maui/_Profiling/merged.mibc
+++ b/src/dotnet/App.Maui/_Profiling/merged.mibc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9964e5f6599dde585aeb2ed0476e8b13355f74861b94d7805c6df7cc0f4c0820
-size 704551
+oid sha256:0d95972d2f65b32521a5c544b8314c16ba7fbd9aadcaefe1b0e165bb44e99e0f
+size 706504

--- a/src/dotnet/Maui/MauiSettings.cs
+++ b/src/dotnet/Maui/MauiSettings.cs
@@ -75,5 +75,8 @@ public static class MauiSettings
         // Looper.loopOnce build two strings per main-thread message and adds two JNI upcalls,
         // i.e. it feeds the ART GC pressure and native->Runnable transitions it's meant to observe.
         public const bool EnableMainThreadMonitor = false;
+        // What EnableMainThreadMonitor warns at. 1s is Android's own broadcast deadline; 30ms is
+        // the startup setting - no single dispatch should get near that while the app is starting.
+        public static readonly TimeSpan MainThreadBlockThreshold = TimeSpan.FromMilliseconds(30);
     }
 }


### PR DESCRIPTION
## Why

Play Vitals flags the app as **"Bad behavior"** — user-perceived ANR rate **0.93%** against a 0.47% threshold, which suppresses discoverability. Crash rate (0.12%) is fine.

Over Aug 22–29 production had **zero crashes and 10 ANR clusters / 15 events**, in two families:

| # | Family | Stack | Events |
|---|---|---|---|
| 1 | Push-woken cold start | `MainApplication.onCreate` → `handleBindApplication`, RyuJIT frames on top (`fgFindBasicBlocks`, `allocateRegistersMinimal`, `isContained`, `emitOutputInstr`) | 13 |
| 2 | Launch-path UI thread | `BlazorAndroidWebView.<init>` → `WebViewChromium.init`, "Input dispatching timed out (No focused window)" | 2 |

An ANR is caused by the length of **one uninterrupted main-thread block**, not by total work — so this PR targets block length. It deliberately does not chase the ~20% generic-instantiation / cctor cost from the 2026-07 profile in `docs/android-specific.md`; that's a throughput problem, and that doc already records a failed attempt in that direction.

Two ideas that came up were already implemented and are left alone: the Blazor DI container is already lazy and built off the main thread, and `WarmUpWebView` already exists (and was deliberately kept out of `MainApplication.OnCreate`).

## What changed

### Headless start skips UI-only init — family 1

`MauiStart` reads `RunningAppProcessInfo.Importance` through `AndroidUtils.GetProcessInfo()` (the accessor `GetProcessStartReason` already used) to tell a broadcast-started process from a user launch. `CreateMauiApp` then skips `WarmupStaticServices`, `SetupBlazorViewAppPostBuildRoutine`, `MarkAppBuilt`, `EnsureStarted` and the Chromium warm-up.

Safe because the container is **already built on demand by whoever needs it** — `PttWakeHandler.cs:54` calls `EnsureStarted()` itself and `PttSession` awaits `WhenAppReady`, while ordinary notification display touches Android APIs only. Detection is fail-safe: an unknown importance takes the full interactive path, so a broken check costs startup time, not correctness. An Activity reaching a headless process (a notification tap) calls `MauiProgram.PromoteToInteractive()`, which runs exactly what was skipped, guarded by an `Interlocked.Exchange` so a normal launch pays nothing.

### WebView attaches when ready instead of blocking — family 2

`CustomBlazorWebViewHandler.SetMauiContext` spin-waited on the main thread — `while (!WhenAppReady.IsCompleted) Thread.Sleep(5)` — for the entire container build, burning the core that finishes the very build it was waiting on, on top of Chromium's provider load.

`MainPage` now leaves `Content` null and attaches the WebView once both the container and the warm-up are ready, off the UI thread. Its `BackgroundColor` is already `SplashBackgroundColor`, so the native splash stands in and the window still draws and can take focus. `Content: null` was already an expected state (the foreground handler recreates from it), so that handler now also checks `IsWebViewAttachPending` to leave the initial attach alone. `MaxAttachDelay` caps the wait at 10s and falls back to today's behaviour rather than leaving a blank splash.

Both the container build and the warm-up now start at the end of `CreateMauiApp` on interactive starts, so they run alongside MAUI's own startup rather than beginning when the Activity already needs them.

### Diagnostics

`MauiSettings.Diagnostics.MainThreadBlockThreshold` now drives `AndroidMainThreadMonitor`. It stays **off by default** — any `Looper` printer feeds the GC pressure it is meant to observe — but the knob is discoverable for a measurement run.

## Diff noise

`MainActivity.cs` shows ~88 changed lines but the functional change is three added lines at the top of `OnCreate` plus the relocation of `WarmUpWebView` to `AndroidUtils`. The rest — moving `CallKeyguardDismissCallback` under `// Nested types`, sealing `SplashDelayer`, wrapping three long lines — is the style hook requiring pre-existing violations in touched files to be fixed. Same for the blank-line insertions in `MauiProgram.cs` and `AndroidUtils.cs`.

## Verification

Builds clean (`net11.0-android`, Debug): 0 errors; the one warning in a touched file (`BL0016`, `MauiProgram.cs:303`) is pre-existing.

**Not yet verified on device.** This touches notifications, which is where a "skip" breaks things silently, so before merge:

- [ ] Push to a headless process (`am kill`, never `am force-stop`) — notification still appears, for each `NotificationKind` branch: chat message, `IncomingCall`, `SpeechStarted` (PTT wake), `Attention`, and a dismissal (`DismissedTags`)
- [ ] Tap a notification on a headless process → promote produces a fully working app (sign-in intact, chat opens, audio works)
- [ ] Cold launcher tap, and warm start (home → relaunch, the `_isFirstTime` path)
- [ ] No WebView provider → still reaches `WebViewMissingActivity`
- [ ] `AndroidMainThreadMonitor` longest-single-block before/after, both start kinds
- [ ] Re-record `android-notif.mibc` — this changes which methods the push path runs, so the profile committed in `44967d77f5` goes stale on merge

Play Vitals ANR rate is a 28-day rolling metric, so the device-side block measurements are the acceptance criterion, not Vitals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc8rXaMZ9kAKNSVjHvFNZN
