### PR TITLE
feat(chat): Download all in the message context menu

### DIFF
--- a/src/dotnet/App.Maui/MaciOS/AppleFileSaver.cs
+++ b/src/dotnet/App.Maui/MaciOS/AppleFileSaver.cs
@@ -1,3 +1,4 @@
+using ActualChat.Localization;
 using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.Services;
 using ActualLab.Generators;
@@ -50,8 +51,8 @@ public sealed class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFile
             await DispatchToBlazor(_ => Save(tempFilePath, GetResourceType(file.ContentType))).ConfigureAwait(false);
         }
 
-        var fileText = files.Count == 1 ? "1 file" : $"{files.Count} files";
-        ToastUI.Show($"{fileText} saved to library", "icon-checkmark-circle-2", ToastDismissDelay.Short);
+        ToastUI.Show(L.FileSaver_SavedToLibrary(files.Count, files.Count),
+            "icon-checkmark-circle-2", ToastDismissDelay.Short);
     }
 
     private async Task SaveViaShareSheet(IReadOnlyList<FileToSave> files)
@@ -64,7 +65,7 @@ public sealed class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFile
         // thread - off it, iOS drops it silently. The await above lands us on a pool thread.
         await MainThread.InvokeOnMainThreadAsync(
             () => DataTransfer.Share.Default.RequestAsync(new DataTransfer.ShareMultipleFilesRequest {
-                Title = files.Count == 1 ? files[0].FileName : $"{files.Count} files",
+                Title = files.Count == 1 ? files[0].FileName : L.Editor_Files(files.Count, files.Count),
                 Files = shareFiles,
             })).ConfigureAwait(false);
     }

--- a/src/dotnet/App.Maui/MaciOS/AppleFileSaver.cs
+++ b/src/dotnet/App.Maui/MaciOS/AppleFileSaver.cs
@@ -1,5 +1,7 @@
 using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.Services;
+using ActualLab.Generators;
+using ActualLab.IO;
 using Foundation;
 using Photos;
 using UIKit;
@@ -7,30 +9,27 @@ using DataTransfer = Microsoft.Maui.ApplicationModel.DataTransfer;
 
 namespace ActualChat.App.Maui;
 
-public class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFileSaver
+public sealed class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFileSaver
 {
     private HttpClient HttpClient
         => field ??= Hub.Services.HttpClientFactory().CreateClient(GetType().Name);
     private AddPhotoPermissionHandler PermissionHandler
         => field ??= Hub.Services.GetRequiredService<AddPhotoPermissionHandler>();
 
-    public async Task Save(string url, string fileName, string contentType)
+    public async Task Save(IReadOnlyList<FileToSave> files)
     {
+        if (files.Count == 0)
+            return;
+
         try {
             // There's no shared Downloads location on iOS - anything that isn't gallery
             // media goes to the share sheet, where "Save to Files" is the user's save.
-            if (!MediaTypeExt.IsSupportedVisualMedia(contentType)) {
-                await SaveViaShareSheet(url, fileName, contentType).ConfigureAwait(false);
-                return;
-            }
-
-            var granted = await PermissionHandler.CheckOrRequest(CancellationToken.None).ConfigureAwait(false);
-            if (!granted)
-                throw StandardError.Unauthorized("No permission to add photos/videos to library");
-
-            var tempFilePath = await DownloadToTempFile(url, fileName, contentType).ConfigureAwait(false);
-            await DispatchToBlazor(_ => Save(tempFilePath, GetResourceType(contentType))).ConfigureAwait(false);
-            ToastUI.Show("Successfully saved media to library", "icon-checkmark-circle-2", ToastDismissDelay.Short);
+            var media = files.Where(f => MediaTypeExt.IsSupportedVisualMedia(f.ContentType)).ToList();
+            var others = files.Where(f => !MediaTypeExt.IsSupportedVisualMedia(f.ContentType)).ToList();
+            if (media.Count != 0)
+                await SaveToLibrary(media).ConfigureAwait(false);
+            if (others.Count != 0)
+                await SaveViaShareSheet(others).ConfigureAwait(false);
         }
         catch (Exception e) {
             Log.LogError(e, "Failed to save media to library");
@@ -40,19 +39,37 @@ public class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFileSaver
 
     // Private methods
 
-    private async Task SaveViaShareSheet(string url, string fileName, string contentType)
+    private async Task SaveToLibrary(IReadOnlyList<FileToSave> files)
     {
-        var tempFilePath = await DownloadToTempFile(url, fileName, contentType).ConfigureAwait(false);
+        var isGranted = await PermissionHandler.CheckOrRequest(CancellationToken.None).ConfigureAwait(false);
+        if (!isGranted)
+            throw StandardError.Unauthorized("No permission to add photos/videos to library");
+
+        foreach (var file in files) {
+            var tempFilePath = await DownloadToTempFile(file).ConfigureAwait(false);
+            await DispatchToBlazor(_ => Save(tempFilePath, GetResourceType(file.ContentType))).ConfigureAwait(false);
+        }
+
+        var fileText = files.Count == 1 ? "1 file" : $"{files.Count} files";
+        ToastUI.Show($"{fileText} saved to library", "icon-checkmark-circle-2", ToastDismissDelay.Short);
+    }
+
+    private async Task SaveViaShareSheet(IReadOnlyList<FileToSave> files)
+    {
+        var shareFiles = new List<DataTransfer.ShareFile>(files.Count);
+        foreach (var file in files)
+            shareFiles.Add(new DataTransfer.ShareFile(await DownloadToTempFile(file).ConfigureAwait(false)));
+
         // The share sheet is a UIViewController presentation, so it must happen on the main
         // thread - off it, iOS drops it silently. The await above lands us on a pool thread.
         await MainThread.InvokeOnMainThreadAsync(
-            () => DataTransfer.Share.Default.RequestAsync(new DataTransfer.ShareFileRequest {
-                Title = fileName,
-                File = new DataTransfer.ShareFile(tempFilePath),
+            () => DataTransfer.Share.Default.RequestAsync(new DataTransfer.ShareMultipleFilesRequest {
+                Title = files.Count == 1 ? files[0].FileName : $"{files.Count} files",
+                Files = shareFiles,
             })).ConfigureAwait(false);
     }
 
-    private Task Save(string tempFilePath, PHAssetResourceType type)
+    private Task Save(FilePath tempFilePath, PHAssetResourceType type)
     {
         var completedSource = AsyncTaskMethodBuilderExt.New();
         PHPhotoLibrary.SharedPhotoLibrary.PerformChanges(
@@ -82,27 +99,27 @@ public class AppleFileSaver(UIHub hub) : UIServiceBase<UIHub>(hub), IFileSaver
         return completedSource.Task;
     }
 
-    private async Task<string> DownloadToTempFile(string url, string fileName, string contentType)
+    private async Task<FilePath> DownloadToTempFile(FileToSave file)
     {
-        var response = await HttpClient.GetAsync(url).ConfigureAwait(false);
+        var response = await HttpClient.GetAsync(file.Url).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         await using var _ = stream.ConfigureAwait(false);
 
         // A per-download subfolder keeps the real file name - which the share sheet shows and
         // "Save to Files" reuses - without colliding with earlier downloads.
-        var downloadsFolder = Directory.CreateDirectory(Path.Combine(
-            FileSystem.Current.CacheDirectory,
-            "downloads",
-            Guid.NewGuid().ToString("N")));
-        var tempFilePath = Path.Combine(downloadsFolder.FullName, GetFileName(fileName, contentType));
+        var cacheDirectory = (FilePath)FileSystem.Current.CacheDirectory;
+        var downloadsFolder = Directory.CreateDirectory(
+            cacheDirectory & "downloads" & RandomStringGenerator.Default.Next());
+        var tempFilePath = (FilePath)downloadsFolder.FullName & GetFileName(file.FileName, file.ContentType);
         var fs = File.OpenWrite(tempFilePath);
         await using var __ = fs.ConfigureAwait(false);
         await stream.CopyToAsync(fs).ConfigureAwait(false);
+
         return tempFilePath;
     }
 
-    private static string GetFileName(string fileName, string contentType)
+    private static FilePath GetFileName(string fileName, string contentType)
     {
         if (!fileName.IsNullOrEmpty())
             return fileName;

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidFileSaver.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidFileSaver.cs
@@ -1,5 +1,7 @@
+using ActualChat.Localization;
 using ActualChat.UI.Blazor.Services;
 using ActualLab.IO;
+using Microsoft.Extensions.Localization;
 using Android;
 using Android.Content;
 using Android.Content.PM;
@@ -19,9 +21,11 @@ public sealed class AndroidFileSaver(IServiceProvider services)
 {
     private const string AppSubFolder = CoreConstants.AppName;
 
-    private ToastUI ToastUI => field ??= services.GetRequiredService<ToastUI>();
-    private IHttpClientFactory HttpClientFactory => field ??= services.GetRequiredService<IHttpClientFactory>();
-    private ILogger Log => field ??= services.LogFor(GetType());
+    private IServiceProvider Services { get; } = services;
+    private ToastUI ToastUI => field ??= Services.GetRequiredService<ToastUI>();
+    private IHttpClientFactory HttpClientFactory => field ??= Services.GetRequiredService<IHttpClientFactory>();
+    private IStringLocalizer L => field ??= Services.GetRequiredService<IStringLocalizer>();
+    private ILogger Log => field ??= Services.LogFor(GetType());
 
     public async Task Save(IReadOnlyList<FileToSave> files)
     {
@@ -34,18 +38,13 @@ public sealed class AndroidFileSaver(IServiceProvider services)
             .Run(() => SaveAll(files), CancellationToken.None)
             .ConfigureAwait(true);
 
-        // A mixed group lands in several places at once, so the toast names none of them.
-        var targets = files.Select(f => GetTarget(f.ContentType)).Distinct().ToList();
-        var suffix = targets.Count == 1 ? $" to {targets[0]}" : "";
         if (savedCount == 0)
-            ToastUI.Show($"Failed to save{suffix}", "icon-alert-circle", ToastDismissDelay.Long);
+            ToastUI.Show(L.FileSaver_SaveFailed(files.Count), "icon-alert-circle", ToastDismissDelay.Long);
         else if (savedCount < files.Count)
-            ToastUI.Show($"{savedCount} of {files.Count} files saved{suffix}",
+            ToastUI.Show(L.FileSaver_PartiallySaved(savedCount, savedCount, files.Count),
                 "icon-alert-circle", ToastDismissDelay.Long);
-        else {
-            var fileText = savedCount == 1 ? "1 file" : $"{savedCount} files";
-            ToastUI.Show($"{fileText} saved{suffix}", "icon-checkmark-circle-2", ToastDismissDelay.Short);
-        }
+        else
+            ToastUI.Show(GetSavedText(files, savedCount), "icon-checkmark-circle-2", ToastDismissDelay.Short);
     }
 
     // Private methods
@@ -53,9 +52,10 @@ public sealed class AndroidFileSaver(IServiceProvider services)
     private async Task<int> SaveAll(IReadOnlyList<FileToSave> files)
     {
         var savedCount = 0;
-        foreach (var file in files)
+        foreach (var file in files) {
             if (await SaveOne(file).ConfigureAwait(false))
                 savedCount++;
+        }
 
         return savedCount;
     }
@@ -156,6 +156,7 @@ public sealed class AndroidFileSaver(IServiceProvider services)
             var filePath = directoryPath & fileName;
             if (System.IO.File.Exists(filePath))
                 filePath = EnsureFilePathIsFree(directoryPath, fileName);
+
             var outputStream = System.IO.File.OpenWrite(filePath);
             await using var _1 = outputStream.ConfigureAwait(false);
             await inputStream.CopyToAsync(outputStream).ConfigureAwait(false);
@@ -193,11 +194,25 @@ public sealed class AndroidFileSaver(IServiceProvider services)
         return (disposition?.FileNameStar ?? disposition?.FileName)?.Trim('"').NullIfEmpty();
     }
 
-    private static string GetTarget(string contentType)
+    private string GetSavedText(IReadOnlyList<FileToSave> files, int savedCount)
+    {
+        // A mixed group lands in several places at once, so the toast names none of them.
+        var targets = files.Select(f => GetTarget(f.ContentType)).Distinct().ToList();
+        if (targets.Count != 1)
+            return L.FileSaver_Saved(savedCount, savedCount);
+
+        return targets[0] switch {
+            SaveTarget.Gallery => L.FileSaver_SavedToGallery(savedCount, savedCount),
+            SaveTarget.Music => L.FileSaver_SavedToMusic(savedCount, savedCount),
+            _ => L.FileSaver_SavedToDownloads(savedCount, savedCount),
+        };
+    }
+
+    private static SaveTarget GetTarget(string contentType)
         => GetContentKind(contentType) switch {
-            ContentKind.Image or ContentKind.Video => "the gallery",
-            ContentKind.Audio => "Music",
-            _ => "Downloads",
+            ContentKind.Image or ContentKind.Video => SaveTarget.Gallery,
+            ContentKind.Audio => SaveTarget.Music,
+            _ => SaveTarget.Downloads,
         };
 
     private static ContentKind GetContentKind(string contentType)
@@ -230,7 +245,7 @@ public sealed class AndroidFileSaver(IServiceProvider services)
         return directoryPath & NewFileName(System.Environment.TickCount64);
 
         FilePath NewFileName(long index) {
-            var newFileName = fileNameWithoutExtension + " (" + index.ToString() + ")";
+            var newFileName = fileNameWithoutExtension + " (" + index + ")";
             if (!extension.IsNullOrEmpty())
                 newFileName += extension;
 
@@ -241,6 +256,8 @@ public sealed class AndroidFileSaver(IServiceProvider services)
     // Nested types
 
     private enum ContentKind { Image, Video, Audio, Other }
+
+    private enum SaveTarget { Gallery, Music, Downloads }
 
     private sealed class ScanCompletedListener(Action<string, Uri> onScanCompleted)
         : JObject, MediaScannerConnection.IOnScanCompletedListener

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidFileSaver.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidFileSaver.cs
@@ -1,4 +1,5 @@
 using ActualChat.UI.Blazor.Services;
+using ActualLab.IO;
 using Android;
 using Android.Content;
 using Android.Content.PM;
@@ -13,7 +14,7 @@ using Uri = Android.Net.Uri;
 
 namespace ActualChat.App.Maui;
 
-public class AndroidFileSaver(IServiceProvider services)
+public sealed class AndroidFileSaver(IServiceProvider services)
     : IFileSaver
 {
     private const string AppSubFolder = CoreConstants.AppName;
@@ -22,48 +23,65 @@ public class AndroidFileSaver(IServiceProvider services)
     private IHttpClientFactory HttpClientFactory => field ??= services.GetRequiredService<IHttpClientFactory>();
     private ILogger Log => field ??= services.LogFor(GetType());
 
-    public async Task Save(string url, string fileName, string contentType)
+    public async Task Save(IReadOnlyList<FileToSave> files)
     {
-        // TODO(DF): Add special handling to ensure reliable file loading. Provide visual feedback for long loading files.
-        var succeeded = await BackgroundTask.Run(
-                () => SaveInternally(url, contentType, fileName),
-            CancellationToken.None)
-            .ConfigureAwait(true); // Continue on Blazor context.
+        if (files.Count == 0)
+            return;
 
-        var target = GetContentKind(contentType) switch {
-            ContentKind.Image or ContentKind.Video => "the gallery",
-            ContentKind.Audio => "Music",
-            _ => "Downloads",
-        };
-        if (succeeded)
-            ToastUI.Show($"1 file saved to {target}", "icon-checkmark-circle-2", ToastDismissDelay.Short);
-        else
-            ToastUI.Show($"Failed to save to {target}", "icon-alert-circle", ToastDismissDelay.Long);
+        // TODO(DF): Add special handling to ensure reliable file loading.
+        // Provide visual feedback for long loading files.
+        var savedCount = await BackgroundTask
+            .Run(() => SaveAll(files), CancellationToken.None)
+            .ConfigureAwait(true);
+
+        // A mixed group lands in several places at once, so the toast names none of them.
+        var targets = files.Select(f => GetTarget(f.ContentType)).Distinct().ToList();
+        var suffix = targets.Count == 1 ? $" to {targets[0]}" : "";
+        if (savedCount == 0)
+            ToastUI.Show($"Failed to save{suffix}", "icon-alert-circle", ToastDismissDelay.Long);
+        else if (savedCount < files.Count)
+            ToastUI.Show($"{savedCount} of {files.Count} files saved{suffix}",
+                "icon-alert-circle", ToastDismissDelay.Long);
+        else {
+            var fileText = savedCount == 1 ? "1 file" : $"{savedCount} files";
+            ToastUI.Show($"{fileText} saved{suffix}", "icon-checkmark-circle-2", ToastDismissDelay.Short);
+        }
     }
 
-    private async Task<bool> SaveInternally(string sUri, string contentType, string fileName)
+    // Private methods
+
+    private async Task<int> SaveAll(IReadOnlyList<FileToSave> files)
     {
-        var succeeded = false;
+        var savedCount = 0;
+        foreach (var file in files)
+            if (await SaveOne(file).ConfigureAwait(false))
+                savedCount++;
+
+        return savedCount;
+    }
+
+    private async Task<bool> SaveOne(FileToSave file)
+    {
+        var isSaved = false;
         try {
             using var client = HttpClientFactory.CreateClient(nameof(AndroidFileSaver));
-            using var response = await client.GetAsync(sUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            using var response = await client
+                .GetAsync(file.Url, HttpCompletionOption.ResponseHeadersRead)
+                .ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            if (fileName.IsNullOrEmpty())
-                fileName = GetResponseFileName(response) ?? "download";
+            var fileName = file.FileName.IsNullOrEmpty()
+                ? GetResponseFileName(response) ?? "download"
+                : file.FileName;
             var inputStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             await using var _1 = inputStream.ConfigureAwait(false);
-            succeeded = await SaveImageToGallery(inputStream, fileName, contentType).ConfigureAwait(false);
+            isSaved = await SaveImageToGallery(inputStream, fileName, file.ContentType).ConfigureAwait(false);
         }
         catch (Exception e) {
-            Log.LogError(e, "Failed to save media. ContentType: '{ContentType}', Uri: '{Uri}'", contentType, sUri);
+            Log.LogError(e, "Failed to save media. ContentType: '{ContentType}', Uri: '{Uri}'",
+                file.ContentType, file.Url);
         }
-        return succeeded;
-    }
 
-    private static string? GetResponseFileName(HttpResponseMessage response)
-    {
-        var disposition = response.Content.Headers.ContentDisposition;
-        return (disposition?.FileNameStar ?? disposition?.FileName)?.Trim('"').NullIfEmpty();
+        return isSaved;
     }
 
     private async Task<bool> SaveImageToGallery(Stream inputStream, string fileName, string contentType)
@@ -106,25 +124,6 @@ public class AndroidFileSaver(IServiceProvider services)
         }
     }
 
-    private static ContentKind GetContentKind(string contentType)
-        => contentType switch {
-            _ when contentType.StartsWith("image/") => ContentKind.Image,
-            _ when contentType.StartsWith("video/") => ContentKind.Video,
-            _ when contentType.StartsWith("audio/") => ContentKind.Audio,
-            _ => ContentKind.Other,
-        };
-
-    private static string GetSubDirectoryForContentKind(ContentKind contentKind)
-    {
-        var contentTypeSubDirectory = contentKind switch {
-            ContentKind.Image => Environment.DirectoryPictures!,
-            ContentKind.Video => Environment.DirectoryMovies!,
-            ContentKind.Audio => Environment.DirectoryMusic!,
-            _ => Environment.DirectoryDownloads!
-        };
-        return contentTypeSubDirectory;
-    }
-
     private async Task<bool> SaveImageToGalleryCompat(Stream inputStream, string fileName, string contentType)
     {
         try {
@@ -132,7 +131,8 @@ public class AndroidFileSaver(IServiceProvider services)
             var writeStoragePermission = activity.CheckSelfPermission(Manifest.Permission.WriteExternalStorage);
             if (writeStoragePermission != Permission.Granted) {
                 var completionSource = AsyncTaskMethodBuilderExt.New<bool>();
-                activity.RequestPermission(Manifest.Permission.WriteExternalStorage, hasGranted1 => completionSource.TrySetResult(hasGranted1));
+                activity.RequestPermission(Manifest.Permission.WriteExternalStorage,
+                    hasGranted1 => completionSource.TrySetResult(hasGranted1));
                 var hasGranted = await completionSource.Task.ConfigureAwait(false);
                 if (!hasGranted) {
                     Log.LogInformation("Permission to store files to external storage was not granted");
@@ -141,25 +141,28 @@ public class AndroidFileSaver(IServiceProvider services)
             }
 
             var contentKind = GetContentKind(contentType);
-            var directory = new File(Environment.GetExternalStoragePublicDirectory(GetSubDirectoryForContentKind(contentKind)), AppSubFolder);
-            var directoryExists = directory.Exists();
-            if (!directoryExists) {
-                directoryExists = directory.Mkdirs();
-                if (!directoryExists) {
+            var subDirectory = GetSubDirectoryForContentKind(contentKind);
+            var directory = new File(Environment.GetExternalStoragePublicDirectory(subDirectory), AppSubFolder);
+            var hasDirectory = directory.Exists();
+            if (!hasDirectory) {
+                hasDirectory = directory.Mkdirs();
+                if (!hasDirectory) {
                     Log.LogWarning("Failed to create directory '{Dir}'", directory.AbsolutePath);
                     return false;
                 }
             }
-            var filePath = Path.Combine(directory.AbsolutePath, fileName);
+
+            var directoryPath = (FilePath)directory.AbsolutePath;
+            var filePath = directoryPath & fileName;
             if (System.IO.File.Exists(filePath))
-                filePath = EnsureFilePathIsFree(directory.AbsolutePath, fileName);
+                filePath = EnsureFilePathIsFree(directoryPath, fileName);
             var outputStream = System.IO.File.OpenWrite(filePath);
             await using var _1 = outputStream.ConfigureAwait(false);
             await inputStream.CopyToAsync(outputStream).ConfigureAwait(false);
             Log.LogDebug("File saved to: '{FilePath}'", filePath);
 
             var contentValues = new ContentValues();
-            contentValues.Put(MediaStore.IMediaColumns.Data, filePath);
+            contentValues.Put(MediaStore.IMediaColumns.Data, filePath.Value);
             contentValues.Put(MediaStore.IMediaColumns.MimeType, contentType);
             var uriToInsert = contentKind switch {
                 ContentKind.Image => MediaStore.Images.Media.ExternalContentUri!,
@@ -171,7 +174,7 @@ public class AndroidFileSaver(IServiceProvider services)
             contentResolver.Insert(uriToInsert, contentValues);
 
             MediaScannerConnection.ScanFile(activity,
-                [filePath],
+                [filePath.Value],
                 [contentType],
                 new ScanCompletedListener(
                     (path, uri) => Log.LogDebug("Scanned '{Path}' -> uri='{Uri}'", path, uri)));
@@ -184,23 +187,53 @@ public class AndroidFileSaver(IServiceProvider services)
         }
     }
 
-    private static string EnsureFilePathIsFree(string directoryAbsolutePath, string fileName)
+    private static string? GetResponseFileName(HttpResponseMessage response)
     {
-        var extension = Path.GetExtension(fileName);
-        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        var disposition = response.Content.Headers.ContentDisposition;
+        return (disposition?.FileNameStar ?? disposition?.FileName)?.Trim('"').NullIfEmpty();
+    }
 
-        for (int i = 1; i <= 20; i++) {
-            var filePath = Path.Combine(directoryAbsolutePath, NewFileName(i));
+    private static string GetTarget(string contentType)
+        => GetContentKind(contentType) switch {
+            ContentKind.Image or ContentKind.Video => "the gallery",
+            ContentKind.Audio => "Music",
+            _ => "Downloads",
+        };
+
+    private static ContentKind GetContentKind(string contentType)
+        => contentType switch {
+            _ when contentType.StartsWith("image/") => ContentKind.Image,
+            _ when contentType.StartsWith("video/") => ContentKind.Video,
+            _ when contentType.StartsWith("audio/") => ContentKind.Audio,
+            _ => ContentKind.Other,
+        };
+
+    private static string GetSubDirectoryForContentKind(ContentKind contentKind)
+        => contentKind switch {
+            ContentKind.Image => Environment.DirectoryPictures!,
+            ContentKind.Video => Environment.DirectoryMovies!,
+            ContentKind.Audio => Environment.DirectoryMusic!,
+            _ => Environment.DirectoryDownloads!,
+        };
+
+    private static FilePath EnsureFilePathIsFree(FilePath directoryPath, FilePath fileName)
+    {
+        var extension = fileName.Extension;
+        var fileNameWithoutExtension = fileName.FileNameWithoutExtension;
+
+        for (var i = 1; i <= 20; i++) {
+            var filePath = directoryPath & NewFileName(i);
             if (!System.IO.File.Exists(filePath))
                 return filePath;
         }
-        return Path.Combine(directoryAbsolutePath, NewFileName(System.Environment.TickCount64));
 
-        string NewFileName(long index)
-        {
+        return directoryPath & NewFileName(System.Environment.TickCount64);
+
+        FilePath NewFileName(long index) {
             var newFileName = fileNameWithoutExtension + " (" + index.ToString() + ")";
             if (!extension.IsNullOrEmpty())
                 newFileName += extension;
+
             return newFileName;
         }
     }
@@ -209,14 +242,10 @@ public class AndroidFileSaver(IServiceProvider services)
 
     private enum ContentKind { Image, Video, Audio, Other }
 
-    private class ScanCompletedListener : JObject, MediaScannerConnection.IOnScanCompletedListener
+    private sealed class ScanCompletedListener(Action<string, Uri> onScanCompleted)
+        : JObject, MediaScannerConnection.IOnScanCompletedListener
     {
-        private readonly Action<string, Uri> _onScanCompleted;
-
-        public ScanCompletedListener(Action<string, Uri> onScanCompleted)
-            => _onScanCompleted = onScanCompleted;
-
         public void OnScanCompleted(string? path, Uri? uri)
-            => _onScanCompleted(path!, uri!);
+            => onScanCompleted(path!, uri!);
     }
 }

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -1399,6 +1399,20 @@ public static class LocalizedStringsLocalizerExt
 
         public string Share_FailedToShareCount(long count, object arg0)
             => l.Plural("Share_FailedToShareCount", count, arg0);
+        public string FileSaver_SavedToGallery(long count, object arg0)
+            => l.Plural("FileSaver_SavedToGallery", count, arg0);
+        public string FileSaver_SavedToMusic(long count, object arg0)
+            => l.Plural("FileSaver_SavedToMusic", count, arg0);
+        public string FileSaver_SavedToDownloads(long count, object arg0)
+            => l.Plural("FileSaver_SavedToDownloads", count, arg0);
+        public string FileSaver_SavedToLibrary(long count, object arg0)
+            => l.Plural("FileSaver_SavedToLibrary", count, arg0);
+        public string FileSaver_Saved(long count, object arg0)
+            => l.Plural("FileSaver_Saved", count, arg0);
+        public string FileSaver_PartiallySaved(long count, object arg0, object arg1)
+            => l.Plural("FileSaver_PartiallySaved", count, arg0, arg1);
+        public string FileSaver_SaveFailed(long count)
+            => l.Plural("FileSaver_SaveFailed", count);
 
         public string Date_MonthNames => l["Date_MonthNames"].Value;
         public string Date_MonthGenitiveNames => l["Date_MonthGenitiveNames"].Value;

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -297,6 +297,7 @@ public static class LocalizedStringsLocalizerExt
         public string MessageMenu_ShareFile => l["MessageMenu_ShareFile"].Value;
         public string MessageMenu_CopyDownloadLink => l["MessageMenu_CopyDownloadLink"].Value;
         public string MessageMenu_Download => l["MessageMenu_Download"].Value;
+        public string MessageMenu_DownloadAll => l["MessageMenu_DownloadAll"].Value;
         public string MessageMenu_PinMessage => l["MessageMenu_PinMessage"].Value;
         public string MessageMenu_UnpinMessage => l["MessageMenu_UnpinMessage"].Value;
 

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Споделете файла",
   "MessageMenu_CopyDownloadLink": "Копирайте линка за изтегляне",
   "MessageMenu_Download": "Изтеглете",
+  "MessageMenu_DownloadAll": "Изтеглете всичко",
   "MessageMenu_PinMessage": "Закачете съобщението",
   "MessageMenu_UnpinMessage": "Откачете съобщението",
 

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Неуспешно споделяне на {0} файл|Неуспешно споделяне на {0} файла",
 
+  "FileSaver_SavedToGallery": "{0} файл е запазен в галерията|{0} файла са запазени в галерията",
+  "FileSaver_SavedToMusic": "{0} файл е запазен в Music|{0} файла са запазени в Music",
+  "FileSaver_SavedToDownloads": "{0} файл е запазен в Downloads|{0} файла са запазени в Downloads",
+  "FileSaver_SavedToLibrary": "{0} файл е запазен в библиотеката|{0} файла са запазени в библиотеката",
+  "FileSaver_Saved": "{0} файл е запазен|{0} файла са запазени",
+  "FileSaver_PartiallySaved": "Запазени са {0} от {1} файла",
+  "FileSaver_SaveFailed": "Файлът не беше запазен|Файловете не бяха запазени",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Neuspješno dijeljenje {0} fajla|Neuspješno dijeljenje {0} fajla|Neuspješno dijeljenje {0} fajlova",
 
+  "FileSaver_SavedToGallery": "{0} fajl sačuvan u galeriju|{0} fajla sačuvana u galeriju|{0} fajlova sačuvano u galeriju",
+  "FileSaver_SavedToMusic": "{0} fajl sačuvan u Music|{0} fajla sačuvana u Music|{0} fajlova sačuvano u Music",
+  "FileSaver_SavedToDownloads": "{0} fajl sačuvan u Downloads|{0} fajla sačuvana u Downloads|{0} fajlova sačuvano u Downloads",
+  "FileSaver_SavedToLibrary": "{0} fajl sačuvan u biblioteku|{0} fajla sačuvana u biblioteku|{0} fajlova sačuvano u biblioteku",
+  "FileSaver_Saved": "{0} fajl sačuvan|{0} fajla sačuvana|{0} fajlova sačuvano",
+  "FileSaver_PartiallySaved": "Sačuvano {0} od {1} fajlova",
+  "FileSaver_SaveFailed": "Fajl nije sačuvan|Fajlovi nisu sačuvani",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Podijelite fajl",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",
   "MessageMenu_Download": "Preuzmite",
+  "MessageMenu_DownloadAll": "Preuzmite sve",
   "MessageMenu_PinMessage": "Zakačite poruku",
   "MessageMenu_UnpinMessage": "Otkačite poruku",
 

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Neuspješno dijeljenje {0} fajla|Neuspješno dijeljenje {0} fajla|Neuspješno dijeljenje {0} fajlova",
 
+  "FileSaver_SavedToGallery": "{0} fajl sačuvan u galeriju|{0} fajla sačuvana u galeriju|{0} fajlova sačuvano u galeriju",
+  "FileSaver_SavedToMusic": "{0} fajl sačuvan u Music|{0} fajla sačuvana u Music|{0} fajlova sačuvano u Music",
+  "FileSaver_SavedToDownloads": "{0} fajl sačuvan u Downloads|{0} fajla sačuvana u Downloads|{0} fajlova sačuvano u Downloads",
+  "FileSaver_SavedToLibrary": "{0} fajl sačuvan u biblioteku|{0} fajla sačuvana u biblioteku|{0} fajlova sačuvano u biblioteku",
+  "FileSaver_Saved": "{0} fajl sačuvan|{0} fajla sačuvana|{0} fajlova sačuvano",
+  "FileSaver_PartiallySaved": "Sačuvano {0} od {1} fajlova",
+  "FileSaver_SaveFailed": "Fajl nije sačuvan|Fajlovi nisu sačuvani",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Podijelite fajl",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",
   "MessageMenu_Download": "Preuzmite",
+  "MessageMenu_DownloadAll": "Preuzmite sve",
   "MessageMenu_PinMessage": "Zakačite poruku",
   "MessageMenu_UnpinMessage": "Otkačite poruku",
 

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Sdílet soubor",
   "MessageMenu_CopyDownloadLink": "Kopírovat odkaz ke stažení",
   "MessageMenu_Download": "Stáhnout",
+  "MessageMenu_DownloadAll": "Stáhnout vše",
   "MessageMenu_PinMessage": "Připnout zprávu",
   "MessageMenu_UnpinMessage": "Odepnout zprávu",
 

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Nepodařilo se sdílet {0} soubor|Nepodařilo se sdílet {0} soubory|Nepodařilo se sdílet {0} souborů",
 
+  "FileSaver_SavedToGallery": "{0} soubor uložen do galerie|{0} soubory uloženy do galerie|{0} souborů uloženo do galerie",
+  "FileSaver_SavedToMusic": "{0} soubor uložen do Music|{0} soubory uloženy do Music|{0} souborů uloženo do Music",
+  "FileSaver_SavedToDownloads": "{0} soubor uložen do Downloads|{0} soubory uloženy do Downloads|{0} souborů uloženo do Downloads",
+  "FileSaver_SavedToLibrary": "{0} soubor uložen do knihovny|{0} soubory uloženy do knihovny|{0} souborů uloženo do knihovny",
+  "FileSaver_Saved": "{0} soubor uložen|{0} soubory uloženy|{0} souborů uloženo",
+  "FileSaver_PartiallySaved": "Uloženo {0} z {1} souborů",
+  "FileSaver_SaveFailed": "Soubor se nepodařilo uložit|Soubory se nepodařilo uložit",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Datei teilen",
   "MessageMenu_CopyDownloadLink": "Download-Link kopieren",
   "MessageMenu_Download": "Herunterladen",
+  "MessageMenu_DownloadAll": "Alle herunterladen",
   "MessageMenu_PinMessage": "Nachricht anpinnen",
   "MessageMenu_UnpinMessage": "Nachricht loslösen",
 

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "{0} Datei konnte nicht geteilt werden|{0} Dateien konnten nicht geteilt werden",
 
+  "FileSaver_SavedToGallery": "{0} Datei in der Galerie gespeichert|{0} Dateien in der Galerie gespeichert",
+  "FileSaver_SavedToMusic": "{0} Datei in Music gespeichert|{0} Dateien in Music gespeichert",
+  "FileSaver_SavedToDownloads": "{0} Datei in Downloads gespeichert|{0} Dateien in Downloads gespeichert",
+  "FileSaver_SavedToLibrary": "{0} Datei in der Mediathek gespeichert|{0} Dateien in der Mediathek gespeichert",
+  "FileSaver_Saved": "{0} Datei gespeichert|{0} Dateien gespeichert",
+  "FileSaver_PartiallySaved": "{0} von {1} Dateien gespeichert",
+  "FileSaver_SaveFailed": "Datei konnte nicht gespeichert werden|Dateien konnten nicht gespeichert werden",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -352,6 +352,7 @@
   "MessageMenu_ShareFile": "Share file",
   "MessageMenu_CopyDownloadLink": "Copy download link",
   "MessageMenu_Download": "Download",
+  "MessageMenu_DownloadAll": "Download all",
   "MessageMenu_PinMessage": "Pin message",
   "MessageMenu_UnpinMessage": "Unpin message",
 

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -1631,6 +1631,17 @@
   // The plural counterpart of Share_FailedToShareFiles above.
   "Share_FailedToShareCount": "Failed to share {0} file|Failed to share {0} files",
 
+  // Toasts the native file savers show after a Download / Save action. The group is
+  // reported as one outcome, so every key counts files; the place is baked into the
+  // phrase rather than spliced in, since it has to inflect.
+  "FileSaver_SavedToGallery": "{0} file saved to the gallery|{0} files saved to the gallery",
+  "FileSaver_SavedToMusic": "{0} file saved to Music|{0} files saved to Music",
+  "FileSaver_SavedToDownloads": "{0} file saved to Downloads|{0} files saved to Downloads",
+  "FileSaver_SavedToLibrary": "{0} file saved to the library|{0} files saved to the library",
+  "FileSaver_Saved": "{0} file saved|{0} files saved",
+  "FileSaver_PartiallySaved": "{0} of {1} files saved",
+  "FileSaver_SaveFailed": "Failed to save the file|Failed to save the files",
+
   // Everything that renders a date, a time or a duration: the transcript's day separators, the
   // conversation card header, and relative times such as "few minutes ago".
   //

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Compartir archivo",
   "MessageMenu_CopyDownloadLink": "Copiar enlace de descarga",
   "MessageMenu_Download": "Descargar",
+  "MessageMenu_DownloadAll": "Descargar todo",
   "MessageMenu_PinMessage": "Fijar el mensaje",
   "MessageMenu_UnpinMessage": "Dejar de fijar el mensaje",
 

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "No se pudo compartir {0} archivo|No se pudieron compartir {0} archivos",
 
+  "FileSaver_SavedToGallery": "{0} archivo guardado en la galería|{0} archivos guardados en la galería",
+  "FileSaver_SavedToMusic": "{0} archivo guardado en Music|{0} archivos guardados en Music",
+  "FileSaver_SavedToDownloads": "{0} archivo guardado en Downloads|{0} archivos guardados en Downloads",
+  "FileSaver_SavedToLibrary": "{0} archivo guardado en la fototeca|{0} archivos guardados en la fototeca",
+  "FileSaver_Saved": "{0} archivo guardado|{0} archivos guardados",
+  "FileSaver_PartiallySaved": "{0} de {1} archivos guardados",
+  "FileSaver_SaveFailed": "No se pudo guardar el archivo|No se pudieron guardar los archivos",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Partager le fichier",
   "MessageMenu_CopyDownloadLink": "Copier le lien de téléchargement",
   "MessageMenu_Download": "Télécharger",
+  "MessageMenu_DownloadAll": "Tout télécharger",
   "MessageMenu_PinMessage": "Épingler le message",
   "MessageMenu_UnpinMessage": "Détacher le message",
 

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Impossible de partager {0} fichier|Impossible de partager {0} fichiers",
 
+  "FileSaver_SavedToGallery": "{0} fichier enregistré dans la galerie|{0} fichiers enregistrés dans la galerie",
+  "FileSaver_SavedToMusic": "{0} fichier enregistré dans Music|{0} fichiers enregistrés dans Music",
+  "FileSaver_SavedToDownloads": "{0} fichier enregistré dans Downloads|{0} fichiers enregistrés dans Downloads",
+  "FileSaver_SavedToLibrary": "{0} fichier enregistré dans la photothèque|{0} fichiers enregistrés dans la photothèque",
+  "FileSaver_Saved": "{0} fichier enregistré|{0} fichiers enregistrés",
+  "FileSaver_PartiallySaved": "{0} fichier sur {1} enregistré|{0} fichiers sur {1} enregistrés",
+  "FileSaver_SaveFailed": "Échec de l'enregistrement du fichier|Échec de l'enregistrement des fichiers",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "{0} फ़ाइल साझा नहीं हो सकी|{0} फ़ाइलें साझा नहीं हो सकीं",
 
+  "FileSaver_SavedToGallery": "{0} फ़ाइल गैलरी में सहेजी गई|{0} फ़ाइलें गैलरी में सहेजी गईं",
+  "FileSaver_SavedToMusic": "{0} फ़ाइल Music में सहेजी गई|{0} फ़ाइलें Music में सहेजी गईं",
+  "FileSaver_SavedToDownloads": "{0} फ़ाइल Downloads में सहेजी गई|{0} फ़ाइलें Downloads में सहेजी गईं",
+  "FileSaver_SavedToLibrary": "{0} फ़ाइल लाइब्रेरी में सहेजी गई|{0} फ़ाइलें लाइब्रेरी में सहेजी गईं",
+  "FileSaver_Saved": "{0} फ़ाइल सहेजी गई|{0} फ़ाइलें सहेजी गईं",
+  "FileSaver_PartiallySaved": "{1} में से {0} फ़ाइलें सहेजी गईं",
+  "FileSaver_SaveFailed": "फ़ाइल सहेजी नहीं जा सकी|फ़ाइलें सहेजी नहीं जा सकीं",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "फ़ाइल साझा करें",
   "MessageMenu_CopyDownloadLink": "डाउनलोड लिंक कॉपी करें",
   "MessageMenu_Download": "डाउनलोड करें",
+  "MessageMenu_DownloadAll": "सभी डाउनलोड करें",
   "MessageMenu_PinMessage": "संदेश पिन करें",
   "MessageMenu_UnpinMessage": "संदेश अनपिन करें",
 

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Neuspješno dijeljenje {0} datoteke|Neuspješno dijeljenje {0} datoteke|Neuspješno dijeljenje {0} datoteka",
 
+  "FileSaver_SavedToGallery": "{0} datoteka sačuvan u galeriju|{0} datoteke sačuvana u galeriju|{0} datoteka sačuvano u galeriju",
+  "FileSaver_SavedToMusic": "{0} datoteka sačuvan u Music|{0} datoteke sačuvana u Music|{0} datoteka sačuvano u Music",
+  "FileSaver_SavedToDownloads": "{0} datoteka sačuvan u Downloads|{0} datoteke sačuvana u Downloads|{0} datoteka sačuvano u Downloads",
+  "FileSaver_SavedToLibrary": "{0} datoteka sačuvan u biblioteku|{0} datoteke sačuvana u biblioteku|{0} datoteka sačuvano u biblioteku",
+  "FileSaver_Saved": "{0} datoteka sačuvan|{0} datoteke sačuvana|{0} datoteka sačuvano",
+  "FileSaver_PartiallySaved": "Sačuvano {0} od {1} datoteka",
+  "FileSaver_SaveFailed": "Datoteka nije sačuvan|Datoteke nisu sačuvani",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Podijelite datoteka",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",
   "MessageMenu_Download": "Preuzmite",
+  "MessageMenu_DownloadAll": "Preuzmite sve",
   "MessageMenu_PinMessage": "Zakačite poruku",
   "MessageMenu_UnpinMessage": "Otkačite poruku",
 

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Bagikan file",
   "MessageMenu_CopyDownloadLink": "Salin tautan unduhan",
   "MessageMenu_Download": "Unduh",
+  "MessageMenu_DownloadAll": "Unduh semua",
   "MessageMenu_PinMessage": "Sematkan pesan",
   "MessageMenu_UnpinMessage": "Lepas sematan pesan",
 

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Gagal membagikan {0} file",
 
+  "FileSaver_SavedToGallery": "{0} file disimpan ke galeri",
+  "FileSaver_SavedToMusic": "{0} file disimpan ke Music",
+  "FileSaver_SavedToDownloads": "{0} file disimpan ke Downloads",
+  "FileSaver_SavedToLibrary": "{0} file disimpan ke pustaka",
+  "FileSaver_Saved": "{0} file disimpan",
+  "FileSaver_PartiallySaved": "{0} dari {1} file disimpan",
+  "FileSaver_SaveFailed": "File gagal disimpan",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Condividi il file",
   "MessageMenu_CopyDownloadLink": "Copia il link di download",
   "MessageMenu_Download": "Scarica",
+  "MessageMenu_DownloadAll": "Scarica tutto",
   "MessageMenu_PinMessage": "Fissa il messaggio",
   "MessageMenu_UnpinMessage": "Rimuovi il messaggio fissato",
 

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Impossibile condividere {0} file",
 
+  "FileSaver_SavedToGallery": "{0} file salvato nella galleria|{0} file salvati nella galleria",
+  "FileSaver_SavedToMusic": "{0} file salvato in Music|{0} file salvati in Music",
+  "FileSaver_SavedToDownloads": "{0} file salvato in Downloads|{0} file salvati in Downloads",
+  "FileSaver_SavedToLibrary": "{0} file salvato nella libreria|{0} file salvati nella libreria",
+  "FileSaver_Saved": "{0} file salvato|{0} file salvati",
+  "FileSaver_PartiallySaved": "{0} di {1} file salvati",
+  "FileSaver_SaveFailed": "Impossibile salvare il file|Impossibile salvare i file",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "{0} 件のファイルを共有できませんでした",
 
+  "FileSaver_SavedToGallery": "{0} 件のファイルをギャラリーに保存しました",
+  "FileSaver_SavedToMusic": "{0} 件のファイルを Music に保存しました",
+  "FileSaver_SavedToDownloads": "{0} 件のファイルを Downloads に保存しました",
+  "FileSaver_SavedToLibrary": "{0} 件のファイルをライブラリに保存しました",
+  "FileSaver_Saved": "{0} 件のファイルを保存しました",
+  "FileSaver_PartiallySaved": "{1} 件中 {0} 件を保存しました",
+  "FileSaver_SaveFailed": "ファイルを保存できませんでした",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "ファイルを共有",
   "MessageMenu_CopyDownloadLink": "ダウンロードリンクをコピー",
   "MessageMenu_Download": "ダウンロード",
+  "MessageMenu_DownloadAll": "すべてダウンロード",
   "MessageMenu_PinMessage": "メッセージをピン留め",
   "MessageMenu_UnpinMessage": "メッセージのピン留めを解除",
 

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "파일 공유",
   "MessageMenu_CopyDownloadLink": "다운로드 링크 복사",
   "MessageMenu_Download": "다운로드",
+  "MessageMenu_DownloadAll": "모두 다운로드",
   "MessageMenu_PinMessage": "메시지 고정",
   "MessageMenu_UnpinMessage": "메시지 고정 해제",
 

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "파일 {0}개를 공유하지 못했습니다",
 
+  "FileSaver_SavedToGallery": "{0}개 파일을 갤러리에 저장했습니다",
+  "FileSaver_SavedToMusic": "{0}개 파일을 Music에 저장했습니다",
+  "FileSaver_SavedToDownloads": "{0}개 파일을 Downloads에 저장했습니다",
+  "FileSaver_SavedToLibrary": "{0}개 파일을 라이브러리에 저장했습니다",
+  "FileSaver_Saved": "{0}개 파일을 저장했습니다",
+  "FileSaver_PartiallySaved": "{1}개 중 {0}개를 저장했습니다",
+  "FileSaver_SaveFailed": "파일을 저장하지 못했습니다",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -352,6 +352,7 @@
   "MessageMenu_ShareFile": "Поделиться файлом",
   "MessageMenu_CopyDownloadLink": "Копіювати посилання для завантаження",
   "MessageMenu_Download": "Herunterladen",
+  "MessageMenu_DownloadAll": "すべてダウンロード",
   "MessageMenu_PinMessage": "Закріпити повідомлення",
   "MessageMenu_UnpinMessage": "メッセージのピン留めを解除",
 

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -1631,6 +1631,17 @@
   // The plural counterpart of Share_FailedToShareFiles above.
   "Share_FailedToShareCount": "{0} 件のファイルを共有できませんでした",
 
+  // Toasts the native file savers show after a Download / Save action. The group is
+  // reported as one outcome, so every key counts files; the place is baked into the
+  // phrase rather than spliced in, since it has to inflect.
+  "FileSaver_SavedToGallery": "{0} 件のファイルをギャラリーに保存しました",
+  "FileSaver_SavedToMusic": "{0} 件のファイルを Music に保存しました",
+  "FileSaver_SavedToDownloads": "{0} 件のファイルを Downloads に保存しました",
+  "FileSaver_SavedToLibrary": "{0} 件のファイルをライブラリに保存しました",
+  "FileSaver_Saved": "{0} 件のファイルを保存しました",
+  "FileSaver_PartiallySaved": "{1} dosyadan {0} tanesi kaydedildi",
+  "FileSaver_SaveFailed": "Dateien konnten nicht gespeichert werden",
+
   // Everything that renders a date, a time or a duration: the transcript's day separators, the
   // conversation card header, and relative times such as "few minutes ago".
   //

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Nie udało się udostępnić {0} pliku|Nie udało się udostępnić {0} plików|Nie udało się udostępnić {0} plików",
 
+  "FileSaver_SavedToGallery": "Zapisano {0} plik w galerii|Zapisano {0} pliki w galerii|Zapisano {0} plików w galerii",
+  "FileSaver_SavedToMusic": "Zapisano {0} plik w Music|Zapisano {0} pliki w Music|Zapisano {0} plików w Music",
+  "FileSaver_SavedToDownloads": "Zapisano {0} plik w Downloads|Zapisano {0} pliki w Downloads|Zapisano {0} plików w Downloads",
+  "FileSaver_SavedToLibrary": "Zapisano {0} plik w bibliotece|Zapisano {0} pliki w bibliotece|Zapisano {0} plików w bibliotece",
+  "FileSaver_Saved": "Zapisano {0} plik|Zapisano {0} pliki|Zapisano {0} plików",
+  "FileSaver_PartiallySaved": "Zapisano {0} z {1} plików",
+  "FileSaver_SaveFailed": "Nie udało się zapisać pliku|Nie udało się zapisać plików",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Udostępnij plik",
   "MessageMenu_CopyDownloadLink": "Kopiuj link do pobrania",
   "MessageMenu_Download": "Pobierz",
+  "MessageMenu_DownloadAll": "Pobierz wszystko",
   "MessageMenu_PinMessage": "Przypnij wiadomość",
   "MessageMenu_UnpinMessage": "Odepnij wiadomość",
 

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Não foi possível compartilhar {0} arquivo|Não foi possível compartilhar {0} arquivos",
 
+  "FileSaver_SavedToGallery": "{0} arquivo salvo na galeria|{0} arquivos salvos na galeria",
+  "FileSaver_SavedToMusic": "{0} arquivo salvo em Music|{0} arquivos salvos em Music",
+  "FileSaver_SavedToDownloads": "{0} arquivo salvo em Downloads|{0} arquivos salvos em Downloads",
+  "FileSaver_SavedToLibrary": "{0} arquivo salvo na biblioteca|{0} arquivos salvos na biblioteca",
+  "FileSaver_Saved": "{0} arquivo salvo|{0} arquivos salvos",
+  "FileSaver_PartiallySaved": "{0} de {1} arquivos salvos",
+  "FileSaver_SaveFailed": "Não foi possível salvar o arquivo|Não foi possível salvar os arquivos",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Compartilhar arquivo",
   "MessageMenu_CopyDownloadLink": "Copiar link de download",
   "MessageMenu_Download": "Baixar",
+  "MessageMenu_DownloadAll": "Baixar tudo",
   "MessageMenu_PinMessage": "Fixar mensagem",
   "MessageMenu_UnpinMessage": "Desafixar mensagem",
 

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Не удалось поделиться {0} файлом|Не удалось поделиться {0} файлами",
 
+  "FileSaver_SavedToGallery": "{0} файл сохранён в галерею|{0} файла сохранено в галерею|{0} файлов сохранено в галерею",
+  "FileSaver_SavedToMusic": "{0} файл сохранён в Music|{0} файла сохранено в Music|{0} файлов сохранено в Music",
+  "FileSaver_SavedToDownloads": "{0} файл сохранён в Downloads|{0} файла сохранено в Downloads|{0} файлов сохранено в Downloads",
+  "FileSaver_SavedToLibrary": "{0} файл сохранён в медиатеку|{0} файла сохранено в медиатеку|{0} файлов сохранено в медиатеку",
+  "FileSaver_Saved": "{0} файл сохранён|{0} файла сохранено|{0} файлов сохранено",
+  "FileSaver_PartiallySaved": "Сохранён {0} файл из {1}|Сохранено {0} файла из {1}|Сохранено {0} файлов из {1}",
+  "FileSaver_SaveFailed": "Не удалось сохранить файл|Не удалось сохранить файлы",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Поделиться файлом",
   "MessageMenu_CopyDownloadLink": "Копировать ссылку для скачивания",
   "MessageMenu_Download": "Скачать",
+  "MessageMenu_DownloadAll": "Скачать все",
   "MessageMenu_PinMessage": "Закрепить сообщение",
   "MessageMenu_UnpinMessage": "Открепить сообщение",
 

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Поделите фајл",
   "MessageMenu_CopyDownloadLink": "Копирајте линк за преузимање",
   "MessageMenu_Download": "Преузмите",
+  "MessageMenu_DownloadAll": "Преузмите све",
   "MessageMenu_PinMessage": "Закачите поруку",
   "MessageMenu_UnpinMessage": "Откачите поруку",
 

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Неуспешно дељење {0} фајла|Неуспешно дељење {0} фајла|Неуспешно дељење {0} фајлова",
 
+  "FileSaver_SavedToGallery": "{0} фајл сачуван у галерију|{0} фајла сачувана у галерију|{0} фајлова сачувано у галерију",
+  "FileSaver_SavedToMusic": "{0} фајл сачуван у Мусиц|{0} фајла сачувана у Мусиц|{0} фајлова сачувано у Мусиц",
+  "FileSaver_SavedToDownloads": "{0} фајл сачуван у Доwнлоадс|{0} фајла сачувана у Доwнлоадс|{0} фајлова сачувано у Доwнлоадс",
+  "FileSaver_SavedToLibrary": "{0} фајл сачуван у библиотеку|{0} фајла сачувана у библиотеку|{0} фајлова сачувано у библиотеку",
+  "FileSaver_Saved": "{0} фајл сачуван|{0} фајла сачувана|{0} фајлова сачувано",
+  "FileSaver_PartiallySaved": "Сачувано {0} од {1} фајлова",
+  "FileSaver_SaveFailed": "Фајл није сачуван|Фајлови нису сачувани",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Dosyayı paylaşın",
   "MessageMenu_CopyDownloadLink": "İndirme bağlantısını kopyalayın",
   "MessageMenu_Download": "İndirin",
+  "MessageMenu_DownloadAll": "Tümünü indirin",
   "MessageMenu_PinMessage": "Mesajı sabitleyin",
   "MessageMenu_UnpinMessage": "Mesajın sabitlemesini kaldırın",
 

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "{0} dosya paylaşılamadı",
 
+  "FileSaver_SavedToGallery": "{0} dosya galeriye kaydedildi",
+  "FileSaver_SavedToMusic": "{0} dosya Music klasörüne kaydedildi",
+  "FileSaver_SavedToDownloads": "{0} dosya Downloads klasörüne kaydedildi",
+  "FileSaver_SavedToLibrary": "{0} dosya kitaplığa kaydedildi",
+  "FileSaver_Saved": "{0} dosya kaydedildi",
+  "FileSaver_PartiallySaved": "{1} dosyadan {0} tanesi kaydedildi",
+  "FileSaver_SaveFailed": "Dosya kaydedilemedi",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Не вдалося поділитися {0} файлом|Не вдалося поділитися {0} файлами",
 
+  "FileSaver_SavedToGallery": "{0} файл збережено в галерею|{0} файли збережено в галерею|{0} файлів збережено в галерею",
+  "FileSaver_SavedToMusic": "{0} файл збережено в Music|{0} файли збережено в Music|{0} файлів збережено в Music",
+  "FileSaver_SavedToDownloads": "{0} файл збережено в Downloads|{0} файли збережено в Downloads|{0} файлів збережено в Downloads",
+  "FileSaver_SavedToLibrary": "{0} файл збережено до медіатеки|{0} файли збережено до медіатеки|{0} файлів збережено до медіатеки",
+  "FileSaver_Saved": "{0} файл збережено|{0} файли збережено|{0} файлів збережено",
+  "FileSaver_PartiallySaved": "Збережено {0} файл із {1}|Збережено {0} файли із {1}|Збережено {0} файлів із {1}",
+  "FileSaver_SaveFailed": "Не вдалося зберегти файл|Не вдалося зберегти файли",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Поділитися файлом",
   "MessageMenu_CopyDownloadLink": "Копіювати посилання для завантаження",
   "MessageMenu_Download": "Завантажити",
+  "MessageMenu_DownloadAll": "Завантажити все",
   "MessageMenu_PinMessage": "Закріпити повідомлення",
   "MessageMenu_UnpinMessage": "Відкріпити повідомлення",
 

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "Không thể chia sẻ {0} tệp",
 
+  "FileSaver_SavedToGallery": "Đã lưu {0} tệp vào thư viện ảnh",
+  "FileSaver_SavedToMusic": "Đã lưu {0} tệp vào Music",
+  "FileSaver_SavedToDownloads": "Đã lưu {0} tệp vào Downloads",
+  "FileSaver_SavedToLibrary": "Đã lưu {0} tệp vào thư viện",
+  "FileSaver_Saved": "Đã lưu {0} tệp",
+  "FileSaver_PartiallySaved": "Đã lưu {0} trong {1} tệp",
+  "FileSaver_SaveFailed": "Không thể lưu tệp",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "Chia sẻ tệp",
   "MessageMenu_CopyDownloadLink": "Sao chép liên kết tải xuống",
   "MessageMenu_Download": "Tải xuống",
+  "MessageMenu_DownloadAll": "Tải xuống tất cả",
   "MessageMenu_PinMessage": "Ghim tin nhắn",
   "MessageMenu_UnpinMessage": "Bỏ ghim tin nhắn",
 

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -276,6 +276,7 @@
   "MessageMenu_ShareFile": "分享文件",
   "MessageMenu_CopyDownloadLink": "复制下载链接",
   "MessageMenu_Download": "下载",
+  "MessageMenu_DownloadAll": "下载全部",
   "MessageMenu_PinMessage": "置顶消息",
   "MessageMenu_UnpinMessage": "取消置顶消息",
 

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -1353,6 +1353,14 @@
 
   "Share_FailedToShareCount": "有 {0} 个文件分享失败",
 
+  "FileSaver_SavedToGallery": "已将 {0} 个文件保存到相册",
+  "FileSaver_SavedToMusic": "已将 {0} 个文件保存到 Music",
+  "FileSaver_SavedToDownloads": "已将 {0} 个文件保存到 Downloads",
+  "FileSaver_SavedToLibrary": "已将 {0} 个文件保存到图库",
+  "FileSaver_Saved": "已保存 {0} 个文件",
+  "FileSaver_PartiallySaved": "已保存 {1} 个文件中的 {0} 个",
+  "FileSaver_SaveFailed": "无法保存文件",
+
   // Date/time data, not prose: the name lists are '|'-separated and must keep their
   // 12/7 entries, and the *Pattern values are .NET date format strings - localize the
   // field order and separators, never the format tokens themselves.

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/MessageMenu/MessageMenuContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/MessageMenu/MessageMenuContent.razor
@@ -16,6 +16,8 @@
     var canCopyCode = !ClickedCode.IsNullOrEmpty();
     var canCopyImage = !ClickedImageUrl.IsNullOrEmpty();
     var canCopyMessageLink = !IsSystem;
+    var attachmentCount = e.Attachments.Length;
+    var canDownloadAttachments = attachmentCount > 0 && !hasSelection;
     var canForward = !e.IsContentStreaming && !IsSystem && !hasSelection;
     var canStartThread = !e.IsContentStreaming && !IsSystem && !hasSelection;
     var canPin = CanPin && isTextEntry && !IsSystem && !hasSelection;
@@ -105,6 +107,13 @@
                 </MenuEntry>
             </CopyTrigger>
         }
+        @if (canDownloadAttachments) {
+            <MenuEntry
+                Icon="icon-download"
+                Text="@(attachmentCount > 1 ? L.MessageMenu_DownloadAll : L.MessageMenu_Download)"
+                Click="@DownloadAttachments">
+            </MenuEntry>
+        }
         @if (canForward) {
             <MenuEntry
                 Icon="icon-share"
@@ -181,6 +190,7 @@
     private SelectionUI SelectionUI => Hub.SelectionUI;
     private ChatEditorUI ChatEditorUI => Hub.ChatEditorUI;
     private ChatPinsUI ChatPinsUI => Hub.ChatPinsUI;
+    private FileDownloadUI FileDownloadUI => Hub.FileDownloadUI;
     private OptimisticReactions OptimisticReactions => Hub.OptimisticReactions;
 
     [CascadingParameter] public ScreenSize ScreenSize { get; set; }
@@ -201,6 +211,14 @@
 
     private Task Pin()
         => IsPinned ? ChatPinsUI.Unpin(ChatEntry.Id) : ChatPinsUI.Pin(ChatEntry.Id);
+
+    private async Task DownloadAttachments() {
+        var attachments = ChatEntry.Attachments;
+        foreach (var attachment in attachments) {
+            var media = attachment.Media;
+            await FileDownloadUI.Download(media.BlobId, media.FileName, media.ContentType).ConfigureAwait(false);
+        }
+    }
 
     private void ShowAllReactions()
         => _showAllReactions = true;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/MessageMenu/MessageMenuContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/MessageMenu/MessageMenuContent.razor
@@ -212,12 +212,12 @@
     private Task Pin()
         => IsPinned ? ChatPinsUI.Unpin(ChatEntry.Id) : ChatPinsUI.Pin(ChatEntry.Id);
 
-    private async Task DownloadAttachments() {
-        var attachments = ChatEntry.Attachments;
-        foreach (var attachment in attachments) {
-            var media = attachment.Media;
-            await FileDownloadUI.Download(media.BlobId, media.FileName, media.ContentType).ConfigureAwait(false);
-        }
+    private Task DownloadAttachments() {
+        var files = ChatEntry.Attachments
+            .Select(a => a.Media)
+            .Select(m => new FileToSave(UrlMapper.ContentDownloadUrl(m.BlobId), m.FileName, m.ContentType))
+            .ToList();
+        return FileDownloadUI.Download(files);
     }
 
     private void ShowAllReactions()

--- a/src/dotnet/UI.Blazor/Services/FileDownload/FileDownloadUI.cs
+++ b/src/dotnet/UI.Blazor/Services/FileDownload/FileDownloadUI.cs
@@ -17,11 +17,23 @@ public sealed class FileDownloadUI(UIHub hub)
     public Task Download(string blobId, string fileName, string contentType)
         => DownloadUrl(Hub.UrlMapper.ContentDownloadUrl(blobId), fileName, contentType);
 
+    public async Task Download(IReadOnlyList<FileToSave> files)
+    {
+        if (files.Count == 0)
+            return;
+
+        if (FileSaver is { } fileSaver) {
+            await fileSaver.Save(files).ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var file in files)
+            await Hub.JS.InvokeVoidAsync(JSDownloadFileMethod, file.Url, file.FileName).ConfigureAwait(false);
+    }
+
     public Task Preview(string blobId)
         => Hub.ExternalUrlOpener.Open(Hub.UrlMapper.ContentUrl(blobId));
 
     public Task DownloadUrl(string url, string fileName, string contentType)
-        => FileSaver is { } fileSaver
-            ? fileSaver.Save(url, fileName, contentType)
-            : Hub.JS.InvokeVoidAsync(JSDownloadFileMethod, url, fileName).AsTask();
+        => Download([new FileToSave(url, fileName, contentType)]);
 }

--- a/src/dotnet/UI.Blazor/Services/FileDownload/FileToSave.cs
+++ b/src/dotnet/UI.Blazor/Services/FileDownload/FileToSave.cs
@@ -1,0 +1,6 @@
+namespace ActualChat.UI.Blazor.Services;
+
+/// <summary>
+/// A single item of a <see cref="IFileSaver"/> save request.
+/// </summary>
+public sealed record FileToSave(string Url, string FileName, string ContentType);

--- a/src/dotnet/UI.Blazor/Services/FileDownload/IFileSaver.cs
+++ b/src/dotnet/UI.Blazor/Services/FileDownload/IFileSaver.cs
@@ -7,5 +7,7 @@ namespace ActualChat.UI.Blazor.Services;
 /// </summary>
 public interface IFileSaver
 {
-    Task Save(string url, string fileName, string contentType);
+    // Takes the whole group so the implementation reports it as one outcome
+    // rather than one toast (and, on iOS, one share sheet) per file.
+    Task Save(IReadOnlyList<FileToSave> files);
 }


### PR DESCRIPTION
## What

Adds a **Download all** entry to the message context menu, and fixes how a group save reports itself.

### 1. The menu entry

Shows up whenever the message carries attachments, and downloads every one of them — images, video, audio and files alike. Reads **Download** for a single attachment and **Download all** for several. It sits between "Copy message link" and "Forward", and goes through `FileDownloadUI` — the same path the per-file menu already used.

### 2. One outcome per group, not one per file

The first version looped over `FileDownloadUI.Download` once per file, which on Android produced one toast per file ("1 file saved to Downloads" ×3). The fix is in the API rather than the menu: `IFileSaver.Save` now takes the whole group, so the implementation decides how to report it.

- **Android** — a single toast: `3 files saved to Downloads`, or `2 of 3 files saved` on a partial failure. A mixed group lands in several places at once (gallery / Music / Downloads), so the toast then names none of them.
- **iOS / Mac Catalyst** — media goes to the library in one pass with one toast, and everything else opens **one** `ShareMultipleFilesRequest` instead of one share sheet per file.
- **Web** — unchanged behaviour; the loop simply moved into `FileDownloadUI`.

### 3. Localization

Seven `FileSaver_*` plural keys replace the hardcoded English the savers used to show. The destination is baked into each phrase rather than spliced in as a noun, because it has to inflect — «в галерею», not «в галерея». Forms follow `i18n.md`: 3 for ru/uk/pl/cs/bs, 2 for en/es/fr/it/de/pt/hi/bg, 1 for tr/id/vi/ja/ko/zh. `MessageMenu_DownloadAll` covers the menu entry itself; the iOS share-sheet title reuses the existing `Editor_Files`.

## Verification

- `dotnet build src/dotnet/UI.Blazor.App` — 0 errors
- `dotnet build src/dotnet/App.Maui -f net11.0-android` — 0 errors
- `AppLocalizationTest` + `PluralLocalizerExtTest` — 136/136 passed
- `scripts/derive-bcms.cmd --check`, `scripts/derive-max.cmd --check` — clean
- **Web, driven through CDP**: no attachments → no entry; 1 attachment → "Download"; 2 attachments → "Download all", and clicking it produced two download events plus two `?download=1` requests
- **Android, on device**: one toast for a three-attachment message

## Not verified

**iOS was not compiled** — `net11.0-ios` only builds on macOS, and this PR changes `AppleFileSaver.Save` to the group form and swaps N share sheets for one `ShareMultipleFilesRequest`. Worth a build on a Mac before merging.

## Note

In a browser, downloading several files makes Chrome ask "site wants to download multiple files" — that is `DownloadRequestLimiter`, which allows one download per user gesture. The prompt is per-origin and asked once; deliberately left as is, since serving a single ZIP would need a new server endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rbAShXH1jjmvFDAx89reC
