### PR TITLE
fix(ui): size the right-panel status badge to its own text

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
@@ -180,13 +180,13 @@ body.narrow .chat-side-panel.has-expanded-header > .c-panel-content {
     @apply text-headline-7 text-02;
     @apply truncate;
 }
-/* The badge is decoration, the title is what says which chat this is - so the badge gives up its
-   width ~100x faster, down to the icon, instead of the title paying the whole shortfall. */
+/* The badge is exactly as wide as its own text, capped at 96px: the title is what says which chat
+   this is, so a label a locale makes long ellipsises instead of squeezing the title out. min-w-0 is
+   what lets it truncate at all - a flex item's automatic minimum is its (nowrap) text otherwise -
+   and shrink-[100] makes the badge, not the title, pay any shortfall left below that cap. */
 .chat-side-panel > .c-top-region > .c-header > .c-bottom > .c-content > .status-badge {
     @apply flex-initial shrink-[100];
-    /* 96px floor: the padding, icon and gap take 34, leaving ~62 for text - enough for the common
-       labels ("Public chat" / "Private chat") to stay whole; longer translations still ellipsise. */
-    @apply min-w-24;
+    @apply min-w-0 max-w-24;
 }
 .chat-side-panel > .c-top-region > .c-header > .c-bottom > .c-content > .c-info {
     @apply flex-x;


### PR DESCRIPTION
The 96px `min-width` added in 0edc33d973 (so the localized "Public chat" / "Private chat" labels stay whole) applied to every badge in the right-panel header, and a `min-width` pads out anything narrower than it. A peer chat's presence badge is one short word, so "Offline" sat in a pill roughly twice the width of its text.

Turned the floor into a cap — one rule, no per-badge-kind special casing:

```css
@apply flex-initial shrink-[100];
@apply min-w-0 max-w-24;
```

- The badge is exactly as wide as its own label (no grow, no floor).
- A label a locale makes longer than 96px ellipsises instead of squeezing out the title, which is what actually identifies the chat.
- `min-w-0` is what makes that ellipsis possible: a flex item's automatic minimum is its nowrap text.
- Since `.c-title` is `flex-auto`, the badge sits flush against the right edge.

Not verified in a browser — no watch server was running in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZo3uCSmtNhtSgxzukhE6D