### PR TITLE
fix(chat): long press opens the message menu; selecting a transcript no longer replays it

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -9,7 +9,12 @@
     @apply flex-y;
     @apply min-h-6;
     @apply border-l-2 border-transparent rounded-2xl;
-    @apply md:select-text;
+    @apply select-text;
+}
+/* Nothing inside a message may opt back into selection on touch: a long press on selectable text
+   starts the native text selection, which cancels the gesture that opens the message menu. */
+.touch-capable .message-wrapper {
+    @apply select-none;
 }
 .message-wrapper.show-author {
     @apply min-h-12;
@@ -210,11 +215,6 @@ body.hoverable .chat-message.mention:hover .chat-message-timestamp-on-hover {
     @apply h-auto;
     @apply my-0.5 pr-1.5;
     @apply text-02 text-text-1;
-}
-.touch-capable .chat-message-markup {
-    -webkit-user-select: none;
-    user-select: none;
-    -webkit-touch-callout: none;
 }
 .chat-message-markup.empty {
     @apply hidden;

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
@@ -91,7 +91,7 @@
 }
 .spoiler-markup.revealed {
     @apply bg-02;
-    @apply select-text;
+    @apply select-auto;
     filter: none;
 }
 
@@ -140,7 +140,6 @@
 
 .playable-text-markup {
     @apply whitespace-break-spaces;
-    @apply select-text;
 }
 .playable-text-markup > span {
     @apply inline;

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/playable-text-markup-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/playable-text-markup-view.ts
@@ -49,10 +49,22 @@ export class PlayableTextMarkupView {
     private onClick = (e: Event) => {
         if (this.element.classList.contains('play-disabled'))
             return;
+        if (this.endsTextSelection())
+            return;
 
         const target = e.target as HTMLElement;
         const word = this.findWord(target);
         this.onWordClick(word);
+    }
+
+    // Selecting text with the mouse ends with a click, which must not start the replay.
+    // mousedown collapses any earlier selection, so a live range here belongs to this very click.
+    private endsTextSelection(): boolean {
+        const selection = getSelection();
+        if (!selection || selection.isCollapsed || selection.rangeCount === 0)
+            return false;
+
+        return selection.getRangeAt(0).intersectsNode(this.element);
     }
 
     private onWordClick(word: Word | null) {


### PR DESCRIPTION
On Android, a long press on a message often selected text instead of opening the
message menu. Fixing the cascade exposed a second, older defect on desktop:
finishing a mouse selection over a transcript started the replay.

## Long press selects text instead of opening the menu

`body` sets `select-none` for the whole UI and `.message-wrapper` opted back in
on `md+`, but `.playable-text-markup` carried an unconditional `select-text`.
That rule sits on the text itself, so it beat the `none` that
`.chat-message-markup` only inherited down on touch. Blink then answered a long
press the way it does for any selectable text — select the word, send
`pointercancel` — and `ContextMenuGesture` disposes on `pointercancel`, so the
menu never opened. Messages with a transcript are most of a chat, hence "often":
typed text renders as `.plain-text-markup` and behaved correctly.

Selection is now decided in one place, on `.message-wrapper`: `select-text`, and
`select-none` under `.touch-capable`. Descendants no longer override it —
`.playable-text-markup` drops its `select-text`, and a revealed spoiler asks for
`select-auto`, i.e. whatever the container says. The `md:` gate goes with it:
what decides is the input, not the window width, so a narrow desktop window
keeps its selection. `.touch-capable .chat-message-markup` is dropped;
`-webkit-touch-callout: none` is inherited from `body`.

Copying is unaffected — "Copy text" in the message menu never depended on a DOM
selection.

## Selecting transcript text starts the replay

`PlayableTextMarkupView` plays from the clicked word, and a mouse drag that
selects text ends with a `click` — so releasing the button after selecting
played the message. `play-disabled` doesn't cover it: it follows `SelectionUI`,
which is about selected *messages*, not selected text. It surfaced now because
the fix above makes a message selectable in a narrow window too.

`onClick` bails when a live range intersects the element. `mousedown` collapses
any earlier selection, so a range still standing at click time belongs to this
very click.

## Verification

Long press, over CDP on a Redmi (Android 10, Chrome 151), with real touch
events:

| cascade | selection after a 900 ms press |
|---|---|
| before, transcript | `"transcript"` |
| before, typed text | `""` |
| after, transcript / revealed spoiler / typed text | `""` |

In the MAUI app on the same device the press yields `selection: ''` and opens the
message menu ("Воспроизвести / Ответить / Копировать текст / …"). Desktop
Chromium, drag-selection over the built `bundle.css`: selectable when
`touch-incapable`, not selectable when `touch-capable`.

Click semantics behind the second fix, measured in Chromium:

| scenario | selection at click time | replay |
|---|---|---|
| drag-select inside the message | live range, intersects | suppressed |
| plain click | collapsed | plays |
| click right after selecting another message | collapsed | plays |

`npm run build:Verify` (tsc + eslint + build) is clean. Both fixes were also
confirmed by hand — on the device for the long press, in the web app for the
replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yQCZErik3wyS7WFgk41Ea
