### PR TITLE
fix(ios): title the push banner with the chat, not the sender #4305

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -76,6 +76,13 @@ way. Clients render every banner themselves — no `webpush.notification`, no
   notification* so the chat avatar replaces the app icon. Its
   `conversationIdentifier` must stay equal to the thread id the dismissal path
   matches on — see that project's README.
+- **Who a banner is named after** — the chat, on both mobile platforms; the
+  author of each message is named by its body line instead. `Title` still ships
+  the composed `"<author> @ <chat>"` string (web renders it, and it's what an
+  iOS banner falls back to), but a client never splits it back apart — `" @ "`
+  occurs in real names. `ChatNotification.SenderName`/`GroupTitle` carry the two
+  halves, and an empty `GroupTitle` means "not a group", which is what keeps a
+  peer chat from becoming an Android `SetGroupConversation(true)`.
 - **App-icon badge** — `AppIconBadgeUpdater.cs` (single source of truth) plus
   native `AppIconBadge` on iOS (`App.Maui/MaciOS/AppIconBadge.cs`) and Windows
   (`Platforms/Windows/WindowsAppIconBadge.cs`). On iOS the badge of a

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -359,6 +359,8 @@ public static partial class Constants
             public const string Link = "link";
             public const string Tag = "tag";
             public const string Title = "title";
+            public const string SenderName = "senderName";
+            public const string GroupTitle = "groupTitle";
             public const string Body = "body";
             public const string ImageUrl = "imageUrl";
             public const string Messages = "messages";
@@ -368,7 +370,7 @@ public static partial class Constants
             public const string Silent = "silent";
 
             public static readonly string[] ValidKeys = {
-                AuthorId, Body, ChatId, ChatEntryId, DismissedIds, DismissedTags, LastEntryLocalId, Icon, ImageUrl, Kind, Link, Messages, NotificationId, Silent, Tag, Title, Timestamp
+                AuthorId, Body, ChatId, ChatEntryId, DismissedIds, DismissedTags, GroupTitle, LastEntryLocalId, Icon, ImageUrl, Kind, Link, Messages, NotificationId, SenderName, Silent, Tag, Title, Timestamp
             };
 
             public static bool IsValidKey(string key)

--- a/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
+++ b/src/dotnet/Api/Notifications/ChatEntryRelatedNotification.cs
@@ -96,6 +96,8 @@ public abstract partial record ChatEntryRelatedNotification(NotificationId Id, l
             // and the banner headline (title/icon) must keep tracking the newest message.
             SentAt = Moment.Max(e.SentAt, SentAt),
             Title = newestIsIncoming ? Title : e.Title,
+            SenderName = newestIsIncoming ? SenderName : e.SenderName,
+            GroupTitle = newestIsIncoming ? GroupTitle : e.GroupTitle,
             IconUrl = newestIsIncoming ? IconUrl : e.IconUrl,
             EntryLid = entryLid,
             StartEntryLid = startEntryLid,

--- a/src/dotnet/Api/Notifications/ChatNotification.cs
+++ b/src/dotnet/Api/Notifications/ChatNotification.cs
@@ -9,6 +9,14 @@ public abstract partial record ChatNotification(NotificationId Id, long Version 
 {
     [DataMember(Order = 8), Key(8)]
     public AuthorId? AuthorId { get; init; }
+    [DataMember(Order = 21), Key(21)]
+    public string SenderName {
+        get => Sanitizer.MaybeSanitize<Sanitizers.PrefixAndLengthHint>(field); init;
+    } = "";
+    [DataMember(Order = 22), Key(22)]
+    public string GroupTitle {
+        get => Sanitizer.MaybeSanitize<Sanitizers.PrefixAndLengthHint>(field); init;
+    } = "";
 
     // Computed
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/PttWakeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/PttWakeHandler.cs
@@ -130,7 +130,8 @@ public static class PttWakeHandler
             "Someone is talking in a chat you keep listening to",
             null,
             Links.Chat(chatId),
-            silent: silent);
+            silent: silent,
+            senderName: null);
 
     // Nested types
 

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
@@ -47,7 +47,8 @@ public class AndroidDeviceNotifications : IDeviceNotifications
                 // Healing a dropped banner must not alert — it's a reconcile, not a new event.
                 NotificationHelper.ShowChatNotification(
                     info.ChatId, info.Tag, info.Title, info.Text, info.IconUrl, info.Url,
-                    silent: true, messages: info.Messages.IsEmpty ? null : PushMessage.From(info.Messages));
+                    silent: true, messages: info.Messages.IsEmpty ? null : PushMessage.From(info.Messages),
+                    senderName: info.SenderName, conversationTitle: info.GroupTitle);
         }
 
         return Task.CompletedTask;

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
@@ -211,10 +211,8 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
         }
 
         var sentTime = new Moment(messageSentTime * 10_000).ToDateTime();
-        var title = data.Title ?? "";
-        var separatorIndex = title.IndexOf('@');
-        if (separatorIndex >= 0)
-            title = title.Substring(separatorIndex + 1).Trim(); // take Chat title only
+        // Names the chat, which for a peer chat is the other party - it carries no group title.
+        var title = data.GroupTitle ?? data.SenderName ?? "";
 
         var request = new ChatAttentionRequest(chatId, data.LastEntryLocalId, sentTime, title, data.Body ?? "", data.ImageUrl ?? "");
         ChatAttentionService.Instance.Ask(request);
@@ -226,6 +224,6 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
         Log.LogDebug("-> ShowChatMessageNotification, text: '{Text}', silent: {Silent}", data.Body!.ToPrivate(), data.Silent);
         NotificationHelper.ShowChatNotification(
             data.ChatId, data.Tag!, data.Title!, data.Body!, data.ImageUrl, data.Link,
-            data.Silent, data.Messages);
+            data.Silent, data.Messages, data.SenderName, data.GroupTitle);
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationData.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationData.cs
@@ -43,6 +43,12 @@ public class NotificationData(string messageId, Dictionary<string, string> data)
     public string? Title
         => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Title, "").NullIfEmpty();
 
+    public string? SenderName
+        => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.SenderName, "").NullIfEmpty();
+
+    public string? GroupTitle
+        => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.GroupTitle, "").NullIfEmpty();
+
     public string? Body
         => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Body, "").NullIfEmpty();
 
@@ -55,25 +61,25 @@ public class NotificationData(string messageId, Dictionary<string, string> data)
     public string? Tag
         => data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Tag, "").NullIfEmpty();
 
-    // Structured transcript lines for MessagingStyle rendering; empty when the push predates them.
     public IReadOnlyList<PushMessage> Messages
+        // Structured transcript lines for MessagingStyle rendering; empty when the push predates them.
         => PushMessage.FromJson(data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Messages));
 
-    // A silent update refreshes the banner content without alerting (sound/vibration).
     public bool Silent
+        // A silent update refreshes the banner content without alerting (sound/vibration).
         => bool.TryParse(data.GetValueOrDefault(Constants.Notification.MessageDataKeys.Silent), out var silent) && silent;
 
-    // The local id of the entry this notification points at (for the read-position skip).
     public long EntryLocalId {
         get {
+            // The local id of the entry this notification points at (for the read-position skip).
             data.TryGetValue(Constants.Notification.MessageDataKeys.ChatEntryId, out var sEntryId);
             return ChatEntryId.TryParse(sEntryId, out var entryId) ? entryId.LocalId : LastEntryLocalId;
         }
     }
 
-    // The wake push's speech-start moment (epoch ms in the Timestamp data key).
     public Moment? StartedAt {
         get {
+            // The wake push's speech-start moment (epoch ms in the Timestamp data key).
             data.TryGetValue(Constants.Notification.MessageDataKeys.Timestamp, out var sTimestamp);
             return long.TryParse(sTimestamp, out var epochMs)
                 ? new Moment(epochMs * 10_000)

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
@@ -1,3 +1,4 @@
+using _Microsoft.Android.Resource.Designer;
 using ActualChat.Notifications;
 using ActualChat.UI.Blazor.Services;
 using Android.App;
@@ -47,20 +48,21 @@ public static class NotificationHelper
         string? imageUrl,
         string? link,
         bool silent = false,
-        IReadOnlyList<PushMessage>? messages = null)
+        IReadOnlyList<PushMessage>? messages = null,
+        string? senderName = null,
+        string? conversationTitle = null)
     {
         var context = Application.Context;
         var contentIntent = CreateViewIntent(context, link);
         var contentPendingIntent = PendingIntent.GetActivity(context, 0,
             contentIntent, PendingIntentFlags.OneShot | PendingIntentFlags.Immutable);
 
-        var largeImage = imageUrl.IsNullOrEmpty() ? null : GetImage(imageUrl!);
+        var largeImage = imageUrl.IsNullOrEmpty() ? null : GetImage(imageUrl);
         var icon = largeImage is null ? null : AndroidChatShortcuts.CreateIcon(largeImage);
-        var (senderName, conversationTitle) = SplitTitle(title);
         var style = CreateStyle(senderName, conversationTitle, body, icon, messages);
         var builder = new NotificationCompat.Builder(context, Constants.DefaultChannelId)
             .SetContentTitle(title)!
-            .SetSmallIcon(Resource.Drawable.notification_app_icon)!
+            .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetColor(0x0036A3)!
             .SetContentText(body)!
             .SetContentIntent(contentPendingIntent)!
@@ -79,7 +81,7 @@ public static class NotificationHelper
         // callers that pass an in-app relative link just stay ordinary notifications.
         if (chatId is not null && Uri.TryCreate(link, UriKind.Absolute, out _)) {
             AndroidChatShortcuts.PushOnce(
-                context, chatId, conversationTitle.NullIfEmpty() ?? senderName, link!, icon);
+                context, chatId, conversationTitle.NullIfEmpty() ?? senderName ?? "", link, icon);
             builder.SetShortcutId(chatId.Value);
         }
         // MessagingStyle already carries the avatar on its Person, so a large icon here is a second,
@@ -184,7 +186,7 @@ public static class NotificationHelper
             : PendingIntent.GetActivity(context, 3, viewIntent, PendingIntentFlags.Immutable);
 
         var builder = new NotificationCompat.Builder(context, Constants.ActivityUploadChannelId)
-            .SetSmallIcon(Resource.Drawable.notification_app_icon)!
+            .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentTitle(title)!
             .SetContentText(summary)!
             .SetStyle(style)!
@@ -200,7 +202,7 @@ public static class NotificationHelper
     // Private methods
 
     private static NotificationCompat.Style CreateStyle(
-        string senderName,
+        string? senderName,
         string? conversationTitle,
         string body,
         IconCompat? icon,
@@ -230,7 +232,7 @@ public static class NotificationHelper
                         var personBuilder = new Person.Builder().SetName(name)!;
                         if (name == newestName && icon != null)
                             personBuilder.SetIcon(icon);
-                        person = personBuilder.Build();
+                        person = personBuilder.Build()!;
                         persons.Add(name, person);
                     }
                     style.AddMessage(message.Text, message.SentAtMs, person);
@@ -249,14 +251,6 @@ public static class NotificationHelper
             Log.LogWarning(e, "Failed to build MessagingStyle; falling back to BigTextStyle");
             return bigText;
         }
-    }
-
-    private static (string SenderName, string? ConversationTitle) SplitTitle(string title)
-    {
-        var index = title.IndexOf(" @ ");
-        return index >= 0
-            ? (title[..index].Trim(), title[(index + 3)..].Trim())
-            : (title, null);
     }
 
     private static Bitmap? DownloadImage(string imageUrl)

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -91,6 +91,12 @@ public class FirebaseMessagingClient(
         };
         if (lastEntryLocalId > 0)
             data.Add(Constants.Notification.MessageDataKeys.LastEntryLocalId, lastEntryLocalId.ToString());
+        // Common data, so these ride inside the 4KB APNs budget - hence omitted when empty.
+        if (chatNotification is not null && !chatNotification.SenderName.IsNullOrEmpty()) {
+            data.Add(Constants.Notification.MessageDataKeys.SenderName, chatNotification.SenderName);
+            if (!chatNotification.GroupTitle.IsNullOrEmpty())
+                data.Add(Constants.Notification.MessageDataKeys.GroupTitle, chatNotification.GroupTitle);
+        }
         // Android and web build the banner themselves, so they also need its content. Both platform
         // blocks override the common data rather than merging into it, hence the copy.
         var renderData = new Dictionary<string, string>(data) {

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -60,11 +60,12 @@ public static class NotificationHelper
         if (messages.IsEmpty)
             return notification.LeadText.IsNullOrEmpty() ? notification.Text : notification.LeadText;
 
-        // Newest first: collapsed banners show only the first line(s), and that must be the
-        // latest message, not the oldest unread one.
+        // The banner headline is the chat, so these lines are the only place a sender is named.
         var showAuthorNames = notification.ChatId.GetThreadOutermostParentOrSelf().Kind
             is ChatKind.Group or ChatKind.Place;
         var lines = new List<string>(messages.Count + 1);
+        // Newest first: collapsed banners show only the first line(s), and that must be the
+        // latest message, not the oldest unread one.
         for (var i = messages.Count - 1; i >= 0; i--) {
             var m = messages[i];
             lines.Add(showAuthorNames && !m.AuthorName.IsNullOrEmpty()

--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -22,12 +22,17 @@ public static class NotificationHelper
             _ => mode == ChatNotificationMode.Default,
         };
 
-    public static string GetTitle(Chat.Chat chat, AuthorFull author)
+    public static (string SenderName, string GroupTitle) GetTitleParts(Chat.Chat chat, AuthorFull author)
+        // Empty GroupTitle means "this chat isn't a group" - Android turns a non-empty one into
+        // SetGroupConversation(true), so a peer chat must leave it empty however it's titled.
         => chat.Id.GetThreadOutermostParentOrSelf().Kind switch {
-            ChatKind.Group or ChatKind.Place => $"{author.Avatar.Name} @ {chat.Title}",
-            ChatKind.Peer => $"{author.Avatar.Name}",
+            ChatKind.Group or ChatKind.Place => (author.Avatar.Name, chat.Title),
+            ChatKind.Peer => (author.Avatar.Name, ""),
             _ => throw new ArgumentOutOfRangeException($"{nameof(chat)}.{nameof(chat.Kind)}", chat.Kind, null),
         };
+
+    public static string GetTitle(string senderName, string groupTitle)
+        => groupTitle.IsNullOrEmpty() ? senderName : $"{senderName} @ {groupTitle}";
 
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
         // Unsized, the generator draws its 80px base, which an avatar slot on a 3x screen upscales.

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -518,6 +518,7 @@ public class NotificationsBackend(IServiceProvider services)
 
             var notification = ConversationNotification.New(userId, conversationId, endEntryLid) with {
                 Title = chat.Title,
+                SenderName = chat.Title,
                 Text = userText,
                 IconUrl = iconUrl,
                 SentAt = now,
@@ -576,6 +577,7 @@ public class NotificationsBackend(IServiceProvider services)
             var l = await UserLocalizers.Get(a.UserId, cancellationToken).ConfigureAwait(false);
             var notification = CallNotification.New(a.UserId, conversationId, caller, hasVideo) with {
                 Title = chat.Title,
+                SenderName = chat.Title,
                 Text = hasVideo ? l.Call_IncomingVideo : l.Call_Incoming,
                 IconUrl = iconUrl,
                 SentAt = now,
@@ -1352,7 +1354,8 @@ public class NotificationsBackend(IServiceProvider services)
             throw new ArgumentOutOfRangeException(nameof(entryId), "entry.ChatId should match given chatId");
 
         var chat = await ChatsBackend.Get(chatId, cancellationToken).Require().ConfigureAwait(false);
-        var title = NotificationHelper.GetTitle(chat, changeAuthor);
+        var (senderName, groupTitle) = NotificationHelper.GetTitleParts(chat, changeAuthor);
+        var title = NotificationHelper.GetTitle(senderName, groupTitle);
         var iconUrl = NotificationHelper.GetIconUrl(chat, changeAuthor, UrlMapper);
         var now = Clocks.CoarseSystemClock.Now;
         var otherUserIds = userIds.Where(userId => userId != changeAuthor.UserId);
@@ -1366,7 +1369,7 @@ public class NotificationsBackend(IServiceProvider services)
 
             var entryLid = entryId?.LocalId ?? 0;
             var fullEntryId = entryId ?? ChatEntryId.New(chatId, entryLid);
-            Notification notification = kind switch {
+            ChatNotification notification = kind switch {
                 NotificationKind.Message => MessageNotification.New(otherUserId, chatId, entryLid, changeAuthor.Id),
                 NotificationKind.Reply => ReplyNotification.New(otherUserId, chatId, entryLid, changeAuthor.Id),
                 NotificationKind.Thread => ThreadNotification.New(otherUserId, chatId, entryLid, changeAuthor.Id),
@@ -1378,6 +1381,8 @@ public class NotificationsBackend(IServiceProvider services)
             };
             notification = notification with {
                 Title = title,
+                SenderName = senderName,
+                GroupTitle = groupTitle,
                 Text = content,
                 IconUrl = iconUrl,
                 SentAt = now,

--- a/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
+++ b/src/dotnet/UI.Blazor.App/Services/IDeviceNotifications.cs
@@ -27,4 +27,6 @@ public sealed record ActiveNotificationInfo(
     string IconUrl,
     string Url,
     ApiArray<NotificationMessage> Messages = default,
-    ChatId? ChatId = null);
+    ChatId? ChatId = null,
+    string? SenderName = null,
+    string? GroupTitle = null);

--- a/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
@@ -106,6 +106,8 @@ public sealed class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub
                 x.Notification.IconUrl,
                 UrlMapper.ToAbsolute(x.Notification.GetChatLink()),
                 (x.Notification as ChatEntryRelatedNotification)?.RecentMessages ?? default,
-                x.Notification.GetChatId()))
+                x.Notification.GetChatId(),
+                (x.Notification as ChatNotification)?.SenderName.NullIfEmpty(),
+                (x.Notification as ChatNotification)?.GroupTitle.NullIfEmpty()))
             .ToList();
 }

--- a/src/swift/VoxtNotificationService/README.md
+++ b/src/swift/VoxtNotificationService/README.md
@@ -2,8 +2,9 @@
 
 A `UNNotificationServiceExtension` (`.appex`) that rewrites every chat push into an iOS
 **communication notification**: the chat or author avatar replaces the app icon on the banner,
-the sender's name becomes the title and the chat name the subtitle — the same shape Messages,
-Telegram and WhatsApp use.
+and the chat's own name is the headline — the same shape Android's `MessagingStyle` renders,
+and the one Telegram and WhatsApp use. The author of each message is named by its body line,
+not by the title.
 
 ## Why the extension has to exist
 
@@ -26,11 +27,21 @@ needs — and the whole job is ~150 lines of `URLSession` plus `Intents`. So it 
 1. Reads the `icon` data key. No icon → deliver the push untouched.
 2. Downloads it (5s timeout, 512 KB cap, HTTP cache honoured — the extension process is
    reused, so a chatty conversation's avatar is normally already cached).
-3. Splits `content.title` on `" @ "` — that's the shape `NotificationHelper.GetTitle`
-   composes for group chats, and the same split Android's `NotificationHelper` does.
-4. Builds an `INSendMessageIntent` whose sender carries the avatar as an `INImage`, donates
-   the interaction (so Focus can allow-list the sender), and returns
-   `content.updating(from: intent)`.
+3. Reads the `groupTitle` data key, falling back to `senderName` — a peer chat carries no
+   group title. Both are empty for a notification composed before the server sent them, and
+   then the banner is delivered as the server titled it. The title is never split back apart:
+   a real name or chat title can contain `" @ "` (`Design @ Voxt` would split into sender
+   "Design", group "Voxt").
+4. Builds an `INSendMessageIntent` whose sender is the *chat* — `groupTitle` when there is
+   one, the other party otherwise — carrying the avatar as an `INImage`, donates the
+   interaction (so Focus can allow-list the chat), and returns `content.updating(from: intent)`.
+
+**Nothing sets `speakableGroupName`, deliberately.** iOS renders it as a subtitle *under* the
+sender's name, giving a two-line header (sender, then chat) — and it only renders it at all for
+a conversation iOS considers a group, which nothing but `recipients.count > 1` makes it. So
+with a sender-named title it silently vanished, which was issue #4305. Naming the banner after
+the chat drops the second line and the group-classification rule along with it: the avatar is
+the chat's picture, so the chat's name is what belongs beside it.
 
 **`conversationIdentifier` must equal `content.threadIdentifier`.** `updating(from:)` rewrites
 the thread id from the conversation id, and `AppDelegate.RemoveDeliveredNotifications` matches
@@ -38,8 +49,7 @@ delivered banners on their thread id when a silent dismissal push arrives — so
 value would silently break dismissal and per-chat grouping.
 
 If `updating(from:)` fails — which is what a missing entitlement looks like — the banner is
-delivered with the sender/chat split applied to title and subtitle, but no avatar. That's the
-pre-#4184 behavior, not a crash.
+delivered titled with the chat but without the avatar, not a crash.
 
 ## Prerequisites
 
@@ -133,9 +143,10 @@ What to look for:
 
 | Result | Meaning |
 |---|---|
-| Circular chat avatar in place of the app icon | working |
-| App icon, but title/subtitle split into sender and chat name | the extension ran; `updating(from:)` failed — check the entitlement on **both** the app and the appex |
-| App icon and a `"<sender> @ <chat>"` title | the extension didn't run at all — check `PlugIns/VoxtNotificationService.appex` exists and is signed |
+| Circular chat avatar, chat name as the title, `Author: text` body lines | working |
+| App icon, chat name as the title | the extension ran; `updating(from:)` failed — check the entitlement on **both** the app and the appex |
+| App icon and a `"<sender> @ <chat>"` title, in **some** chats | expected, not a fault: those notifications were already in the store before the server sent `senderName`/`groupTitle`, so the extension leaves them alone. Clears as each is read or receives another message |
+| App icon and a `"<sender> @ <chat>"` title, in **every** chat | the extension didn't run at all — check `PlugIns/VoxtNotificationService.appex` exists and is signed |
 
 The extension is a separate process, so the app's debugger session won't stop in it — attach
 to `VoxtNotificationService` explicitly, or read its `os_log` output with

--- a/src/swift/VoxtNotificationService/Service/NotificationService.swift
+++ b/src/swift/VoxtNotificationService/Service/NotificationService.swift
@@ -9,8 +9,8 @@ final class NotificationService: UNNotificationServiceExtension {
     // The FCM data keys `FirebaseMessagingClient` sends alongside `aps`.
     private static let iconKey = "icon"
     private static let chatIdKey = "chatId"
-    // `NotificationHelper.GetTitle` composes group-chat titles as "<author> @ <chat>".
-    private static let titleSeparator = " @ "
+    private static let senderNameKey = "senderName"
+    private static let groupTitleKey = "groupTitle"
     // The system allows 30s, but a banner that lands seconds late is worse than an iconless
     // one - and these are 128px avatars, so a slow fetch means the network is gone anyway.
     private static let downloadTimeout: TimeInterval = 5
@@ -101,15 +101,16 @@ final class NotificationService: UNNotificationServiceExtension {
         _ iconData: Data?,
         to content: UNMutableNotificationContent
     ) -> UNNotificationContent {
-        let (senderName, groupName) = splitTitle(content.title)
+        // The chat names the banner: the icon is its picture, and each body line carries its own
+        // author. A peer chat has no group title, so the other party stays the headline.
+        let headline = headline(of: content)
         guard let iconData,
-              let intent = makeIntent(senderName: senderName, groupName: groupName, content: content, iconData: iconData)
+              let intent = makeIntent(headline: headline, content: content, iconData: iconData)
         else { return content }
 
-        // Titling the banner ourselves keeps the sender/chat split readable even when the
-        // update below fails - which it does when the communication entitlement is missing.
-        content.title = senderName
-        content.subtitle = groupName ?? ""
+        // Titling the banner ourselves keeps it right even when the update below fails -
+        // which it does when the communication entitlement is missing.
+        content.title = headline
         let updated: UNNotificationContent
         do {
             updated = try content.updating(from: intent)
@@ -120,7 +121,7 @@ final class NotificationService: UNNotificationServiceExtension {
             return content
         }
 
-        // Makes the sender addressable by Focus ("Allow notifications from") and Siri.
+        // Makes the chat addressable by Focus ("Allow notifications from") and Siri.
         let interaction = INInteraction(intent: intent, response: nil)
         interaction.direction = .incoming
         interaction.donate(completion: nil)
@@ -128,12 +129,11 @@ final class NotificationService: UNNotificationServiceExtension {
     }
 
     private static func makeIntent(
-        senderName: String,
-        groupName: String?,
+        headline: String,
         content: UNMutableNotificationContent,
         iconData: Data
     ) -> INSendMessageIntent? {
-        guard !senderName.isEmpty else { return nil }
+        guard !headline.isEmpty else { return nil }
         // The thread id is the chat tag the server groups banners under, and AppDelegate's
         // dismissal path matches delivered notifications on it. updating(from:) rewrites the
         // thread id from the conversation id, so these two must be the same string.
@@ -143,33 +143,32 @@ final class NotificationService: UNNotificationServiceExtension {
         guard !conversationId.isEmpty else { return nil }
 
         let image = INImage(imageData: iconData)
+        // The chat is the intent's sender. speakableGroupName stays unset on purpose: iOS renders
+        // it as a subtitle beneath the sender, the second line this banner doesn't want.
         let sender = INPerson(
             personHandle: INPersonHandle(value: conversationId, type: .unknown),
             nameComponents: nil,
-            displayName: senderName,
+            displayName: headline,
             image: image,
             contactIdentifier: nil,
             customIdentifier: conversationId)
-        let intent = INSendMessageIntent(
+        return INSendMessageIntent(
             recipients: nil,
             outgoingMessageType: .outgoingMessageText,
             content: nil,
-            speakableGroupName: groupName.map { INSpeakableString(spokenPhrase: $0) },
+            speakableGroupName: nil,
             conversationIdentifier: conversationId,
             serviceName: nil,
             sender: sender,
             attachments: nil)
-        // For a group or place chat the server's icon is the chat's own picture, not the
-        // author's, so it belongs on the group rather than only on the sender.
-        if groupName != nil {
-            intent.setImage(image, forParameterNamed: \.speakableGroupName)
-        }
-        return intent
     }
 
-    private static func splitTitle(_ title: String) -> (senderName: String, groupName: String?) {
-        guard let range = title.range(of: titleSeparator) else { return (title, nil) }
-        let groupName = String(title[range.upperBound...])
-        return (String(title[..<range.lowerBound]), groupName.isEmpty ? nil : groupName)
+    // Empty for a notification composed before the server sent these keys, which leaves the
+    // banner as the server titled it rather than rewriting it into a communication one.
+    private static func headline(of content: UNMutableNotificationContent) -> String {
+        if let group = content.userInfo[groupTitleKey] as? String, !group.isEmpty {
+            return group
+        }
+        return content.userInfo[senderNameKey] as? String ?? ""
     }
 }

--- a/tests/Notifications.IntegrationTests/NotificationContentTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationContentTest.cs
@@ -27,11 +27,33 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
         aliceNotification.Title.Should().Be($"Bobby @ {chat.Title}");
+        aliceNotification.SenderName.Should().Be("Bobby");
+        aliceNotification.GroupTitle.Should().Be(chat.Title);
         aliceNotification.Text.Should().Be("Bobby: Ok!");
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be($"Alice @ {chat.Title}");
         bobNotification.Text.Should().Be("❤️ to \"Ok!\"");
+    }
+
+    [Fact]
+    public async Task ShouldCarryTitlePartsForAChatTitledWithTheSeparator()
+    {
+        // arrange
+        var alice = await Tester.SignInAsAlice();
+        var bob = await Tester.SignInAsBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "Design @ Voxt");
+        await Tester.InviteToChat(chat.Id, alice);
+
+        // act
+        await Tester.SignIn(bob);
+        var entry = await Tester.CreateTextEntry(chat.Id, "Ok!");
+
+        // assert
+        var aliceNotification = await GetNotification(alice, entry.Id);
+        aliceNotification.Title.Should().Be("Bobby @ Design @ Voxt");
+        aliceNotification.SenderName.Should().Be("Bobby");
+        aliceNotification.GroupTitle.Should().Be("Design @ Voxt");
     }
 
     [Fact]
@@ -192,12 +214,13 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         notification.IconUrl.Should().Contain("api/content/");
     }
 
-    private async Task<Notification> GetNotification(AccountFull user, ChatEntryId entryId)
+    private async Task<ChatNotification> GetNotification(AccountFull user, ChatEntryId entryId)
     {
-        Notification notification = null!;
+        ChatNotification notification = null!;
         await TestExt.When(async () => {
             var info = await Tester.NotificationsBackend.GetUserNotificationInfo(user.Id, CancellationToken.None);
             var notifications = info.Items
+                .OfType<ChatNotification>()
                 .Where(n => EntryIdOf(n) == entryId)
                 .ToList();
             notifications.Should().HaveCount(1);

--- a/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
@@ -36,13 +36,13 @@ public class NotificationLocalizationTest(AppHostFixture fixture, ITestOutputHel
     public void AggregatedTextShouldPrefixEveryLineWithItsAuthor()
     {
         // arrange
-        var notification = NewAggregated(shownCount: 2, moreCount: 0);
+        var notification = NewAggregated(shownCount: 2, moreCount: 0, authorCount: 2);
 
         // act
         var text = NotificationHelper.ComposeAggregatedText(notification, Russian);
 
         // assert
-        text.Should().Be("Алиса: сообщение 1\nАлиса: сообщение 0");
+        text.Should().Be("Борис: сообщение 1\nАлиса: сообщение 0");
     }
 
     [Fact]
@@ -153,17 +153,21 @@ public class NotificationLocalizationTest(AppHostFixture fixture, ITestOutputHel
     private static string[] NewNames(int count)
         => Enumerable.Range(0, count).Select(i => $"Участник{i}").ToArray();
 
-    private static MessageNotification NewAggregated(int shownCount, int moreCount)
+    private static MessageNotification NewAggregated(int shownCount, int moreCount, int authorCount = 1)
     {
-        var authorId = AuthorId.New(TestChatId, 1);
+        var authorIds = Enumerable.Range(0, authorCount)
+            .Select(i => AuthorId.New(TestChatId, i + 1))
+            .ToArray();
+        var authorNames = new[] { "Алиса", "Борис", "Виктор" };
         var messages = Enumerable.Range(0, shownCount)
             .Select(i => NotificationMessage.New(
-                authorId, "Алиса", $"сообщение {i}", 100 + i, Moment.EpochStart + TimeSpan.FromSeconds(i)))
+                authorIds[i % authorCount], authorNames[i % authorCount],
+                $"сообщение {i}", 100 + i, Moment.EpochStart + TimeSpan.FromSeconds(i)))
             .ToApiArray();
-        return MessageNotification.New(TestUserId, TestChatId, 100 + shownCount - 1, authorId) with {
+        return MessageNotification.New(TestUserId, TestChatId, 100 + shownCount - 1, authorIds[^1]) with {
             StartEntryLid = 100,
             UnreadCount = shownCount + moreCount,
-            AuthorIds = new[] { authorId }.ToApiArray(),
+            AuthorIds = authorIds.ToApiArray(),
             RecentMessages = messages,
             LeadText = "сообщение 0",
             LeadCount = 1,


### PR DESCRIPTION
Fixes #4305.

## The bug

A group chat's name was missing from iOS push banners entirely — the banner showed only the sender.

This is a regression from #4184 (2026-08-27), four days old. Before that commit nothing rewrote the payload, so iOS rendered the server's composed `"<author> @ <chat>"` title verbatim and the chat name was visible. The notification service extension added there split that title and passed the chat name to the intent as `speakableGroupName` — which iOS silently drops, because it renders that only for a conversation it classifies as a group, and nothing but `recipients.count > 1` makes it one.

## The fix

The banner is now titled with **the chat**, and each body line names its own author:

```
[chat avatar]  Talk
Frol G: hey there
Frol G: 123
```

Rather than satisfying the group rule with a synthetic second recipient — which brings the chat name back as a *subtitle*, on a second line — this drops `speakableGroupName` altogether, and the group-classification rule with it. Two reasons it's the right shape:

- **Android already renders exactly this** via `MessagingStyle` (`SetConversationTitle` + a `Person` per message).
- **The avatar is already the chat's picture** for group chats, not the author's, so the chat's name is what belongs beside it.

A peer chat has no group title and keeps the other party as the headline.

## Sending the title's halves instead of splitting it

Every client needed the sender and chat name apart, and each recovered them by splitting the composed `Title` on a separator — a guess, since `" @ "` occurs in real names and chat titles. A chat called `Design @ Voxt` split into sender "Design", group "Voxt". Android's attention path scanned for a **bare `@`**, which any address mangles.

`ChatNotification` now persists the halves it composed `Title` from (`SenderName`, `GroupTitle`) and they ride in the push payload. `GetTitle` composes from the same pair, so the string and its parts can't drift. `ConversationNotification` and `CallNotification` have no author, so they set `SenderName` to the chat itself and keep rendering as before.

All four splits are **deleted**, not kept as fallbacks:

| Where | Was | Now |
|---|---|---|
| iOS extension | `title.range(of: " @ ")` | `groupTitle ?? senderName` |
| Android banner | `SplitTitle(title)` | passed in from `NotificationData` |
| Android attention | `title.IndexOf('@')` | `GroupTitle ?? SenderName` |
| Android heal path | `SplitTitle(title)` | `ActiveNotificationInfo` carries them |

Nothing needs them. The server always deploys ahead of the apps, so no client meets a server that doesn't send the keys. The one case left is a notification **already in the store** when this ships, which pushes both halves empty — and that degrades cosmetically on every path rather than failing:

- **iOS** — empty headline, `makeIntent` returns nil, banner delivered exactly as the server titled it (app icon, no avatar).
- **Android** — `CreateStyle` already falls back to `BigTextStyle` on an empty sender.
- **Android attention** — blank chat name on that one banner.

It also self-heals: `MergeWith` takes the incoming notification's halves, so only a notification that stays unread *and* receives nothing further is ever affected.

Two details worth a reviewer's eye:

- The attention path needs `GroupTitle ?? SenderName`, not `GroupTitle` alone — a peer chat carries no group title **by design**, so `GroupTitle` alone would blank the chat name on every peer attention notification, not just old ones.
- `PttWakeHandler` passes no author, so its fallback banner is now `BigTextStyle` instead of a `MessagingStyle` addressed from a fabricated "Voxt" person. Behaviour change, deliberate.

## Testing

- Full solution builds clean; 157/157 in `Notifications.IntegrationTests`.
- New test `ShouldCarryTitlePartsForAChatTitledWithTheSeparator` locks in the `Design @ Voxt` case.
- `AggregatedTextShouldPrefixEveryLineWithItsAuthor` had been passing on a single-author fixture; it now uses two authors.

## Not yet verified

**The rendered banner has not been seen on a device.** Everything above about how iOS lays out a chat-named communication notification is reasoning from the API, not observation — and an earlier round of the same reasoning in this session turned out wrong. A build was deployed to a device mid-way, but it predates the last two commits, so the current code has never run anywhere.

It is testable against the **current** dev server without deploying this: a live push carries the composed title, and before the fallbacks were removed the extension read the keys when present. After this change an old-server push simply renders untouched.
