### PR TITLE
fix(audio): stop the recording toggle turning itself off

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioCapture.cs
@@ -131,7 +131,10 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
 
             if (deviceEnumerator != null) {
                 try {
-                    deviceWatcher = new DefaultCaptureDeviceWatcher(OnDefaultCaptureDeviceChanged);
+                    // The endpoint the graph actually opened, so a re-pick landing back on it is
+                    // ignored: WinRT ids embed the WASAPI endpoint id the notification carries.
+                    var openedDeviceId = inputNode?.Device?.Id;
+                    deviceWatcher = new DefaultCaptureDeviceWatcher(openedDeviceId, OnDefaultCaptureDeviceChanged);
                     deviceEnumerator.RegisterEndpointNotificationCallback(deviceWatcher);
                 }
                 catch (Exception e) {
@@ -556,12 +559,22 @@ public sealed class WindowsAudioCapture(ILogger<WindowsAudioCapture> log) : IAud
 
     // Nested types
 
-    private sealed class DefaultCaptureDeviceWatcher(Action onChanged) : IMMNotificationClient
+    private sealed class DefaultCaptureDeviceWatcher(
+        string? openedDeviceId,
+        Action onChanged
+        ) : IMMNotificationClient
     {
         public void OnDefaultDeviceChanged(DataFlow dataFlow, Role role, string defaultDeviceId)
         {
-            if (dataFlow == DataFlow.Capture && role == Role.Multimedia)
-                onChanged();
+            if (dataFlow != DataFlow.Capture || role != Role.Multimedia)
+                return;
+            // Still the endpoint the graph holds
+            if (openedDeviceId != null
+                && !defaultDeviceId.IsNullOrEmpty()
+                && openedDeviceId.Contains(defaultDeviceId, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            onChanged();
         }
 
         public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }

--- a/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/Audio/WindowsAudioPlaybackEngine.cs
@@ -184,6 +184,15 @@ internal sealed class WindowsAudioPlaybackEngine(
         }
 
         if (_graph != null) {
+            // Stopped before it's disposed: a graph left running wedges WinRT audio for the whole
+            // process, and every later AudioGraph.CreateAsync - capture included - then fails.
+            try {
+                _frameInput?.Stop();
+                _graph.Stop();
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "Failed to stop the playback AudioGraph before disposing it");
+            }
             _frameInput.DisposeSilently();
             _deviceOutput.DisposeSilently();
             _graph.DisposeSilently();

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
@@ -297,13 +297,11 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
 
     private void MarkStopped()
     {
+        // Reached only once the engine is stopped, so "recording, but in no chat" is never true here.
         var currentState = State.Value;
         var (_, isRecording, isSignalDetected, isConnected, isVoiceActive) = currentState;
         UpdateState(new AudioRecorderState(null) {
-            IsRecording = isRecording,
-            IsSignalDetected = isSignalDetected,
             IsConnected = isConnected,
-            IsVoiceActive = isVoiceActive,
             RecordingStartTime = currentState.RecordingStartTime,
         });
         _recordingActivity

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
@@ -280,6 +280,7 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         UpdateState(new AudioRecorderState(chatId) {
             IsConnected = isConnected,
             RecordingStartTime = currentState.RecordingStartTime,
+            LastFailure = currentState.LastFailure,
         });
         // ReSharper disable once ExplicitCallerInfoArgument
         _recordingActivity = AppUIInstruments.ActivitySource.StartActivity(GetType(), "Record");
@@ -303,6 +304,7 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
         UpdateState(new AudioRecorderState(null) {
             IsConnected = isConnected,
             RecordingStartTime = currentState.RecordingStartTime,
+            LastFailure = currentState.LastFailure,
         });
         _recordingActivity
             ?.AddSentrySimulatedEvent(new ActivityEvent("Recording is stopped",

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/AudioRecorder.cs
@@ -274,13 +274,11 @@ public sealed class AudioRecorder : ProcessorBase, IAudioRecorderBackend
 
     private void MarkStarting(ChatId chatId)
     {
+        // Per-session flags belong to the session that just ended; only IsConnected is transport-level.
         var currentState = State.Value;
         var (_, isRecording, isSignalDetected, isConnected, isVoiceActive) = currentState;
         UpdateState(new AudioRecorderState(chatId) {
-            IsRecording = isRecording,
-            IsSignalDetected = isSignalDetected,
             IsConnected = isConnected,
-            IsVoiceActive = isVoiceActive,
             RecordingStartTime = currentState.RecordingStartTime,
         });
         // ReSharper disable once ExplicitCallerInfoArgument

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/audio-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/audio-recorder.ts
@@ -166,8 +166,13 @@ export class AudioRecorder {
     }
 
     private readonly heartbeatThrottled = throttle(() => this.heartbeat(), HEARTBEAT_INTERVAL);
+    // Skipped while starting: frames start flowing before startRecording()'s state roundtrip
+    // reaches Blazor, so a heartbeat in that window reads "not recording" and stops the start.
     private async heartbeat(): Promise<void> {
         try {
+            if (this.state === 'starting')
+                return;
+
             const chatId = this.chatId;
             if (!chatId) {
                 void this.stopRecording();

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
@@ -451,9 +451,14 @@ export class OpusMediaRecorder implements RecorderStateServer {
                 AudioRecorderState.setRecording(this.isRecording);
             }
             catch (e) {
+                const isStillWanted = this.chatId === chatId;
                 this.state = 'stopped';
                 this.stopHeartbeat();
-                AudioRecorderState.setFailed(chatId, e);
+                // A stop that landed first already cleared chatId - reporting then would put a
+                // failure tooltip on a toggle the user has already switched off.
+                if (isStillWanted)
+                    AudioRecorderState.setFailed(chatId, e);
+
                 await this.stopMicrophoneStream();
                 throw e;
             }

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
@@ -641,9 +641,9 @@ export class OpusMediaRecorder implements RecorderStateServer {
         } catch (e) {
             await this.stopMicrophoneStream();
             warnLog?.log('startMicrophoneStream(): getMicrophoneStream() failed:', e);
-            // Still swallowed, but reported: above here only the absence of a stream was visible.
-            if (this.chatId)
-                AudioRecorderState.setFailed(this.chatId, e);
+            // Rethrown so start()'s handler runs: swallowing it left state === 'recording' and
+            // the heartbeat alive for a pipeline with no microphone behind it.
+            throw e;
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/recorder-toggle.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/recorder-toggle.ts
@@ -1,22 +1,13 @@
-// TODO: Fix ESLint errors
-/* eslint-disable @typescript-eslint/require-await, @typescript-eslint/no-floating-promises */
-import { audioContextSource, recordingAudioContextSource } from '../../Services/audio-context-source';
+import { initAudioContextsOnClick } from '../../Services/audio-context-source';
 
 export class RecorderToggle {
     private static isInitialized = false;
 
-    public static async init(): Promise<void> {
+    public static init(): void {
         if (this.isInitialized)
             return;
 
-        const buttons = [...document.querySelectorAll<HTMLButtonElement>('div.recorder-wrapper > button')];
-        buttons.forEach(btn => {
-            btn.addEventListener('click', () => {
-                recordingAudioContextSource.initContextInteractively();
-                audioContextSource.initContextInteractively();
-            });
-        });
-
         this.isInitialized = true;
+        initAudioContextsOnClick('div.recorder-wrapper > button');
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ActiveChatsUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ActiveChatsUI.cs
@@ -80,15 +80,15 @@ public class ActiveChatsUI : UIServiceBase<AppUIHub>
             .Collect(ApiConstants.Concurrency.High, cancellationToken)
             .ConfigureAwait(false);
 
-        var recordingChat = chatsAndRules
+        var recordingChatId = chatsAndRules
             .Where(x => x.Chat.IsRecording && x.Rules.CanWrite())
             .OrderByDescending(x => x.Chat.Recency)
             .FirstOrDefault()
-            .Chat;
+            .Chat?.ChatId;
         foreach (var (chat, rules) in chatsAndRules) {
-            // There must be just 1 recording chat
+            // There must be just 1 recording chat, and none when write access is gone
             var newChat = chat;
-            if (newChat.IsRecording && newChat.ChatId != recordingChat.ChatId)
+            if (newChat.IsRecording && newChat.ChatId != recordingChatId)
                 newChat = newChat with { IsRecording = false };
             if (!(newChat.IsListening || newChat.IsRecording)) // Must be active
                 newChat = null;

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -138,11 +138,18 @@ public partial class ChatAudioUI
             .ConfigureAwait(false);
         var restartDelays = RetryDelaySeq.Exp(0.5, 8);
         var restartAttempt = 0;
+        var restartChatId = (ChatId?)null;
         while (!cancellationToken.IsCancellationRequested) {
             var cRecordingState = await cRecordingStateBase
                 .When(x => x.ChatId is not null, FixedDelayer.MinDelay, cancellationToken)
                 .ConfigureAwait(false);
             var intendedChatId = cRecordingState.Value.ChatId;
+            // A chat switched to during the backoff delay is a fresh user start, not attempt N+1 -
+            // it gets its own begin tune and its own retry budget.
+            if (intendedChatId != restartChatId) {
+                restartAttempt = 0;
+                restartChatId = intendedChatId;
+            }
             if (restartAttempt > 0)
                 Log.LogInformation(
                     nameof(PushRecordingState) + ": retrying recorder for chat #{ChatId} (attempt {Attempt})",
@@ -217,6 +224,7 @@ public partial class ChatAudioUI
                 var operation = $"recording in \"{chat.Title}\"";
                 isConfirmed = await InteractiveUI.Demand(operation, cancellationToken).ConfigureAwait(false);
             }
+
             if (!isConfirmed) {
                 await SetRecordingChatId(null).ConfigureAwait(false);
                 return;
@@ -226,6 +234,8 @@ public partial class ChatAudioUI
         if (!cRecordingState.IsConsistent())
             return;
 
+        Task? whenStopped = null;
+        Task? whenRecorderStopped = null;
         Task? whenIdle = null;
         Task? whenWinner = null;
         var abortTokenSource = cancellationToken.CreateLinkedTokenSource();
@@ -247,12 +257,13 @@ public partial class ChatAudioUI
             await TuneUI.PlayAndWait(Tune.BeginRecording, mustPlay: mustPlayBeginTune).ConfigureAwait(false);
             // Install before StartRecording so we don't miss a fast false→true→false
             // transition (e.g., pipeline dies during JS init).
-            var whenRecorderStopped = ForegroundTask.Run(async () => {
+            whenRecorderStopped = ForegroundTask.Run(async () => {
                 var sawRecording = false;
                 await foreach (var c in AudioRecorder.State.Computed.Changes(abortToken).ConfigureAwait(false)) {
                     var s = c.Value;
                     if (s.ChatId != chatId)
                         continue;
+
                     if (s.IsRecording)
                         sawRecording = true;
                     else if (sawRecording)
@@ -261,7 +272,7 @@ public partial class ChatAudioUI
             }, abortToken);
             await AudioRecorder.StartRecording(chatId, repliedEntryId, abortToken).ConfigureAwait(false);
             _ = IncomingShareSuggestions?.Push(chatId);
-            var whenStopped = ForegroundTask.Run(
+            whenStopped = ForegroundTask.Run(
                 async () => await cRecordingState
                     .When(x => x.ChatId != chatId || x.Language != language, abortToken)
                     .ConfigureAwait(false),
@@ -290,10 +301,16 @@ public partial class ChatAudioUI
         finally {
             abortTokenSource.CancelAndDisposeSilently();
             _stopRecordingAt.Value = null;
-            // Winner identity, not whenIdle.IsCompleted: the latter races with abortToken-triggered
-            // cancellation. Identity also means it completed before that cancellation, so the
-            // success check below can only reject a watcher that actually failed.
-            if (ReferenceEquals(whenWinner, whenIdle) && whenIdle.IsCompletedSuccessfully) {
+            // The losers fault unobserved otherwise - the cancellation above ends most of them,
+            // but a watcher that throws on its way out would go unreported.
+            _ = whenStopped?.SilentAwait(false);
+            _ = whenRecorderStopped?.SilentAwait(false);
+            _ = whenIdle?.SilentAwait(false);
+            // Only a whenIdle that ran to completion means the mic went idle. Anything else -
+            // a fault, or a throw before whenIdle was even assigned, which is every failure to
+            // open the microphone - used to land here as ReferenceEquals(null, null) and clear
+            // the user's recording intent with nothing but an "idle threshold reached" log.
+            if (whenIdle is { IsCompletedSuccessfully: true } && ReferenceEquals(whenWinner, whenIdle)) {
                 Log.LogInformation(
                     nameof(RecordChat) + ": idle threshold reached for chat #{ChatId}, stopping recording",
                     chatId);
@@ -306,6 +323,7 @@ public partial class ChatAudioUI
                     _ = TuneUI.Play(Tune.EndRecording);
                     break;
                 }
+
                 if (tryIndex >= MaxStopRecordingTryCount) {
                     Log.LogError(nameof(RecordChat) + ": couldn't stop recording in {TryCount} tries",
                         MaxStopRecordingTryCount);

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -291,21 +291,15 @@ public partial class ChatAudioUI
                 }
             }, abortToken);
             whenWinner = await Task.WhenAny(whenStopped, whenIdle, whenRecorderStopped).ConfigureAwait(false);
-            // Task.WhenAny never throws, so a faulted watcher wins the race indistinguishably from
-            // a clean one - and a faulted whenIdle would read as a genuine idle timeout below.
-            if (whenWinner is { IsCompletedSuccessfully: false, IsCanceled: false })
-                Log.LogError(whenWinner.Exception,
-                    nameof(RecordChat) + ": a recording watcher failed for chat #{ChatId}",
-                    chatId);
         }
         finally {
             abortTokenSource.CancelAndDisposeSilently();
             _stopRecordingAt.Value = null;
-            // The losers fault unobserved otherwise - the cancellation above ends most of them,
-            // but a watcher that throws on its way out would go unreported.
-            _ = whenStopped?.SilentAwait(false);
-            _ = whenRecorderStopped?.SilentAwait(false);
-            _ = whenIdle?.SilentAwait(false);
+            // Task.WhenAny never throws, so a faulted watcher is indistinguishable from a clean one
+            // here - and until this, a faulted whenIdle read as a genuine idle timeout below.
+            LogWatcherFault(whenStopped, chatId);
+            LogWatcherFault(whenRecorderStopped, chatId);
+            LogWatcherFault(whenIdle, chatId);
             // Only a whenIdle that ran to completion means the mic went idle. Anything else -
             // a fault, or a throw before whenIdle was even assigned, which is every failure to
             // open the microphone - used to land here as ReferenceEquals(null, null) and clear
@@ -334,6 +328,18 @@ public partial class ChatAudioUI
             }
         }
     }
+
+    private void LogWatcherFault(Task? watcherTask, ChatId chatId)
+        // Attached rather than awaited: the losers are still running when RecordChat exits, and an
+        // unobserved fault would otherwise surface as an UnobservedTaskException and nothing else.
+        => _ = watcherTask?.ContinueWith(
+            (t, state) => Log.LogError(t.Exception,
+                nameof(RecordChat) + ": a recording watcher failed for chat #{ChatId}",
+                (ChatId)state!),
+            chatId,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private async Task StartStopListeningPlayers(CancellationToken cancellationToken)
     {

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -49,9 +49,7 @@ public partial class ChatAudioUI
         // A SetListeningState landing before the stored active chats are read would make
         // StoredState discard them.
         await ActiveChatsUI.WhenReady.WaitAsync(cancellationToken).ConfigureAwait(false);
-        var chatIdsToListenTo = await GetChatsYouNeedToKeepListeningTo(cancellationToken).ConfigureAwait(false);
-        foreach (var chatId in chatIdsToListenTo)
-            await SetListeningState(chatId, true).ConfigureAwait(false);
+        await RestoreKeepListeningChats(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task StopListeningWhenPttDisarmed(CancellationToken cancellationToken)
@@ -150,7 +148,7 @@ public partial class ChatAudioUI
                     nameof(PushRecordingState) + ": retrying recorder for chat #{ChatId} (attempt {Attempt})",
                     intendedChatId, restartAttempt);
             await BackgroundTask.Run(
-                () => RecordChat(cRecordingState, cancellationToken),
+                () => RecordChat(cRecordingState, restartAttempt > 0, cancellationToken),
                 Log, $"{nameof(RecordChat)} failed",
                 cancellationToken
                 ).SilentAwait(false);
@@ -162,14 +160,17 @@ public partial class ChatAudioUI
                 restartAttempt++;
                 var delay = restartDelays[restartAttempt];
                 Log.LogWarning(
-                    nameof(PushRecordingState) + ": recorder for chat #{ChatId} exited with user intent intact (attempt {Attempt}); restarting in {Delay}",
+                    nameof(PushRecordingState)
+                    + ": recorder for chat #{ChatId} exited with user intent intact"
+                    + " (attempt {Attempt}); restarting in {Delay}",
                     intendedChatId, restartAttempt, delay);
                 await Clocks.CpuClock.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
             else {
                 if (restartAttempt > 0)
                     Log.LogInformation(
-                        nameof(PushRecordingState) + ": recorder for chat #{ChatId} stopped after {Attempt} restart attempt(s)",
+                        nameof(PushRecordingState)
+                        + ": recorder for chat #{ChatId} stopped after {Attempt} restart attempt(s)",
                         intendedChatId, restartAttempt);
                 restartAttempt = 0;
             }
@@ -191,11 +192,16 @@ public partial class ChatAudioUI
             var chatId = cRecordingState.Value.ChatId;
             if (_replayState.Value is { } replayState && replayState.ChatId != chatId)
                 StopReplay();
-            cRecordingState = await cRecordingState.When(x => x.ChatId is null || x.ChatId != chatId, cancellationToken).ConfigureAwait(false);
+            cRecordingState = await cRecordingState
+                .When(x => x.ChatId is null || x.ChatId != chatId, cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 
-    private async Task RecordChat(Computed<RecordingState> cRecordingState, CancellationToken cancellationToken)
+    private async Task RecordChat(
+        Computed<RecordingState> cRecordingState,
+        bool isRestart,
+        CancellationToken cancellationToken)
     {
         AudioInitializer.StartInitialization();
         var serverClock = Clocks.ServerClock;
@@ -235,8 +241,10 @@ public partial class ChatAudioUI
             // audioSession is set to 'play-and-record' after getUserMedia,
             // and WebKit AEC does not register the DestinationFallbackTrait
             // playback path, so a tune playing into a live mic feeds back.
-            await TuneUI.PlayAndWait(Tune.BeginRecording, mustPlay: !Volatile.Read(ref _isBeginTuneSuppressed))
-                .ConfigureAwait(false);
+            // A restart is the recorder recovering, not the user starting: chiming on each one
+            // turns a run of capture failures into a burst of tones.
+            var mustPlayBeginTune = !isRestart && !Volatile.Read(ref _isBeginTuneSuppressed);
+            await TuneUI.PlayAndWait(Tune.BeginRecording, mustPlay: mustPlayBeginTune).ConfigureAwait(false);
             // Install before StartRecording so we don't miss a fast false→true→false
             // transition (e.g., pipeline dies during JS init).
             var whenRecorderStopped = ForegroundTask.Run(async () => {
@@ -272,13 +280,20 @@ public partial class ChatAudioUI
                 }
             }, abortToken);
             whenWinner = await Task.WhenAny(whenStopped, whenIdle, whenRecorderStopped).ConfigureAwait(false);
-            // No need to await for the result of WhenAny: we're stopping anyway
+            // Task.WhenAny never throws, so a faulted watcher wins the race indistinguishably from
+            // a clean one - and a faulted whenIdle would read as a genuine idle timeout below.
+            if (whenWinner is { IsCompletedSuccessfully: false, IsCanceled: false })
+                Log.LogError(whenWinner.Exception,
+                    nameof(RecordChat) + ": a recording watcher failed for chat #{ChatId}",
+                    chatId);
         }
         finally {
             abortTokenSource.CancelAndDisposeSilently();
             _stopRecordingAt.Value = null;
-            // Use winner identity, not whenIdle.IsCompleted: the latter races with abortToken-triggered cancellation
-            if (ReferenceEquals(whenWinner, whenIdle)) {
+            // Winner identity, not whenIdle.IsCompleted: the latter races with abortToken-triggered
+            // cancellation. Identity also means it completed before that cancellation, so the
+            // success check below can only reject a watcher that actually failed.
+            if (ReferenceEquals(whenWinner, whenIdle) && whenIdle.IsCompletedSuccessfully) {
                 Log.LogInformation(
                     nameof(RecordChat) + ": idle threshold reached for chat #{ChatId}, stopping recording",
                     chatId);
@@ -292,7 +307,8 @@ public partial class ChatAudioUI
                     break;
                 }
                 if (tryIndex >= MaxStopRecordingTryCount) {
-                    Log.LogError(nameof(RecordChat) + ": couldn't stop recording in {TryCount} tries", MaxStopRecordingTryCount);
+                    Log.LogError(nameof(RecordChat) + ": couldn't stop recording in {TryCount} tries",
+                        MaxStopRecordingTryCount);
                     break;
                 }
 
@@ -405,7 +421,8 @@ public partial class ChatAudioUI
             var delay = restartDelays[restartAttempt];
             Log.LogWarning(
                 nameof(KeepListeningPlayerAlive)
-                + ": listener for chat #{ChatId} exited with user intent intact (attempt {Attempt}); restarting in {Delay}",
+                + ": listener for chat #{ChatId} exited with user intent intact"
+                + " (attempt {Attempt}); restarting in {Delay}",
                 chatId, restartAttempt, delay);
             await Clocks.CpuClock.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
@@ -467,7 +484,9 @@ public partial class ChatAudioUI
                 _ = BackgroundTask.Run(async () => {
                     var endPlaybackTask = await startTask.ConfigureAwait(false);
                     await endPlaybackTask.ConfigureAwait(false);
-                    await Clocks.CpuClock.Delay(RestorePreviousPlaybackStateDelay, cancellationToken).ConfigureAwait(false);
+                    await Clocks.CpuClock
+                        .Delay(RestorePreviousPlaybackStateDelay, cancellationToken)
+                        .ConfigureAwait(false);
                     // Don't clear state if it was paused or changed since we started
                     var currentState = _replayState.Value;
                     if (ReferenceEquals(currentState, newState))
@@ -812,10 +831,13 @@ public partial class ChatAudioUI
         await WhenEnabled.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         while (!cancellationToken.IsCancellationRequested) {
-            var cNextBeep = await _nextBeep.Computed.When(x => x != null && x.At > CpuNow, cancellationToken).ConfigureAwait(false);
+            var cNextBeep = await _nextBeep.Computed
+                .When(x => x != null && x.At > CpuNow, cancellationToken)
+                .ConfigureAwait(false);
             var nextBeepAt = cNextBeep.Value!.At;
             var nextBeepIn = nextBeepAt - CpuNow;
-            await Task.Delay(TimeSpanExt.Max(nextBeepIn, TimeSpan.FromMilliseconds(50)), cancellationToken).ConfigureAwait(false);
+            await Task.Delay(TimeSpanExt.Max(nextBeepIn, TimeSpan.FromMilliseconds(50)), cancellationToken)
+                .ConfigureAwait(false);
             if (!await IsNotCancelled(nextBeepAt).ConfigureAwait(false))
                 continue;
 
@@ -956,7 +978,8 @@ public partial class ChatAudioUI
     }
 
     [ComputeMethod]
-    protected virtual async Task<(ChatId? ChatId, bool IsTroubleshootRequired)> GetRecordingTroubleshootState(CancellationToken cancellationToken)
+    protected virtual async Task<(ChatId? ChatId, bool IsTroubleshootRequired)> GetRecordingTroubleshootState(
+        CancellationToken cancellationToken)
     {
         var chatId = await GetRecordingChatId().ConfigureAwait(false);
         var state = await AudioRecorder.State.Use(cancellationToken).ConfigureAwait(false);
@@ -1019,9 +1042,11 @@ public partial class ChatAudioUI
             // The holds are observed by invalidation rather than polled: HasActivity is a level
             // that clears at the end of every VAD utterance, so a sampled reading anchors the
             // countdown to whichever pause the sample landed in, not to the end of the conversation.
-            var isHeld = cHasActivity.Value
-                || cIsWatching.Value
-                || cOwnSourceKind.Value is not null;
+            // HasError first: reading an errored dependency would end this method, which
+            // RecordChat takes for an idle timeout. Unreadable counts as held.
+            var isHeld = cHasActivity.HasError || cHasActivity.Value
+                || cIsWatching.HasError || cIsWatching.Value
+                || cOwnSourceKind.HasError || cOwnSourceKind.Value is not null;
             if (isHeld) {
                 yield return null; // No countdown
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.cs
@@ -333,7 +333,7 @@ public partial class ChatAudioUI : UIWorkerBase<AppUIHub>, IComputeService, INot
             : stats.GetSpeechDuration(ownAuthorId) >= audioSettings.SpeechDurationThreshold;
     }
 
-    public ValueTask SetRecordingChatId(
+    public async ValueTask SetRecordingChatId(
         ChatId? chatId,
         bool isPtt = false,
         TimeSpan? idleDuration = null,
@@ -347,70 +347,66 @@ public partial class ChatAudioUI : UIWorkerBase<AppUIHub>, IComputeService, INot
         Volatile.Write(ref _isBeginTuneSuppressed, chatId is not null && !mustPlayBeginTune);
         if (chatId is not null)
             Hub.AudioAttachmentPlayer.OnConversationJoined();
-        return ActiveChatsUI.UpdateActiveChats(activeChats => {
-                var oldRecordingChat = activeChats.FirstOrDefault(c => c.IsRecording);
-                if (oldRecordingChat?.ChatId == chatId)
-                    return activeChats;
 
-                var now = CpuNow;
-                if (chatId is null) {
-                    // End recording
-                    if (oldRecordingChat != null) {
-                        activeChats = activeChats.WithOrReplace(oldRecordingChat with {
-                            IsRecording = false,
-                            Recency = now,
-                        }).ToArray();
-                        _ = RestoreListening(StopToken);
-                    }
-                    return activeChats;
-                }
-
-                // Begin recording
-                var chat = activeChats.FirstOrDefault(c => c.ChatId == chatId);
-                var mustListen = !isPtt;
-                if (chat == null)
-                    chat = new ActiveChat(chatId, mustListen, true, now, mustListen ? now : default);
-                else {
-                    var isListening = mustListen || chat.IsListening;
-                    chat = chat with {
-                        IsListening = isListening,
-                        IsRecording = true,
-                        Recency = now,
-                        ListeningRecency = isListening && !chat.IsListening ? now : chat.ListeningRecency,
-                    };
-                }
-                activeChats = activeChats.WithOrReplace(chat, true).ToArray();
-                // Turn off listening for all the rest chats if mustListen
-                activeChats = mustListen
-                    ? activeChats.WithUpdate(
-                        c => c.ChatId != chatId && (c.IsRecording || c.IsListening),
-                        c => c with { IsRecording = false, IsListening = false })
-                        .ToArray()
-                    : activeChats.WithUpdate(
-                        c => c.ChatId != chatId && c.IsRecording,
-                        c => c with { IsRecording = false })
-                        .ToArray();
+        var hasStoppedRecording = false;
+        await ActiveChatsUI.UpdateActiveChats(activeChats => {
+            var oldRecordingChat = activeChats.FirstOrDefault(c => c.IsRecording);
+            if (oldRecordingChat?.ChatId == chatId)
                 return activeChats;
 
-                async Task RestoreListening(CancellationToken ct)
-                {
-                    var chatIdsToListenTo = await GetChatsYouNeedToKeepListeningTo(ct).ConfigureAwait(false);
-                    foreach (var cid in chatIdsToListenTo) {
-                        chat = activeChats.FirstOrDefault(c => c.ChatId == cid);
-                        chat = chat == null
-                            ? new ActiveChat(cid,
-                                true,
-                                false,
-                                now,
-                                now)
-                            : chat with {
-                                IsListening = true,
-                                ListeningRecency = now,
-                            };
-                        activeChats = activeChats.WithOrReplace(chat).ToArray();
-                    }
+            var now = CpuNow;
+            if (chatId is null) {
+                // End recording
+                if (oldRecordingChat != null) {
+                    activeChats = activeChats.WithOrReplace(oldRecordingChat with {
+                        IsRecording = false,
+                        Recency = now,
+                    }).ToArray();
+                    hasStoppedRecording = true;
                 }
-            },
-            StopToken);
+                return activeChats;
+            }
+
+            // Begin recording
+            var chat = activeChats.FirstOrDefault(c => c.ChatId == chatId);
+            var mustListen = !isPtt;
+            if (chat == null)
+                chat = new ActiveChat(chatId, mustListen, true, now, mustListen ? now : default);
+            else {
+                var isListening = mustListen || chat.IsListening;
+                chat = chat with {
+                    IsListening = isListening,
+                    IsRecording = true,
+                    Recency = now,
+                    ListeningRecency = isListening && !chat.IsListening ? now : chat.ListeningRecency,
+                };
+            }
+            activeChats = activeChats.WithOrReplace(chat, true).ToArray();
+            // Turn off listening for all the rest chats if mustListen
+            activeChats = mustListen
+                ? activeChats.WithUpdate(
+                    c => c.ChatId != chatId && (c.IsRecording || c.IsListening),
+                    c => c with { IsRecording = false, IsListening = false })
+                    .ToArray()
+                : activeChats.WithUpdate(
+                    c => c.ChatId != chatId && c.IsRecording,
+                    c => c with { IsRecording = false })
+                    .ToArray();
+            return activeChats;
+        }, StopToken).ConfigureAwait(false);
+
+        if (hasStoppedRecording)
+            await RestoreKeepListeningChats(StopToken).ConfigureAwait(false);
+    }
+
+    // Private methods
+
+    private async Task RestoreKeepListeningChats(CancellationToken cancellationToken)
+    {
+        // Runs after UpdateActiveChats rather than inside its updater: only the array the updater
+        // returns is published, so writes made to the captured one afterwards are lost.
+        var chatIdsToListenTo = await GetChatsYouNeedToKeepListeningTo(cancellationToken).ConfigureAwait(false);
+        foreach (var chatId in chatIdsToListenTo)
+            await SetListeningState(chatId, true).ConfigureAwait(false);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -18,6 +18,9 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(45);
     // Give up watching if the call we just started never shows up as dialing.
     private static readonly TimeSpan DialingWaitTimeout = TimeSpan.FromSeconds(15);
+    // How long a mute verdict must survive before it stops a recording - long enough for a
+    // peer's own mute lift to come back from the server, short enough to feel immediate.
+    private static readonly TimeSpan MuteEnforcementDelay = TimeSpan.FromSeconds(1);
 
     private static readonly string JSStartRingback = $"{BlazorUIAppModule.ImportName}.OutgoingCallRingback.start";
     private static readonly string JSStopRingback = $"{BlazorUIAppModule.ImportName}.OutgoingCallRingback.stop";
@@ -150,13 +153,29 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         return await ChatVideoUI.IsWatching(chatId, cancellationToken).ConfigureAwait(false);
     }
 
-    public Task SetParticipation(ChatId chatId, ParticipationKind kind, bool isActive, CancellationToken cancellationToken)
+    public Task SetParticipation(
+        ChatId chatId,
+        ParticipationKind kind,
+        bool isActive,
+        CancellationToken cancellationToken)
         => LiveSessions.SetParticipation(Session, chatId, kind, isActive, cancellationToken);
 
-    protected override async Task OnRun(CancellationToken cancellationToken)
-        => await Task.WhenAll(
-            RunParticipationSync(cancellationToken),
-            RunMuteEnforcement(cancellationToken)).ConfigureAwait(false);
+    protected override Task OnRun(CancellationToken cancellationToken)
+    {
+        // Retried rather than awaited together: UIWorkerBase never restarts a worker that threw,
+        // so one errored computed used to end participation reporting for the rest of the session.
+        var baseChains = new[] {
+            AsyncChain.From(RunParticipationSync),
+            AsyncChain.From(RunMuteEnforcement),
+        };
+        var retryDelays = RetryDelaySeq.Exp(0.5, 8);
+        return (
+            from chain in baseChains
+            select chain
+                .Log(LogLevel.Debug, Log)
+                .RetryForever(retryDelays, Log)
+            ).RunIsolated(cancellationToken);
+    }
 
     private async Task RunParticipationSync(CancellationToken cancellationToken)
     {
@@ -167,21 +186,25 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         var lastHeartbeatAt = Clocks.CpuClock.Now;
         try {
             while (!cancellationToken.IsCancellationRequested) {
-                var next = cParticipations.Value;
-                var now = Clocks.CpuClock.Now;
-                var isHeartbeat = now - lastHeartbeatAt >= HeartbeatInterval;
-                if (isHeartbeat)
-                    lastHeartbeatAt = now;
+                // Reading an errored computed would throw and drop every reported participation;
+                // skipping the pass keeps them until the next recompute succeeds.
+                if (!cParticipations.HasError) {
+                    var next = cParticipations.Value;
+                    var now = Clocks.CpuClock.Now;
+                    var isHeartbeat = now - lastHeartbeatAt >= HeartbeatInterval;
+                    if (isHeartbeat)
+                        lastHeartbeatAt = now;
 
-                foreach (var chatId in current.Keys.Except(next.Keys).ToList()) {
-                    await SetParticipation(chatId, current[chatId], false, cancellationToken).ConfigureAwait(false);
-                    current.Remove(chatId);
-                }
-                foreach (var (chatId, kind) in next)
-                    if (isHeartbeat || !current.TryGetValue(chatId, out var existing) || existing != kind) {
-                        await SetParticipation(chatId, kind, true, cancellationToken).ConfigureAwait(false);
-                        current[chatId] = kind;
+                    foreach (var chatId in current.Keys.Except(next.Keys).ToList()) {
+                        await SetParticipation(chatId, current[chatId], false, cancellationToken).ConfigureAwait(false);
+                        current.Remove(chatId);
                     }
+                    foreach (var (chatId, kind) in next)
+                        if (isHeartbeat || !current.TryGetValue(chatId, out var existing) || existing != kind) {
+                            await SetParticipation(chatId, kind, true, cancellationToken).ConfigureAwait(false);
+                            current[chatId] = kind;
+                        }
+                }
 
                 using var cts = cancellationToken.CreateLinkedTokenSource();
                 var whenInvalidated = cParticipations.WhenInvalidated(cts.Token);
@@ -196,23 +219,37 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         }
     }
 
-    // Soft mute enforcement: when the host turns off my recording (MicMuted) — either
-    // per-peer or via mute-all — my own recorder stops and I'm told why. MicMuted is
-    // peer-revocable: tapping record clears it (see RecorderToggle).
     private async Task RunMuteEnforcement(CancellationToken cancellationToken)
     {
+        // Soft mute enforcement: when the host turns off my recording (MicMuted) — either
+        // per-peer or via mute-all — my own recorder stops and I'm told why. MicMuted is
+        // peer-revocable: tapping record clears it (see RecorderToggle).
         var cMuted = await Computed
             .Capture(() => GetMutedRecordingChat(cancellationToken), cancellationToken)
             .ConfigureAwait(false);
         while (!cancellationToken.IsCancellationRequested) {
-            if (cMuted.Value is { } chatId && !chatId.Value.IsNullOrEmpty()) {
-                await ChatAudioUI.SetRecordingChatId(null).ConfigureAwait(false);
-                Hub.ToastUI.Show(L.Call_RecordingTurnedOffByHost, "icon-mic-off", ToastDismissDelay.Short);
+            if (IsMuted(cMuted)) {
+                // Tapping record lifts the mute server-side before it sets the recording intent,
+                // but only the intent invalidates locally - the lifted session snapshot arrives a
+                // round trip later. Acting on the first read would stop the recording it was for.
+                await Clocks.CpuClock.Delay(MuteEnforcementDelay, cancellationToken).ConfigureAwait(false);
+                cMuted = await cMuted.Update(cancellationToken).ConfigureAwait(false);
+                if (IsMuted(cMuted)) {
+                    await ChatAudioUI.SetRecordingChatId(null).ConfigureAwait(false);
+                    Hub.ToastUI.Show(L.Call_RecordingTurnedOffByHost, "icon-mic-off", ToastDismissDelay.Short);
+                }
             }
 
             await cMuted.WhenInvalidated(cancellationToken).ConfigureAwait(false);
             cMuted = await cMuted.Update(cancellationToken).ConfigureAwait(false);
         }
+        return;
+
+        // An errored computed must not reach .Value: the throw would take down the whole worker.
+        static bool IsMuted(Computed<ChatId?> computed)
+            => !computed.HasError
+                && computed.Value is { } chatId
+                && !chatId.Value.IsNullOrEmpty();
     }
 
     // Protected/internal methods
@@ -242,7 +279,8 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     }
 
     [ComputeMethod]
-    protected virtual async Task<ImmutableDictionary<ChatId, ParticipationKind>> GetMyParticipations(CancellationToken cancellationToken)
+    protected virtual async Task<ImmutableDictionary<ChatId, ParticipationKind>> GetMyParticipations(
+        CancellationToken cancellationToken)
     {
         var result = ImmutableDictionary.CreateBuilder<ChatId, ParticipationKind>();
         var activeChats = await ActiveChatsUI.ActiveChats.Use(cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -186,10 +186,9 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         var lastHeartbeatAt = Clocks.CpuClock.Now;
         try {
             while (!cancellationToken.IsCancellationRequested) {
-                // Reading an errored computed would throw and drop every reported participation;
-                // skipping the pass keeps them until the next recompute succeeds.
-                if (!cParticipations.HasError) {
-                    var next = cParticipations.Value;
+                // ValueOrDefault is null only when the computed errored; skipping the pass keeps
+                // the reported participations until a recompute succeeds, where .Value would throw.
+                if (cParticipations.ValueOrDefault is { } next) {
                     var now = Clocks.CpuClock.Now;
                     var isHeartbeat = now - lastHeartbeatAt >= HeartbeatInterval;
                     if (isHeartbeat)
@@ -245,11 +244,9 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         }
         return;
 
-        // An errored computed must not reach .Value: the throw would take down the whole worker.
+        // ValueOrDefault, not Value: an errored computed would throw and take the whole worker down.
         static bool IsMuted(Computed<ChatId?> computed)
-            => !computed.HasError
-                && computed.Value is { } chatId
-                && !chatId.Value.IsNullOrEmpty();
+            => computed.ValueOrDefault is { } chatId && !chatId.Value.IsNullOrEmpty();
     }
 
     // Protected/internal methods

--- a/src/dotnet/UI.Blazor.App/Services/audio-context-source.ts
+++ b/src/dotnet/UI.Blazor.App/Services/audio-context-source.ts
@@ -1156,3 +1156,17 @@ if (BrowserInfo.hostKind !== 'MauiApp') {
         void audioContextSource.addTrait(new DestinationFallbackTrait());
     }
 }
+
+// Resumes both contexts from a click on anything matching `selector`. Delegated, so buttons
+// rendered after this call are covered too, and capturing, so it runs inside the user-gesture
+// stack that resume() requires.
+export function initAudioContextsOnClick(selector: string): void {
+    document.addEventListener('click', (event: Event) => {
+        const target = event.target;
+        if (!(target instanceof Element) || !target.closest(selector))
+            return;
+
+        void recordingAudioContextSource.initContextInteractively();
+        void audioContextSource.initContextInteractively();
+    }, { capture: true, passive: true });
+}


### PR DESCRIPTION
## The bug

On the **Voxt Windows app**, tapping the mic button in the message editor while
**someone else is already talking** turns recording on and then instantly off
again — silently, no toast, no modal, no error. It works when nobody is talking,
it works if you start recording *first* and someone talks after, and it works in
a browser on the same machine.

The toggle's state is `ActiveChats[…].IsRecording` — pure intent — so an engine
failure can't turn it off (it leaves the button on and `PushRecordingState`
retries). Only `SetRecordingChatId(null)` can, and exactly one of its call sites
is silent, instant and uncorrelated with a tap.

## Root cause

`ChatAudioUI.RecordChat` picks its stop reason with `Task.WhenAny`, which returns
the first task to complete **in any state**, and builds `whenIdle` with the
2-arg `ForegroundTask.Run` overload that turns a throw into a *faulted task
without logging*. The winner was then deliberately not awaited:

```csharp
whenWinner = await Task.WhenAny(whenStopped, whenIdle, whenRecorderStopped);
// No need to await for the result of WhenAny: we're stopping anyway
…
if (ReferenceEquals(whenWinner, whenIdle)) { Log…("idle threshold reached"); await SetRecordingChatId(null); }
```

So **any** exception inside the idle observer was relabelled as an idle timeout,
cleared the intent, and left nothing behind but a misleading info-level log line.
A genuine idle stop takes 30s and shows a countdown, so an *instant* one was
always a fault.

The playback-conditionality comes from `ObserveStreamingIdleBoundaries`: its
`isHeld` branch is taken only while someone is streaming, and that branch loops
on `WhenInvalidated` → `Update()` → the `LiveSessions.HasActivity` RPC,
repeatedly, from the moment the mic opens. The idle branch instead parks for
~20s and touches nothing.

The same file already knew better — `StopListeningWhenIdle` carries the comment
*"Task.WhenAny itself never throws, so the winner must be awaited"*.

## Everything fixed

Verified by an independent audit pass before any code changed.

| | Fix |
|---|---|
| **A1** | `RecordChat` observes the winner and logs a faulted watcher; only a *successful* `whenIdle` clears the intent |
| **A2** | The idle observer reads `HasError` before `.Value`; an unreadable hold counts as held |
| **A3** | The Windows default-capture-device watcher compares against the endpoint the input node opened, so a no-op re-pick no longer ends the capture |
| **N4** | `WindowsAudioPlaybackEngine` stops its `AudioGraph` before disposing it — a graph left running wedges WinRT audio process-wide and kills every later `CreateAsync`, capture included |
| **B1** | `recorder-toggle.ts` / `playback-toggle.ts` used a static one-shot that bound only the buttons present at first render; both now share one delegated capturing listener |
| **B2** | `ActiveChatsUI.FixActiveChats` NRE'd on a recording chat without write access, aborting the whole update |
| **B3** | `startMicrophoneStream` rethrows instead of swallowing, so `state` and the heartbeat don't stay live for a pipeline with no mic |
| **B4** | The web heartbeat skips while the recorder is `'starting'` — it used to stop the start it was racing |
| **B5** | `MarkStarting` no longer carries the previous session's `IsRecording` into the new state |
| **B6** | `whenStopped` / `whenRecorderStopped` faults are logged rather than silently costing a restart cycle |
| **N1** | `SetRecordingChatId` restored keep-listening chats by mutating an array the updater had already returned — the write was lost. Now runs after the update, via the helper `InitializeListening` shares |
| **N2** | `LiveSessionUI`'s loops read `.Value` off possibly-errored computeds under a bare `Task.WhenAll`, so one error ended participation reporting *and* mute enforcement permanently. Now `AsyncChain` + `RetryForever`, and mute enforcement re-confirms after a settle delay so a peer's own mute lift doesn't race it |
| **N3** | `PushRecordingState` no longer replays the begin-recording tune on each restart |

Not changed: **A5** (the 500ms tap guard) and **A6** (the pre-`9784b72705`
loopback→`NoPermission` chain) — audited and found not to be defects here.

## Verified

- `npm run build:Debug` (`tsc --noEmit` + bundle) and the full server `dotnet build`: clean.
- `dotnet build App.Maui -f net11.0-windows10.0.22621.0`: 0 errors.
- In live Chrome against the dev server: a `div.recorder-wrapper > button` created
  *after* `init()` ran fires both `initContextInteractively` calls, and a
  non-matching button fires neither — the B1 regression, directly exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rg8JuS6YcbvqAgYkDj8PRA