### PR TITLE
fix(docker): copy the embedded font into the dotnet build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ COPY resources/sounds/converted /src/resources/sounds/converted
 RUN npm run build:Release
 
 FROM dotnet-restore AS base
+# Users.Service embeds src/nodejs/fonts/TT-Commons-Pro-Medium.ttf as a resource,
+# so the .ttf files have to be here even though nothing else of src/nodejs/ is
+COPY src/nodejs/fonts/*.ttf src/nodejs/fonts/
 COPY src/dotnet/ src/dotnet/
 COPY tests/ tests/
 COPY *.props *.targets ./


### PR DESCRIPTION
## The break

The image build fails on `dev` and on every PR:

```
CSC : error CS1566: Error reading resource 'TT-Commons-Pro-Medium.ttf' --
'Could not find a part of the path '/src/src/nodejs/fonts/TT-Commons-Pro-Medium.ttf'.'
[/src/src/dotnet/Users.Service/Users.Service.csproj]
```

Failing runs: [33291094467](https://github.com/Actual-Chat/actual-chat/actions/runs/33291094467) (dev), [33309932387](https://github.com/Actual-Chat/actual-chat/actions/runs/33309932387) (PR 4294).

## Why

`Users.Service` embeds the font so a server-generated marble avatar draws its initial with the same face the app uses — SkiaSharp resolves family names through the host's fontconfig, which on the server image is whatever it happens to ship, so the face has to be carried along. That `EmbeddedResource` arrived with 6e304625ed.

In the `Dockerfile` the `base` stage — the one `dotnet-build` and `migrations-build` derive from — copies only `src/dotnet/`, `tests/` and `*.props *.targets`. `src/nodejs/` is copied into `nodejs-restore`, a separate `node:20-alpine` lineage, so the font path doesn't exist where `dotnet publish` runs. The file is committed and `.dockerignore` doesn't exclude it: purely a missing COPY.

## The fix

Three lines: copy the `.ttf` faces into `base`, ahead of `COPY src/dotnet/` so a C# edit doesn't invalidate the fonts layer. Scoped to `*.ttf` rather than the whole `fonts/` folder because `fonts/svgtofont/` holds generated icon-font output that churns on a local `npm run build`.

## Verification — Docker actually ran

- **Path**: with the new COPY, the file lands at `/src/src/nodejs/fonts/TT-Commons-Pro-Medium.ttf`, and the relative reference from `Users.Service` resolves to exactly that.
- **Compile**: on `mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7`, replicating the `base` stage layout, `dotnet build -c Release src/dotnet/Users.Service/Users.Service.csproj` gave **0 errors and no CS1566** (10 pre-existing warnings).

The full `dotnet-build` stage was not run locally: it pulls from `nodejs-build`, which needs `NPM_READ_TOKEN` for the `@actual-chat` registry plus a full wasm publish. CI covers that.

## Related

`Chat.Service.csproj:18` also points outside its own directory (`tests/Streaming.IntegrationTests/data/**`), but it is safe — `base` does `COPY tests/ tests/`, and `.dockerignore`'s `test` entry matches only a root-level `test`. Same class of fragility, though: any future `EmbeddedResource`/`None` reaching outside `src/dotnet/` or `tests/` breaks the image build the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rbAShXH1jjmvFDAx89reC
