### PR TITLE
fix(android): let Android draw chat notification avatars natively

### DIFF
--- a/src/dotnet/Api/Notifications/NotificationExt.cs
+++ b/src/dotnet/Api/Notifications/NotificationExt.cs
@@ -28,6 +28,9 @@ public static class NotificationExt
             _ => null,
         };
 
+    public static ChatId? GetChatId(this Notification notification)
+        => ChatId.TryParse(notification.GetChatTag() ?? "", out var chatId) ? chatId : null;
+
     // The in-app deep link a notification points at (entry if it has one, else the chat).
     // Mirrors the link the FCM send path builds; used by the client reconciler to create a
     // missing notification with a working tap target.
@@ -41,8 +44,7 @@ public static class NotificationExt
         };
         if (entryId is { } e)
             return Links.Chat(e);
-        return ChatId.TryParse(notification.GetChatTag() ?? "", out var chatId)
-            ? Links.Chat(chatId)
-            : Links.Chats;
+
+        return notification.GetChatId() is { } chatId ? Links.Chat(chatId) : Links.Chats;
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/PttWakeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/PttWakeHandler.cs
@@ -124,6 +124,7 @@ public static class PttWakeHandler
         // Tagged by chat id, so a whole night of suppressed wakes collapses into one entry
         // per chat instead of stacking.
         => NotificationHelper.ShowChatNotification(
+            chatId,
             chatId.Value,
             "Voxt",
             "Someone is talking in a chat you keep listening to",

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
@@ -16,10 +16,10 @@ public class AndroidDeviceNotifications : IDeviceNotifications
         IReadOnlyCollection<string> createTags,
         CancellationToken cancellationToken)
     {
-        var activeTags = active.Select(x => x.Tag).ToHashSet(StringComparer.Ordinal);
+        var activeTags = active.Select(x => x.Tag).ToHashSet();
         var notificationManager = NotificationManagerCompat.From(Android.App.Application.Context);
 
-        var shownTags = new HashSet<string>(StringComparer.Ordinal);
+        var shownTags = new HashSet<string>();
         var shown = notificationManager?.ActiveNotifications;
         if (shown != null)
             foreach (var statusBarNotification in shown) {
@@ -45,9 +45,11 @@ public class AndroidDeviceNotifications : IDeviceNotifications
                 IncomingCallNotifications.Show(callChatId, tag, info.Url, info.Title, info.IconUrl);
             else
                 // Healing a dropped banner must not alert — it's a reconcile, not a new event.
-                NotificationHelper.ShowChatNotification(info.Tag, info.Title, info.Text, info.IconUrl, info.Url,
+                NotificationHelper.ShowChatNotification(
+                    info.ChatId, info.Tag, info.Title, info.Text, info.IconUrl, info.Url,
                     silent: true, messages: info.Messages.IsEmpty ? null : PushMessage.From(info.Messages));
         }
+
         return Task.CompletedTask;
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
@@ -16,31 +16,18 @@ namespace ActualChat.App.Maui;
 #pragma warning disable CA1861 // Prefer 'static readonly' fields over constant array arguments
 [IntentFilter(["com.google.firebase.MESSAGING_EVENT"])]
 #pragma warning restore CA1861
-public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingService
+public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingService
 {
     private static ILogger? _log;
-    /**
-    * Request code used by display notification pending intents.
-    *
-    * Android only keeps one PendingIntent instance if it thinks multiple pending intents match.
-    * Our intents often only differ by the payload which is stored in intent extras. As comparing
-    * PendingIntents/Intents does not inspect the payload data, multiple pending intents, such as the
-    * ones for click/dismiss will conflict.
-    *
-    * We also need to avoid conflicts with notifications started by an earlier launch of the app,
-    * so use the truncated uptime of when the class was instantiated. The uptime will only overflow
-    * every ~50 days, and even then chances of conflict will be rare.
-    */
-
     private static ILogger Log => _log ??= StaticLog.Factory.CreateLogger<FirebaseMessagingService>();
     private static ILogger? DebugLog => Log.IfEnabled(LogLevel.Information, Constants.DebugMode.AndroidIncomingCalls);
 
- #pragma warning disable CS0169 // Field is never used
- #pragma warning disable CA1823
+#pragma warning disable CS0169 // Field is never used
+#pragma warning disable CA1823
     // Keep reference to FirebaseAnalytics type to ensure FA package is used and will be initialized.
     private FirebaseAnalytics? _firebaseAnalytics;
- #pragma warning restore CA1823
- #pragma warning restore CS0169 // Field is never used
+#pragma warning restore CA1823
+#pragma warning restore CS0169 // Field is never used
 
     public override void OnNewToken(string token)
     {
@@ -81,7 +68,8 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
     {
         Log.LogDebug("OnMessageReceived: message #{MessageId}, CollapseKey='{CollapseKey}'" +
             ", Priority={Priority}, OriginalPriority={OriginalPriority}, IsDeprioritized={IsDeprioritized}",
-            message.MessageId, message.CollapseKey, message.Priority, message.OriginalPriority, message.Priority != message.OriginalPriority);
+            message.MessageId, message.CollapseKey, message.Priority, message.OriginalPriority,
+            message.Priority != message.OriginalPriority);
 
         // There are 2 types of messages:
         // https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages
@@ -101,6 +89,7 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
             foreach (var tag in data.DismissedTags)
                 notificationManager.Cancel(tag, 0);
             ClearForegroundCallRings(data.DismissedTags);
+
             return;
         }
 
@@ -130,12 +119,11 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
 
     // Private methods
 
-    // Decides whether this device should suppress the banner using its own (fresher-than-server)
-    // read/view state. Fail-open: this runs on background deliveries too, where the Blazor scope
-    // may be disposed and the scoped-service calls throw — a failed check must never suppress a
-    // message or crash, so it returns false (show the notification) on any error.
     private static bool ShouldSuppressForDevice(ChatId chatId, long entryLid)
     {
+        // Fail-open: this runs on background deliveries too, where the Blazor scope may be disposed
+        // and the scoped-service calls throw - a failed check must never suppress a message or
+        // crash, so it returns false (show the notification) on any error.
         try {
             if (!TryGetScopedServices(out var scopedServices))
                 return false;
@@ -171,6 +159,7 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
             return false;
         }
     }
+
     private static void ClearForegroundCallRings(IReadOnlyList<string> dismissedTags)
     {
         // A foreground ring lives in the in-app banner/ringer, not a system notification, so a
@@ -213,9 +202,7 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
                 "IncomingCallUI.OnRing");
     }
 
-    private static bool ShowGetAttentionNotification(
-        NotificationData data,
-        long messageSentTime)
+    private static bool ShowGetAttentionNotification(NotificationData data, long messageSentTime)
     {
         var chatId = data.ChatId;
         if (chatId is null) {
@@ -238,6 +225,7 @@ public class FirebaseMessagingService : Firebase.Messaging.FirebaseMessagingServ
     {
         Log.LogDebug("-> ShowChatMessageNotification, text: '{Text}', silent: {Silent}", data.Body!.ToPrivate(), data.Silent);
         NotificationHelper.ShowChatNotification(
-            data.Tag!, data.Title!, data.Body!, data.ImageUrl, data.Link, data.Silent, data.Messages);
+            data.ChatId, data.Tag!, data.Title!, data.Body!, data.ImageUrl, data.Link,
+            data.Silent, data.Messages);
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
@@ -15,12 +15,13 @@ namespace ActualChat.App.Maui;
 
 public static class NotificationHelper
 {
-    private const int ImageCacheSize = 5;
-    private const int MaxUploadLines = 5;
-    private static readonly ThreadSafeLruCache<string, Bitmap?> ImagesCache = new (ImageCacheSize);
-    private static ILogger? _log;
     public static readonly AtomicInteger RequestCodeProvider =
         new((int)Android.OS.SystemClock.ElapsedRealtime());
+
+    private const int ImageCacheSize = 5;
+    private const int MaxUploadLines = 5;
+    private static readonly ThreadSafeLruCache<string, Bitmap?> ImagesCache = new(ImageCacheSize);
+    private static ILogger? _log;
     public static string NotificationViewAction => Application.Context.PackageName + ".NotificationView";
     private static ILogger Log => _log ??= StaticLog.Factory.CreateLogger(typeof(NotificationHelper));
 
@@ -38,11 +39,15 @@ public static class NotificationHelper
         manager.CreateNotificationChannel(channel);
     }
 
-    // Builds and shows a chat notification under the given tag. Shared by the FCM receive path
-    // and the client reconciler's create-missing path so they stay identical.
     public static void ShowChatNotification(
-        string tag, string title, string body, string? imageUrl, string? link,
-        bool silent = false, IReadOnlyList<PushMessage>? messages = null)
+        ChatId? chatId,
+        string tag,
+        string title,
+        string body,
+        string? imageUrl,
+        string? link,
+        bool silent = false,
+        IReadOnlyList<PushMessage>? messages = null)
     {
         var context = Application.Context;
         var contentIntent = CreateViewIntent(context, link);
@@ -50,8 +55,9 @@ public static class NotificationHelper
             contentIntent, PendingIntentFlags.OneShot | PendingIntentFlags.Immutable);
 
         var largeImage = imageUrl.IsNullOrEmpty() ? null : GetImage(imageUrl!);
+        var icon = largeImage is null ? null : AndroidChatShortcuts.CreateIcon(largeImage);
         var (senderName, conversationTitle) = SplitTitle(title);
-        var style = CreateStyle(senderName, conversationTitle, body, largeImage, messages);
+        var style = CreateStyle(senderName, conversationTitle, body, icon, messages);
         var builder = new NotificationCompat.Builder(context, Constants.DefaultChannelId)
             .SetContentTitle(title)!
             .SetSmallIcon(Resource.Drawable.notification_app_icon)!
@@ -66,68 +72,21 @@ public static class NotificationHelper
         if (style is NotificationCompat.MessagingStyle && !conversationTitle.IsNullOrEmpty())
             builder.SetSubText(conversationTitle);
         builder.SetStyle(style);
-        if (largeImage != null)
+        // Naming a long-lived shortcut is what promotes this to a conversation notification, and
+        // that's the only mode where the system draws the avatar itself - masked, in its own
+        // circle - instead of showing our bitmap as-is in the collapsed banner's icon box.
+        // The shortcut is launched from outside the app, so its intent needs the absolute chat URL;
+        // callers that pass an in-app relative link just stay ordinary notifications.
+        if (chatId is not null && Uri.TryCreate(link, UriKind.Absolute, out _)) {
+            AndroidChatShortcuts.PushOnce(
+                context, chatId, conversationTitle.NullIfEmpty() ?? senderName, link!, icon);
+            builder.SetShortcutId(chatId.Value);
+        }
+        // MessagingStyle already carries the avatar on its Person, so a large icon here is a second,
+        // unmasked copy of it.
+        if (largeImage != null && style is not NotificationCompat.MessagingStyle)
             builder.SetLargeIcon(largeImage);
         NotificationManagerCompat.From(context)!.Notify(tag, 0, builder.Build());
-    }
-
-    // Telegram-style rendering: one MessagingStyle line per pushed message (sender + text +
-    // timestamp) when structured messages are present; single-message and BigTextStyle fallbacks
-    // keep old-server pushes and non-chat titles working.
-    private static NotificationCompat.Style CreateStyle(
-        string senderName,
-        string? conversationTitle,
-        string body,
-        Bitmap? largeImage,
-        IReadOnlyList<PushMessage>? messages)
-    {
-        var bigText = new NotificationCompat.BigTextStyle().BigText(body)!;
-        if (senderName.IsNullOrEmpty())
-            return bigText;
-
-        try {
-            var self = new Person.Builder().SetName("You")!.Build();
-            var style = new NotificationCompat.MessagingStyle(self);
-            if (!conversationTitle.IsNullOrEmpty()) {
-                style.SetGroupConversation(true);
-                style.SetConversationTitle(conversationTitle);
-            }
-            if (messages is { Count: > 0 }) {
-                // Only the newest sender carries the avatar — it's the banner headline's icon.
-                var newestName = messages[^1].AuthorName.NullIfEmpty() ?? senderName;
-                var persons = new Dictionary<string, Person>();
-                foreach (var message in messages) {
-                    var name = message.AuthorName.NullIfEmpty() ?? senderName;
-                    if (!persons.TryGetValue(name, out var person)) {
-                        var personBuilder = new Person.Builder().SetName(name)!;
-                        if (name == newestName && largeImage != null)
-                            personBuilder.SetIcon(IconCompat.CreateWithBitmap(largeImage));
-                        person = personBuilder.Build();
-                        persons.Add(name, person);
-                    }
-                    style.AddMessage(message.Text, message.SentAtMs, person);
-                }
-            }
-            else {
-                var senderBuilder = new Person.Builder().SetName(senderName)!;
-                if (largeImage != null)
-                    senderBuilder.SetIcon(IconCompat.CreateWithBitmap(largeImage));
-                style.AddMessage(body, Java.Lang.JavaSystem.CurrentTimeMillis(), senderBuilder.Build());
-            }
-            return style;
-        }
-        catch (Exception e) {
-            Log.LogWarning(e, "Failed to build MessagingStyle; falling back to BigTextStyle");
-            return bigText;
-        }
-    }
-
-    private static (string SenderName, string? ConversationTitle) SplitTitle(string title)
-    {
-        var index = title.IndexOf(" @ ");
-        return index >= 0
-            ? (title[..index].Trim(), title[(index + 3)..].Trim())
-            : (title, null);
     }
 
     public static Bitmap? GetImage(string imageUrl)
@@ -152,24 +111,6 @@ public static class NotificationHelper
         return tcs.Task;
     }
 
-    private static Bitmap? DownloadImage(string imageUrl)
-    {
-        var sw = Stopwatch.GetTimestamp();
-        Bitmap? largeImage = null;
-        try {
-            var imageDownload = AndroidUtils.StartImageDownloadInBackground(imageUrl.ToUri());
-            largeImage = AndroidUtils.WaitForAndApplyImageDownload(imageDownload);
-        }
-        catch (Exception e) {
-            Log.LogError(e, "Failed to download image '{Url}'", imageUrl);
-        }
-        var elapsed = (int)Stopwatch.GetElapsedTime(sw).TotalMilliseconds;
-        Log.Log(elapsed > 5000 ? LogLevel.Warning : LogLevel.Information,
-            "Downloading image '{Url}' took {Elapsed} ms",
-            imageUrl, elapsed);
-        return largeImage;
-    }
-
     public static Intent? CreateViewIntent(Context context, string? link)
     {
         var uri = !link.IsNullOrEmpty() ? Android.Net.Uri.Parse(link) : null;
@@ -180,6 +121,7 @@ public static class NotificationHelper
         var intent = context.PackageManager!.GetLaunchIntentForPackage(context.PackageName!);
         if (intent == null)
             Log.LogWarning("No activity found to launch app");
+
         return intent;
     }
 
@@ -211,18 +153,18 @@ public static class NotificationHelper
                 // ReSharper disable once AccessToStaticMemberViaDerivedType
                 + Microsoft.Maui.Resource.Raw.attention_ringtone);
             channel.SetSound(ringtoneUri, attrs);
-            var vibratePattern = new long[]{0, 700, 500, 700, 500, 500};
+            var vibratePattern = new long[] { 0, 700, 500, 700, 500, 500 };
             channel.SetVibrationPattern(vibratePattern);
             notificationManager.CreateNotificationChannel(channel);
         }
     }
 
-    // Shared by the foreground service (when uploading is the primary activity) and
-    // AndroidActivitiesBackend (when it isn't and needs its own notification).
     public static Android.App.Notification BuildUploadNotification(
         Context context,
         UploadActivity upload)
     {
+        // Shared by the foreground service (when uploading is the primary activity) and
+        // AndroidActivitiesBackend (when it isn't and needs its own notification).
         var percent = upload.TotalBytes == 0 ? 0 : (int)(100.0 * upload.BytesUploaded / upload.TotalBytes);
         var title = upload.FileCount == 1 ? "Uploading 1 file" : $"Uploading {upload.FileCount} files";
         var summary = $"{FormatBytes(upload.BytesUploaded)} / {FormatBytes(upload.TotalBytes)} ({percent}%)";
@@ -256,6 +198,85 @@ public static class NotificationHelper
     }
 
     // Private methods
+
+    private static NotificationCompat.Style CreateStyle(
+        string senderName,
+        string? conversationTitle,
+        string body,
+        IconCompat? icon,
+        IReadOnlyList<PushMessage>? messages)
+    {
+        // Telegram-style rendering: one MessagingStyle line per pushed message (sender + text +
+        // timestamp) when structured messages are present; single-message and BigTextStyle
+        // fallbacks keep old-server pushes and non-chat titles working.
+        var bigText = new NotificationCompat.BigTextStyle().BigText(body)!;
+        if (senderName.IsNullOrEmpty())
+            return bigText;
+
+        try {
+            var self = new Person.Builder().SetName("You")!.Build();
+            var style = new NotificationCompat.MessagingStyle(self);
+            if (!conversationTitle.IsNullOrEmpty()) {
+                style.SetGroupConversation(true);
+                style.SetConversationTitle(conversationTitle);
+            }
+            if (messages is { Count: > 0 }) {
+                // Only the newest sender carries the avatar — it's the banner headline's icon.
+                var newestName = messages[^1].AuthorName.NullIfEmpty() ?? senderName;
+                var persons = new Dictionary<string, Person>();
+                foreach (var message in messages) {
+                    var name = message.AuthorName.NullIfEmpty() ?? senderName;
+                    if (!persons.TryGetValue(name, out var person)) {
+                        var personBuilder = new Person.Builder().SetName(name)!;
+                        if (name == newestName && icon != null)
+                            personBuilder.SetIcon(icon);
+                        person = personBuilder.Build();
+                        persons.Add(name, person);
+                    }
+                    style.AddMessage(message.Text, message.SentAtMs, person);
+                }
+            }
+            else {
+                var senderBuilder = new Person.Builder().SetName(senderName)!;
+                if (icon != null)
+                    senderBuilder.SetIcon(icon);
+                style.AddMessage(body, Java.Lang.JavaSystem.CurrentTimeMillis(), senderBuilder.Build());
+            }
+
+            return style;
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to build MessagingStyle; falling back to BigTextStyle");
+            return bigText;
+        }
+    }
+
+    private static (string SenderName, string? ConversationTitle) SplitTitle(string title)
+    {
+        var index = title.IndexOf(" @ ");
+        return index >= 0
+            ? (title[..index].Trim(), title[(index + 3)..].Trim())
+            : (title, null);
+    }
+
+    private static Bitmap? DownloadImage(string imageUrl)
+    {
+        var sw = Stopwatch.GetTimestamp();
+        Bitmap? largeImage = null;
+        try {
+            var imageDownload = AndroidUtils.StartImageDownloadInBackground(imageUrl.ToUri());
+            largeImage = AndroidUtils.WaitForAndApplyImageDownload(imageDownload);
+        }
+        catch (Exception e) {
+            Log.LogError(e, "Failed to download image '{Url}'", imageUrl);
+        }
+        var elapsed = (int)Stopwatch.GetElapsedTime(sw).TotalMilliseconds;
+        Log.Log(elapsed > 5000 ? LogLevel.Warning : LogLevel.Information,
+            "Downloading image '{Url}' took {Elapsed} ms",
+            imageUrl, elapsed);
+
+        return largeImage;
+    }
 
     private static string FormatBytes(long bytes)
     {

--- a/src/dotnet/Maui/Platforms/Android/AndroidChatShortcuts.cs
+++ b/src/dotnet/Maui/Platforms/Android/AndroidChatShortcuts.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using Android.Content;
+using Android.Graphics;
+using AndroidX.Core.Content.PM;
+using AndroidX.Core.Graphics.Drawable;
+using Person = AndroidX.Core.App.Person;
+
+namespace ActualChat.Maui;
+
+// A chat reaches Android through one long-lived shortcut, keyed by the chat id: the share sheet
+// lists it, and a notification that names it becomes a conversation notification - which is what
+// makes the system draw the avatar itself, masked, instead of pasting our bitmap in a box.
+// Both publishers build it here so the two can't drift apart.
+public static class AndroidChatShortcuts
+{
+    public const string ShareTargetCategory = "chat.actual.app.category.SHARE_TARGET";
+
+    private const int AdaptiveIconSafeZone = 108;
+    private const int AdaptiveIconSize = AdaptiveIconSafeZone * 3 / 2;
+    private const int AdaptiveIconInset = (AdaptiveIconSize - AdaptiveIconSafeZone) / 2;
+    private const int MaxShortLabelLength = 25;
+    private static readonly ConcurrentDictionary<string, byte> IconizedChatSids = new();
+
+    public static void PushOnce(
+        Context context,
+        ChatId chatId,
+        string title,
+        string url,
+        IconCompat? icon)
+    {
+        // Republishing on every notification would spend the shortcut rate limit the share sheet
+        // draws on too, and the share path already refreshes title and icon whenever the user posts
+        // to the chat. An iconless push isn't recorded, so the next one carrying one still lands.
+        var chatSid = chatId.Value;
+        if (IconizedChatSids.ContainsKey(chatSid))
+            return;
+
+        Push(context, chatId, title, url, icon);
+        if (icon is not null)
+            IconizedChatSids.TryAdd(chatSid, 0);
+    }
+
+    public static void Push(
+        Context context,
+        ChatId chatId,
+        string title,
+        string url,
+        IconCompat? icon)
+    {
+        var chatSid = chatId.Value;
+        var intent = new Intent(Intent.ActionDefault);
+        intent.SetData(Android.Net.Uri.Parse(url));
+        var shortLabel = title.Length > MaxShortLabelLength ? title[..MaxShortLabelLength] : title;
+
+        var personBuilder = new Person.Builder()
+            .SetName(title)!
+            .SetKey(chatSid)!;
+        if (icon is not null)
+            personBuilder.SetIcon(icon);
+
+        var builder = new ShortcutInfoCompat.Builder(context, chatSid)
+            .SetShortLabel(shortLabel)!
+            .SetLongLabel(title)!
+            .SetIntent(intent)!
+            .SetLongLived(true)!
+            .SetCategories([ShareTargetCategory])!
+            .SetPerson(personBuilder.Build())!;
+        if (icon is not null)
+            builder.SetIcon(icon);
+
+        ShortcutManagerCompat.PushDynamicShortcut(context, builder.Build());
+    }
+
+    public static IconCompat CreateIcon(Bitmap avatar)
+        => IconCompat.CreateWithAdaptiveBitmap(ToAdaptiveIcon(avatar))!;
+
+    // Private methods
+
+    private static Bitmap ToAdaptiveIcon(Bitmap source)
+    {
+        // CreateWithAdaptiveBitmap treats the whole bitmap as the icon canvas, but the
+        // launcher mask reveals only the inner safe zone - the avatar is drawn into that
+        // zone (center-cropped to a square) and the surrounding inset is left transparent.
+        var result = Bitmap.CreateBitmap(AdaptiveIconSize, AdaptiveIconSize, Bitmap.Config.Argb8888!)!;
+        using var canvas = new Canvas(result);
+        using var paint = new Paint { AntiAlias = true, FilterBitmap = true };
+
+        var side = Math.Min(source.Width, source.Height);
+        var src = new Rect(
+            (source.Width - side) / 2,
+            (source.Height - side) / 2,
+            (source.Width + side) / 2,
+            (source.Height + side) / 2);
+        var dest = new Rect(
+            AdaptiveIconInset,
+            AdaptiveIconInset,
+            AdaptiveIconSize - AdaptiveIconInset,
+            AdaptiveIconSize - AdaptiveIconInset);
+        canvas.DrawBitmap(source, src, dest, paint);
+        return result;
+    }
+}

--- a/src/dotnet/Maui/Platforms/Android/AndroidIncomingShareSuggestions.cs
+++ b/src/dotnet/Maui/Platforms/Android/AndroidIncomingShareSuggestions.cs
@@ -1,9 +1,7 @@
 using ActualChat.Maui.Services;
 using ActualChat.UI.App.Services;
 using ActualLab.Diagnostics;
-using Android.Content;
 using Android.Graphics;
-using AndroidX.Core.Content.PM;
 using AndroidX.Core.Graphics.Drawable;
 using Microsoft.Maui.ApplicationModel;
 
@@ -11,11 +9,6 @@ namespace ActualChat.Maui;
 
 public class AndroidIncomingShareSuggestions(IServiceProvider services) : IncomingShareSuggestions(services)
 {
-    private const int AdaptiveIconSafeZone = 108;
-    private const int AdaptiveIconSize = AdaptiveIconSafeZone * 3 / 2;
-    private const int AdaptiveIconInset = (AdaptiveIconSize - AdaptiveIconSafeZone) / 2;
-    private const int MaxShortLabelLength = 25;
-
     private IconUI IconUI => field ??= Services.GetRequiredService<IconUI>();
     private UrlMapper UrlMapper => field ??= Services.UrlMapper();
     private ILogger? DebugLog => Log.IfEnabled(LogLevel.Information, Constants.DebugMode.ShareSuggestions);
@@ -27,34 +20,8 @@ public class AndroidIncomingShareSuggestions(IServiceProvider services) : Incomi
 
         var iconCompat = await LoadIcon(contact, cancellationToken).ConfigureAwait(false);
         try {
-            var person = new AndroidX.Core.App.Person.Builder()
-                .SetName(chat.Title)!
-                .SetKey(chat.Id.Value)!
-                .SetIcon(iconCompat)!
-                .Build();
-
-            var context = Platform.AppContext;
-            var localId = Links.Chat(chat.Id);
-            var chatUrl = UrlMapper.ToAbsolute(localId);
-            var intent = new Intent(Intent.ActionDefault);
-            intent.SetData(Android.Net.Uri.Parse(chatUrl));
-
-            var shortLabel = chat.Title.Length > MaxShortLabelLength
-                ? chat.Title[..MaxShortLabelLength]
-                : chat.Title;
-
-            var shortcutInfo = new ShortcutInfoCompat.Builder(context, chat.Id.Value)
-                .SetShortLabel(shortLabel)!
-                .SetLongLabel(chat.Title)!
-                .SetIcon(iconCompat)!
-                .SetIntent(intent)!
-                .SetLongLived(true)!
-                .SetCategories(["chat.actual.app.category.SHARE_TARGET"])!
-                .SetPerson(person)!
-                .Build();
-
-            ShortcutManagerCompat.PushDynamicShortcut(context, shortcutInfo);
-
+            var chatUrl = UrlMapper.ToAbsolute(Links.Chat(chat.Id));
+            AndroidChatShortcuts.Push(Platform.AppContext, chat.Id, chat.Title, chatUrl, iconCompat);
             DebugLog?.LogInformation("Pushed dynamic shortcut for chat {ChatId}", chat.Id);
         }
         finally {
@@ -74,7 +41,7 @@ public class AndroidIncomingShareSuggestions(IServiceProvider services) : Incomi
                 var bitmap = await BitmapFactory.DecodeFileAsync(loadedImage.FilePath).ConfigureAwait(false);
                 if (bitmap is not null) {
                     try {
-                        return IconCompat.CreateWithAdaptiveBitmap(ToAdaptiveIcon(bitmap))!;
+                        return AndroidChatShortcuts.CreateIcon(bitmap);
                     }
                     finally {
                         bitmap.Recycle();
@@ -88,29 +55,5 @@ public class AndroidIncomingShareSuggestions(IServiceProvider services) : Incomi
 
         var context = Platform.AppContext;
         return IconCompat.CreateWithResource(context, context.ApplicationInfo!.Icon)!;
-    }
-
-    private static Bitmap ToAdaptiveIcon(Bitmap source)
-    {
-        // CreateWithAdaptiveBitmap treats the whole bitmap as the icon canvas, but the
-        // launcher mask reveals only the inner safe zone - the avatar is drawn into that
-        // zone (center-cropped to a square) and the surrounding inset is left transparent.
-        var result = Bitmap.CreateBitmap(AdaptiveIconSize, AdaptiveIconSize, Bitmap.Config.Argb8888!)!;
-        using var canvas = new Canvas(result);
-        using var paint = new Paint { AntiAlias = true, FilterBitmap = true };
-
-        var side = Math.Min(source.Width, source.Height);
-        var src = new Rect(
-            (source.Width - side) / 2,
-            (source.Height - side) / 2,
-            (source.Width + side) / 2,
-            (source.Height + side) / 2);
-        var dest = new Rect(
-            AdaptiveIconInset,
-            AdaptiveIconInset,
-            AdaptiveIconSize - AdaptiveIconInset,
-            AdaptiveIconSize - AdaptiveIconInset);
-        canvas.DrawBitmap(source, src, dest, paint);
-        return result;
     }
 }

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -30,7 +30,8 @@ public static class NotificationHelper
         };
 
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
-        => urlMapper.IconUrl(chat.GetIconQuery(author, renderAvatarTitle: true));
+        // Unsized, the generator draws its 80px base, which an avatar slot on a 3x screen upscales.
+        => urlMapper.IconUrl(chat.GetIconQuery(author, AvatarQuery.SupportedSizes[^1], renderAvatarTitle: true));
 
     public static string GetVoiceChatStartedText(IReadOnlyList<string> authorNames, IStringLocalizer l)
     {

--- a/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
+++ b/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
@@ -26,4 +26,5 @@ public sealed record ActiveNotificationInfo(
     string Text,
     string IconUrl,
     string Url,
-    ApiArray<NotificationMessage> Messages = default);
+    ApiArray<NotificationMessage> Messages = default,
+    ChatId? ChatId = null);

--- a/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
@@ -11,9 +11,9 @@ namespace ActualChat.UI.Blazor.App.Services;
 // - Create: re-shows a notification that newly entered the active set but isn't on the device —
 //   healing a dropped delivery push. Only newly-added tags are create candidates, so dismissing a
 //   banner (which doesn't change the active set) never resurrects it. iOS is prune-only.
-public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
+public sealed class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
 {
-    private HashSet<string> _lastActiveTags = new(StringComparer.Ordinal);
+    private HashSet<string> _lastActiveTags = new();
     private bool _isInitialized;
 
     private UrlMapper UrlMapper => field ??= Services.UrlMapper();
@@ -40,7 +40,7 @@ public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
     {
         // Reseed on every (re)start: carrying the previous run's tags across a restart would make
         // the first observation look like a diff and re-create banners the user already dismissed.
-        _lastActiveTags = new HashSet<string>(StringComparer.Ordinal);
+        _lastActiveTags = new HashSet<string>();
         _isInitialized = false;
         var cActive = await Computed
             .Capture(() => Hub.Notifications.ListActive(Hub.Session, cancellationToken), cancellationToken)
@@ -50,7 +50,7 @@ public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
                 continue;
 
             var infos = ToInfos(c.Value);
-            var currentTags = infos.Select(x => x.Tag).ToHashSet(StringComparer.Ordinal);
+            var currentTags = infos.Select(x => x.Tag).ToHashSet();
             // First observation seeds the baseline without creating, so existing unread chats
             // don't all pop as banners on startup.
             var createTags = _isInitialized
@@ -90,6 +90,7 @@ public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
                     Log.LogWarning(e, "Foreground notification reconcile failed");
                 }
             }
+
             wasBackground = isBackground;
         }
     }
@@ -104,6 +105,7 @@ public class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
                 x.Notification.Text,
                 x.Notification.IconUrl,
                 UrlMapper.ToAbsolute(x.Notification.GetChatLink()),
-                (x.Notification as ChatEntryRelatedNotification)?.RecentMessages ?? default))
+                (x.Notification as ChatEntryRelatedNotification)?.RecentMessages ?? default,
+                x.Notification.GetChatId()))
             .ToList();
 }

--- a/src/dotnet/Users.Service/AvatarIcons/MarbleAvatars.cs
+++ b/src/dotnet/Users.Service/AvatarIcons/MarbleAvatars.cs
@@ -3,18 +3,20 @@ using SkiaSharp;
 
 namespace ActualChat.Users.AvatarIcons;
 
-/// <summary>
-/// Generates marble-style PNG avatars using SkiaSharp.
-/// </summary>
 public static class MarbleAvatars
 {
     private const int Size = 80;
     private const int Elements = 3;
     private const float BlurSigma = 7f;
     private const float FontSize = Size * 0.5f;
-    private static readonly string[] DefaultColors = ["F56095", "F5CD65", "00B27D", "37D3F5", "2F89EB"];
+    private const string TitleFontResourceName = "TT-Commons-Pro-Medium.ttf";
     private const string BasePathData = "M32.414 59.35L50.376 70.5H72.5v-71H33.728L26.5 13.381l19.057 27.08L32.414 59.35z";
     private const string OverlayPathData = "M22.216 24L0 46.75l14.108 38.129L78 86l-3.081-59.276-22.378 4.005 12.972 20.186-23.35 27.395L22.215 24z";
+    private static readonly string[] DefaultColors = ["F56095", "F5CD65", "00B27D", "37D3F5", "2F89EB"];
+    private static readonly SKTypeface TitleTypeface = LoadTitleTypeface();
+    private static ILogger? _log;
+
+    private static ILogger Log => _log ??= StaticLog.Factory.CreateLogger(typeof(MarbleAvatars));
 
     public static void GeneratePng(string key, FilePath filePath, string title = "", bool doNotBlur = false, int? size = null)
     {
@@ -153,14 +155,32 @@ public static class MarbleAvatars
         canvas.Restore();
     }
 
+    private static SKTypeface LoadTitleTypeface()
+    {
+        try {
+            using var stream = typeof(MarbleAvatars).Assembly.GetManifestResourceStream(TitleFontResourceName);
+            if (stream is not null && SKTypeface.FromStream(stream) is { } typeface)
+                return typeface;
+
+            Log.LogWarning("'{Resource}' isn't embedded - avatar titles will use the host's default font",
+                TitleFontResourceName);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to load '{Resource}' - avatar titles will use the host's default font",
+                TitleFontResourceName);
+        }
+
+        var fontStyle = new SKFontStyle(SKFontStyleWeight.Medium, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+        return SKTypeface.FromFamilyName(null, fontStyle) ?? SKTypeface.Default;
+    }
+
     private static void DrawTitle(SKCanvas canvas, string title)
     {
         using var paint = new SKPaint();
         paint.Color = SKColors.White;
         paint.IsAntialias = true;
 
-        var typeface = SKTypeface.FromFamilyName(null, new SKFontStyle(SKFontStyleWeight.Medium, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
-        using var font = new SKFont(typeface, FontSize);
+        using var font = new SKFont(TitleTypeface, FontSize);
 
         var metrics = font.Metrics;
         var x = Size / 2f;
@@ -203,10 +223,7 @@ public static class MarbleAvatars
 
     // Nested types
 
-    /// <summary>
-    /// Properties for a colored element in a marble avatar.
-    /// </summary>
-    private record ColorProperty
+    private sealed record ColorProperty
     {
         public required string Color { get; init; }
         public required double TranslateX { get; init; }

--- a/src/dotnet/Users.Service/AvatarPictures.cs
+++ b/src/dotnet/Users.Service/AvatarPictures.cs
@@ -6,14 +6,13 @@ using ActualLab.IO;
 
 namespace ActualChat.Users;
 
-/// <summary>
-/// Service for avatar picture generation with file caching.
-/// </summary>
 public sealed class AvatarPictures(IServiceProvider services)
 {
+    private const string RendererVersion = "2";
+
     private FilePath? _cacheDir;
 
-    private ILogger Log => field ??= services.LogFor<AvatarPictures>();
+    private ILogger Log => field ??= services.LogFor(GetType());
     private UsersSettings Settings => field ??= services.GetRequiredService<UsersSettings>();
     private HostInfo HostInfo => field ??= services.GetRequiredService<HostInfo>();
     private CoreSettings CoreSettings => field ??= services.GetRequiredService<CoreSettings>();
@@ -28,6 +27,7 @@ public sealed class AvatarPictures(IServiceProvider services)
         var baseDir = FilePath.GetApplicationTempDirectory();
         if (HostInfo.IsTested)
             baseDir |= $"tst-{CoreSettings.Instance}";
+
         return baseDir | "avatars";
     }
 
@@ -46,7 +46,8 @@ public sealed class AvatarPictures(IServiceProvider services)
             .Select(f => new FileInfo(f))
             .OrderBy(f => f.LastWriteTimeUtc);
         foreach (var file in files)
-            cache.TryAdd(Path.GetFileNameWithoutExtension(file.Name), file.FullName);
+            cache.TryAdd(((FilePath)file.Name).FileNameWithoutExtension, file.FullName);
+
         return cache;
     }
 
@@ -90,7 +91,9 @@ public sealed class AvatarPictures(IServiceProvider services)
 
     private static string GetCacheKey(AvatarQuery query)
     {
-        var cacheKey = $"{query.Kind}_{query.Key}_{query.Format}_{query.Size ?? 0}_{query.Title ?? ""}";
+        // Bump RendererVersion whenever the generators change what they draw: cached files outlive a deploy.
+        var cacheKey =
+            $"{RendererVersion}_{query.Kind}_{query.Key}_{query.Format}_{query.Size ?? 0}_{query.Title ?? ""}";
         return cacheKey.Hash().SHA256().AlphaNumeric();
     }
 

--- a/src/dotnet/Users.Service/Users.Service.csproj
+++ b/src/dotnet/Users.Service/Users.Service.csproj
@@ -5,6 +5,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The letter on a generated avatar has to be the same glyph the app draws in its own UI, and
+         SkiaSharp resolves family names through the host's fontconfig - which on the server image is
+         whatever it happens to ship. Carrying the face itself is the only way to pin it. -->
+    <EmbeddedResource Include="..\..\nodejs\fonts\TT-Commons-Pro-Medium.ttf" LogicalName="TT-Commons-Pro-Medium.ttf" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Chat.ML\Chat.ML.csproj" />
     <ProjectReference Include="..\Core.Server\Core.Server.csproj" />
     <ProjectReference Include="..\Db\Db.csproj" />


### PR DESCRIPTION
## The premise, corrected

The share sheet isn't rendering the letter avatar natively — **both surfaces fetch the identical server-rendered PNG** from `/api/avatars/marble/{chatId}?format=png&title=A` (SkiaSharp, `MarbleAvatars.GeneratePng`). What differed was everything around that bitmap:

| | Notification (before) | Share shortcut |
|---|---|---|
| icon type | `IconCompat.CreateWithBitmap` → large icon | `CreateWithAdaptiveBitmap` + safe-zone composition |
| size requested | none → generator's **80px** base | **160px** |
| linked to a shortcut | no | n/a |

So Android 12+ drew it as a right-side rounded square from an 80px bitmap upscaled ~2.5x on a 3x screen — which reads as "wrong font, in a box". The typeface really was wrong too, but on the server, not the client.

## Changes

**Font** — `MarbleAvatars.DrawTitle` used `SKTypeface.FromFamilyName(null, …)`: the host's fontconfig default, whatever the container image ships. The app draws these avatars in TT Commons Pro (`marble-avatar.lit.ts:56`, and `GenerateSvg`'s own twin already said so). `TT-Commons-Pro-Medium.ttf` is now an `EmbeddedResource` in `Users.Service`, linked from `src/nodejs/fonts/` — no asset copy — with a fallback to the old behavior if it's missing.

**Size** — `Notifications.Service/NotificationHelper.GetIconUrl` now passes `AvatarQuery.SupportedSizes[^1]` (160), matching the share path.

**Native rendering** — the notification builds the same adaptive icon the shortcut does, publishes the chat's long-lived shortcut, and calls `SetShortcutId`. That promotes the banner to a **conversation notification**, the mode where SystemUI draws and masks the avatar itself. The redundant `SetLargeIcon` is now set only for the non-MessagingStyle fallback.

**Cache** — `AvatarPictures.GetCacheKey` gained a `RendererVersion`; without it the old-font PNGs would survive the deploy in both the server's file cache and the clients' 30-day immutable one.

## Reuse

`ToAdaptiveIcon` and the shortcut builder moved out of `AndroidIncomingShareSuggestions` into `Maui/Platforms/Android/AndroidChatShortcuts.cs` (the `Maui` project, so `App.Maui` can see it). Both publishers now build the same shortcut under the same id, so the share sheet and the notification can't drift. Also reused: `IconQueryExt.GetIconQuery(avatarSize:)`, `AvatarQuery.SupportedSizes`, `ShortcutManagerCompat.PushDynamicShortcut`, and a new `NotificationExt.GetChatId()` that `GetChatLink()` now shares.

Notifications push the shortcut once per process (`PushOnce`) so a busy chat doesn't spend the rate limit the share sheet's own shortcuts draw on.

## Verification

`ActualChat.CI.slnf`, `Maui` and `App.Maui` (`net11.0-android`) all build clean; the font is confirmed embedded. **Not yet verified on a device** — the visual result needs a real Android install.

Part of the diff in `NotificationHelper.cs` / `FirebaseMessagingService.cs` is member reordering and comment placement the repo's style hook required on files this change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZo3uCSmtNhtSgxzukhE6D