### PR TITLE
fix(chat): drop the stuck "sending" twin left next to a posted message

### DIFF
--- a/src/dotnet/App.Maui/FirebaseAnalyticsExt.cs
+++ b/src/dotnet/App.Maui/FirebaseAnalyticsExt.cs
@@ -42,7 +42,7 @@ public static class FirebaseAnalyticsExt
             _history.LocationChanged += OnLocationChanged;
             var analyticEvents = hub.AnalyticEvents;
             analyticEvents.ModalStateChanged += OnAnalyticEventsOnModalStateChanged;
-            analyticEvents.MessagedPosted += OnMessagePosted;
+            analyticEvents.MessagePosted += OnMessagePosted;
             analyticEvents.RecordingStarted += OnRecordingStarted;
             analyticEvents.RecordingCompleted += OnRecordingCompleted;
             analyticEvents.VideoStreamStarted += OnVideoStreamStarted;

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessages.cs
@@ -45,7 +45,7 @@ public class ChatSendingMessages
         InvalidateCollection(sendingMessage);
     }
 
-    public void ConfirmMessageHasSent(SendingMessage sendingMessage, ChatEntry chatEntry, Moment now, bool complete)
+    public void ConfirmMessageWasSent(SendingMessage sendingMessage, ChatEntry chatEntry, Moment now, bool complete)
     {
         lock (_lock) {
             sendingMessage.Posted(chatEntry, now);
@@ -55,7 +55,7 @@ public class ChatSendingMessages
         OnMessageSent(sendingMessage);
     }
 
-    public void ConfirmMessageAttachmentsHaveSent(SendingMessage sendingMessage, ChatEntry? chatEntry, Moment now)
+    public void ConfirmMessageAttachmentsWereSent(SendingMessage sendingMessage, ChatEntry? chatEntry, Moment now)
     {
         lock (_lock) {
             if (chatEntry is not null)
@@ -89,7 +89,7 @@ public class ChatSendingMessages
         }
     }
 
-    public void ConfirmEditedMessagedHasLoaded(SendingMessage sendingMessage)
+    public void ConfirmEditedMessageWasLoaded(SendingMessage sendingMessage)
         => sendingMessage.MarkToRemove();
 
     public void PruneSentMessages(Moment now)
@@ -129,8 +129,10 @@ public class ChatSendingMessages
 
     private void OnMessageSent(SendingMessage sendingMessage)
     {
-        if (sendingMessage.LocalId.HasValue)
-            InvalidateCollection(sendingMessage);
+        // New messages must invalidate the collection too: the tail tile drops the optimistic copy only
+        // when ProcessLoadedEntriesRange sees PostedChatEntry, which is set right here - so if the real
+        // entry rendered first, nothing else would ever recompute that tile and both rows would stick.
+        InvalidateCollection(sendingMessage);
         using (Invalidation.Begin())
             _ = _triggers.IsSending(sendingMessage);
     }

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessagesAccessor.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessagesAccessor.cs
@@ -32,7 +32,7 @@ public class ChatSendingMessagesAccessor(ChatSendingMessages chatSendingMessages
             return chatEntry;
 
         if (sendingMessage.PostedChatEntry is not null && sendingMessage.PostedChatEntry.Version <= chatEntry.Version)
-            ChatSendingMessages.ConfirmEditedMessagedHasLoaded(sendingMessage);
+            ChatSendingMessages.ConfirmEditedMessageWasLoaded(sendingMessage);
         else {
             chatEntry = chatEntry with {
                 //BeginsAt = e2.BeginsAt,

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendMessageRequestsRepo.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendMessageRequestsRepo.cs
@@ -45,7 +45,7 @@ public class SendMessageRequestsRepo
         await _internal.Flush(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task MarkMessageHasCreated(string requestUuid, long chatEntryLocalId, CancellationToken cancellationToken)
+    public async Task MarkMessageWasCreated(string requestUuid, long chatEntryLocalId, CancellationToken cancellationToken)
     {
         using var releaser = await _asyncLock.Lock(cancellationToken).ConfigureAwait(false);
         var entry = await _internal.Get<SendMessageRequestEntry>(requestUuid, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.Queue.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.Queue.cs
@@ -40,7 +40,7 @@ partial class SendingMessages
     {
         var request = item.Request;
         if (request.CheckResend) {
-            var chatEntry1 = await TryFindPreviouslySendEntry(request.ChatId, request.ClientId, cancellationToken).ConfigureAwait(false);
+            var chatEntry1 = await TryFindPreviouslySentEntry(request.ChatId, request.ClientId, cancellationToken).ConfigureAwait(false);
             if (chatEntry1 is not null)
                 return chatEntry1;
         }
@@ -84,7 +84,7 @@ partial class SendingMessages
         return chatEntry;
     }
 
-    private async Task<ChatEntry?> TryFindPreviouslySendEntry(ChatId chatId, string clientId, CancellationToken cancellationToken)
+    private async Task<ChatEntry?> TryFindPreviouslySentEntry(ChatId chatId, string clientId, CancellationToken cancellationToken)
     {
         var range = await Chats.GetIdRange(Session, chatId, cancellationToken).ConfigureAwait(false);
         if (range.IsEmpty)

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.cs
@@ -351,13 +351,13 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
                 ChatEntryId = ChatEntryId.New(request.ChatId, request.NewChatEntryLocalId.Value);
             var result = ChatEntryId is null
                 ? await ExecutePostRequestViaQueue(request, cancellationToken1).ConfigureAwait(false)
-                : await TryGetExistentPostMessage(ChatEntryId, cancellationToken1).ConfigureAwait(false);
+                : await TryGetExistingPostMessage(ChatEntryId, cancellationToken1).ConfigureAwait(false);
 
             var chatSendingMessages = GetChatSendingMessages(request.ChatId);
             if (result.IsValue(out var chatEntry1, out var exception)) {
                 ChatEntryId = chatEntry1.Id;
                 var hasAttachmentUploads = request.AttachmentUploads is not null;// chatEntry1.HasUploadingAttachments || chatEntry1.Attachments.Any(c => !(c.Media?.IsReady ?? false));
-                chatSendingMessages.ConfirmMessageHasSent(sendingMessage, chatEntry1, Now, !hasAttachmentUploads);
+                chatSendingMessages.ConfirmMessageWasSent(sendingMessage, chatEntry1, Now, !hasAttachmentUploads);
                 _mediaUploadsUI.Invalidate(sendingMessage);
                 try {
                     if (hasAttachmentUploads)
@@ -454,7 +454,7 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
         return result;
     }
 
-    private async Task<Result<ChatEntry>> TryGetExistentPostMessage(ChatEntryId chatEntryId, CancellationToken cancellationToken1)
+    private async Task<Result<ChatEntry>> TryGetExistingPostMessage(ChatEntryId chatEntryId, CancellationToken cancellationToken1)
     {
         Result<ChatEntry> result;
         var chatEntry = await Hub.Chats.GetEntry(Hub.Session, chatEntryId, cancellationToken1).ConfigureAwait(false);
@@ -475,14 +475,14 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
         if (request.AttachmentUploads is null) {
             // NOTE(DF): this should never happen.
             Log.LogError("Attachment uploads are not set for message with local id '{LocalId}'", chatEntry.LocalId);
-            chatSendingMessages.ConfirmMessageHasSent(sendingMessage, chatEntry, Now, true);
+            chatSendingMessages.ConfirmMessageWasSent(sendingMessage, chatEntry, Now, true);
             return chatEntry;
         }
 
         if (!request.NewChatEntryLocalId.HasValue)
             // Persist that the message has been sent before we continue further processing with attachments.
             await _requestsRepo
-                .MarkMessageHasCreated(request.Uuid, chatEntry.LocalId, cancellationToken)
+                .MarkMessageWasCreated(request.Uuid, chatEntry.LocalId, cancellationToken)
                 .ConfigureAwait(false);
 
         ChatEntry? chatEntry1;
@@ -521,7 +521,7 @@ public partial class SendingMessages : UIServiceBase<AppUIHub>, IComputeService,
             chatEntry1 = await Commander.Call(cmd, cancellationToken).ConfigureAwait(false);
         }
 
-        chatSendingMessages.ConfirmMessageAttachmentsHaveSent(sendingMessage, chatEntry1, Now);
+        chatSendingMessages.ConfirmMessageAttachmentsWereSent(sendingMessage, chatEntry1, Now);
         // Delete upload info with delay to avoid flickering in the UI.
         // Linked to service lifetime so it's cancelled on dispose instead of running against a disposed scope.
         var serviceToken = _cancellationTokenSource.Token;

--- a/src/dotnet/UI.Blazor/Services/AnalyticEvents.cs
+++ b/src/dotnet/UI.Blazor/Services/AnalyticEvents.cs
@@ -3,14 +3,14 @@ namespace ActualChat.UI.Blazor.Services;
 
 public class AnalyticEvents
 {
-    public event EventHandler<MessagePostedEventArgs>? MessagedPosted;
+    public event EventHandler<MessagePostedEventArgs>? MessagePosted;
     public event EventHandler? RecordingStarted;
     public event EventHandler<RecordingCompletedEventArgs>? RecordingCompleted;
     public event EventHandler<VideoStreamStartedEventArgs>? VideoStreamStarted;
     public event EventHandler<ModalStateChangedEventArgs>? ModalStateChanged;
 
     public void RaiseMessagePosted(bool isReply, bool hasText, int attachmentCount)
-        => MessagedPosted?.Invoke(this, new MessagePostedEventArgs(isReply, hasText, attachmentCount));
+        => MessagePosted?.Invoke(this, new MessagePostedEventArgs(isReply, hasText, attachmentCount));
 
     public void RaiseRecordingStarted()
         => RecordingStarted?.Invoke(this, EventArgs.Empty);

--- a/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
@@ -58,6 +58,63 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
             .Should().Contain("TEST_SENDING");
     }
 
+    // The optimistic copy is dropped only when ProcessLoadedEntriesRange sees PostedChatEntry, and that
+    // is set by ConfirmMessageWasSent - which can land after the real entry has already rendered, since
+    // the post result and the entry's invalidation reach the client over unordered channels. Confirming
+    // has to invalidate the tail tile, or the message keeps a stuck "sending" twin next to itself.
+    [Fact]
+    public async Task ShouldDropSendingMessageConfirmedAfterEntryRendered()
+    {
+        // arrange: the real entry is already posted and rendered, but its send is still unconfirmed
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "sending-confirm-test");
+        var entry = await Tester.CreateTextEntry(chat.Id, "CONFIRM_RACE");
+
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var sendingMessages = Tester.ScopedAppServices.GetRequiredService<SendingMessages>();
+        var now = Tester.AppServices.Clocks().SystemClock.Now;
+
+        var accessor = sendingMessages.GetSendingMessages(chat.Id);
+        var sendingMessage = new SendingMessage(
+            Guid.NewGuid().ToString(),
+            chat.Id,
+            null,
+            now,
+            "CONFIRM_RACE",
+            HashString.None,
+            null,
+            () => { });
+        accessor.ChatSendingMessages.AddSendingMessage(sendingMessage);
+
+        // act
+        await ComputedTest.When(async ct => {
+            var sending = await GetSendingContents(chatUI, chat.Id, ct);
+            sending.Should().Equal("CONFIRM_RACE");
+        }, TimeSpan.FromSeconds(10));
+
+        accessor.ChatSendingMessages.ConfirmMessageWasSent(sendingMessage, entry, now, true);
+
+        // assert: the optimistic twin is gone
+        await ComputedTest.When(async ct => {
+            var sending = await GetSendingContents(chatUI, chat.Id, ct);
+            sending.Should().BeEmpty();
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    private async Task<List<string>> GetSendingContents(
+        ChatUI chatUI,
+        ChatId chatId,
+        CancellationToken cancellationToken)
+    {
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chatId, cancellationToken);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var items = await chatUI.GetChatItems(chatId, query, 0, cancellationToken);
+        return items.Items.OfType<ChatEntryMessage>()
+            .Where(m => m.Entry.IsSending)
+            .Select(m => m.Entry.Content)
+            .ToList();
+    }
+
     // Each chat-items entry renders with a @key; duplicate sibling keys throw inside Blazor's keyed
     // render-tree diff and tear down the circuit. A conversation at the chat tail used to be emitted
     // twice - once by the last loaded tile, once by the explicit tail-tile fallback - producing a


### PR DESCRIPTION
## Problem

After sending a message it sometimes renders twice — once as the real entry, once as a pending copy with the clock badge — and the ghost row sticks until something unrelated changes that tile.

<img width="300" alt="the stuck twin" src="https://github.com/user-attachments/assets/placeholder">

## Root cause

The optimistic copy is a synthetic `ChatEntry` with `SendingTag` set, emitted by `ChatSendingMessagesAccessor.GetNewMessages()` and appended after the real tile entries. It stops being emitted only when `ProcessLoadedEntriesRange` marks it, which requires the posted entry to be known:

```csharp
foreach (var m in _newMessages.Where(m => m.PostedChatEntry is not null && m.PostedChatEntry.LocalId < rangeEnd))
```

Two things combine:

1. **Race.** `PostedChatEntry` is set by `ConfirmMessageWasSent`, several async hops after the server accepted the entry (`Commander.Call` → `MessageProcessor` queue completion → `WhenCompleted.WaitAsync` continuation → `PostInternal`). The server-pushed invalidation of `Chats.GetIdRange`/`Chats.GetTile` can land inside that window, so `GetTile` recomputes with the real entry present *and* `PostedChatEntry == null` — both rows render.

2. **It never repaired itself.** `OnMessageSent` invalidated the collection only for edits:

   ```csharp
   if (sendingMessage.LocalId.HasValue)   // edits only
       InvalidateCollection(sendingMessage);
   using (Invalidation.Begin())
       _ = _triggers.IsSending(sendingMessage);   // not a GetTile dependency
   ```

   `AddSendingMessage` and `ConfirmMessageFailedToSend` both invalidate it; the success path for a *new* message was the one case that didn't, and `PruneSentMessages` doesn't either. Once the bad `GetTile` result was cached (`MinCacheDuration = 30`), nothing invalidated it.

## Fix

`OnMessageSent` invalidates `OnNewMessagesChanged` unconditionally. `InvalidateCollection` already picks the right trigger per message kind.

## Test

`SendingMessagesDisplayTest.ShouldDropSendingMessageConfirmedAfterEntryRendered` posts the real entry, registers an unconfirmed optimistic twin, waits for the tail to render it, confirms the send, and asserts no `IsSending` entry survives. Verified both ways — with the old guard restored it fails with *"Expected sending to be empty, but found at least one item {"CONFIRM_RACE"}"*.

## Drive-by renames

Grammatically wrong names in the same area (`send` is transitive — a message can't "have sent"), plus two misspellings:

| Before | After |
|---|---|
| `ConfirmMessageHasSent` | `ConfirmMessageWasSent` |
| `ConfirmMessageAttachmentsHaveSent` | `ConfirmMessageAttachmentsWereSent` |
| `ConfirmEditedMessagedHasLoaded` | `ConfirmEditedMessageWasLoaded` |
| `MarkMessageHasCreated` | `MarkMessageWasCreated` |
| `AnalyticEvents.MessagedPosted` | `MessagePosted` |
| `TryGetExistentPostMessage` | `TryGetExistingPostMessage` |
| `TryFindPreviouslySendEntry` | `TryFindPreviouslySentEntry` |

`src/` and `tests/` were swept for the same error classes; everything else that matched is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZo3uCSmtNhtSgxzukhE6D
