### PR TITLE
fix(ios): rework the share sheet's loading state

### DIFF
--- a/ActualChat.sln.DotSettings
+++ b/ActualChat.sln.DotSettings
@@ -228,6 +228,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=healthz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kvas/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kvasar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kvass/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Memoizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=memoizer/@EntryIndexedValue">True</s:Boolean>

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactListSkeletonView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactListSkeletonView.cs
@@ -1,0 +1,98 @@
+using ActualChat.Maui;
+
+namespace ActualChat.App.Maui.IosShareExt.Components;
+
+/// <summary>
+/// Placeholder rows shown while <see cref="ContactListView"/> waits for its first result.
+/// Laid out on <see cref="ContactView"/>'s geometry, so the real rows land where these sat.
+/// </summary>
+public sealed class ContactListSkeletonView : UIView
+{
+    private const int RowCount = 8;
+    private const int IconLeading = 16;
+    private const int TextLeading = IconLeading + ContactIconView.Size + 12;
+    private const int TitleHeight = 12;
+    private const int SubtitleHeight = 10;
+    private const double PulseDuration = 0.9;
+    private const float PulseAlpha = 0.35f;
+    // Equal-length rows read as a table rather than as text, so the widths cycle instead
+    private static readonly int[] TitleWidths = [140, 96, 168, 120, 152, 104, 132, 112];
+    private static readonly int[] SubtitleWidths = [200, 148, 176, 128, 208, 160, 184, 136];
+
+    private readonly UIView _rows;
+
+    public ContactListSkeletonView()
+    {
+        TranslatesAutoresizingMaskIntoConstraints = false;
+        // Opaque, and the pulse runs on _rows: fading this view would fade past its own background
+        BackgroundColor = AppColors.Background01;
+        UserInteractionEnabled = false;
+
+        _rows = new UIView {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            BackgroundColor = UIColor.Clear,
+        };
+        AddSubview(_rows);
+
+        var constraints = new List<NSLayoutConstraint> {
+            _rows.TopAnchor.ConstraintEqualTo(TopAnchor),
+            _rows.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
+            _rows.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
+            _rows.BottomAnchor.ConstraintEqualTo(BottomAnchor),
+        };
+        for (var i = 0; i < RowCount; i++) {
+            var rowTop = i * ContactView.Height;
+            var icon = AddBlock(ContactIconView.Size / 2f);
+            var title = AddBlock(TitleHeight / 2f);
+            var subtitle = AddBlock(SubtitleHeight / 2f);
+            constraints.AddRange([
+                icon.LeadingAnchor.ConstraintEqualTo(_rows.LeadingAnchor, IconLeading),
+                icon.TopAnchor.ConstraintEqualTo(_rows.TopAnchor, rowTop + 6),
+                icon.WidthAnchor.ConstraintEqualTo(ContactIconView.Size),
+                icon.HeightAnchor.ConstraintEqualTo(ContactIconView.Size),
+
+                title.LeadingAnchor.ConstraintEqualTo(_rows.LeadingAnchor, TextLeading),
+                title.TopAnchor.ConstraintEqualTo(_rows.TopAnchor, rowTop + 11),
+                title.WidthAnchor.ConstraintEqualTo(TitleWidths[i]),
+                title.HeightAnchor.ConstraintEqualTo(TitleHeight),
+
+                subtitle.LeadingAnchor.ConstraintEqualTo(_rows.LeadingAnchor, TextLeading),
+                subtitle.TopAnchor.ConstraintEqualTo(_rows.TopAnchor, rowTop + 31),
+                subtitle.WidthAnchor.ConstraintEqualTo(SubtitleWidths[i]),
+                subtitle.HeightAnchor.ConstraintEqualTo(SubtitleHeight),
+            ]);
+        }
+        NSLayoutConstraint.ActivateConstraints([..constraints]);
+    }
+
+    public override void MovedToWindow()
+    {
+        // UIKit drops animations added to a view that isn't in a window yet
+        base.MovedToWindow();
+        if (Window is not null)
+            StartPulsing();
+    }
+
+    // Private methods
+
+    private UIView AddBlock(float cornerRadius)
+    {
+        var block = new UIView {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            BackgroundColor = AppColors.Square,
+            Layer = { CornerRadius = cornerRadius, MasksToBounds = true },
+        };
+        _rows.AddSubview(block);
+        return block;
+    }
+
+    private void StartPulsing()
+        => UIView.Animate(PulseDuration,
+            0,
+            UIViewAnimationOptions.Repeat
+            | UIViewAnimationOptions.Autoreverse
+            | UIViewAnimationOptions.CurveEaseInOut
+            | UIViewAnimationOptions.AllowUserInteraction,
+            () => _rows.Alpha = PulseAlpha,
+            () => { });
+}

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactListSkeletonView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactListSkeletonView.cs
@@ -27,6 +27,8 @@ public sealed class ContactListSkeletonView : UIView
         // Opaque, and the pulse runs on _rows: fading this view would fade past its own background
         BackgroundColor = AppColors.Background01;
         UserInteractionEnabled = false;
+        // RowCount rows of fixed height overflow a short list - and the comment field sits right below
+        ClipsToBounds = true;
 
         _rows = new UIView {
             TranslatesAutoresizingMaskIntoConstraints = false,
@@ -63,6 +65,22 @@ public sealed class ContactListSkeletonView : UIView
             ]);
         }
         NSLayoutConstraint.ActivateConstraints([..constraints]);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // The pulse is attached to _rows and keeps running on a detached layer otherwise; the
+        // blocks hold managed peers of their own, and the appex process outlives a single share.
+        if (disposing) {
+            _rows.Layer.RemoveAllAnimations();
+            foreach (var block in _rows.Subviews) {
+                block.RemoveFromSuperview();
+                block.Dispose();
+            }
+            _rows.RemoveFromSuperview();
+            _rows.Dispose();
+        }
+        base.Dispose(disposing);
     }
 
     public override void MovedToWindow()

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactListView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactListView.cs
@@ -6,15 +6,17 @@ using NSContact = ActualChat.App.Maui.IosShareExt.UI.NSHasId<ActualChat.Contacts
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
 
-public sealed class ContactListView(IosHub hub) : ComputedStateView<ContactListView.Model?>(hub), IUICollectionViewDelegate
+public sealed class ContactListView : ComputedStateView<ContactListView.Model?>, IUICollectionViewDelegate
 {
     private static readonly NSString SectionId = (NSString)"Main";
-    private UICollectionViewDiffableDataSource<NSString, NSContact> _dataSource = null!;
-    private UICollectionView _collectionView = null!;
+    private readonly UICollectionViewDiffableDataSource<NSString, NSContact> _dataSource;
+    private readonly UICollectionView _collectionView;
+    private ContactListSkeletonView? _skeletonView;
 
     private ShareUI ShareUI => Hub.ShareUI;
 
-    protected override void OnInitialRender(Model? model)
+    // Built here, not in OnInitialRender: that runs once the contacts are in, too late for a skeleton
+    public ContactListView(IosHub hub) : base(hub)
     {
         TranslatesAutoresizingMaskIntoConstraints = false;
         BackgroundColor = UIColor.Clear;
@@ -22,25 +24,29 @@ public sealed class ContactListView(IosHub hub) : ComputedStateView<ContactListV
         var configuration = new UICollectionLayoutListConfiguration(UICollectionLayoutListAppearance.Plain);
         configuration.ShowsSeparators = false;
         var layout = UICollectionViewCompositionalLayout.GetLayout(configuration);
-        _collectionView = new UICollectionView(CGRect.Empty, layout)
-        {
+        _collectionView = new UICollectionView(CGRect.Empty, layout) {
             TranslatesAutoresizingMaskIntoConstraints = false,
             BackgroundColor = UIColor.Clear,
-            // ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never,
         };
-
         AddSubview(_collectionView);
+
+        _skeletonView = new ContactListSkeletonView();
+        AddSubview(_skeletonView);
 
         NSLayoutConstraint.ActivateConstraints([
             _collectionView.TopAnchor.ConstraintEqualTo(TopAnchor),
             _collectionView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
             _collectionView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _collectionView.BottomAnchor.ConstraintEqualTo(BottomAnchor)
+            _collectionView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
+
+            _skeletonView.TopAnchor.ConstraintEqualTo(TopAnchor),
+            _skeletonView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
+            _skeletonView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
+            _skeletonView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
         ]);
 
         var cellRegistration = UICollectionViewCellRegistrationExt.GetRegistration<UICollectionViewListCell, NSContact>(
-            (cell, _, contact) =>
-            {
+            (cell, _, contact) => {
                 foreach (var subview in cell.ContentView.Subviews) {
                     subview.RemoveFromSuperview();
                     subview.DisposeSilently();
@@ -65,19 +71,10 @@ public sealed class ContactListView(IosHub hub) : ComputedStateView<ContactListV
             _collectionView,
             (collectionView1, indexPath, itemIdentifier) =>
                 collectionView1.DequeueConfiguredReusableCell(cellRegistration, indexPath, itemIdentifier));
-
-        SetContacts(model?.Contacts);
     }
 
-    private void SetContacts(IReadOnlyList<Contact>? contacts)
-    {
-        contacts ??= [];
-        var snapshot = new NSDiffableDataSourceSnapshot<NSString, NSContact>();
-        snapshot.AppendSections([SectionId]);
-        var items = contacts.Select(c => new NSContact(c)).ToArray();
-        snapshot.AppendItems(items, SectionId);
-        _dataSource.ApplySnapshot(snapshot, true);
-    }
+    protected override void OnInitialRender(Model? model)
+        => SetContacts(model?.Contacts);
 
     protected override void OnStateChanged(Model? model)
         => SetContacts(model?.Contacts);
@@ -103,6 +100,32 @@ public sealed class ContactListView(IosHub hub) : ComputedStateView<ContactListV
             return;
 
         ShareUI.ToggleSelection(contact.Id!);
+    }
+
+    // Private methods
+
+    private void SetContacts(IReadOnlyList<Contact>? contacts)
+    {
+        // Null is "no result yet"; an empty list is a real answer, and retires the skeleton
+        if (contacts is not null)
+            HideSkeleton();
+
+        contacts ??= [];
+        var snapshot = new NSDiffableDataSourceSnapshot<NSString, NSContact>();
+        snapshot.AppendSections([SectionId]);
+        var items = contacts.Select(c => new NSContact(c)).ToArray();
+        snapshot.AppendItems(items, SectionId);
+        _dataSource.ApplySnapshot(snapshot, true);
+    }
+
+    private void HideSkeleton()
+    {
+        if (_skeletonView is null)
+            return;
+
+        _skeletonView.RemoveFromSuperview();
+        _skeletonView.DisposeSilently();
+        _skeletonView = null;
     }
 
     // Nested types

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
@@ -83,10 +83,12 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
 
         // Place list
         var placeListView = new PlaceListView(Hub);
+        placeListView.TranslatesAutoresizingMaskIntoConstraints = false;
         AddSubview(placeListView);
 
         // Contact list
         var contactListView = new ContactListView(Hub);
+        contactListView.TranslatesAutoresizingMaskIntoConstraints = false;
         AddSubview(contactListView);
 
         // Comment field

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactSelectionView.cs
@@ -180,13 +180,13 @@ public sealed class ContactSelectionView(IosHub hub) : ComputedStateView<Contact
         });
     }
 
-    protected override void Dispose(bool disposing)
+    protected override void DisposeStatesCore()
     {
-        if (disposing) {
-            _keyboardShowObserver?.Dispose();
-            _keyboardHideObserver?.Dispose();
-        }
-        base.Dispose(disposing);
+        // Not Dispose: a step view leaves the tree via RemoveAndDisposeStates, which never reaches
+        // it - and a live observer would keep relayouting the orphan on every keyboard show.
+        _keyboardShowObserver.DisposeSilently();
+        _keyboardHideObserver.DisposeSilently();
+        base.DisposeStatesCore();
     }
 
     protected override void OnStateChanged(Model? model)

--- a/src/dotnet/App.Maui.IosShareExt/Components/ContactView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ContactView.cs
@@ -24,6 +24,7 @@ public sealed class ContactView(Contact contact, IosHub hub) : ComputedStateView
 
         // Avatar
         _iconView = new ContactIconView(model.IconQuery, null, contact.Chat.Title, true, Hub);
+        _iconView.TranslatesAutoresizingMaskIntoConstraints = false;
 
         // Text container
         var textContainer = new UIStackView

--- a/src/dotnet/App.Maui.IosShareExt/Components/PlaceListView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/PlaceListView.cs
@@ -60,6 +60,7 @@ public sealed class PlaceListView(IosHub hub) : ComputedStateView<PlaceListView.
                 }
 
                 var placeCellView = new PlaceView(place.Value, Hub);
+                placeCellView.TranslatesAutoresizingMaskIntoConstraints = false;
                 cell.AddSubview(placeCellView);
                 cell.BackgroundConfiguration = UIBackgroundConfiguration.ClearConfiguration;
 

--- a/src/dotnet/App.Maui.IosShareExt/Components/PlaceView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/PlaceView.cs
@@ -18,6 +18,7 @@ public sealed class PlaceView(Place? place, IosHub hub) : ComputedStateView<bool
 
         // Icon view
         _iconView = new ContactIconView(place?.GetIconQuery(), UIImage.GetSystemImage("message"), place?.Title ?? "", false, Hub);
+        _iconView.TranslatesAutoresizingMaskIntoConstraints = false;
 
         // Underline indicator
         _underlineView = new UIView

--- a/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
@@ -5,28 +5,33 @@ using ActualChat.Maui;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
 
-public class ShareView(IosHub hub) : ComputedStateView<ShareView.Model>(hub)
+public sealed class ShareView : ComputedStateView<ShareView.Model>
 {
+    private const double FadeDuration = 0.3;
+    private StatefulView? _stepView;
+    private ShareStep? _displayedStep;
     private ShareUI ShareUI => Hub.ShareUI;
-    private SignInView? _signInView;
-    private ContactSelectionView? _contactSelectionView;
-    private UploadProgressView? _uploadProgressView;
-    private ErrorView? _errorView;
-    private SuccessView? _successView;
-    private ShareStep _displayedStep;
+
+    public ShareView(IosHub hub) : base(hub)
+    {
+        // OnInitialRender waits on GetStep, and that waits on Accounts.GetOwn - a whole round trip
+        // of blank sheet if the UI waits with it.
+        BackgroundColor = AppColors.Background01;
+        ShowContactSelection();
+        _displayedStep = ShareStep.ContactSelection;
+    }
 
     protected override void OnInitialRender(Model model)
-    {
-        BackgroundColor = AppColors.Background01;
-        OnStateChanged(model);
-    }
+        => OnStateChanged(model);
 
     protected override void OnStateChanged(Model model)
     {
-        if (model.Step == _displayedStep)
+        // None only means the suggested-recipient lookup is still running - the guest check is past.
+        var step = model.Step == ShareStep.None ? ShareStep.ContactSelection : model.Step;
+        if (step == _displayedStep)
             return;
 
-        switch (model.Step) {
+        switch (step) {
             case ShareStep.SignIn:
                 ShowSignIn();
                 break;
@@ -43,120 +48,7 @@ public class ShareView(IosHub hub) : ComputedStateView<ShareView.Model>(hub)
                 ShowCompleted();
                 break;
         }
-        _displayedStep = model.Step;
-    }
-
-    private void ShowSignIn()
-    {
-        _signInView = new SignInView(Hub);
-        _signInView.TranslatesAutoresizingMaskIntoConstraints = false;
-        AddSubview(_signInView);
-
-        NSLayoutConstraint.ActivateConstraints([
-            _signInView.TopAnchor.ConstraintEqualTo(TopAnchor),
-            _signInView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
-            _signInView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _signInView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
-        ]);
-    }
-
-    private void ShowContactSelection()
-    {
-        _contactSelectionView = new ContactSelectionView(Hub);
-        _contactSelectionView.TranslatesAutoresizingMaskIntoConstraints = false;
-        AddSubview(_contactSelectionView);
-
-        NSLayoutConstraint.ActivateConstraints([
-            _contactSelectionView.TopAnchor.ConstraintEqualTo(TopAnchor),
-            _contactSelectionView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
-            _contactSelectionView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _contactSelectionView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
-        ]);
-    }
-
-    private void ShowUploading()
-    {
-        _uploadProgressView = new UploadProgressView(Hub);
-        _uploadProgressView.TranslatesAutoresizingMaskIntoConstraints = false;
-        _uploadProgressView.Alpha = 0;
-        AddSubview(_uploadProgressView);
-
-        NSLayoutConstraint.ActivateConstraints([
-            _uploadProgressView.TopAnchor.ConstraintEqualTo(TopAnchor),
-            _uploadProgressView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
-            _uploadProgressView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _uploadProgressView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
-        ]);
-
-        var animator = new UIViewPropertyAnimator(0.3,
-            UIViewAnimationCurve.EaseInOut,
-            () => {
-                _contactSelectionView?.Transform = CGAffineTransform.MakeScale(0.0f, 0.0f);
-                _uploadProgressView!.Transform = CGAffineTransform.MakeScale(1.0f, 1.0f);
-                _uploadProgressView.Alpha = 1;
-            });
-        animator.AddCompletion(_ => {
-            _contactSelectionView?.RemoveAndDisposeStates();
-        });
-        animator.StartAnimation();
-    }
-
-    private void ShowFailed()
-    {
-        _errorView = new ErrorView(Hub);
-        _errorView.TranslatesAutoresizingMaskIntoConstraints = false;
-        _errorView.Alpha = 0;
-        AddSubview(_errorView);
-
-        NSLayoutConstraint.ActivateConstraints([
-            _errorView.TopAnchor.ConstraintEqualTo(TopAnchor),
-            _errorView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
-            _errorView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _errorView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
-        ]);
-
-        var animator = new UIViewPropertyAnimator(0.5,
-            UIViewAnimationCurve.EaseInOut,
-            () => {
-                _contactSelectionView?.Transform = CGAffineTransform.MakeScale(0.0f, 0.0f);
-                _uploadProgressView?.Transform = CGAffineTransform.MakeScale(0.0f, 0.0f);
-                _errorView!.Transform = CGAffineTransform.MakeScale(1.0f, 1.0f);
-                _errorView.Alpha = 1;
-            });
-        animator.AddCompletion(_ => {
-            _contactSelectionView?.RemoveAndDisposeStates();
-            _uploadProgressView?.RemoveAndDisposeStates();
-        });
-        animator.StartAnimation();
-    }
-
-    private void ShowCompleted()
-    {
-        _successView = new SuccessView(Hub);
-        _successView.TranslatesAutoresizingMaskIntoConstraints = false;
-        _successView.Alpha = 0;
-        AddSubview(_successView);
-
-        NSLayoutConstraint.ActivateConstraints([
-            _successView.TopAnchor.ConstraintEqualTo(TopAnchor),
-            _successView.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
-            _successView.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
-            _successView.BottomAnchor.ConstraintEqualTo(BottomAnchor),
-        ]);
-
-        var animator = new UIViewPropertyAnimator(0.5,
-            UIViewAnimationCurve.EaseInOut,
-            () => {
-                _contactSelectionView?.Transform = CGAffineTransform.MakeScale(0.0f, 0.0f);
-                _uploadProgressView?.Transform = CGAffineTransform.MakeScale(0.0f, 0.0f);
-                _successView!.Transform = CGAffineTransform.MakeScale(1.0f, 1.0f);
-                _successView.Alpha = 1;
-            });
-        animator.AddCompletion(_ => {
-            _contactSelectionView?.RemoveAndDisposeStates();
-            _uploadProgressView?.RemoveAndDisposeStates();
-        });
-        animator.StartAnimation();
+        _displayedStep = step;
     }
 
     protected override ComputedState<Model>.Options GetStateOptions()
@@ -170,6 +62,60 @@ public class ShareView(IosHub hub) : ComputedStateView<ShareView.Model>(hub)
     {
         var step = await ShareUI.GetStep(cancellationToken).ConfigureAwait(false);
         return new Model(step);
+    }
+
+    // Private methods
+
+    private void ShowSignIn()
+        => ShowStep(new SignInView(Hub));
+
+    private void ShowContactSelection()
+        => ShowStep(new ContactSelectionView(Hub));
+
+    private void ShowUploading()
+        => ShowStep(new UploadProgressView(Hub));
+
+    private void ShowFailed()
+        => ShowStep(new ErrorView(Hub));
+
+    private void ShowCompleted()
+        => ShowStep(new SuccessView(Hub));
+
+    private void ShowStep(StatefulView view)
+    {
+        // Opaque, and set here rather than in the view's OnInitialRender, which runs too late to
+        // cover what this replaces.
+        view.BackgroundColor = AppColors.Background01;
+        view.TranslatesAutoresizingMaskIntoConstraints = false;
+        AddSubview(view);
+
+        NSLayoutConstraint.ActivateConstraints([
+            view.TopAnchor.ConstraintEqualTo(TopAnchor),
+            view.LeadingAnchor.ConstraintEqualTo(LeadingAnchor),
+            view.TrailingAnchor.ConstraintEqualTo(TrailingAnchor),
+            view.BottomAnchor.ConstraintEqualTo(BottomAnchor),
+        ]);
+
+        var isFirst = _stepView is null;
+        _stepView = view;
+        if (isFirst)
+            return;
+
+        // Alpha, never a scale transform: Auto Layout recomputes the frame out from under a
+        // non-identity one, so the outgoing view comes straight back.
+        view.Alpha = 0;
+        var animator = new UIViewPropertyAnimator(FadeDuration, UIViewAnimationCurve.EaseInOut, () => view.Alpha = 1);
+        animator.AddCompletion(_ => RemoveStepViewsExcept(_stepView));
+        animator.StartAnimation();
+    }
+
+    private void RemoveStepViewsExcept(UIView? keep)
+    {
+        // By subview, not by tracked field: an untracked step is exactly the one that would linger.
+        foreach (var subview in Subviews) {
+            if (!ReferenceEquals(subview, keep))
+                subview.RemoveAndDisposeStates();
+        }
     }
 
     // Nested types

--- a/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Components/ShareView.cs
@@ -2,54 +2,38 @@ using ActualChat.App.Maui.IosShareExt.UI;
 using ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 using ActualChat.App.Maui.IosShareExt.Services;
 using ActualChat.Maui;
+using CoreFoundation;
 
 namespace ActualChat.App.Maui.IosShareExt.Components;
 
 public sealed class ShareView : ComputedStateView<ShareView.Model>
 {
     private const double FadeDuration = 0.3;
+    private static readonly TimeSpan OptimisticStepDelay = TimeSpan.FromMilliseconds(250);
+
     private StatefulView? _stepView;
     private ShareStep? _displayedStep;
     private ShareUI ShareUI => Hub.ShareUI;
 
     public ShareView(IosHub hub) : base(hub)
     {
-        // OnInitialRender waits on GetStep, and that waits on Accounts.GetOwn - a whole round trip
-        // of blank sheet if the UI waits with it.
+        // GetStep waits on Accounts.GetOwn, which the computed cache now answers - so the sheet is
+        // better off waiting a beat than painting a contact list a guest can't use. The optimistic
+        // paint stays as the cold-cache fallback, where that wait really is a round trip, and the
+        // delay is short enough to sit inside the share sheet's own presentation animation.
         BackgroundColor = AppColors.Background01;
-        ShowContactSelection();
-        _displayedStep = ShareStep.ContactSelection;
+        DispatchQueue.MainQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, OptimisticStepDelay), () => {
+            if (!IsDisposed && _displayedStep is null)
+                ShowStep(ShareStep.ContactSelection);
+        });
     }
 
     protected override void OnInitialRender(Model model)
         => OnStateChanged(model);
 
     protected override void OnStateChanged(Model model)
-    {
         // None only means the suggested-recipient lookup is still running - the guest check is past.
-        var step = model.Step == ShareStep.None ? ShareStep.ContactSelection : model.Step;
-        if (step == _displayedStep)
-            return;
-
-        switch (step) {
-            case ShareStep.SignIn:
-                ShowSignIn();
-                break;
-            case ShareStep.ContactSelection:
-                ShowContactSelection();
-                break;
-            case ShareStep.Uploading:
-                ShowUploading();
-                break;
-            case ShareStep.Failed:
-                ShowFailed();
-                break;
-            case ShareStep.Completed:
-                ShowCompleted();
-                break;
-        }
-        _displayedStep = step;
-    }
+        => ShowStep(model.Step == ShareStep.None ? ShareStep.ContactSelection : model.Step);
 
     protected override ComputedState<Model>.Options GetStateOptions()
         => GetStateOptions(GetType(),
@@ -66,22 +50,32 @@ public sealed class ShareView : ComputedStateView<ShareView.Model>
 
     // Private methods
 
-    private void ShowSignIn()
-        => ShowStep(new SignInView(Hub));
+    private void ShowStep(ShareStep step)
+    {
+        if (step == _displayedStep)
+            return;
 
-    private void ShowContactSelection()
-        => ShowStep(new ContactSelectionView(Hub));
+        switch (step) {
+            case ShareStep.SignIn:
+                SetStepView(new SignInView(Hub));
+                break;
+            case ShareStep.ContactSelection:
+                SetStepView(new ContactSelectionView(Hub));
+                break;
+            case ShareStep.Uploading:
+                SetStepView(new UploadProgressView(Hub));
+                break;
+            case ShareStep.Failed:
+                SetStepView(new ErrorView(Hub));
+                break;
+            case ShareStep.Completed:
+                SetStepView(new SuccessView(Hub));
+                break;
+        }
+        _displayedStep = step;
+    }
 
-    private void ShowUploading()
-        => ShowStep(new UploadProgressView(Hub));
-
-    private void ShowFailed()
-        => ShowStep(new ErrorView(Hub));
-
-    private void ShowCompleted()
-        => ShowStep(new SuccessView(Hub));
-
-    private void ShowStep(StatefulView view)
+    private void SetStepView(StatefulView view)
     {
         // Opaque, and set here rather than in the view's OnInitialRender, which runs too late to
         // cover what this replaces.

--- a/src/dotnet/App.Maui.IosShareExt/Services/ShareUI.cs
+++ b/src/dotnet/App.Maui.IosShareExt/Services/ShareUI.cs
@@ -65,7 +65,11 @@ public class ShareUI : WorkerBase, IComputeService, INotifyInitialized
             if (ownAccount.IsGuest)
                 return;
 
+            // The contact list can render before this lands, and CanSendTo filters on _hasFiles
             _hasFiles = await SharedInputs.HasFiles().ConfigureAwait(false);
+            using (Invalidation.Begin())
+                _ = ListContacts(default);
+
             if (await UIKitExt.GetSuggestedRecipient().ConfigureAwait(false) is not { } chatId)
                 return;
 

--- a/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
@@ -1,5 +1,5 @@
 using ActualLab.Caching;
-using Microsoft.Maui.ApplicationModel;
+using CoreFoundation;
 
 namespace ActualChat.App.Maui.IosShareExt.UI.Fusion.Ios;
 
@@ -82,7 +82,9 @@ public abstract class ComputedStateView<T>(IosHub hub) : ComputedStateView(hub),
     protected override void NotifyStateHasChanged()
     {
         var model = State.Value;
-        MainThread.BeginInvokeOnMainThread(() => {
+        // DispatchAsync, not MainThread.BeginInvokeOnMainThread: that runs inline on the main
+        // thread, and the state starts in the base ctor - a sync computed would render mid-build.
+        DispatchQueue.MainQueue.DispatchAsync(() => {
             try {
                 if (!_isInitiallyRendered) {
                     OnInitialRender(model);

--- a/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
@@ -97,6 +97,8 @@ public abstract class ComputedStateView<T>(IosHub hub) : ComputedStateView(hub),
         });
     }
 
+    // Runs on the first state update, not on construction - so a parent laying this view out must
+    // clear its TranslatesAutoresizingMaskIntoConstraints itself rather than wait for this.
     protected abstract void OnInitialRender(T model);
     protected abstract void OnStateChanged(T model);
     protected abstract Task<T> ComputeState(CancellationToken cancellationToken);

--- a/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
+++ b/src/dotnet/App.Maui.IosShareExt/UI/Fusion/Ios/ComputedStateView.cs
@@ -81,7 +81,15 @@ public abstract class ComputedStateView<T>(IosHub hub) : ComputedStateView(hub),
 
     protected override void NotifyStateHasChanged()
     {
-        var model = State.Value;
+        var computed = State.Computed;
+        if (computed.Error is { } error) {
+            // State.Value would rethrow this into Fusion's event handler, where it's swallowed -
+            // and the view would sit on whatever it last rendered with nothing logged here.
+            Log.LogError(error, "Failed to compute state");
+            return;
+        }
+
+        var model = computed.Value;
         // DispatchAsync, not MainThread.BeginInvokeOnMainThread: that runs inline on the main
         // thread, and the state starts in the base ctor - a sync computed would render mid-build.
         DispatchQueue.MainQueue.DispatchAsync(() => {

--- a/src/dotnet/UI/Caching/AppRemoteComputedCache.cs
+++ b/src/dotnet/UI/Caching/AppRemoteComputedCache.cs
@@ -19,6 +19,7 @@ public abstract class AppRemoteComputedCache : SafeAsyncDisposableBase, IRemoteC
         public string Version { get; init; } = ApiConstants.VersionString;
         public ImmutableHashSet<Symbol> ForceFlushFor { get; init; } = ImmutableHashSet<Symbol>.Empty
             .Add(RpcMethodDef.ComposeFullName(nameof(IAccounts), nameof(IAccounts.GetOwn)));
+        public TimeSpan ActivationTimeout { get; init; } = TimeSpan.FromSeconds(2);
     }
 
     protected Options Settings { get; }
@@ -31,6 +32,10 @@ public abstract class AppRemoteComputedCache : SafeAsyncDisposableBase, IRemoteC
     protected ILogger Log => field ??= Services.LogFor(GetType());
     protected ILogger? DebugLog
         => Constants.DebugMode.RemoteComputedCache ? Log.IfEnabled(LogLevel.Debug) : null;
+
+    protected Task WhenReady
+        // One shared deadline, so a store that never activates costs a launch one wait, not one per lookup
+        => field ??= WhenInitialized.WaitAsync(Settings.ActivationTimeout);
 
     public IServiceProvider Services { get; }
     public IKvasStore Store { get; protected init; } = null!; // Must be set by descendant!
@@ -74,8 +79,15 @@ public abstract class AppRemoteComputedCache : SafeAsyncDisposableBase, IRemoteC
 
     public async ValueTask<RpcCacheValue?> Get(RpcCacheKey key, CancellationToken cancellationToken = default)
     {
-        if (!WhenInitialized.IsCompleted)
-            return null;
+        if (!WhenInitialized.IsCompleted) {
+            // The store is picked by session and the session id comes from storage, so a launch's
+            // first lookups can beat Activate there - and a miss costs a needless round trip.
+            var whenReady = WhenReady;
+            if (!whenReady.IsCompleted)
+                await whenReady.SilentAwait(false);
+            if (!WhenInitialized.IsCompleted)
+                return null;
+        }
 
         var bytes = await Store.Get(key.ToString(), cancellationToken).ConfigureAwait(false);
         var cacheValue = FromBytes(bytes);

--- a/src/dotnet/UI/Caching/AppRemoteComputedCache.cs
+++ b/src/dotnet/UI/Caching/AppRemoteComputedCache.cs
@@ -22,6 +22,8 @@ public abstract class AppRemoteComputedCache : SafeAsyncDisposableBase, IRemoteC
         public TimeSpan ActivationTimeout { get; init; } = TimeSpan.FromSeconds(2);
     }
 
+    private readonly Lock _whenReadyLock = new();
+
     protected Options Settings { get; }
     protected HashSet<Symbol> ForceFlushFor { get; }
     protected RpcHub Hub { get; }
@@ -33,9 +35,14 @@ public abstract class AppRemoteComputedCache : SafeAsyncDisposableBase, IRemoteC
     protected ILogger? DebugLog
         => Constants.DebugMode.RemoteComputedCache ? Log.IfEnabled(LogLevel.Debug) : null;
 
-    protected Task WhenReady
-        // One shared deadline, so a store that never activates costs a launch one wait, not one per lookup
-        => field ??= WhenInitialized.WaitAsync(Settings.ActivationTimeout);
+    protected Task WhenReady {
+        get {
+            // One shared deadline, so a store that never activates costs a launch one wait rather
+            // than one per lookup; the lock keeps racers from each arming their own unawaited timer.
+            lock (_whenReadyLock)
+                return field ??= WhenInitialized.WaitAsync(Settings.ActivationTimeout);
+        }
+    }
 
     public IServiceProvider Services { get; }
     public IKvasStore Store { get; protected init; } = null!; // Must be set by descendant!

--- a/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
+++ b/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
@@ -20,6 +20,7 @@ public sealed class KvasarRemoteComputedCache : AppRemoteComputedCache
         public TimeSpan FlushDelay { get; init; } = TimeSpan.FromSeconds(0.667);
     }
 
+    private readonly TaskCompletionSource _whenActivated = new(TaskCreationOptions.RunContinuationsAsynchronously);
     public new Options Settings { get; }
     public KvasarKvas Kvas { get; }
 
@@ -41,11 +42,16 @@ public sealed class KvasarRemoteComputedCache : AppRemoteComputedCache
             RequiresActivation = true,
         }, services);
         Store = Kvas;
-        WhenInitialized = Kvas.WhenInitialized;
+        // Not Kvas.WhenInitialized: a RequiresActivation store reports that completed from its
+        // constructor, so it says nothing about whether there's a folder to read from yet.
+        WhenInitialized = _whenActivated.Task;
     }
 
-    public Task Activate(Session session)
-        => Kvas.Activate(session.Hash);
+    public async Task Activate(Session session)
+    {
+        await Kvas.Activate(session.Hash).ConfigureAwait(false);
+        _whenActivated.TrySetResult();
+    }
 
     public Task Deactivate(bool clear)
         => Kvas.Deactivate(clear);

--- a/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
+++ b/src/dotnet/UI/Caching/KvasarRemoteComputedCache.cs
@@ -49,8 +49,18 @@ public sealed class KvasarRemoteComputedCache : AppRemoteComputedCache
 
     public async Task Activate(Session session)
     {
-        await Kvas.Activate(session.Hash).ConfigureAwait(false);
-        _whenActivated.TrySetResult();
+        try {
+            await Kvas.Activate(session.Hash).ConfigureAwait(false);
+            _whenActivated.TrySetResult();
+        }
+        catch (Exception e) {
+            // Faulted, never left pending: a pending WhenInitialized would silently turn every
+            // Get into a miss and every Set into a no-op for the rest of the process.
+            Log.LogError(e, "Activate failed");
+            _whenActivated.TrySetException(e);
+            _ = _whenActivated.Task.Exception; // Nothing awaits WhenInitialized, so observe it here
+            throw;
+        }
     }
 
     public Task Deactivate(bool clear)


### PR DESCRIPTION
Closes #4306.

The reported bug was the comment field sitting in the wrong place while the iOS share sheet loaded its contacts, then jumping to the bottom once they arrived. Chasing it turned up five more defects on the same path, all of which are fixed here.

## Commits

One concern each, in order:

1. `fix(ios): keep the share sheet's comment field in place while contacts load` — the reported bug
2. `fix(ios): rework the share sheet's loading state and step transitions`
3. `fix(cache): let a lookup wait for the store the session picks`
4. `feat(ios): show contact skeletons while the share sheet loads`
5. `fix(ios): never render a share ext view while its constructor is running`

## The comment field moved

`ContactSelectionView` adds `PlaceListView` and `ContactListView` and immediately activates the constraint set that also positions the comment field. Both of those views cleared `TranslatesAutoresizingMaskIntoConstraints` in their own `OnInitialRender` — which `ComputedStateView` fires on the *first Fusion state update*, i.e. only once contacts and places return from the network.

Until then they carried the autoresizing mask over a `CGRect.Zero` frame, so UIKit synthesized required-priority size and origin constraints that fought the explicit ones. The comment field is what visibly lost, because its position chains through `contactListView.BottomAnchor`.

Cleared at the point of use now, the way `ShareView` already did for its children. `ContactView`, `PlaceView` and `PlaceListView` had the same latent mismatch.

## The sheet was blank while it loaded

Two windows, neither of which drew anything:

- `OnInitialRender` runs on the first state update, and `ShareView`'s state is `GetStep`, whose first await is `Accounts.GetOwn`. Until that returned there were no subviews and no background — an empty rectangle, not just an empty list.
- After that, `GetStep` reports `None` until `ShareUI.OnRun` finishes looking up the share sheet's suggested recipient, and the switch had no case for `None`. `_displayedStep` also started *at* `None`, so the "same step" guard swallowed the first update regardless.

`None` is already past the guest check, so it maps to the selection UI, and `ShareView` puts that up from its constructor.

## The computed cache never answered on the first share

`KvasarRemoteComputedCache` reported `WhenInitialized` as `Kvas.WhenInitialized`, which for a `RequiresActivation` store is `NoStoreTask` — a completed task handed out by the constructor. All three `IsCompleted` guards in `AppRemoteComputedCache` were therefore dead code, and "is there a folder to read from yet?" was never actually asked. Lookups fell through to `KvasarKvas`, whose `GetStore` returns null until `Activate`, and every one reported a miss.

That window is not theoretical: the store is keyed per session, the session id comes from the shared keychain, and `Session` resolves to `Session.Default` synchronously — so `Accounts.GetOwn` and everything under it are in flight while `SessionInitializer` is still reading storage. On the first share of a process the cache answered nothing *and* recorded nothing, so the next launch missed too.

`WhenInitialized` now completes when `Activate` does, and a lookup arriving first waits for it. The wait is one shared deadline (`ActivationTimeout`, 2s), so a device with no stored session costs a launch a single wait rather than one per lookup.

## Skeletons instead of an empty list

`ContactListView` carries placeholder rows until its first result. They sit on `ContactView`'s geometry — same 52pt pitch, same 16/68 leading — so the real rows land where the placeholders were.

This forced `ContactListView` to build its collection view in its constructor: `OnInitialRender` runs on the first state update, which is exactly when the contacts the skeleton stands in for have already arrived.

The skeleton is opaque and the pulse runs on an inner rows container. Animating alpha on the view itself would fade straight past the background it needs, which is the same transparency trap as the next item.

## The upload view drew over a live contact list

Found on device — screenshot in #4306. Two independent defects:

- Only `ErrorContentView` set a root background, so every other step view was transparent and anything left behind showed through.
- The outgoing step was dismissed by animating its transform to `MakeScale(0, 0)`. A zero scale is singular, and a view's `frame` is undefined on any non-identity transform, so the next layout pass — `UploadProgressView` building its subviews a runloop turn later triggers one — recomputed the frame from the constraints and undid it. Removal then rode on the animator's completion and a `?.` against one tracked field.

Steps cross-fade now. The incoming view is opaque before it's added, which is what makes this correct rather than tidy, and the completion sweeps every subview that isn't the current step rather than the ones a field remembers. Collapses five per-step fields and five near-identical `Show` methods into one.

## Views rendered before their own constructors finished

Caught in device logs, firing on **every** share:

```
ERR [ContactListView] Failed to render state changes
System.NullReferenceException
   at ContactListView.SetContacts(...)      ← _dataSource.ApplySnapshot(...)
   at ContactListView.OnInitialRender(Model)
```

`MainThread.BeginInvokeOnMainThread` runs its action inline when it's already on the main thread, and `StatefulView` creates the Fusion state from its constructor. So a computed that resolved synchronously — the normal case once the cache above started answering — raised `Updated` inside `base(hub)` and rendered the view before a single derived field existed.

The exception is swallowed and logged, so the symptom was subtle: `HideSkeleton()` runs on the line above the throw, so the skeleton was torn down while the snapshot that should have replaced it was lost, and the list refilled on some later update. Net effect was a skeleton nobody ever saw and a list that briefly stayed empty. `ShareView` had the same shape waiting — a synchronous first render would have put up a step view, then its constructor would have added a second.

`DispatchQueue.MainQueue.DispatchAsync` always queues, so the first render lands no earlier than the next runloop turn.

## Testing

Built clean for `net11.0-ios`; `App.Maui` builds too, since `MauiSession` shares the two cache call sites.

Verified on an iPhone 15 Pro Max, against device logs (`idevicesyslog`) as well as by eye:

- comment field holds its place through a cold-cache load under Network Link Conditioner "Very Bad Network"
- skeleton rows render and hand off to the real contacts — only observable after wiping the app container, since a warm cache resolves sub-frame
- send flow: cross-fade to the upload view is clean, no overlap; upload, Отмена mid-upload, and text and image shares all work
- signed-out path: the selection chrome appears briefly, then cross-fades to sign-in with no bleed-through
- **0 render failures** across ~10k extension log lines post-fix, against two per share before

The one deliberate trade: a signed-out user sees the selection chrome for a moment before it swaps to sign-in, because `ShareView` puts the UI up before `Accounts.GetOwn` can answer. That is what removes the blank sheet for everyone else. Confirmed on device as brief and reading as an intentional transition, but it is the call in here most worth a second opinion — gating on the guest check instead is a few lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
