### PR TITLE
fix(audio): iOS loudspeaker routing, and the silent-stall family behind it

### DIFF
--- a/docs/live-audio/07-receiver.md
+++ b/docs/live-audio/07-receiver.md
@@ -356,8 +356,12 @@ audio is short, voice-gated, and rarely overlapping.
   - `canDuck = true` (transient): ignore (no ducking implementation;
     keeps playing).
   - `canDuck = false` (loss): pause or stop.
-- On focus regain: resume from paused offset (live → resume listening,
-  replay → resume from saved position).
+- On focus regain: replay resumes from its saved position. **Live listening does
+  not resume** — a non-duckable loss clears the listening chats
+  (`ChatAudioUI.OnAudioFocusLost`) and only replay registers a restore handler,
+  so the user re-enables listening themselves. This is deliberate: coming back
+  from a phone call into a live conversation that resumed unattended is worse
+  than a toggle.
 
 iOS uses MAUI-side audio session APIs in the iOS app; on the web this
 collapses to "always have focus".

--- a/src/dotnet/Api/AppConstants.Audio.cs
+++ b/src/dotnet/Api/AppConstants.Audio.cs
@@ -94,9 +94,8 @@ partial record AppConstants
             public int MaxBufferedFrames { get; init; } = 1500;
             // Max streaming speed relative to real-time.
             public int MaxSpeed { get; init; } = 2;
-            public int InterStreamDelayMs { get; init; } = 100;
-            public int StreamErrorDelayMs { get; init; } = 1000;
-            public int ConnectErrorDelayMs { get; init; } = 1000;
+            public int StreamErrorRetryDelayMs { get; init; } =
+                (int)Constants.Audio.StreamErrorRetryDelay.TotalMilliseconds;
             // Debug switch — random disconnect period (0 = disabled).
             public int DebugRandomDisconnectPeriodMs { get; init; } = 0;
             public int RecordingRpcStreamAckPeriod { get; init; } = Constants.Audio.RecordingRpcStreamAckPeriod;

--- a/src/dotnet/Api/Constants.Audio.cs
+++ b/src/dotnet/Api/Constants.Audio.cs
@@ -94,6 +94,11 @@ public static partial class Constants
         public static readonly TimeSpan RecorderDrainTimeout = TimeSpan.FromSeconds(1);
         // Startup waits the recorder proceeds without rather than lose the utterance.
         public static readonly TimeSpan RecorderStartupWaitTimeout = TimeSpan.FromSeconds(3);
+        // Between a failed audio push and the retry that replaces it. Short, because the usual
+        // cause is a peer change that the next attempt resolves - it exists to stop a persistent
+        // rejection tight-looping, not to pace a reconnect - and every millisecond here is
+        // silence for the listeners.
+        public static readonly TimeSpan StreamErrorRetryDelay = TimeSpan.FromMilliseconds(100);
         // How long the mic staying shut or the connection staying down must last before the UI
         // calls it a failure: a healthy start passes through both states on its way up.
         public static readonly TimeSpan RecordingProblemGracePeriod = TimeSpan.FromSeconds(1.5);

--- a/src/dotnet/Api/MediaPlayback/TrackPlayer.cs
+++ b/src/dotnet/Api/MediaPlayback/TrackPlayer.cs
@@ -45,7 +45,8 @@ public abstract class TrackPlayer(TrackInfo trackInfo, IMediaSource source, ILog
     /// <summary>
     /// Starts playing the track which is represented by <see cref="IMediaSource"/> (from ctor).
     /// </summary>
-    /// <returns>A running task, which will be completed after playing all media frames or on a cancel + disposing things</returns>
+    /// <returns>A running task, which will be completed after playing all media frames
+    /// or on a cancel + disposing things</returns>
     public Task Play(CancellationToken cancellationToken = default)
     {
         // Hint: the code here is almost a copy of WorkerBase.Run
@@ -83,7 +84,8 @@ public abstract class TrackPlayer(TrackInfo trackInfo, IMediaSource source, ILog
     /// <summary>
     /// Stops the playback.
     /// </summary>
-    /// <returns>A running task which is completed when you can run <see cref="Play(CancellationToken)"/> again</returns>
+    /// <returns>A running task which is completed when you can run
+    /// <see cref="Play(CancellationToken)"/> again</returns>
     public Task Stop()
     {
         PlayTokenSource.CancelAndDisposeSilently();
@@ -103,6 +105,11 @@ public abstract class TrackPlayer(TrackInfo trackInfo, IMediaSource source, ILog
             var frameCount = 0;
             var frames = Source.GetFramesUntyped(cancellationToken);
             await foreach (var frame in frames.ConfigureAwait(false)) {
+                // An engine that already reported its end - errored, or its device died - would
+                // otherwise be fed for as long as the source keeps producing.
+                if (State.IsEnded)
+                    break;
+
                 if (!isPlayCommandProcessed) {
                     await playTask.ConfigureAwait(false);
                     isPlayCommandProcessed = true;
@@ -118,7 +125,17 @@ public abstract class TrackPlayer(TrackInfo trackInfo, IMediaSource source, ILog
             // this prevents sending (end + stop) commands simultaneously, don't change this.
             // change to get (end + stop) exists, for example, with a thread abort exception,
             // but it's a pretty rare situation
-            await ProcessCommand(EndCommand.Instance, CancellationToken.None).ConfigureAwait(false);
+            // Bounded: it's the one engine call on the normal path that wasn't, and
+            // Playback.OnAbortCommand awaits this task inline in its command loop.
+            try {
+                await ProcessCommand(EndCommand.Instance, CancellationToken.None).AsTask()
+                    .WaitAsync(StopTimeout, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException) {
+                Log.LogWarning("PlayInternal: the engine didn't finish End in {Timeout}, abandoning it",
+                    StopTimeout.ToShortString());
+            }
 
             // Now we're waiting for a report when the client side has actually played all frames or Cancel()
             // At the same time we need to pump commands queue in case pause or resume command arrive.

--- a/src/dotnet/App.Maui/MaciOS/Audio/AVAudioPcmBufferExt.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AVAudioPcmBufferExt.cs
@@ -17,7 +17,7 @@ public static class AVAudioPcmBufferExt
 
     public static AVAudioPcmBuffer ToPcmBuffer2(this Span<float> data, AVAudioFormat format)
     {
-        var buffer = new AVAudioPcmBuffer(AudioEngine.VoiceRecordingFormat, (uint)data.Length);
+        var buffer = new AVAudioPcmBuffer(format, (uint)data.Length);
         buffer.SetData(data);
         return buffer;
     }

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -10,6 +10,10 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
 {
     private static readonly TimeSpan InputNodeHoldTimeout = TimeSpan.FromMinutes(30);
     private static readonly TimeSpan InputNodeHeartbeatTimeout = TimeSpan.FromSeconds(30);
+    // A tap delivers continuously regardless of speech, so a gap this long isn't silence.
+    private static readonly TimeSpan CaptureStallTimeout = TimeSpan.FromSeconds(5);
+    // Past InterruptionEndTimeout, so a Began that never gets its End can't hold this open.
+    private static readonly TimeSpan MaxInterruptionDeferral = TimeSpan.FromSeconds(60);
 
     private static long _inputNodeHeldAt;
     private static long _inputNodeHeartbeatAt;
@@ -47,7 +51,8 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
         // their iterator: here the whole AVAudioEngine setup is inside CaptureInternal.
         => Task.FromResult(AudioCaptureResult.Ok(CaptureInternal(cancellationToken)));
 
-    private async IAsyncEnumerable<IMemoryOwner<float>> CaptureInternal([EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<IMemoryOwner<float>> CaptureInternal(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // First statement, before TryTake() stops the pre-roll engine: everything below is
         // blocking native work, and a press landing in that window would see a free input node
@@ -119,13 +124,38 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
             await AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
 
             var frameLen = Constants.Audio.OpusFrameLength;
+            var deferringSince = default(CpuTimestamp?);
             while (!cancellationToken.IsCancellationRequested) {
                 var owner = ArrayPools.SharedFloatPool.LeaseArrayOwner(frameLen, true);
                 if (!outBuffer.TryRead(owner.Span, out var whenReady)) {
                     owner.Dispose();
-                    await whenReady.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    continue;
+                    if (await whenReady.TryWaitAsync(CaptureStallTimeout, cancellationToken).ConfigureAwait(false))
+                        continue;
+
+                    // hwFormat, the resampler and the tap are pinned at start, and Reconnect()
+                    // rebuilds none of them - so a route change that moves the mic (AirPods swap
+                    // 48kHz built-in for 8/16kHz HFP) leaves them built for a format that never
+                    // arrives, silently. Ending lets PushRecordingState rebuild the lot.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    // An interruption stops the tap legitimately and RecoverInternal resumes the
+                    // engine after it, so ending here would split the recording. Bounded, though:
+                    // the flag is a raw latch with no expiry outside SetModeUnsafe, and iOS
+                    // doesn't guarantee an End.
+                    var focus = AudioFocusUI.GetDiagnostics();
+                    var isDeferred = focus is { IsInterrupted: true } or { IsSuspended: true };
+                    if (isDeferred) {
+                        deferringSince ??= CpuTimestamp.Now;
+                        if (deferringSince.GetValueOrDefault().Elapsed < MaxInterruptionDeferral)
+                            continue;
+                    }
+
+                    Log.LogWarning("CaptureInternal: no samples for {Elapsed} ({Reason}) - ending the capture",
+                        (deferringSince?.Elapsed ?? CaptureStallTimeout).ToShortString(),
+                        isDeferred ? "still interrupted" : "input stopped");
+                    yield break;
                 }
+
+                deferringSince = null;
                 yield return owner;
             }
             yield break;
@@ -136,7 +166,8 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
                 // The engine is alive and still owns the input node - see IsInputNodeHeld.
                 Volatile.Write(ref _inputNodeHeartbeatAt, CpuTimestamp.Now.Value);
                 try {
-                    var estimatedResampledLength = pcmBuffer.FrameLength / hwFormat.SampleRate * AudioEngine.VoiceRecordingFormat.SampleRate;
+                    var estimatedResampledLength = pcmBuffer.FrameLength / hwFormat.SampleRate
+                        * AudioEngine.VoiceRecordingFormat.SampleRate;
                     if (outBuffer.RemainingCapacity < estimatedResampledLength) {
                         Log.LogWarning("Buffer full, dropping samples");
                         return;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -73,9 +73,15 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     {
         using var _1 = await _lock.Lock(StopToken).ConfigureAwait(false);
         var scope = _activeScopes.Get(requester);
-        if (scope is not null) {
+        if (scope is { IsDisposed: false }) {
             Log.LogInformation("Returning existing scope {Scope} ({Mode})", scope, requester.Kind);
             return scope;
+        }
+        if (scope is not null) {
+            // Its Release is queued behind this very lock; handing it back would let that Release
+            // tear the engine down under whatever the caller starts next.
+            Log.LogInformation("Dropping disposed scope {Scope} ({Mode})", scope, requester.Kind);
+            _activeScopes.TryRemove(requester, scope);
         }
 
         var needsReconfigure = !_isSessionConfigured
@@ -215,9 +221,10 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     {
         using var _1 = await _lock.Lock(cancellationToken).ConfigureAwait(false);
         if (_activeScopes.IsEmpty) {
-            // Nothing wants the session, so recovering it would just re-acquire the cost
-            // SetModeUnsafe released - the next acquire reactivates anyway.
+            // Nothing wants the session; the next acquire reactivates anyway. The flag still has
+            // to go - left set, it disables configuration-change handling for every later scope.
             Log.LogInformation("Recover: no active scopes, leaving the session deactivated");
+            _isSuspended = false;
             return;
         }
 
@@ -302,15 +309,20 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     {
         using var _1 = await _lock.Lock(cancellationToken).ConfigureAwait(false);
         (_isSessionConfigured, _isSessionActivated) = (false, false);
-        if (_activeScopes.IsEmpty)
+        if (_activeScopes.IsEmpty) {
+            _isSuspended = false;
             return;
+        }
 
         var mode = _activeScopes.GetMode();
-        Log.LogWarning("Rebuild: reconfiguring session in {Mode}", mode);
-        AudioEngines.Pause();
+        Log.LogWarning("Rebuild: rebuilding engines and session in {Mode}", mode);
+        // Released, not paused: the reset invalidated these instances, and Apple's contract is
+        // to dispose and rebuild. Pause/Resume left zombies, so the "rebuild" restarted nothing.
+        AudioEngines.Release();
         var setup = await AudioSession.Reconfigure(mode).ConfigureAwait(false);
         (_isSessionConfigured, _isSessionActivated) = (setup.IsConfigured, setup.IsActivated);
-        AudioEngines.Resume(mode);
+        // No Resume: Release cleared _isStarted, so it'd no-op. Recovery is the restore handlers
+        // below plus the capture stall and buffer-low timeouts, which rebuild what was live.
         InvokeRestoreUnsafe();
         _isSuspended = false;
     }
@@ -379,11 +391,20 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
 
     private sealed class Scope(AppleAudioFocusUI owner, AudioFocusRequester requester) : AudioFocusScope
     {
+        private int _isDisposed;
+
         public AudioFocusRequester Requester => requester;
         public AudioFocusRestoreHandler? PendingRestore { get; set; }
+        // Set before Release is queued, so a TryAcquire winning the lock sees it's on its way out.
+        public bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
 
         public override void Dispose()
-            => _ = owner.Release(requester, this);
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+                return;
+
+            _ = owner.Release(requester, this);
+        }
     }
 
     private sealed class ActiveScopes(ILogger log) : IDisposable
@@ -413,7 +434,10 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
 
         public bool TryRemove(AudioFocusRequester requester, Scope scope)
         {
-            if (!_byMode[requester.Kind].Remove(requester, out var existing)) {
+            // Peek before removing: removing first evicted whoever held the key, so a late
+            // Release for a superseded scope threw away the live scope that replaced it.
+            var scopes = _byMode[requester.Kind];
+            if (!scopes.TryGetValue(requester, out var existing)) {
                 log.LogWarning("Requester {Requester} not found in active scopes", requester);
                 return false;
             }
@@ -426,6 +450,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
                 return false;
             }
 
+            scopes.Remove(requester);
             return true;
         }
 

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
@@ -7,7 +7,7 @@ using ActualLab.Opus.MaciOS;
 
 namespace ActualChat.App.Maui.Audio;
 
-public class AppleAudioPlaybackEngine(
+public sealed class AppleAudioPlaybackEngine(
     string playerId,
     TrackInfo info,
     IAudioPlayerBackend backend,
@@ -44,9 +44,6 @@ public class AppleAudioPlaybackEngine(
     public async Task Play(CancellationToken cancellationToken)
     {
         DebugLog?.LogInformation("#{PlayerId}.Play", playerId);
-        // Focus is taken seconds before the first frames arrive, and a route the session picked
-        // back then may no longer be the one this track should come out of.
-        await hub.AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
         _frames.SetTargetDuration(GetEncodedBufferDuration(info.TargetBufferSize));
 
         _voicePlayer = new VoicePlayer(playerId, hub);
@@ -58,6 +55,8 @@ public class AppleAudioPlaybackEngine(
             "Failed to decode/feed iOS audio",
             _decodeFeedCts.Token);
         _voicePlayer.Play();
+        // After Play(), not before: starting the player is what builds the engine and moves the route.
+        await hub.AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
     }
 
     public Task Pause(CancellationToken cancellationToken)
@@ -71,7 +70,9 @@ public class AppleAudioPlaybackEngine(
     {
         DebugLog?.LogInformation("#{PlayerId}.Resume", playerId);
         _voicePlayer.Play();
-        return Task.CompletedTask;
+        // Same reason as Play(): resuming restarts the engine, and a restart that lands after
+        // voice processing came up needs the route restated.
+        return hub.AudioFocusUI.EnsureOutputRoute(cancellationToken);
     }
 
     public Task End(bool abort, CancellationToken cancellationToken)
@@ -85,6 +86,7 @@ public class AppleAudioPlaybackEngine(
         }
         else
             _frames.Complete();
+
         return Task.CompletedTask;
     }
 
@@ -103,8 +105,13 @@ public class AppleAudioPlaybackEngine(
         await foreach (var cPosition in _voicePlayer.PlaybackState.Computed.Changes(cancellationToken).ConfigureAwait(false)) {
             var state = cPosition.Value;
             backend.OnPlaying(state.Position.TotalSeconds, !state.IsPlaying, state.IsBufferLow);
-            if (state.IsPlaying && state.Position > TimeSpan.Zero)
+            if (state.IsPlaying && state.Position > TimeSpan.Zero) {
+                // Rendering progress, not frames handed in: TrackPlayer keeps pushing into a dead
+                // engine, so a push-based heartbeat would tell the owner watchdog the session is
+                // fine in precisely the case it exists to rescue.
+                AudioSession.NotifyPlaybackActivity();
                 TryReportPresentationLag(state.Position);
+            }
         }
     }
 
@@ -113,6 +120,7 @@ public class AppleAudioPlaybackEngine(
         var nowTicks = Environment.TickCount64;
         if (nowTicks < Interlocked.Read(ref _nextLagReportAtTicks))
             return;
+
         Interlocked.Exchange(ref _nextLagReportAtTicks, nowTicks + LagReportIntervalMs);
 
         var anchor = info.SourceRecordedAt != default ? info.SourceRecordedAt : info.RecordedAt;

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
@@ -15,6 +15,7 @@ public sealed class AppleTuneUI(UIHub hub) : MauiTuneUI(hub)
     };
 
     private AudioEngines AudioEngines => field ??= Hub.Services.GetRequiredService<AudioEngines>();
+    private AudioFocusUI AudioFocusUI => field ??= Hub.Services.GetRequiredService<AudioFocusUI>();
 #if IOS
     private Haptics Haptics => field ??= Hub.Services.GetRequiredService<Haptics>();
 #endif
@@ -42,6 +43,10 @@ public sealed class AppleTuneUI(UIHub hub) : MauiTuneUI(hub)
             using var node = engine.NewPlayer(audioFile.ProcessingFormat);
             engine.EnsureRunning();
             node.Play();
+            // A tune started while the recording engine's VoiceProcessingIO runs is a source
+            // started after it, so it lands on the earpiece unless the route is restated - and
+            // the recording-confirm tune plays right after that engine starts, every time.
+            await AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
             using var cts = cancellationToken.CreateLinkedTokenSource(TimeSpan.FromSeconds(10));
             await node.ScheduleFileAndWait(audioFile, cts.Token).ConfigureAwait(false);
         }

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
@@ -27,8 +27,9 @@ public class AudioEngines : ProcessorBase
         Hub = hub;
         Tunes = new AudioEngine(AudioFocusMode.Tune, hub, TuneIdleReleaseDelay);
         Playback = new AudioEngine(AudioFocusMode.Playback, hub, PlaybackIdleReleaseDelay);
-        // Recording has no player nodes - it's released explicitly, when the capture ends.
-        Recording = new AudioEngine(AudioFocusMode.Recording, hub);
+        // Recording has no player nodes - it's released explicitly, when the capture ends. Its
+        // silent output is the exception, and stays off that list so it can't trigger a release.
+        Recording = new AudioEngine(AudioFocusMode.Recording, hub, hasSilentOutput: true);
         _configurationChangeSubscription =
             Disposable.New(AVAudioEngine.Notifications.ObserveConfigurationChange(OnConfigurationChange),
                 NSNotificationCenter.DefaultCenter.RemoveObserver);
@@ -48,6 +49,15 @@ public class AudioEngines : ProcessorBase
         Tunes.Pause();
         Playback.Pause();
         Recording.Pause();
+    }
+
+    // Apple's contract after a media-services reset: the engines are invalid and have to be
+    // recreated, not restarted. Releasing them is what makes the next use build fresh ones.
+    public void Release()
+    {
+        Tunes.Release();
+        Playback.Release();
+        Recording.Release();
     }
 
     public void Resume(AudioFocusMode mode)

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -5,20 +5,26 @@ using Foundation;
 
 namespace ActualChat.App.Maui.Audio;
 
-public class AudioSession(AppUIHub hub) : IAsyncDisposable
+public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
 {
     // Past the hot window: while that window is open the owner legitimately stays PTT-held with
     // no callback in between, so anything shorter would revert a live PTT session.
     private static readonly TimeSpan OwnerWatchdogTimeout =
         Constants.Audio.PttIdleTimeout + TimeSpan.FromMinutes(1);
     private static readonly TimeSpan OwnerWatchdogPeriod = TimeSpan.FromSeconds(30);
+    // A heartbeat, not a hold - so unlike a leaked latch it can't wedge the watchdog.
+    private static readonly TimeSpan PlaybackActivityTimeout = TimeSpan.FromSeconds(10);
 
     private static readonly Lock OwnerLock = new();
     private static int _owner;
     private static long _ownerChangedAt;
     private static int _isOwnerWatchdogRunning;
     private static Action? _ownerWatchdogRecovery;
+    private static long _playbackActivityAt;
 
+    private AppUIHub Hub { get; } = hub;
+    private static ILogger OwnerLog => field ??= StaticLog.For(typeof(AudioSession));
+    private ILogger Log => field ??= Hub.LogFor(GetType());
     public static AudioSessionOwner Owner => (AudioSessionOwner)Volatile.Read(ref _owner);
     public static bool MayActivateNow => AudioSessionOwnership.MayActivate(Owner);
 
@@ -36,8 +42,8 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
     public static void SetOwnerWatchdogRecovery(Action recovery)
         => Volatile.Write(ref _ownerWatchdogRecovery, recovery);
 
-    private static ILogger OwnerLog => field ??= StaticLog.For(typeof(AudioSession));
-    private ILogger Log => field ??= hub.LogFor(GetType());
+    public static void NotifyPlaybackActivity()
+        => Volatile.Write(ref _playbackActivityAt, CpuTimestamp.Now.Value);
 
     public ValueTask DisposeAsync()
         => BackgroundTask.Run(() => DispatchToMainThread(() => {
@@ -146,6 +152,12 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
     {
         // Every PTT callback republishes the owner, so an old stamp means none arrived.
         if (OwnerHeldFor() < OwnerWatchdogTimeout)
+            return false;
+
+        // The idle window restarts on activity but the owner's timestamp doesn't, so sustained
+        // traffic grows OwnerHeldFor without bound. Playing audio proves the session is wanted.
+        var playbackActivityAt = Volatile.Read(ref _playbackActivityAt);
+        if (playbackActivityAt != 0 && new CpuTimestamp(playbackActivityAt).Elapsed < PlaybackActivityTimeout)
             return false;
 
         // A live recorder may only defer the revert, never cancel it: the latch is cleared by
@@ -276,14 +288,31 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
         if (GetPortOverride(outputs) is not { } portOverride)
             return;
 
-        Log.LogInformation("ApplyOutputRoute: mode={Mode}, outputs={Outputs} -> {Override}",
-            mode, string.Join(", ", outputs.Select(x => x.PortType)), portOverride);
-        if (!session.OverrideOutputAudioPort(portOverride, out var error))
-            Log.LogWarning("ApplyOutputRoute: override failed: {Error}", error.LocalizedDescription);
+        var isOverridden = ForceOverride(session, portOverride, out var error);
+        Log.LogInformation(
+            "ApplyOutputRoute: mode={Mode}, sessionMode={SessionMode}, {Outputs} -> {Override} -> {Result}",
+            mode,
+            session.Mode,
+            Describe(outputs),
+            portOverride,
+            isOverridden ? Describe(session.CurrentRoute.Outputs) : $"failed: {error.LocalizedDescription}");
         return;
 
-        // Null means the route is already where it should be - which also covers Macs, where
-        // there's no receiver to be pushed off.
+        static string Describe(AVAudioSessionPortDescription[] outputs)
+            => string.Join(", ", outputs.Select(x => x.PortType));
+
+        // Restating an override the session already holds is a no-op, and a no-op won't move a
+        // source started after VoiceProcessingIO. Clearing first makes it a real transition.
+        static bool ForceOverride(AVAudioSession session, AVAudioSessionPortOverride portOverride, out NSError error) {
+            if (portOverride is AVAudioSessionPortOverride.None)
+                return session.OverrideOutputAudioPort(portOverride, out error);
+
+            return session.OverrideOutputAudioPort(AVAudioSessionPortOverride.None, out error)
+                && session.OverrideOutputAudioPort(portOverride, out error);
+        }
+
+        // Null means there's nothing to state - which covers Macs, where there's no receiver to
+        // be pushed off.
         static AVAudioSessionPortOverride? GetPortOverride(AVAudioSessionPortDescription[] outputs) {
             // An external device is the user's own choice of where to listen, so it outranks the
             // speaker default - and clearing the override is also what hands the route back to a
@@ -291,9 +320,11 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
             if (outputs.Any(x => IsExternalPort(x.PortType)))
                 return AVAudioSessionPortOverride.None;
 
-            return outputs.Any(x => x.PortType == AVAudioSession.PortBuiltInReceiver)
-                ? AVAudioSessionPortOverride.Speaker
-                : null;
+            // Unconditional: the session reports the speaker even while a post-VPIO source plays
+            // on the receiver, so the old "only if I see the receiver" test never once fired.
+            return OperatingSystem.IsMacCatalyst()
+                ? null
+                : AVAudioSessionPortOverride.Speaker;
         }
     }
 
@@ -311,13 +342,10 @@ public class AudioSession(AppUIHub hub) : IAsyncDisposable
     {
         Log.LogInformation("Configure: mode={Mode}", mode);
         if (mode is AudioFocusMode.Recording) {
-            // Mode is a sticky global the framework sets, so it has to be stated explicitly in
-            // both directions: VoiceChat carries the PTT call's AEC and must survive under a PTT
-            // owner, but it must go back to Default once the app owns the session again - stacked
-            // under SetVoiceProcessingEnabled, and paired with AllowBluetoothA2DP, it fights the
-            // app's own recording.
+            // VoiceChat carries the PTT call's AEC under a PTT owner. VideoChat, not Default, for
+            // ours: SetVoiceProcessingEnabled replaces Default and drops DefaultToSpeaker with it.
             var sessionMode = Owner == AudioSessionOwner.App
-                ? AVAudioSessionMode.Default
+                ? AVAudioSessionMode.VideoChat
                 : AVAudioSessionMode.VoiceChat;
             session.SetCategory(AVAudioSessionCategory.PlayAndRecord,
                     sessionMode,

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -14,21 +14,27 @@ namespace ActualChat.App.Maui.Audio;
 /// <summary>
 /// An <see cref="AVAudioEngine"/> that exists only while it has at least one player node.
 /// </summary>
-public class AudioEngine : IDisposable
+public sealed class AudioEngine : IDisposable
 {
-    public static readonly AVAudioFormat VoicePlaybackFormat = new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.PlaybackSampleRate, 1, false);
-    public static readonly AVAudioFormat VoiceRecordingFormat = new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.RecordingSampleRate, 1, false);
+    public static readonly AVAudioFormat VoicePlaybackFormat =
+        new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.PlaybackSampleRate, 1, false);
+    public static readonly AVAudioFormat VoiceRecordingFormat =
+        new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.RecordingSampleRate, 1, false);
+    private static readonly AVAudioFormat SilentOutputFormat =
+        new (AVAudioCommonFormat.PCMFloat32, Constants.Audio.PlaybackSampleRate, 2, false);
 
     private readonly Lock _lock = new ();
     private readonly ComputedState<bool> _isRunning;
     private readonly Debouncer<Unit> _idleReleaseDebouncer;
     private readonly List<PlayerNode> _playerNodes = new();
+    private readonly bool _hasSilentOutput;
     private AVAudioEngine? _engine;
+    private AVAudioPlayerNode? _silentOutputNode;
     private InputNode? _inputNode;
     private bool _isStarted;
     private bool _isDisposed;
     private AudioFocusMode Mode { get; }
-    private AppUIHub Hub { get;  }
+    private AppUIHub Hub { get; }
     private ILogger Log => field ??= Hub.LogFor(GetType());
     public IState<bool> IsRunning => _isRunning;
 
@@ -41,10 +47,15 @@ public class AudioEngine : IDisposable
 
     private AVAudioEngine EngineUnsafe => _engine ??= new AVAudioEngine();
 
-    public AudioEngine(AudioFocusMode mode, AppUIHub hub, TimeSpan idleReleaseDelay = default)
+    public AudioEngine(
+        AudioFocusMode mode,
+        AppUIHub hub,
+        TimeSpan idleReleaseDelay = default,
+        bool hasSilentOutput = false)
     {
         Mode = mode;
         Hub = hub;
+        _hasSilentOutput = hasSilentOutput;
         _isRunning = hub.StateFactory.NewComputed(GetIsRunning, StateCategories.Get(GetType(), nameof(IsRunning)));
         _idleReleaseDebouncer = Debouncer.New<Unit>(idleReleaseDelay, ReleaseIfIdle);
     }
@@ -124,6 +135,8 @@ public class AudioEngine : IDisposable
                 // that's the only thing observed to bring the sound back after a change.
                 foreach (var playerNode in playerNodes)
                     engine.Connect(playerNode.Node, engine.MainMixerNode, playerNode.Format);
+                if (_silentOutputNode is { } silentOutputNode)
+                    engine.Connect(silentOutputNode, engine.MainMixerNode, SilentOutputFormat);
             }
             if (!TryEnsureEngineRunningUnsafe()) {
                 Log.LogWarning("{Mode}.Reconnect: Engine failed, attempting reset", Mode);
@@ -236,15 +249,32 @@ public class AudioEngine : IDisposable
         if (_engine is null)
             return;
 
+        // Every native call here is wrapped: after a media-services reset the engine and its
+        // nodes are already invalid, and this is the path that has to dispose them anyway.
         // Reached through the cached wrapper, never through Input - see Release().
-        _inputNode?.Reset();
-        _engine.Stop();
+        InvokeSilently(() => _inputNode?.Reset());
+        InvokeSilently(() => _engine.Stop());
         // Before the engine, so the node is released while the graph that owns it is still there.
-        _inputNode?.Dispose();
+        InvokeSilently(() => _inputNode?.Dispose());
+        if (_silentOutputNode is { } silentOutput) {
+            InvokeSilently(() => _engine.DetachNode(silentOutput));
+            silentOutput.DisposeSilently();
+            _silentOutputNode = null;
+        }
         _engine.DisposeSilently();
         _engine = null;
         _inputNode = null;
         _isStarted = false;
+        return;
+
+        void InvokeSilently(Action action) {
+            try {
+                action.Invoke();
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "{Mode}.ReleaseUnsafe: a native call failed, continuing", Mode);
+            }
+        }
     }
 
     private void DisposeNode(AVAudioNode node)
@@ -266,6 +296,7 @@ public class AudioEngine : IDisposable
     private void EnsureEngineRunningUnsafe()
     {
         var engine = EngineUnsafe;
+        EnsureSilentOutputUnsafe();
         if (!engine.Running) {
             Log.LogInformation("{Mode}.EnsureEngineRunningUnsafe: Engine not running, starting", Mode);
             engine.StartAndReturnError(out var nsError);
@@ -274,15 +305,30 @@ public class AudioEngine : IDisposable
         _isStarted = true;
     }
 
+    private void EnsureSilentOutputUnsafe()
+    {
+        // Owned by the engine, not by a capture: it's what gives VoiceProcessingIO an output side,
+        // and it must never reach _playerNodes, whose emptying is what releases the engine.
+        if (!_hasSilentOutput || _silentOutputNode is not null)
+            return;
+
+        var engine = EngineUnsafe;
+        _silentOutputNode = new AVAudioPlayerNode();
+        engine.AttachNode(_silentOutputNode);
+        engine.Connect(_silentOutputNode, engine.MainMixerNode, SilentOutputFormat);
+    }
+
     private bool TryEnsureEngineRunningUnsafe()
     {
         var engine = EngineUnsafe;
+        EnsureSilentOutputUnsafe();
         if (engine.Running)
             return true;
 
         Log.LogInformation("{Mode}.TryEnsureEngineRunningUnsafe: Engine not running, attempting to start", Mode);
         if (!engine.StartAndReturnError(out var nsError)) {
-            Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}", Mode, nsError.LocalizedDescription);
+            Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}",
+                Mode, nsError.LocalizedDescription);
             return false;
         }
         _isStarted = true;

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioCapture.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioCapture.cs
@@ -85,6 +85,9 @@ public class AndroidAudioCapture(IServiceProvider services) : IAudioCapture
         }
 
         var buffer = new BlockRingBuffer<float>(Constants.Audio.RecordingSampleRate * 10);
+        // The consumer parks on the ring buffer with no timeout, so a producer that dies has to
+        // say so - otherwise the whole recording wedges behind a wait nothing will ever satisfy.
+        var whenProducerEndedCts = new CancellationTokenSource();
         // Dedicated high-priority thread instead of ThreadPool. Two reasons:
         //   1) AudioRecord.Read() is a blocking JNI call; running it on a ThreadPool
         //      worker means each read holds a worker for ~40ms and resumption after
@@ -211,10 +214,13 @@ public class AndroidAudioCapture(IServiceProvider services) : IAudioCapture
                 Log.LogError(ex, "Error while capturing audio on Android");
             }
             finally {
-                // The consumer parks on the ring buffer with no timeout, so a producer that ends
-                // before cancellation wedges the whole recording silently.
                 if (!cancellationToken.IsCancellationRequested)
                     Log.LogWarning("Capture producer ended before the recording was stopped");
+                // Silently, because the consumer disposes this source and usually gets there
+                // first - this thread is still parked in a blocking Read. Cancel() on a disposed
+                // source throws, which would skip the rest of this finally: the mic would stay
+                // held until finalization and the throw would escape a raw Thread entry point.
+                whenProducerEndedCts.CancelSilently();
                 floatReadBuffer.Release();
                 try {
                     if (recorder.RecordingState == RecordState.Recording)
@@ -233,19 +239,26 @@ public class AndroidAudioCapture(IServiceProvider services) : IAudioCapture
 
         async IAsyncEnumerable<IMemoryOwner<float>> Enumerate([EnumeratorCancellation] CancellationToken ct)
         {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, whenProducerEndedCts.Token);
             try {
                 const int frameSize = Constants.Audio.OpusFrameLength;
-                while (!ct.IsCancellationRequested) {
+                while (!cts.IsCancellationRequested) {
                     var owner = ArrayPools.SharedFloatPool.LeaseArrayOwner(frameSize, true);
                     if (!buffer.TryRead(owner.Span, out var whenReady)) {
                         owner.Dispose();
-                        await whenReady.WaitAsync(ct).ConfigureAwait(false);
-                        continue;
+                        if (await whenReady.TryWaitAsync(cts.Token).ConfigureAwait(false))
+                            continue;
+
+                        // A real stop still cancels as it always did; only a dead producer ends
+                        // the stream, which is what lets PushRecordingState restart the recorder.
+                        ct.ThrowIfCancellationRequested();
+                        yield break;
                     }
                     yield return owner;
                 }
             }
             finally {
+                whenProducerEndedCts.DisposeSilently();
                 buffer.DisposeSilently();
             }
         }

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
@@ -202,6 +202,15 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         _hasFocus = result == AudioFocusRequest.Granted;
         _isCommunicationFocus = _hasFocus && isCommunication;
         _log.LogInformation("Requested audio focus for '{Usage}', granted = {Result}", audioUsageKind, _hasFocus);
+        if (isCommunication && !_hasFocus) {
+            // The mode was raised before the request, and a denial - the normal answer during a
+            // real phone call, which is exactly when a PTT wake arrives - used to leave it on
+            // InCommunication with no focus. Nothing resets it after that: AbandonFocus is
+            // unreachable because the failure path nulls _focusRequest, so ringtones and media
+            // kept routing to the earpiece until some later full cycle happened to fix it.
+            _log.LogWarning("Audio focus denied for '{Usage}' - restoring Mode.Normal", audioUsageKind);
+            _audioManager.Mode = Mode.Normal;
+        }
 
         // After gaining focus, apply routing preference (handles external devices like Bluetooth)
         if (_hasFocus && isCommunication)

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioPlaybackEngine.cs
@@ -281,6 +281,14 @@ internal sealed class AndroidAudioPlaybackEngine(
                     var written = await audioTrack
                         .WriteAsync(audioData, skip, playSamples, WriteMode.Blocking)
                         .ConfigureAwait(false);
+                    if (written < 0) {
+                        // An AudioTrack error code - ERROR_DEAD_OBJECT after an audioserver restart
+                        // or a route teardown. The track still reports Initialized/Playing, so
+                        // CanContinuePlaying never trips and later writes discard audio in silence.
+                        _frames.Complete();
+                        throw StandardError.External($"AudioTrack.Write failed with {written}.");
+                    }
+
                     // Interlocked, not Volatile.Write: this publishes a delta, not the latest value.
                     if (written > 0)
                         Interlocked.Add(ref _fedSampleCount, written);
@@ -398,7 +406,19 @@ internal sealed class AndroidAudioPlaybackEngine(
         if (pauseEndTokenSource is null)
             return;
 
-        await TaskExt.NeverEnding(pauseEndTokenSource.Token).SilentAwait(false);
+        CancellationToken pauseEndToken;
+        try {
+            pauseEndToken = pauseEndTokenSource.Token;
+        }
+        catch (ObjectDisposedException) {
+            // Resume() and End() cancel-and-dispose this source from the command loop, racing the
+            // read above. A disposed source means the pause is already over, so returning is
+            // right - and the alternative was this exception reaching DecodeAndFeed's catch and
+            // ending a live track, on a path that runs every time focus churns.
+            return;
+        }
+
+        await TaskExt.NeverEnding(pauseEndToken).SilentAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
     }
 

--- a/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
@@ -100,10 +100,15 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
 
             try {
                 deviceEnumerator = new MMDeviceEnumerator();
-                micDevice = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+                // Multimedia, matching what CreateDeviceInputNodeAsync opens below. Under
+                // Communications, AGC drove a mic nobody was recording and never converged.
+                micDevice = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Multimedia);
                 var loopbackDevice = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
                 loopbackCapture = new CustomWasapiLoopbackCapture(loopbackDevice, true, CaptureBufferMs);
                 loopbackCapture.DataAvailable += OnLoopbackCaptureOnDataAvailable;
+                // NAudio's only channel for a capture-thread failure. Unsubscribed, losing the
+                // render endpoint silently ends the AEC reference for the rest of the session.
+                loopbackCapture.RecordingStopped += OnLoopbackRecordingStopped;
                 loopbackCapture.WaveFormat =
                     WaveFormat.CreateIeeeFloatWaveFormat(Constants.Audio.RecordingSampleRate, 1);
             }
@@ -244,15 +249,29 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
                     /* Expected */
                 }
                 catch (Exception ex) {
-                    Log.LogError(ex, "Mic processing loop failed");
+                    // Ending is what lets it restart: dying quietly leaves the graph and loopback
+                    // running with the heartbeat stopped, so the mic stays hot and nothing records.
+                    Log.LogError(ex, "Mic processing loop failed - ending the capture");
+                    _ = Stop();
                 }
                 finally {
                     ArrayPools.SharedFloatPool.Return(emptyArray);
                 }
             }, processingCts.Token);
 
+            if (loopbackCapture is not null)
+                try {
+                    loopbackCapture.StartRecording();
+                }
+                catch (Exception e) {
+                    // Degraded, not fatal: WASAPI Initialize happens inside StartRecording, so an
+                    // app holding the render endpoint exclusively used to kill the whole recording.
+                    Log.LogWarning(e, "AEC loopback failed to start; continuing without it");
+                    loopbackCapture.DisposeSilently();
+                    loopbackCapture = null;
+                }
+
             try {
-                loopbackCapture?.StartRecording();
                 graph!.Start();
                 inputNode!.Start();
             }
@@ -436,6 +455,9 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
             catch (Exception e) {
                 Log.LogWarning(e, "Failed to restore the microphone volume");
             }
+            // Its native callback registration otherwise lives until finalization.
+            endpointVolume.DisposeSilently();
+            endpointVolume = null;
         }
 
         void OnUnrecoverableError(AudioGraph sender, AudioGraphUnrecoverableErrorOccurredEventArgs args) {
@@ -443,6 +465,11 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
             // the rest of the process, so end the capture and let the next attempt build a new one.
             Log.LogWarning("AudioGraph hit an unrecoverable error: {Error}", args.Error);
             _ = Stop();
+        }
+
+        void OnLoopbackRecordingStopped(object? sender, StoppedEventArgs e) {
+            if (e.Exception is { } error)
+                Log.LogWarning(error, "AEC loopback capture stopped - echo cancellation is degraded");
         }
 
         void OnDefaultCaptureDeviceChanged() {
@@ -533,7 +560,7 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
     {
         public void OnDefaultDeviceChanged(DataFlow dataFlow, Role role, string defaultDeviceId)
         {
-            if (dataFlow == DataFlow.Capture && role == Role.Communications)
+            if (dataFlow == DataFlow.Capture && role == Role.Multimedia)
                 onChanged();
         }
 

--- a/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioPlaybackEngine.cs
@@ -72,22 +72,36 @@ internal sealed class WindowsAudioPlaybackEngine(
 
         var settings = new AudioGraphSettings(Windows.Media.Render.AudioRenderCategory.Media) {
             QuantumSizeSelectionMode = QuantumSizeSelectionMode.ClosestToDesired,
-            DesiredSamplesPerQuantum = Constants.Audio.RecordingSampleRate / 1000 * Constants.Audio.OpusFrameDurationMs,
+            // Playback rate: the recording rate asked for a third of a frame's samples.
+            DesiredSamplesPerQuantum =
+                Constants.Audio.PlaybackSampleRate / 1000 * Constants.Audio.OpusFrameDurationMs,
         };
 
         var graphCreate = await AudioGraph.CreateAsync(settings).AsTask(cancellationToken).ConfigureAwait(false);
-        if (graphCreate.Status != AudioGraphCreationStatus.Success || graphCreate.Graph is null)
+        if (graphCreate.Status != AudioGraphCreationStatus.Success || graphCreate.Graph is null) {
+            // Logged here because nothing above will - TrackPlayer swallows this and reports a
+            // clean end. ExtendedError carries the HRESULT; without it it's "UnknownFailure".
+            Log.LogError(graphCreate.ExtendedError,
+                "Playback AudioGraph creation failed: {Status}", graphCreate.Status);
             throw new InvalidOperationException($"AudioGraph creation failed: {graphCreate.Status}");
+        }
 
         _graph = graphCreate.Graph;
 
         var deviceOutputResult = await _graph.CreateDeviceOutputNodeAsync().AsTask(cancellationToken).ConfigureAwait(false);
-        if (deviceOutputResult.Status != AudioDeviceNodeCreationStatus.Success || deviceOutputResult.DeviceOutputNode is null)
-            throw new InvalidOperationException($"AudioGraph device output creation failed: {deviceOutputResult.Status}");
+        if (deviceOutputResult.Status != AudioDeviceNodeCreationStatus.Success || deviceOutputResult.DeviceOutputNode is null) {
+            Log.LogError(deviceOutputResult.ExtendedError,
+                "Playback device output creation failed: {Status}", deviceOutputResult.Status);
+            throw new InvalidOperationException(
+                $"AudioGraph device output creation failed: {deviceOutputResult.Status}");
+        }
         _deviceOutput = deviceOutputResult.DeviceOutputNode;
         _frameInput = _graph.CreateFrameInputNode(encoding);
         _frameInput.AddOutgoingConnection(_deviceOutput);
         _frameInput.QuantumStarted += OnQuantumStarted;
+        // Without this a dead graph is silent: QuantumStarted stops firing, nothing reports an
+        // end, and TrackPlayer waits on a completion that never comes.
+        _graph.UnrecoverableErrorOccurred += OnUnrecoverableError;
 
         // Start background decode loop
         var ct = _decodeCts.Token;
@@ -190,14 +204,20 @@ internal sealed class WindowsAudioPlaybackEngine(
             // Wait until we have enough decoded samples buffered before starting playback
             var minSamples = (int)(Constants.Audio.StartPlaybackWhenBufferedDuration.TotalSeconds * Constants.Audio.PlaybackSampleRate);
             if (minSamples > 0)
-                while (_decodeBuffer.Count < minSamples && !cancellationToken.IsCancellationRequested)
+                // Decode completion ends the wait too: a track shorter than the threshold never
+                // reaches minSamples, so it would never start and never end.
+                while (_decodeBuffer.Count < minSamples
+                    && Volatile.Read(ref _decodeCompleted) == 0
+                    && !cancellationToken.IsCancellationRequested)
                     try {
                         var count = _decodeBuffer.Count;
                         if (count > 0) {
                             // Buffer has data but not enough yet; wait estimated time for the rest
                             var remaining = minSamples - count;
+                            // At least 1ms: the estimate rounds to zero under ~48 samples.
+                            var delayMs = Math.Max(1, remaining * 1000 / Constants.Audio.PlaybackSampleRate);
                             await Clocks.CoarseSystemClock
-                                .Delay(remaining * 1000 / Constants.Audio.PlaybackSampleRate, cancellationToken)
+                                .Delay(delayMs, cancellationToken)
                                 .ConfigureAwait(false);
                         }
                         else {
@@ -228,6 +248,12 @@ internal sealed class WindowsAudioPlaybackEngine(
             Log.LogError(e, "Failed to start playback graph");
             throw;
         }
+    }
+
+    private void OnUnrecoverableError(AudioGraph sender, AudioGraphUnrecoverableErrorOccurredEventArgs args)
+    {
+        Log.LogError("Playback AudioGraph failed: {Error}", args.Error);
+        TryReportEnded($"Playback AudioGraph failed: {args.Error}");
     }
 
     private async Task DecodeAndFeed(CancellationToken cancellationToken)

--- a/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
@@ -89,7 +89,8 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 
         if (_lastAudioFocusHolder.Scopes.Count == 0) {
             _lastAudioFocusHolder.Handle.Release();
-            _restoreAudioFocusHandlers.Clear();
+            lock (_restoreAudioFocusHandlers)
+                _restoreAudioFocusHandlers.Clear();
             _lastAudioFocusHolder = null;
             return;
         }
@@ -110,7 +111,8 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
         var audioFocusHandle = await RequestAudioFocus(desiredMode).ConfigureAwait(false);
         if (audioFocusHandle is null) {
             Log.LogInformation("Failed to get/update audio focus");
-            _restoreAudioFocusHandlers.Clear();
+            lock (_restoreAudioFocusHandlers)
+                _restoreAudioFocusHandlers.Clear();
             _lastAudioFocusHolder = null;
             InvokeLostFocus(temp, false, false);
             return null;
@@ -133,7 +135,16 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
         };
         audioFocusHandle.FocusRecover += () => {
             holder.Suspend(false);
-            foreach (var handler in _restoreAudioFocusHandlers) {
+            // Taken and cleared, because they were only ever added: the Nth recover replayed every
+            // restore from all N cycles, racing StartReplay against itself and growing unbounded
+            // over a long session. The snapshot also keeps this off the live list, which these
+            // callbacks touch from the Android main thread while other threads mutate it.
+            AudioFocusRestoreHandler[] handlers;
+            lock (_restoreAudioFocusHandlers) {
+                handlers = [.. _restoreAudioFocusHandlers];
+                _restoreAudioFocusHandlers.Clear();
+            }
+            foreach (var handler in handlers) {
                 handler.Invoke();
             }
         };
@@ -150,10 +161,12 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
             scope.Suspend(true);
             var restoreHandler = requester.AudioFocusLostHandler(mayRecover, canDuck);
             if (restoreHandler is not null) {
-                _restoreAudioFocusHandlers.Add(() => {
-                    scope.Suspend(false);
-                    restoreHandler.Invoke();
-                });
+                lock (_restoreAudioFocusHandlers) {
+                    _restoreAudioFocusHandlers.Add(() => {
+                        scope.Suspend(false);
+                        restoreHandler.Invoke();
+                    });
+                }
             }
         }
     }

--- a/src/dotnet/App.Maui/Services/MauiTuneUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiTuneUI.cs
@@ -89,8 +89,16 @@ public class MauiTuneUI : TuneUI
             if (scope is null)
                 return;
 
-            await player.PlayAsync(CancellationToken.None).ConfigureAwait(false);
-            ReleaseAudioFocus();
+            // In a finally, because a throw from PlayAsync used to skip the release: the tune's
+            // scope then kept the holder non-empty, so the "last scope released" cleanup that
+            // abandons focus, restores Mode.Normal and stops SCO never ran until the next tune
+            // that happened to succeed.
+            try {
+                await player.PlayAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            finally {
+                ReleaseAudioFocus();
+            }
         }
         catch (Exception e) {
             Log.LogError(e, "Failed to play sound {SoundName}", soundName);

--- a/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
+++ b/src/dotnet/App.Maui/Services/Recording/MauiRecorderEngine.cs
@@ -399,12 +399,17 @@ public class MauiRecorderEngine : IAudioRecorderEngine
         // un-ACKed window at peer-change are lost (the old server-side entry ends there);
         // everything in the channel is preserved.
         var session = _hub.Session;
+        var sentFrameCount = 0;
 
         while (!cancellationToken.IsCancellationRequested) {
             // Per-call state: each iteration is a fresh PushAudio = fresh chat entry,
-            // so packetIndex (→ frame Offset) and sourceStartOffset reset.
+            // so packetIndex (→ frame Offset) resets. The claimed start advances by what earlier
+            // calls sent: repeating it registers the retry with a BeginsAt equal to the dead
+            // call's, and ListeningStreamMuxer then keeps the dead one.
             var packetIndex = 0;
-            var sourceStartOffsetSeconds = firstFrameSourceCapturedAt.EpochOffset.TotalSeconds;
+            var callStartAt = firstFrameSourceCapturedAt
+                + TimeSpan.FromMilliseconds(sentFrameCount * Constants.Audio.OpusFrameDurationMs);
+            var sourceStartOffsetSeconds = callStartAt.EpochOffset.TotalSeconds;
 
             // Cadence tracking: warn when wall-clock between successful yields drifts
             // above 60ms (3+ frames of expected 20ms pace). Bursty send → all listeners
@@ -496,10 +501,11 @@ public class MauiRecorderEngine : IAudioRecorderEngine
                 // The channel still holds whatever packets weren't yet consumed, and the encoder
                 // keeps writing new ones.
                 Log.LogWarning(e, "PushAudio call ended ({SentFrames} frames), retrying with a new call", packetIndex);
+                sentFrameCount += packetIndex;
                 repliedChatEntryId = null; // Only the initial segment carries the reply target.
                 // Short delay to avoid tight-looping on a persistent failure; the recording CT
-                // cancels this delay when the user stops recording.
-                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+                // cancels this delay when the user stops recording. Shared with the web sender.
+                await Task.Delay(Constants.Audio.StreamErrorRetryDelay, cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -565,7 +571,10 @@ public class MauiRecorderEngine : IAudioRecorderEngine
 
         private readonly BlockRingBuffer<float> _vadBuffer = new (Constants.Audio.RecordingSampleRate * 2); // 2s
         private readonly BlockRingBuffer<float> _encodingBuffer = new (Constants.Audio.RecordingSampleRate / 2); // 500ms
-        private readonly Queue<Moment> _encodingFrameSourceCapturedAts = new();
+        // Concurrent: written from the capture task, read from the encode worker. A plain
+        // Queue<T> can corrupt or throw when a grow races a dequeue, and corruption here skews
+        // firstFrameSourceCapturedAt - the stream's BeginsAt and the A/V-sync anchor.
+        private readonly ConcurrentQueue<Moment> _encodingFrameSourceCapturedAts = new();
 
         private FuncWorker? _encodeSendWorker;
         private bool _voiceActive;
@@ -851,8 +860,16 @@ public class MauiRecorderEngine : IAudioRecorderEngine
                     if (packet.Memory.Length == 0)
                         continue;
 
-                    if (!stream.TryWrite(packet))
-                        await stream.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+                    // Retried, not just waited on: a bare wait drops this packet - 20ms of speech,
+                    // exactly during the RPC stall this buffer exists to bridge.
+                    while (!stream.TryWrite(packet)) {
+                        if (await stream.WaitToWriteAsync(cancellationToken).ConfigureAwait(false))
+                            continue;
+
+                        // The reader is gone, so nothing else will ever release this packet.
+                        packet.Dispose();
+                        return;
+                    }
                 }
             }
             catch (OperationCanceledException) {

--- a/src/dotnet/App.Maui/Services/Recording/OpusAudioCodec.cs
+++ b/src/dotnet/App.Maui/Services/Recording/OpusAudioCodec.cs
@@ -27,6 +27,7 @@ public sealed class OpusAudioCodec(ILogger<OpusAudioCodec> log) : IAudioCodec
 
 #if WINDOWS || ANDROID
                 OpusSharp.Core.OpusEncoder? encoder = null;
+                Exception? error = null;
                 try {
                     encoder = new OpusSharp.Core.OpusEncoder(
                         Constants.Audio.RecordingSampleRate,
@@ -120,12 +121,18 @@ public sealed class OpusAudioCodec(ILogger<OpusAudioCodec> log) : IAudioCodec
                 catch (OperationCanceledException) {
                     /* Ignore */
                 }
+                catch (Exception e) {
+                    // Completing without it would tell the reader the utterance ended normally,
+                    // and this task is discarded, so the throw would surface nowhere at all.
+                    log.LogError(e, "Opus encoding failed");
+                    error = e;
+                }
                 finally {
                     try { encoder?.Dispose(); }
                     catch {
                         /* Ignore */
                     }
-                    channel.Writer.TryComplete();
+                    channel.Writer.TryComplete(error);
                 }
 #else
             // Other platforms default to not implemented to avoid accidental use without Opus
@@ -157,6 +164,7 @@ public sealed class OpusAudioCodec(ILogger<OpusAudioCodec> log) : IAudioCodec
         _ = Task.Run(async () => {
 #if WINDOWS || ANDROID
                 OpusSharp.Core.OpusDecoder? decoder = null;
+                Exception? error = null;
                 try {
                     decoder = new OpusSharp.Core.OpusDecoder(
                         Constants.Audio.PlaybackSampleRate,
@@ -193,12 +201,18 @@ public sealed class OpusAudioCodec(ILogger<OpusAudioCodec> log) : IAudioCodec
                 catch (OperationCanceledException) {
                     /* Ignore */
                 }
+                catch (Exception e) {
+                    // Completing without it would tell the reader the track ended normally, and
+                    // this task is discarded, so the throw would surface nowhere at all.
+                    log.LogError(e, "Opus decoding failed");
+                    error = e;
+                }
                 finally {
                     try { decoder?.Dispose(); }
                     catch {
                         /* Ignore */
                     }
-                    channel.Writer.TryComplete();
+                    channel.Writer.TryComplete(error);
                 }
 #else
             try {

--- a/src/dotnet/Core/Collections/BlockRingBuffer.cs
+++ b/src/dotnet/Core/Collections/BlockRingBuffer.cs
@@ -26,6 +26,7 @@ public sealed class BlockRingBuffer<T> : IDisposable
     private int _writePos;  // physical position in [0, 2*capacity)
     private int _wrapPos;   // physical position where data ends before gap; -1 = no gap
     private volatile int _count; // valid readable items
+    private bool _isDisposed;
 
     private Task<int>? _whenReadyToRead;
     private Task<int>? _whenReadyToWrite;
@@ -50,12 +51,18 @@ public sealed class BlockRingBuffer<T> : IDisposable
     {
         Task<int>? t1, t2;
         lock (_lock) {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
             (t1, t2) = (_whenReadyToRead, _whenReadyToWrite);
             (_whenReadyToRead, _whenReadyToWrite) = (null, null);
+            // Under the lock, because TryWrite and TryRead copy under it too: outside, a producer
+            // could still be writing into an array the pool had handed to someone else.
+            _pool.Return(_buffer, RuntimeHelpers.IsReferenceOrContainsReferences<T>());
         }
         TrySetCanceled(t1);
         TrySetCanceled(t2);
-        _pool.Return(_buffer, RuntimeHelpers.IsReferenceOrContainsReferences<T>());
     }
 
     /// <summary>
@@ -89,6 +96,14 @@ public sealed class BlockRingBuffer<T> : IDisposable
 
         Task<int>? completedWhenReadyToWrite;
         lock (_lock) {
+            if (_isDisposed) {
+                // Cancelled, not null and not completed: null breaks NotNullWhen(false), and a
+                // completed task turns a wait loop into a spin.
+                writtenCount = 0;
+                whenReadyToWrite = Task.FromCanceled(new CancellationToken(true));
+                return false;
+            }
+
             var free = _capacity - _count;
             var toWrite = Math.Min(data.Length, free);
 
@@ -145,6 +160,12 @@ public sealed class BlockRingBuffer<T> : IDisposable
 
         Task<int>? completedWhenReadyToWrite;
         lock (_lock) {
+            if (_isDisposed) {
+                // See TryWrite - a completed task here spun WindowsAudioCapture's Enumerate.
+                whenReadyToRead = Task.FromCanceled(new CancellationToken(true));
+                return false;
+            }
+
             if (_count < destination.Length) {
                 _whenReadyToRead ??= AsyncTaskMethodBuilderExt.New<int>().Task;
                 whenReadyToRead = _whenReadyToRead;
@@ -189,6 +210,9 @@ public sealed class BlockRingBuffer<T> : IDisposable
     public Task? WhenReadyToRead()
     {
         lock (_lock) {
+            if (_isDisposed)
+                return Task.FromCanceled(new CancellationToken(true));
+
             return _count > 0
                 ? null
                 : _whenReadyToRead ??= AsyncTaskMethodBuilderExt.New<int>().Task;

--- a/src/dotnet/Core/TaskExt.cs
+++ b/src/dotnet/Core/TaskExt.cs
@@ -9,6 +9,36 @@ public static class TaskExt
     public static Task NeverEnding(CancellationToken cancellationToken)
         => Task.Delay(System.Threading.Timeout.Infinite, cancellationToken);
 
+    // TryWaitAsync
+
+    // False means the wait was cut short rather than the task completing, so the caller decides
+    // what that was - both current callers re-check their own token right after.
+    public static async Task<bool> TryWaitAsync(this Task task, CancellationToken cancellationToken)
+    {
+        try {
+            await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) {
+            return false;
+        }
+    }
+
+    public static async Task<bool> TryWaitAsync(
+        this Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        try {
+            await task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) {
+            return false;
+        }
+        catch (TimeoutException) {
+            return false;
+        }
+    }
+
     // WithDelay
 
     public static async Task WithDelay(

--- a/src/dotnet/Streaming.Service/Services/ListeningStreamMuxer.cs
+++ b/src/dotnet/Streaming.Service/Services/ListeningStreamMuxer.cs
@@ -19,6 +19,9 @@ public sealed class ListeningStreamMuxer : WorkerBase
     private readonly ConcurrentDictionary<AuthorId, StreamEntry> _streamByAuthor = new();
     private readonly ConcurrentDictionary<string, byte> _excludedStreamIds = new();
     private readonly ConcurrentDictionary<string, int> _preStartRetryCountByStreamId = new();
+    // Restarted after failing mid-relay: marked preexisting so GetSkipTo serves them live rather
+    // than replaying the utterance.
+    private readonly ConcurrentDictionary<string, byte> _resumedStreamIds = new();
     private TaskCompletionSource _whenRetryNeededSource = TaskCompletionSourceExt.New();
     private int _nextStreamIndex;
 
@@ -101,7 +104,8 @@ public sealed class ListeningStreamMuxer : WorkerBase
                                 Interlocked.Increment(ref _nextStreamIndex),
                                 streamInfo,
                                 cancellationToken.CreateLinkedTokenSource()) {
-                                IsPreexisting = isColdSnapshot,
+                                IsPreexisting = isColdSnapshot
+                                    || _resumedStreamIds.ContainsKey(streamInfo.StreamId),
                             };
                             Log.LogDebug(
                                 "Starting stream #{StreamIndex} for {AuthorId} stream #{StreamId}",
@@ -150,9 +154,9 @@ public sealed class ListeningStreamMuxer : WorkerBase
         var streamStopToken = streamStopTokenSource.Token;
         var frameCount = 0;
         var mustRetry = false;
-        var mustExclude = false;
         var isStartEmitted = false;
         var shouldRetry = false;
+        var mustResume = false;
         try {
             if (!TryRegister(streamEntry))
                 return; // See `finally` block below
@@ -190,11 +194,12 @@ public sealed class ListeningStreamMuxer : WorkerBase
         }
         catch (RpcReconnectFailedException e) {
             if (isStartEmitted)
-                mustExclude = true;
+                mustResume = true;
             else
                 mustRetry = true;
             Log.LogWarning(e,
-                "Reconnect failed processing stream #{StreamIndex} for {AuthorId} #{StreamId}, {FrameCount} frames emitted",
+                "Reconnect failed processing stream #{StreamIndex} for {AuthorId} #{StreamId}, "
+                + "{FrameCount} frames emitted",
                 streamIndex, authorId, streamId, frameCount);
         }
         catch (OperationCanceledException)
@@ -209,7 +214,7 @@ public sealed class ListeningStreamMuxer : WorkerBase
         }
         catch (Exception e) {
             if (isStartEmitted)
-                mustExclude = true;
+                mustResume = true;
             else
                 mustRetry = true;
             Log.LogWarning(e,
@@ -220,8 +225,24 @@ public sealed class ListeningStreamMuxer : WorkerBase
             streamStopTokenSource.CancelAndDisposeSilently();
             await EmitEndSafe().ConfigureAwait(false);
 
-            if (mustExclude)
-                _excludedStreamIds.TryAdd(streamId, 0);
+            if (mustResume) {
+                // Excluding here silenced the speaker until their next utterance. The retry path
+                // builds a fresh entry with a new index, so the listener gets a clean start item.
+                var resumeCount = _preStartRetryCountByStreamId.AddOrUpdate(streamId, 1, (_, count) => count + 1);
+                if (resumeCount <= MaxPreStartRetryCount) {
+                    _resumedStreamIds.TryAdd(streamId, 0);
+                    await Task.Delay(PreStartRetryDelays[resumeCount], CancellationToken.None).ConfigureAwait(false);
+                    shouldRetry = true;
+                }
+                else {
+                    Log.LogWarning(
+                        "ProcessStream: Stream #{StreamId} failed mid-relay {ResumeCount} times, excluding",
+                        streamId, MaxPreStartRetryCount);
+                    _excludedStreamIds.TryAdd(streamId, 0);
+                    _preStartRetryCountByStreamId.TryRemove(streamId, out _);
+                    _resumedStreamIds.TryRemove(streamId, out _);
+                }
+            }
             if (mustRetry) {
                 var retryCount = _preStartRetryCountByStreamId.AddOrUpdate(streamId, 1, (_, count) => count + 1);
                 if (retryCount <= MaxPreStartRetryCount) {
@@ -234,14 +255,18 @@ public sealed class ListeningStreamMuxer : WorkerBase
                         streamId, MaxPreStartRetryCount);
                     _excludedStreamIds.TryAdd(streamId, 0);
                     _preStartRetryCountByStreamId.TryRemove(streamId, out _);
+                    _resumedStreamIds.TryRemove(streamId, out _);
                 }
             }
-            else if (!mustExclude) {
+            else if (mustResume) {
+                // Nothing to clear: the resume block owns the counter, and falling through to the
+                // else below wiped the increment it had just made.
+            }
+            else {
                 _preStartRetryCountByStreamId.TryRemove(streamId, out _);
+                _resumedStreamIds.TryRemove(streamId, out _);
                 await Task.Delay(EvictionDelay, CancellationToken.None).ConfigureAwait(false);
             }
-            else
-                _preStartRetryCountByStreamId.TryRemove(streamId, out _);
 
             // Unregister the stream
             _streamById.TryRemove(streamId, streamEntry);
@@ -272,19 +297,26 @@ public sealed class ListeningStreamMuxer : WorkerBase
             entry.AuthorId,
             _ => entry,
             (_, existing) => {
-                if (entry.StreamId != existing.StreamId && entry.BeginsAt > existing.BeginsAt) {
+                // Ties go to the newcomer: a retry within MaxBeginsAtDrift claims a start equal to
+                // the call it replaces, and keeping the older entry means keeping the dead one.
+                if (entry.StreamId != existing.StreamId && entry.BeginsAt >= existing.BeginsAt) {
                     // New stream is fresher — cancel the old one
                     Log.LogInformation(
-                        "Author {AuthorId}: stream {NewStreamId} (beginsAt={NewBeginsAt}) replaces {OldStreamId} (beginsAt={OldBeginsAt})",
+                        "Author {AuthorId}: stream {NewStreamId} (beginsAt={NewBeginsAt}) replaces "
+                        + "{OldStreamId} (beginsAt={OldBeginsAt})",
                         entry.AuthorId, entry.StreamId, entry.BeginsAt, existing.StreamId, existing.BeginsAt);
                     try { existing.StopTokenSource.CancelAndDisposeSilently(); }
                     catch (ObjectDisposedException) { }
+                    // Excluded so the scanner can't recreate it: with ties to the newcomer it
+                    // would come back, win against the live one, and replay from position 0.
+                    _excludedStreamIds.TryAdd(existing.StreamId, 0);
                     return entry;
                 }
 
                 // It's either the same stream or existing stream is fresher — cancel ourselves
                 Log.LogInformation(
-                    "Author {AuthorId}: stream {NewStreamId} (beginsAt={NewBeginsAt}) is stale, keeping {OldStreamId} (beginsAt={OldBeginsAt})",
+                    "Author {AuthorId}: stream {NewStreamId} (beginsAt={NewBeginsAt}) is stale, keeping "
+                    + "{OldStreamId} (beginsAt={OldBeginsAt})",
                     entry.AuthorId, entry.StreamId, entry.BeginsAt, existing.StreamId, existing.BeginsAt);
                 entry.StopTokenSource.CancelAndDisposeSilently();
                 return existing;

--- a/src/dotnet/UI.Blazor.App/Components/AudioPlayer/AudioTrackPlayer.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioPlayer/AudioTrackPlayer.cs
@@ -12,6 +12,8 @@ public sealed class AudioTrackPlayer : TrackPlayer, IAudioPlayerBackend
     // flow control takes over after that.
     private static readonly TimeSpan PacingHeadStartDuration = TimeSpan.FromMilliseconds(30);
     private static readonly TimeSpan PacingDuration = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan BufferLowTimeout = TimeSpan.FromSeconds(10);
+    private const int MaxBufferLowTimeoutCount = 3;
     private const int AudioSyncPolicySamplePeriodFrames = 10;
     // OnPresentationLag arrives at ~2 Hz per track; report every 5th, so ~1 sample per 2.5 s.
     private const int LagReportSamplePeriod = 5;
@@ -29,6 +31,7 @@ public sealed class AudioTrackPlayer : TrackPlayer, IAudioPlayerBackend
     private CpuTimestamp _lastBufferAdjustAt;
     private bool _isOwnStream;
     private int _underrunCount;
+    private int _bufferLowTimeoutCount;
     private int _lagReportSampleIn;
 
     private IServiceProvider Services { get; }
@@ -164,16 +167,29 @@ public sealed class AudioTrackPlayer : TrackPlayer, IAudioPlayerBackend
             ApplyAudioSync();
             await _playbackEngine.PushFrame(audioFrame, cancellationToken).ConfigureAwait(false);
             await _whenBufferLowSource.Task
-                .WaitAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .WaitAsync(BufferLowTimeout, cancellationToken)
                 .ConfigureAwait(false);
+            _bufferLowTimeoutCount = 0;
         }
         catch (TimeoutException e) {
+            // The signal only ever comes from the engine, so its absence means the engine stopped
+            // reporting. Swallowing every timeout turns that into one frame per BufferLowTimeout.
             Log.LogError(
                 e,
                 "[AudioTrackPlayer #{AudioTrackPlayerId}] ProcessMediaFrame: "
-                + "ready-to-buffer wait timed out, offset={FrameOffset}",
+                + "ready-to-buffer wait timed out ({TimeoutCount}/{MaxTimeoutCount}), offset={FrameOffset}",
                 _id,
+                _bufferLowTimeoutCount + 1,
+                MaxBufferLowTimeoutCount,
                 frame.Offset);
+            // Not while paused: no engine consumes its buffer then, so buffer-low can never
+            // arrive and this would kill any track paused longer than the threshold.
+            if (State.IsPaused)
+                _bufferLowTimeoutCount = 0;
+            else if (++_bufferLowTimeoutCount >= MaxBufferLowTimeoutCount)
+                throw StandardError.External(
+                    $"The playback engine stopped reporting buffer state for "
+                    + $"{(MaxBufferLowTimeoutCount * BufferLowTimeout).ToShortString()}.");
         }
     }
 
@@ -190,7 +206,16 @@ public sealed class AudioTrackPlayer : TrackPlayer, IAudioPlayerBackend
                     "[AudioTrackPlayer #{AudioTrackPlayerId}] Ended after {PlayDuration}, "
                     + "{UnderrunCount} underruns",
                     _id, _playDuration.ToShortString(), _underrunCount);
-            await _playbackEngine.DisposeSilentlyAsync().ConfigureAwait(false);
+            // Bounded for the same reason End is - a hang here holds up every PlayTask waiter.
+            try {
+                await _playbackEngine.DisposeSilentlyAsync().AsTask()
+                    .WaitAsync(StopTimeout, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException) {
+                Log.LogWarning("[AudioTrackPlayer #{AudioTrackPlayerId}] the engine didn't dispose in {Timeout}",
+                    _id, StopTimeout.ToShortString());
+            }
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/AudioPlayer/workers/opus-decoder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioPlayer/workers/opus-decoder.ts
@@ -234,7 +234,14 @@ export class OpusDecoder implements BufferHandler, AsyncDisposable {
         try {
             if (item === 'end') {
                 debugLog?.log(`#${this.streamId}.process: got 'end'`, this.mustAbort);
-                await this.systemDecoder?.flush();
+                // A rejecting flush - what a closed AudioDecoder does - must not swallow the end,
+                // or the feeder never reports 'ended' and TrackPlayer waits forever.
+                try {
+                    await this.systemDecoder?.flush();
+                }
+                catch (e) {
+                    errorLog?.log(`#${this.streamId}.process: system decoder flush failed`, e);
+                }
 
                 void this.feederWorklet.end(this.mustAbort, rpcNoWait);
                 return true;
@@ -257,6 +264,7 @@ export class OpusDecoder implements BufferHandler, AsyncDisposable {
                 const typedViewSamples = this.decoder.decode(item.data);
                 if (typedViewSamples == null || typedViewSamples.length === 0) {
                     warnLog?.log(`#${this.streamId}.process: decoder returned empty result`);
+                    this.rearmDecodeDemand();
                     return true;
                 }
 
@@ -282,9 +290,17 @@ export class OpusDecoder implements BufferHandler, AsyncDisposable {
         }
         catch (e) {
             errorLog?.log(`#${this.streamId}.process: error:`, e);
+            this.rearmDecodeDemand();
         }
         // Keep running for reuse
         return true;
+    }
+
+    // Flow control is one token per side, and a pass that emits no frame loses both at once: the
+    // feeder never asks again and the decoder never dequeues again. Re-arm to skip the bad packet.
+    private rearmDecodeDemand(): void {
+        this.frameRequested = true;
+        this.flushDecodeDemand();
     }
 
     private onSystemDecoderError = (error: DOMException): void => {

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
@@ -422,8 +422,11 @@ export class OpusMediaRecorder implements RecorderStateServer {
         this.recordingAction = this.recordingContextRef.run(async (context) => {
             try {
                 debugLog?.log(`start(): awaiting encoder worker start, worklet start and vad worker reset ...`);
-                if (this.chatId === chatId && this.stream)
-                    return; // Already started
+                // The context matters as much as the chat: after a context failure this action
+                // re-runs on the new one, and the pipeline, worklets and mic source all still
+                // belong to the dead context. startMicrophoneStream makes the same comparison.
+                if (this.chatId === chatId && this.stream && this.source?.context === context)
+                    return; // Already started on this context
 
                 // Get the attached pipeline
                 const pipeline = this.recordingContextRef?.getTrait<AttachedRecordingPipeline>(this.recordingPipelineTrait);

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/audio-streamer.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/audio-streamer.ts
@@ -47,7 +47,6 @@ export class AudioStream implements Disposable {
             try {
                 await this.stream();
             } catch { }
-            await delayAsync(AUDIO.stream.interStreamDelayMs);
         })();
     }
 
@@ -128,6 +127,7 @@ export class AudioStream implements Disposable {
         // Natural termination (source returned after `isCompleted && frames empty`) also resolves
         // whenSent; the loop guard handles that case.
         const self = this;
+        let sentFrameCount = 0;
         try {
             while (!this.isDisposed) {
                 if (this.isCompleted && this.frames.length === 0)
@@ -140,12 +140,13 @@ export class AudioStream implements Disposable {
                 const liveAudioStreams = streamingApi.liveAudioStreams;
                 const peer = Api.peer;
 
-                // frameIndex and sourceStartedAt are per-PushAudio (per chat entry on the
-                // server); each retry iteration is a fresh entry, so both reset.
-                // debugOffsetMs is a DebugUI knob that lets us bias the source-time stamp
-                // forwards/backwards to simulate drift; in production it's always 0.
+                // frameIndex is per-PushAudio, so it resets; the claimed start doesn't - it
+                // advances by what earlier calls sent. Repeating it makes the server register the
+                // retry with a BeginsAt equal to the dead call's, and the muxer keeps the dead one.
+                // debugOffsetMs is a DebugUI knob to simulate drift; in production it's 0.
                 let frameIndex = 0;
-                const sourceStartedAtMs = this.sourceStartedAtMs ?? ServerClock.now();
+                const sourceStartedAtMs = (this.sourceStartedAtMs ?? ServerClock.now())
+                    + sentFrameCount * AUDIO.frameDurationMs;
                 const sourceStartOffsetSeconds = (sourceStartedAtMs + AudioStreamer.debugOffsetMs) / 1000;
                 infoLog?.log(`${this.name}: PushAudio sourceStartOffset=${sourceStartOffsetSeconds.toFixed(3)}s ` +
                     `(sourceStartedAtMs=${sourceStartedAtMs.toFixed(0)}, ` +
@@ -196,6 +197,13 @@ export class AudioStream implements Disposable {
                 this.repliedChatEntryId = undefined;
 
                 await stream.whenSent;
+                sentFrameCount += frameIndex;
+                if (this.isDisposed || (this.isCompleted && this.frames.length === 0))
+                    return;
+
+                // Only once we know this is a retry: addStream chains each stream on the previous
+                // one's whenDisposed, so an unconditional delay pushes back every later utterance.
+                await delayAsync(AUDIO.stream.streamErrorRetryDelayMs);
             }
         } catch (error) {
             warnLog?.log(`${this.name}: stream error:`, error);

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/audio-vad-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/audio-vad-worker.ts
@@ -219,9 +219,12 @@ async function processQueue(): Promise<void> {
                 const expectedSampleRate = AUDIO.rec.sampleRate;
                 const actualSampleRate = Math.floor(samplesBuffer.byteLength / 4 / vads.windowSizeMs * 1000 / 100) * 100;
                 const resampler = await resamplerLoader.getResampler(actualSampleRate, expectedSampleRate);
-                const samples = resampler.resample(samplesBuffer, new Float32Array(samplesBuffer, 0, expectedWindowSizeSamples));
-                vadRingBuffer.push([samples]);
-                if (samples.length != 0)
+                // Its own array, not a view over samplesBuffer - see the same fix in
+                // opus-encoder-worker: the view is sized for the 48kHz window and the buffer
+                // isn't, so it threw RangeError instead of resampling.
+                const samples = resampler.resample(samplesBuffer, new Float32Array(expectedWindowSizeSamples));
+                // Once, not twice: the second push was a leftover that double-fed the ring.
+                if (samples.length !== 0)
                     vadRingBuffer.push([samples]);
             }
             void vadWorklet.releaseBuffer(samplesBuffer, rpcNoWait);

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/opus-encoder-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/workers/opus-encoder-worker.ts
@@ -225,7 +225,10 @@ function onSystemEncoderError(error: DOMException): void {
 let lastRecoveryAt = 0;
 const RECOVERY_MIN_INTERVAL_MS = 2000;
 function ensureAudioStream(): void {
-    if (!audioStream?.isDisposed)
+    // Note the shape: a null stream has to fall through to the recovery below. `!audioStream?.
+    // isDisposed` returned early for null too, so once a disconnect nulled it, recovery was
+    // unreachable and every later frame was discarded even after the connection came back.
+    if (audioStream && !audioStream.isDisposed)
         return;
 
     // Don't retry if peer not connected or too soon after last recovery
@@ -361,7 +364,11 @@ async function processQueue(fade: 'in' | 'out' | 'none' = 'none'): Promise<void>
                 const expectedSampleRate = AUDIO.rec.sampleRate;
                 const actualSampleRate = Math.floor(samplesBuffer.byteLength / 4 / 20 * 1000 / 100) * 100;
                 const resampler = await resamplerLoader.getResampler(actualSampleRate, expectedSampleRate);
-                samples = resampler.resample(samplesBuffer, new Float32Array(samplesBuffer, 0, expectedWindowSizeSamples));
+                // The output has to be its own array: a view over samplesBuffer is sized for the
+                // 48kHz window while the buffer holds the device's smaller one (882 samples at
+                // 44.1kHz), so constructing it threw RangeError before resample was even called -
+                // every frame dropped, silent sender, on any 44.1kHz device under Firefox.
+                samples = resampler.resample(samplesBuffer, new Float32Array(expectedWindowSizeSamples));
                 if (samples.length === 0) {
                     // resampler needs more data
                     continue;

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/worklets/audio-vad-worklet-processor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/worklets/audio-vad-worklet-processor.ts
@@ -101,8 +101,11 @@ export class AudioVadWorkletProcessor extends AudioWorkletProcessor implements A
 
             if (this.buffer.pull([vadArray])) {
                 if (this.worker)
-                    this.promiseQueue = this.promiseQueue.then(() =>
-                        this.worker.onFrame(vadArrayBuffer, rpcNoWait));
+                    // See the same guard in opus-encoder-worklet-processor: without it one
+                    // rejection poisons the chain and the VAD stops receiving frames for good.
+                    this.promiseQueue = this.promiseQueue
+                        .then(() => this.worker.onFrame(vadArrayBuffer, rpcNoWait))
+                        .catch((e: unknown) => warnLog?.log('process: failed to hand a frame to the worker', e));
                 else
                     warnLog?.log('process: worklet port is still undefined!');
             } else {

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/worklets/opus-encoder-worklet-processor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/worklets/opus-encoder-worklet-processor.ts
@@ -113,8 +113,14 @@ export class OpusEncoderWorkletProcessor extends AudioWorkletProcessor implement
 
                 if (this.buffer.pull([audioArray])) {
                     if (this.worker != null)
-                        this.promiseQueue = this.promiseQueue.then(() =>
-                            this.worker.onEncoderWorkletSamples(audioArrayBuffer, capturedAtMs, rpcNoWait));
+                        // The catch keeps the chain alive: one rejection - a DataCloneError on a
+                        // detached pooled buffer, a disposed proxy - leaves promiseQueue
+                        // permanently rejected, so every later .then is skipped and mic samples
+                        // stop reaching the encoder for good, with nothing but an unhandled
+                        // rejection to show for it.
+                        this.promiseQueue = this.promiseQueue
+                            .then(() => this.worker.onEncoderWorkletSamples(audioArrayBuffer, capturedAtMs, rpcNoWait))
+                            .catch((e: unknown) => warnLog?.log('process: failed to hand samples to the worker', e));
                     else
                         warnLog?.log('process: worklet port is still undefined!');
                 } else {

--- a/src/dotnet/UI.Blazor.App/Services/audio-context-source.ts
+++ b/src/dotnet/UI.Blazor.App/Services/audio-context-source.ts
@@ -223,22 +223,55 @@ export class AudioContextAction implements Disposable {
 
     private async execute(action: (context: AudioContext) => Promise<void>): Promise<void> {
         try {
-            // Wait for context to be ready or ref to be disposed
-            const context = await Promise.race([
-                this._ref.whenReady(),
-                this._ref.whenDisposed().then(() => null),
-            ]);
+            while (!this._disposed) {
+                // Wait for context to be ready or ref to be disposed
+                const context = await Promise.race([
+                    this._ref.whenReady(),
+                    this._ref.whenDisposed().then(() => null),
+                ]);
 
-            if (!context || this._disposed) {
-                return;
+                if (!context || this._disposed) {
+                    return;
+                }
+
+                // A rejection is an outcome rather than a throw: when the context dies the
+                // action's own awaits fail first, and racing that settled the loop without a re-run.
+                let actionError: unknown;
+                const actionTask = action(context).then(
+                    () => 'completed' as const,
+                    e => { actionError = e; return 'errored' as const; });
+                const outcome = await Promise.race([
+                    actionTask,
+                    this._ref.whenFailed().then(() => 'failed' as const),
+                    this._ref.whenDisposed().then(() => 'disposed' as const),
+                ]);
+                if (outcome === 'completed' || outcome === 'disposed' || this._disposed)
+                    return;
+
+                if (outcome === 'errored') {
+                    // context.state is synchronous and authoritative; isReady alone isn't, since
+                    // the ref only flips it when the maintain loop closes the context.
+                    if (this._ref.isReady && context.state !== 'closed') {
+                        warnLog?.log('AudioContextAction failed:', actionError);
+                        return;
+                    }
+
+                    warnLog?.log('AudioContextAction: action failed with a dead context:', actionError);
+                    // Wait for the source to acknowledge the death: whenReady still holds the dead
+                    // context until _setFailed re-arms it, so looping now re-runs against that one -
+                    // and the recorder's early-out then matches dead against dead and exits for good.
+                    const failure = await Promise.race([
+                        this._ref.whenFailed().then(() => 'failed' as const),
+                        this._ref.whenDisposed().then(() => 'disposed' as const),
+                    ]);
+                    if (failure === 'disposed' || this._disposed)
+                        return;
+                }
+
+                // attach() rebuilds only the bare pipeline on a recycle - whatever the action
+                // initialized on top of it stays bound to the dead context until it runs again.
+                warnLog?.log('AudioContextAction: context failed, re-running on the new one');
             }
-
-            // Run the action, racing against failure/disposal
-            await Promise.race([
-                action(context),
-                this._ref.whenFailed(),
-                this._ref.whenDisposed(),
-            ]);
         } catch (e) {
             if (!this._disposed) {
                 warnLog?.log('AudioContextAction failed:', e);

--- a/src/nodejs/src/app-constants.ts
+++ b/src/nodejs/src/app-constants.ts
@@ -185,18 +185,12 @@ export interface AudioStreamConstants {
     readonly maxPackFrames: number;
     readonly maxBufferedFrames: number;
     readonly maxSpeed: number;
-    readonly interStreamDelayMs: number;
-    readonly streamErrorDelayMs: number;
-    readonly connectErrorDelayMs: number;
+    readonly streamErrorRetryDelayMs: number;
     readonly debugRandomDisconnectPeriodMs: number;
     readonly recordingRpcStreamAckPeriod: number;
     readonly deliveryRpcStreamAckPeriod: number;
     readonly rpcAckPeriod: number;
     readonly rpcBufferSize: number;
-    // Derived in TS (seconds aliases)
-    readonly interStreamDelay: number;
-    readonly streamErrorDelay: number;
-    readonly connectErrorDelay: number;
 }
 
 export interface AudioVadConstants {
@@ -400,12 +394,6 @@ function expandAudio(audio: AudioConstants): AudioConstants {
             frameSamples: recSamplesPerMs * frameDurationMs,
             frameBytes,
             frameBufferBytes: 2 * frameBytes,
-        },
-        stream: {
-            ...audio.stream,
-            interStreamDelay: audio.stream.interStreamDelayMs / 1000,
-            streamErrorDelay: audio.stream.streamErrorDelayMs / 1000,
-            connectErrorDelay: audio.stream.connectErrorDelayMs / 1000,
         },
         vad: {
             ...audio.vad,

--- a/src/nodejs/src/async-processor.ts
+++ b/src/nodejs/src/async-processor.ts
@@ -56,6 +56,9 @@ export class AsyncProcessor<T> {
             throw e;
         }
         finally {
+            // The loop is gone either way, so the flag has to say so: left true after a throw,
+            // enqueue goes on silently accepting items nothing will ever process.
+            this._isRunning = false;
             this.queue.clear();
         }
     }


### PR DESCRIPTION
Fixes the iOS earpiece-routing bug, then everything a five-agent review of the audio pipeline turned up behind it. Each fix is its own commit.

## The bug that started this

Incoming voice played out of the **ear speaker** whenever you were the one who started recording. Joining a chat where someone was already talking was fine — which pointed at ordering, not configuration, since both cases end with an identical session.

It's a known iOS defect ([Apple forum 721535](https://developer.apple.com/forums/thread/721535)): once an `AVAudioEngine` with VoiceProcessingIO is running, **any source started afterwards plays on the receiver while the session keeps reporting the speaker**. Measured on an iPhone 13 Pro: 33 consecutive `ApplyOutputRoute` calls logged `Speaker -> Speaker -> Speaker` while the audio was audibly on the earpiece. Restating an override the session already holds is a no-op, so the fix has to make it a *transition* — clear to `.none`, then set `.speaker` — re-applied per source, not once per recording.

Two things found on the way: the session mode was `Default`, which `SetVoiceProcessingEnabled` silently replaces with `VoiceChat` (taking `DefaultToSpeaker` with it) and which also **disables VPIO's echo cancellation outright** — so the app was running without AEC. And the recording engine had no output bus, so its downlink DSP errored on every render: 11,004 `render err: -1` lines in one 35k-line capture. Both fixed.

Verified on device.

## Probable cause of "streams stop until the sender restarts"

Independently confirmed in both senders, .NET and TypeScript, with the same incorrect comment in each:

The push retry loop resets `frameIndex` but **reuses the original stream start**. A retry within `MaxBeginsAtDrift` (5 s) therefore registers a new streamId whose `BeginsAt` *equals* the dead one's — and `ListeningStreamMuxer` replaced a same-author stream only on a **strictly** greater `BeginsAt`. So it cancelled the new live stream, kept the dead one, and nothing re-scans afterwards. Listeners go silent for the rest of the utterance while the server keeps ingesting and transcribing — which is why the server looks healthy and live captions keep scrolling over dead audio.

Fixed on all three sides: both senders advance the claimed start, and the muxer gives ties to the newcomer.

## Everything else

**Cross-platform** — a full send channel dropped and leaked the packet instead of retrying it (found independently by two reviewers). The Opus codec caught only cancellation and then completed its channel *without* the exception, so one bad packet reported a clean end mid-utterance with no log line anywhere. `TrackPlayer` kept feeding an engine that had already reported its end, and `AudioTrackPlayer` swallowed every buffer-low timeout — degrading to one frame per 10 s forever rather than failing.

**iOS** — tunes and `Resume()` never restated the route (the recording-confirm tune hit this on *every* recording). A disposed scope could be handed back to the next consumer, tearing down the recording engine under a live capture. `_isSuspended` could stick and disable configuration-change handling for good.

**Android** — negative `AudioTrack.Write` results were ignored entirely, so a dead track silently discarded the rest of the stream. A dead capture producer left the consumer parked forever, behind a comment that already described the wedge.

**Windows** — the playback graph subscribed to no error or device events. Tracks under 100 ms never started and hot-spun a core. A throw in the capture loop left the mic hot with nothing recorded. `RecordingStopped` was unsubscribed, which is the *only* channel NAudio has for a capture-thread failure, so losing the render endpoint silently ended echo cancellation. A loopback that couldn't start killed the whole recording. And AGC was driving a mic that wasn't the one being captured.

**Web** — resampling threw `RangeError` before it ever ran on any non-48 kHz device (silent sender on Firefox), and the VAD pushed each window twice. A nulled audio stream could never be recovered. A failed decoder flush suppressed the track end, hanging the track forever. One rejection poisoned a worklet's promise chain permanently.

## The last round

Everything remaining from the reviews, after the items above:

**Cross-platform** — `_encodingFrameSourceCapturedAts` was a plain `Queue<Moment>` written from the capture task and read from the encode worker; it's concurrent now. `TrackPlayer`'s `EndCommand` and the engine's `DisposeAsync` were the only unbounded waits on the normal teardown path, and `Playback.OnAbortCommand` awaits them inline in its command loop — so one hung engine call stopped listening being started or stopped anywhere in the app. Both bounded. `BlockRingBuffer.Dispose` returned its pooled array outside the lock while `TryWrite`/`TryRead` copy under it — a producer mid-write kept writing into an array the pool had already handed to someone else, and that pool backs every audio buffer in the app.

**Server** — a transient mid-relay failure put the streamId in `_excludedStreamIds` for the life of the subscription, silencing that speaker until they started a new stream. It resumes now, bounded, and is marked preexisting so `GetSkipTo` serves it at the live edge rather than replaying the utterance from zero.

**Android** — focus-restore handlers were only ever appended, so the Nth recover replayed all N cycles' restores. `Mode.InCommunication` is raised before the focus request and was left stranded on denial — the normal answer during a phone call, which is exactly when a PTT wake arrives. Plus an `ObjectDisposedException` race in `WhenUnpaused` that killed live tracks on every focus churn, and a tune's focus scope leaking when playback threw.

**Windows** — graph-creation failures now log (every layer above swallows them, so a process-wide `CreateAsync` failure showed up as every track ending normally with no trace); the playback quantum was computed from the recording rate; `endpointVolume` was never disposed.

**Web** — `streamErrorDelayMs` exists for the push retry loop and was referenced nowhere, so a persistent rejection spun one call per round trip; `AsyncProcessor` left `_isRunning` true after its loop died, so `enqueue` kept accepting items nothing would process.

## Not fixed — deliberate

- **Focus loss ends live listening and doesn't resume it.** Confirmed intentional; `docs/live-audio/07-receiver.md` promised the opposite and was corrected instead.
- **`WhenPlaybackDrained` doesn't complete for a paused track.** Correct as written — a paused track shouldn't end — and the abort path plus the newly bounded `End` cap the exposure.
- **No render-default watcher on Windows (M5).** The serious case, the endpoint disappearing, is now covered by `UnrecoverableErrorOccurred`; the remaining harm is split output for at most one utterance.

One reviewer finding was **rejected as a false positive**: iOS `GetDiagnostics` reading `_activeScopes` without the lock. Both accessors only enumerate `_byMode`, which is fixed at construction and never mutated — they read an `int` Count, so no throw is possible.

## Verification

Three adversarial review rounds over the branch's **end state**, not per commit. They found **15 defects in my own fixes** — 6 high-severity in round 1, 2 in round 2, 1 in round 3 — all now fixed and re-verified. Worth knowing what they were, because the pattern is instructive:

- A `Cancel()` on a CTS the other side disposes — throws, and skipped the rest of a `finally` on the **normal** stop path.
- A `TryRemove` that removes before comparing identity, so my "drop the stale scope" fix evicted the *live* one every time it fired.
- A buffer-low escalation that couldn't tell a stopped engine from a **paused** one, killing any track paused over 30 s.
- A retry backoff that ran on the **success** path, delaying every following utterance and risking silent drops at `MaxStreams`.
- A "bounded" retry whose counter was wiped by a trailing `else` it fell through to.
- A disposed-buffer read returning a **completed** task, spinning a core.
- An interruption guard that read a raw latch with no expiry — trading a 10 s glitch for a capture wedged until manually stopped, because the timeout it suppressed *was* the self-heal.
- An `AudioContextAction` retry that re-ran against the same dead context, where the recorder's early-out matched dead-against-dead and exited the loop permanently — reproducing the exact bug the loop was added to fix.

Two findings were **rejected**: an iOS `GetDiagnostics` lock (the accessors only enumerate a dictionary fixed at construction — no throw possible), and applying the 10 s interruption expiry inside the capture guard (a real phone call holds that latch for minutes; a 60 s deferral cap is the right trade, and the reviewer agreed).

Knowingly accepted, not overlooked: a stale `State.IsPaused` edge; supersede-exclusion silencing a genuinely-live superseded stream (the pre-fix comeback replayed from position 0, so this is the better of two imperfect behaviours); Android restoring `Mode.Normal` rather than the pre-raise mode; and the web retry backoff being 1 s against MAUI's 100 ms — a one-constant change if you'd rather have parity.

## Testing

All four .NET targets build (CI filter, android, windows, ios) and `npm run build:Verify` passes.

Full branch on device (iPhone 13 Pro): recording ran to the app's own 30 s silence auto-stop (`RecordChat: idle threshold reached`) with 0 ObjC exceptions, 0 recording failures, 0 `render err: -1`, and 0 stall-timeout firings — that last one matters, since the capture timeout had to *not* fire during normal recording or during the idle stop.

The iOS routing fix is confirmed against a real reproduction. Everything else is verified by build, by device soak, and by reading — not by reproducing each failure.

**The riskiest change is `AudioContextAction` re-running after a context failure.** It is shared by every web audio consumer and I could not reproduce a context failure to test it. Worth the closest look in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G86jKcZ7xu1NL4y1fXAAQo



