### PR TITLE
fix(settings): back button returns to the tab list on a narrow screen

### DIFF
--- a/src/dotnet/UI.Blazor/Components/SettingsPanel/SettingsPanel.razor
+++ b/src/dotnet/UI.Blazor/Components/SettingsPanel/SettingsPanel.razor
@@ -1,3 +1,4 @@
+@using ActualChat.UI.Blazor.Services
 @namespace ActualChat.UI.Blazor.Components
 @{
     var tabs = Tabs;
@@ -69,6 +70,10 @@
 @code {
     private IReadOnlyList<SettingsTabDef> _lastTabs = [];
     private bool _isRightSideVisible;
+    private ModalStepRef? _tabStepRef;
+
+    [CascadingParameter] public Modal? Modal { get; set; }
+    [CascadingParameter] public ScreenSize ScreenSize { get; set; }
 
     [Parameter, EditorRequired] public IReadOnlyList<SettingsTabDef> Tabs { get; set; } = [];
     [Parameter] public string Class { get; set; } = "";
@@ -103,7 +108,11 @@
     }
 
     public void OnTabArrowClick() {
+        var stepRef = _tabStepRef;
+        _tabStepRef = null;
         _isRightSideVisible = false;
+        if (stepRef != null)
+            Modal!.StepBack();
         StateHasChanged();
     }
 
@@ -138,5 +147,33 @@
 
         SelectedTabId = tab.Id;
         _isRightSideVisible = true;
+        StepIn();
+    }
+
+    private void StepIn() {
+        // Only a narrow screen hides the tab list behind the tab content, so only there
+        // the tab is a place the back button should return from.
+        if (_tabStepRef != null || Modal is not { } modal || !ScreenSize.IsNarrow())
+            return;
+
+        var stepRef = modal.StepIn("settings-tab");
+        _tabStepRef = stepRef;
+        _ = stepRef.WhenClosed.ContinueWith(
+            task => InvokeAsync(() => OnStepClosed(stepRef, task)),
+            TaskScheduler.Default);
+    }
+
+    private void OnStepClosed(ModalStepRef stepRef, Task<bool> whenClosed) {
+        // A mismatch means OnTabArrowClick has already handled this step
+        if (_tabStepRef != stepRef)
+            return;
+
+        _tabStepRef = null;
+        // The step result is false when it's closed because the entire modal is closing.
+        if (!whenClosed.IsCompletedSuccessfully || !whenClosed.Result)
+            return;
+
+        _isRightSideVisible = false;
+        StateHasChanged();
     }
 }


### PR DESCRIPTION
## Problem

On a narrow screen (phone) the settings modal shows either the tab list **or** the selected tab's content, never both. Opening Settings → picking a tab (e.g. *Application*) → pressing Back closed the whole modal instead of returning to the tab list.

## Cause

That left/right switch was a plain component field, `SettingsPanel._isRightSideVisible`. `History` knew nothing about it, so the only back step registered for the open modal was `ModalHost.OwnHistoryState` — the modal itself. One Back, modal gone.

## Fix

Reuse the nested-step mechanism the codebase already has for multi-page modals — `Modal.StepIn(name)` / `Modal.StepBack()` on top of `HistoryStepper`, the same thing `DiveInDialogFrame` uses:

- `OnTabClick` pushes a `settings-tab` step when the screen is narrow, so Back returns to the tab list.
- The header arrow (`OnTabArrowClick`) now goes through `Modal.StepBack()` so the browser history stays in sync with the panel.
- When the step is closed because the whole modal is closing, `WhenClosed` yields `false` and the panel leaves its state alone — `ModalHost.CloseInternal` → `CloseSteps()` does the cleanup.

The step is pushed **only** on a narrow screen: on `md+` the tab list is always visible (`hidden md:flex-y` in `settings-panel.css`), so a step there would just make one Back press do nothing.

Opening the modal directly at a tab (`DefaultTabId` — `ShowSettingsEvent` with a `TabId`, or `/settings/<option>`) still pushes no step: the user never saw the list, so Back closing the modal is the right behavior. The header arrow still reaches the list.

## Testing

`dotnet build src/dotnet/UI.Blazor/UI.Blazor.csproj` — 0 errors.

Verified manually on a narrow viewport:

1. Settings → *Application* → Back ⇒ tab list.
2. Back again ⇒ modal closes.
3. Header arrow ⇒ tab list, then Back ⇒ modal closes (no dead back press left over).
4. Wide screen: Back closes the modal in one press, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
