### PR TITLE
feat(banners): collapsible banner stack under chat header + banner redesign

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/Banners/AddChatMembersBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/AddChatMembersBanner.razor
@@ -14,9 +14,8 @@
         @L.Banner_OnlyPersonInChat
     </Body>
     <Buttons>
-        <Button
-            Class="btn-transparent unhovered"
-            Click="@OnInviteClick">@L.Banner_AddMembers</Button>
+        <BannerButton
+            Click="@OnInviteClick">@L.Banner_AddMembers</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/AddToContactsBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/AddToContactsBanner.razor
@@ -7,13 +7,13 @@
         return;
 }
 
-<Banner IsVisible="@m.CanAddToContacts" Severity="BannerSeverity.Default" ShowDismissButton="true">
+<Banner IsVisible="@m.CanAddToContacts" ShowDismissButton="true">
     <Body>
         @L.Banner_NotInContacts
     </Body>
     <Buttons>
-        <Button Class="btn-danger btn-sm btn-modal" Click="@OnBlockClick">@L.Common_Block</Button>
-        <Button Class="btn-primary btn-sm btn-modal" Click="@OnAddClick">@L.Banner_AddToContacts</Button>
+        <BannerButton Class="btn-danger" Click="@OnBlockClick">@L.Common_Block</BannerButton>
+        <BannerButton Click="@OnAddClick">@L.Banner_AddToContacts</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/BannerStack.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/BannerStack.razor
@@ -1,0 +1,31 @@
+@using ActualChat.UI.Blazor.App.Module
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits ComponentBase<AppUIHub>
+@implements IAsyncDisposable
+
+<div @ref="Ref" class="banner-stack @Class">
+    @ChildContent
+</div>
+
+@code {
+    private static readonly string JSCreateMethod = $"{BlazorUIAppModule.ImportName}.BannerStack.create";
+    private IJSObjectReference? _jsRef;
+
+    private ElementReference Ref { get; set; }
+
+    [Parameter] public string Class { get; set; } = "";
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    public async ValueTask DisposeAsync() {
+        if (_jsRef is not null)
+            await _jsRef.DisposeSilentlyAsync("dispose");
+        _jsRef = null;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!firstRender)
+            return;
+
+        _jsRef = await JS.InvokeAsync<IJSObjectReference>(JSCreateMethod, Ref);
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/Banners/Banners.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/Banners.razor
@@ -5,21 +5,29 @@
     var chat = Chat;
 }
 
+@* Urgent, actionable banners stay full-size above the stack *@
 <ReconnectBanner/>
 <IncomingCallBanner/>
-@foreach (var banner in m.Banners.Take(MaxCount)) {
-    @banner.View
-}
 @if (chat is not null) {
     <NoComponent @key="Chat">
         <OutgoingCallBanner/>
-        <ChatCopyBanner/>
-        <AddToContactsBanner/>
-        <AddChatMembersBanner/>
-        <PttJoinBanner/>
     </NoComponent>
 }
-<PermissionBannerSwitch/>
+@foreach (var banner in m.Banners.Take(MaxCount)) {
+    @banner.View
+}
+@* Non-urgent nudges collapse into an iOS-style stack so they + pinned bar don't eat the view *@
+<BannerStack>
+    @if (chat is not null) {
+        <NoComponent @key="Chat">
+            <ChatCopyBanner/>
+            <AddToContactsBanner/>
+            <AddChatMembersBanner/>
+            <PttJoinBanner/>
+        </NoComponent>
+    }
+    <PermissionBannerSwitch/>
+</BannerStack>
 
 @code {
     private const int MaxCount = 2;

--- a/src/dotnet/UI.Blazor.App/Components/Banners/ChatCopyBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/ChatCopyBanner.razor
@@ -14,14 +14,12 @@
         @L.Banner_ChatCopiedToPlace
     </Body>
     <Buttons>
-        <Button
+        <BannerButton
             IsDisabled="@_isCopying"
-            Class="btn-transparent on"
-            Click="@(() => OnUpdateClick(copiedChat))">@L.Common_Update</Button>
-        <Button
+            Click="@(() => OnUpdateClick(copiedChat))">@L.Common_Update</BannerButton>
+        <BannerButton
             IsDisabled="@(!copiedChat.IsCopiedSuccessfully)"
-            Class="btn-transparent on"
-            Click="@(() => OnPublishClick(copiedChat))">@L.Common_Publish</Button>
+            Click="@(() => OnPublishClick(copiedChat))">@L.Common_Publish</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/ContactsPermissionBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/ContactsPermissionBanner.razor
@@ -22,9 +22,8 @@
                     >@L.Banner_ImportContactsTarget</strong>@L.Banner_ImportContacts_Suffix
             </Body>
             <Buttons>
-                <Button
-                    Class="btn-transparent unhovered"
-                    Click="@OnConfigureClick">@L.Common_Configure</Button>
+                <BannerButton
+                    Click="@OnConfigureClick">@L.Common_Configure</BannerButton>
             </Buttons>
         </Banner>
     </RenderIntoSlot>

--- a/src/dotnet/UI.Blazor.App/Components/Banners/FullScreenCallsDisabledBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/FullScreenCallsDisabledBanner.razor
@@ -27,11 +27,10 @@
                 >@L.Banner_LockScreenCallsTarget</strong>@L.Banner_LockScreenCalls_Suffix
         </Body>
         <Buttons>
-            <Button
-                Class="btn-transparent unhovered"
+            <BannerButton
                 Click="@OnConfigureClick">
                 @L.Common_Settings
-            </Button>
+            </BannerButton>
         </Buttons>
     </Banner>
 </RenderIntoSlot>

--- a/src/dotnet/UI.Blazor.App/Components/Banners/IncomingCallBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/IncomingCallBanner.razor
@@ -13,8 +13,8 @@
         </div>
     </Body>
     <Buttons>
-        <Button Class="btn-transparent unhovered on" Click="@OnAcceptClick">@L.Common_Accept</Button>
-        <Button Class="btn-transparent unhovered" Click="@OnDeclineClick">@L.Common_Decline</Button>
+        <BannerButton Click="@OnAcceptClick">@L.Common_Accept</BannerButton>
+        <BannerButton Click="@OnDeclineClick">@L.Common_Decline</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/LiveActivitiesDisabledBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/LiveActivitiesDisabledBanner.razor
@@ -27,9 +27,8 @@
                     >@L.Banner_LiveActivitiesTarget</strong>@L.Banner_LiveActivities_Suffix
             </Body>
             <Buttons>
-                <Button
-                    Class="btn-transparent unhovered"
-                    Click="@OnConfigureClick">@L.Common_Settings</Button>
+                <BannerButton
+                    Click="@OnConfigureClick">@L.Common_Settings</BannerButton>
             </Buttons>
         </Banner>
     </RenderIntoSlot>

--- a/src/dotnet/UI.Blazor.App/Components/Banners/NotificationsPermissionBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/NotificationsPermissionBanner.razor
@@ -26,10 +26,9 @@
                     >@L.Banner_NotifyTarget</strong>@L.Banner_Notify_Suffix
             </Body>
             <Buttons>
-                <Button
-                    Class="btn-transparent unhovered"
+                <BannerButton
                     Click="@OnConfigureClick"
-                    Rendered="@OnConfigureRendered">@L.Common_Configure</Button>
+                    Rendered="@OnConfigureRendered">@L.Common_Configure</BannerButton>
             </Buttons>
         </Banner>
     </RenderIntoSlot>

--- a/src/dotnet/UI.Blazor.App/Components/Banners/PttJoinBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/PttJoinBanner.razor
@@ -17,9 +17,8 @@
         @(kind == PttJoinBannerKind.EnableDevice ? L.Banner_PttUseDevice : L.Banner_PttAllow)
     </Body>
     <Buttons>
-        <Button
-            Class="btn-transparent unhovered"
-            Click="@OnJoinClick">@L.Common_Allow</Button>
+        <BannerButton
+            Click="@OnJoinClick">@L.Common_Allow</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/ReconnectBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/ReconnectBanner.razor
@@ -35,9 +35,8 @@
     </Body>
     <Buttons>
         @if (m.ReconnectsIn != default && !isOffline) {
-            <Button
-                Class="btn-transparent unhovered on"
-                Click="@(_ => ReconnectUI.ReconnectIfDisconnected())">@L.Common_Retry</Button>
+            <BannerButton
+                Click="@(_ => ReconnectUI.ReconnectIfDisconnected())">@L.Common_Retry</BannerButton>
         }
     </Buttons>
 </Banner>

--- a/src/dotnet/UI.Blazor.App/Components/Banners/SwitchToWasmBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/SwitchToWasmBanner.razor
@@ -8,7 +8,7 @@
     </Icon>
     <Body>@L.Banner_ReadyToRestart_Format(CoreConstants.AppName)</Body>
     <Buttons>
-        <Button Class="btn-transparent on unhovered">@L.Common_Restart</Button>
+        <BannerButton>@L.Common_Restart</BannerButton>
     </Buttons>
 </Banner>
 

--- a/src/dotnet/UI.Blazor.App/Components/Banners/banner-stack.css
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/banner-stack.css
@@ -1,0 +1,19 @@
+.banner-stack {
+    @apply relative;
+    @apply w-full;
+    @apply overflow-hidden;
+    height: var(--bs-height, 0px);
+    transition: height 220ms ease;
+}
+.banner-stack.is-empty {
+    @apply hidden;
+}
+.banner-stack .banner {
+    @apply absolute top-0 left-0 right-0;
+    @apply mx-auto;
+    transform-origin: top center;
+    transition:
+        transform 220ms ease,
+        opacity 220ms ease;
+    will-change: transform, opacity;
+}

--- a/src/dotnet/UI.Blazor.App/Components/Banners/banner-stack.ts
+++ b/src/dotnet/UI.Blazor.App/Components/Banners/banner-stack.ts
@@ -1,0 +1,150 @@
+import { Disposable } from 'disposable';
+import { fromEvent, Subject, takeUntil } from 'rxjs';
+
+const PeekOffsetPx = 8;
+const MaxPeek = 2;
+const ExpandedGapPx = 6;
+const ScaleStep = 0.04;
+
+export class BannerStack implements Disposable {
+    private readonly disposed$: Subject<void> = new Subject<void>();
+    private readonly mutationObserver: MutationObserver;
+    private readonly resizeObserver: ResizeObserver;
+    private readonly observed = new Set<HTMLElement>();
+    private expanded = false;
+    private rafHandle = 0;
+
+    public static create(root: HTMLElement): BannerStack {
+        return new BannerStack(root);
+    }
+
+    constructor(private readonly root: HTMLElement) {
+        fromEvent<MouseEvent>(root, 'click')
+            .pipe(takeUntil(this.disposed$))
+            .subscribe(event => this.handleClick(event));
+        this.mutationObserver = new MutationObserver(() => this.scheduleLayout());
+        this.mutationObserver.observe(root, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['class'],
+        });
+        this.resizeObserver = new ResizeObserver(() => this.scheduleLayout());
+        this.scheduleLayout();
+    }
+
+    public dispose(): void {
+        if (this.disposed$.closed)
+            return;
+
+        this.disposed$.next();
+        this.disposed$.complete();
+        this.mutationObserver.disconnect();
+        this.resizeObserver.disconnect();
+        this.observed.clear();
+        if (this.rafHandle)
+            cancelAnimationFrame(this.rafHandle);
+    }
+
+    private handleClick(event: MouseEvent): void {
+        const target = event.target as HTMLElement | null;
+        // Buttons and links inside a banner keep acting; only a tap on the banner body toggles the stack.
+        if (target?.closest('.banner-buttons, button, a, [role="button"]'))
+            return;
+
+        const banners = this.getBanners();
+        if (banners.length <= 1 && !this.expanded)
+            return;
+
+        this.expanded = !this.expanded;
+        this.layout();
+    }
+
+    private scheduleLayout(): void {
+        if (this.disposed$.closed || this.rafHandle)
+            return;
+
+        this.rafHandle = requestAnimationFrame(() => {
+            this.rafHandle = 0;
+            this.layout();
+        });
+    }
+
+    // A banner is only in the DOM while visible (Banner.razor drops it when hidden), so presence
+    // is the visibility test. offsetHeight can't be used: an is-empty container is display:none,
+    // which zeroes its children's height and would latch the stack empty forever.
+    private getBanners(): HTMLElement[] {
+        return Array.from(this.root.querySelectorAll<HTMLElement>('.banner'));
+    }
+
+    // Keep the ResizeObserver tracking exactly the live banners — unobserve ones that left the DOM,
+    // otherwise detached banner nodes pile up in the observer and never get collected.
+    private reconcileObserved(banners: HTMLElement[]): void {
+        const current = new Set(banners);
+        for (const banner of this.observed)
+            if (!current.has(banner)) {
+                this.resizeObserver.unobserve(banner);
+                this.observed.delete(banner);
+            }
+        for (const banner of banners)
+            if (!this.observed.has(banner)) {
+                this.resizeObserver.observe(banner);
+                this.observed.add(banner);
+            }
+    }
+
+    private layout(): void {
+        if (this.disposed$.closed)
+            return;
+
+        const banners = this.getBanners();
+        const count = banners.length;
+        const isExpanded = this.expanded && count > 1;
+        this.root.classList.toggle('is-empty', count === 0);
+        this.root.classList.toggle('expanded', isExpanded);
+        this.reconcileObserved(banners);
+
+        if (count === 0) {
+            this.root.style.setProperty('--bs-height', '0px');
+            return;
+        }
+
+        if (isExpanded) {
+            let y = 0;
+            banners.forEach((banner, i) => {
+                banner.style.transform = `translateY(${y}px)`;
+                banner.style.opacity = '1';
+                banner.style.zIndex = `${count - i}`;
+                banner.style.pointerEvents = 'auto';
+                y += banner.offsetHeight + ExpandedGapPx;
+            });
+            this.root.style.setProperty('--bs-height', `${Math.max(0, y - ExpandedGapPx)}px`);
+            return;
+        }
+
+        const topHeight = banners[0].offsetHeight;
+        const peekCount = Math.min(count - 1, MaxPeek);
+        banners.forEach((banner, i) => {
+            if (i === 0) {
+                banner.style.transform = 'translateY(0) scaleX(1)';
+                banner.style.opacity = '1';
+                banner.style.zIndex = `${count}`;
+                banner.style.pointerEvents = 'auto';
+            } else if (i <= MaxPeek) {
+                // Bottom-align each peek so exactly i*PeekOffset sticks out below the top banner,
+                // keeping its rounded corners visible regardless of the peek banner's own height.
+                const y = topHeight - banner.offsetHeight + i * PeekOffsetPx;
+                banner.style.transform = `translateY(${y}px) scaleX(${1 - i * ScaleStep})`;
+                banner.style.opacity = '1';
+                banner.style.zIndex = `${count - i}`;
+                banner.style.pointerEvents = 'none';
+            } else {
+                banner.style.transform = `translateY(${topHeight + MaxPeek * PeekOffsetPx}px) scaleX(${1 - MaxPeek * ScaleStep})`;
+                banner.style.opacity = '0';
+                banner.style.zIndex = '0';
+                banner.style.pointerEvents = 'none';
+            }
+        });
+        this.root.style.setProperty('--bs-height', `${topHeight + peekCount * PeekOffsetPx}px`);
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarContent.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarContent.razor
@@ -84,6 +84,7 @@
         var isDev = HostInfo.IsDevelopmentInstance;
         var pages = new List<TestPageEntry> {
             new("/test/audio-blob-download", "Audio Blob Download"),
+            new("/test/banner-stack", "Banner Stack"),
             new("/test/blazor", "Blazor"),
             new("/test/content-swap", "Content Swap"),
             new("/test/copy-chat2place", "Copy Chat to Place"),

--- a/src/dotnet/UI.Blazor.App/Pages/Test/BannerStackTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/BannerStackTestPage.razor
@@ -1,0 +1,143 @@
+@page "/test/banner-stack"
+
+<RequireAccount MustBeAdmin="true"/>
+
+<MainHeader>Banner Stack Test Page</MainHeader>
+
+@* Sub-headers sit at the top of the region, exactly like Recording/Audio/Translation (Order -1M) *@
+<RenderIntoStack Name="@LayoutSlots.SubHeader" Order="-1000_000" Key="TestSubHeaders">
+    @foreach (var id in _subHeaders) {
+        <SubHeader @key="id" IsVisible="true" Class="banner-stack-test-subheader">
+            <div class="c-body">
+                <i class="icon-translate text-2xl"></i>
+                <div class="c-text">Sub-header #@id</div>
+                <Button Class="btn-sm btn-transparent" Click="@(_ => RemoveSubHeader(id))">
+                    <i class="icon-close text-2xl"></i>
+                </Button>
+            </div>
+        </SubHeader>
+    }
+</RenderIntoStack>
+
+@* Important banners stay full-size above the stack; the nudges collapse inside BannerStack (Order 1M) *@
+<RenderIntoStack Name="@LayoutSlots.SubHeader" Order="1000_000" Key="TestBanners">
+    @foreach (var id in _importantBanners) {
+        <Banner @key="id"
+                Severity="BannerSeverity.Warning"
+                ShowDismissButton="true"
+                Dismiss="@(() => RemoveImportant(id))">
+            <Body>Important banner #@id — needs your attention right now</Body>
+            <Buttons>
+                <BannerButton>Action</BannerButton>
+            </Buttons>
+        </Banner>
+    }
+    <BannerStack>
+        @foreach (var kind in _addedNudges) {
+            <Banner @key="kind.Key"
+                    Severity="@kind.Severity"
+                    ShowDismissButton="true"
+                    Dismiss="@(() => RemoveNudge(kind.Key))">
+                <Body>@kind.Text</Body>
+                <Buttons>
+                    @foreach (var action in kind.Actions) {
+                        <BannerButton Class="@action.Cls">@action.Label</BannerButton>
+                    }
+                </Buttons>
+            </Banner>
+        }
+    </BannerStack>
+</RenderIntoStack>
+
+@* Pinned bar stand-in reuses the real .pinned-bar markup/CSS at the same spot (Order 1.5M) *@
+<RenderIntoStack Name="@LayoutSlots.SubHeader" Order="1500_000" Key="TestPinnedBar">
+    @if (_pinCount > 0) {
+        <div class="pinned-bar">
+            <button type="button" class="c-cycle">
+                <div class="c-indicator">
+                    @for (var i = 0; i < _pinCount; i++) {
+                        <span class="c-seg @(i == 0 ? "active" : "")"></span>
+                    }
+                </div>
+                <div class="c-text">Pinned message #1 of @_pinCount — tap to cycle in the real chat</div>
+            </button>
+            <i class="c-pin-icon icon-pin"></i>
+        </div>
+    }
+</RenderIntoStack>
+
+<div class="test-page-wrapper">
+    <div class="banner-stack-test">
+        <div class="c-title">Banner stack test</div>
+        <div class="c-note">
+            Buttons add real components into the chat sub-header region above. Tap the collapsed nudge
+            stack to expand it, tap again to collapse. Banner action buttons still work while collapsed.
+        </div>
+        <div class="c-buttons">
+            <Button Class="btn-primary" Click="@(_ => AddNudge())">Add banner (@_addedNudges.Count/@NudgeKinds.Length)</Button>
+            <Button Class="btn-primary" Click="@(_ => AddPin())">Add pinned bar (@_pinCount)</Button>
+            <Button Class="btn-primary" Click="@(_ => AddImportant())">Add important banner (@_importantBanners.Count)</Button>
+            <Button Class="btn-primary" Click="@(_ => AddSubHeader())">Add sub-header (@_subHeaders.Count)</Button>
+            <Button Class="btn-outline" Click="@(_ => ClearAll())">Clear all</Button>
+        </div>
+    </div>
+</div>
+
+@code {
+    // Every banner kind that can live in the BannerStack, in the order they're rendered in Banners.razor.
+    // Button classes mirror the real components so the test matches production styling.
+    private static readonly NudgeKind[] NudgeKinds = [
+        new("add-members", "You're the only person in this chat", BannerSeverity.Warning,
+            [new("Add members", "")]),
+        new("add-contacts", "This user is not in your contacts", BannerSeverity.Info,
+            [new("Block", "btn-danger"), new("Add", "")]),
+        new("ptt", "Enable your device to use push-to-talk in this chat", BannerSeverity.Info,
+            [new("Allow", "")]),
+        new("chat-copy", "This chat was copied to the place — publish it when you're ready", BannerSeverity.Info,
+            [new("Update", ""), new("Publish", "")]),
+        new("notifications", "Turn on notifications so you don't miss messages in this chat and others you follow", BannerSeverity.Info,
+            [new("Configure", "")]),
+    ];
+
+    private readonly List<NudgeKind> _addedNudges = [];
+    private readonly List<int> _importantBanners = [];
+    private readonly List<int> _subHeaders = [];
+    private int _pinCount;
+    private int _nextId;
+
+    private void AddNudge() {
+        foreach (var kind in NudgeKinds)
+            if (!_addedNudges.Exists(a => a.Key == kind.Key)) {
+                _addedNudges.Add(kind);
+                return;
+            }
+    }
+
+    private void AddImportant()
+        => _importantBanners.Add(_nextId++);
+
+    private void AddSubHeader()
+        => _subHeaders.Add(_nextId++);
+
+    private void AddPin()
+        => _pinCount++;
+
+    private void RemoveNudge(string key)
+        => _addedNudges.RemoveAll(k => k.Key == key);
+
+    private void RemoveImportant(int id)
+        => _importantBanners.Remove(id);
+
+    private void RemoveSubHeader(int id)
+        => _subHeaders.Remove(id);
+
+    private void ClearAll() {
+        _addedNudges.Clear();
+        _importantBanners.Clear();
+        _subHeaders.Clear();
+        _pinCount = 0;
+    }
+
+    private sealed record NudgeAction(string Label, string Cls);
+    private sealed record NudgeKind(string Key, string Text, BannerSeverity Severity, NudgeAction[] Actions);
+}

--- a/src/dotnet/UI.Blazor.App/Pages/Test/banner-stack-test-page.css
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/banner-stack-test-page.css
@@ -1,0 +1,20 @@
+.banner-stack-test {
+    @apply flex-y gap-y-3;
+    @apply p-4;
+}
+.banner-stack-test .c-title {
+    @apply text-headline-1;
+}
+.banner-stack-test .c-note {
+    @apply text-02;
+}
+.banner-stack-test .c-buttons {
+    @apply flex-x flex-wrap gap-2;
+}
+.banner-stack-test-subheader .c-body {
+    @apply flex-1 flex-x items-center gap-x-2;
+    @apply px-2;
+}
+.banner-stack-test-subheader .c-body .c-text {
+    @apply flex-1;
+}

--- a/src/dotnet/UI.Blazor.App/exports.ts
+++ b/src/dotnet/UI.Blazor.App/exports.ts
@@ -51,6 +51,7 @@ export * from './Components/Selection/selection-host';
 export * from './Components/TranslationSubHeader/translation-svg.lit';
 export * from './Components/SubHeader/sub-header';
 export * from './Components/SubHeader/sub-header.lit';
+export * from './Components/Banners/banner-stack';
 export * from './Services/incoming-call-ringtone';
 export * from './Services/outgoing-call-ringback';
 export * from './Services/Location/location-tracker';

--- a/src/dotnet/UI.Blazor.App/styles.css
+++ b/src/dotnet/UI.Blazor.App/styles.css
@@ -8,6 +8,7 @@
 @import './Components/AccountModal/account-modal.css';
 @import './Components/Author/author.css';
 @import './Components/Banners/banners.css';
+@import './Components/Banners/banner-stack.css';
 @import './Components/ContactSelector/contact-selector.css';
 @import './Components/ContactView/contact-view.css';
 @import './Components/ChatActivities/chat-activities.css';
@@ -108,6 +109,7 @@
 @import './Pages/user-page.css';
 @import './Pages/emojis-test-page.css';
 @import './Pages/Test/date-time-test-page.css';
+@import './Pages/Test/banner-stack-test-page.css';
 
 @import './Components/AudioRecorder/Guides/guides.css';
 @import './Components/PhotoPermission/photo-troubleshooter-modal.css';

--- a/src/dotnet/UI.Blazor/Components/Banner/Banner.razor
+++ b/src/dotnet/UI.Blazor/Components/Banner/Banner.razor
@@ -61,7 +61,7 @@
     // Opt-out for banners that must stay a single fixed-height line, e.g. the reconnect status strip
     [Parameter] public bool NoWrap { get; set; }
     [Parameter] public bool IsVisible { get; set; } = true;
-    [Parameter] public BannerSeverity Severity { get; set; } = BannerSeverity.Default;
+    [Parameter] public BannerSeverity Severity { get; set; } = BannerSeverity.Info;
     [Parameter] public EventCallback Dismiss { get; set; }
 
     protected override void OnInitialized()

--- a/src/dotnet/UI.Blazor/Components/Banner/BannerButton.razor
+++ b/src/dotnet/UI.Blazor/Components/Banner/BannerButton.razor
@@ -1,0 +1,17 @@
+@namespace ActualChat.UI.Blazor.Components
+
+@* Standard banner action button: applies the shared banner-button classes so each banner doesn't repeat them *@
+<Button Class="@($"btn-transparent unhovered btn-modal {Class}")"
+        Click="@Click"
+        Rendered="@Rendered"
+        @attributes="Attributes">
+    @ChildContent
+</Button>
+
+@code {
+    [Parameter] public string Class { get; set; } = "";
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public EventCallback<MouseEventArgs> Click { get; set; }
+    [Parameter] public EventCallback<ElementReference> Rendered { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? Attributes { get; set; }
+}

--- a/src/dotnet/UI.Blazor/Components/Banner/banner.css
+++ b/src/dotnet/UI.Blazor/Components/Banner/banner.css
@@ -2,7 +2,7 @@
     @apply flex-x gap-x-2 items-center justify-center;
     @apply w-full lg:max-w-192 h-14;
     @apply px-2;
-    @apply rounded-lg border-banner-default border-2;
+    @apply rounded-lg border-b border-banner-default;
     @apply bg-banner-default;
     @apply text-banner-default;
 }
@@ -17,14 +17,12 @@
 .banner-body {
     @apply flex-1;
     @apply ml-1;
+    @apply text-text-1;
 }
 .banner-buttons {
     @apply flex-x items-center justify-end gap-x-2;
     @apply ml-auto;
     @apply text-03;
-}
-.banner .btn:not(.close-banner) {
-    @apply px-2;
 }
 .banner.banner-wrap {
     @apply relative;
@@ -51,7 +49,12 @@
     @apply ml-auto;
 }
 .banner.banner-wrap .close-banner-abs {
-    @apply absolute top-2 md:top-3.5 right-2;
+    @apply absolute top-2 right-2;
+}
+/* Desktop: the close button sits at the banner's vertical center; mobile keeps it top-right */
+body.wide .banner.banner-wrap .close-banner-abs {
+    @apply top-1/2 right-2;
+    transform: translateY(-50%);
 }
 /* The query sees the content box, 20px narrower than the banner, so 22rem still fired up to a 380px
    viewport and cost English a row on every phone. A translation that doesn't fit wraps regardless -
@@ -70,9 +73,35 @@
         @apply flex-1;
     }
 }
+/* Mobile: stack the body over a centered button row instead of body-left / buttons-right */
+body.narrow .banner.banner-wrap > .c-content {
+    @apply flex-y items-stretch gap-y-1;
+}
+body.narrow .banner.banner-wrap.banner-dismissible > .c-content {
+    @apply pr-0;
+}
+body.narrow .banner.banner-wrap.banner-dismissible .banner-body {
+    @apply pr-9;
+}
+body.narrow .banner.banner-wrap .banner-body {
+    @apply min-w-0 min-h-6;
+    @apply text-caption-4;
+}
+body.narrow .banner.banner-wrap .banner-buttons {
+    @apply justify-end basis-auto;
+    @apply ml-0;
+}
+/* Banner action buttons are default style, but capped at 2rem tall and half-width */
+.banner .banner-buttons .btn.btn-transparent {
+    @apply min-h-8 max-h-8;
+}
 body.hoverable .banner .btn:hover,
 body.hoverable .banner .btn-h:hover {
     @apply brightness-125 ;
+}
+/* Touch tap keeps only the blur from .btn:active — no background fill */
+.touch-capable .banner .btn.btn-transparent:active::after {
+    @apply hidden;
 }
 .severity-icon {
     @apply flex items-center justify-center;
@@ -116,4 +145,9 @@ body.hoverable .banner .btn-h:hover {
 .bg-banner-error .btn .btn-content,
 .bg-banner-error i {
     @apply text-banner-error;
+}
+/* A danger action stays red even inside a severity-tinted banner */
+.banner .btn.btn-danger .btn-content,
+.banner .btn.btn-danger i {
+    @apply text-danger;
 }


### PR DESCRIPTION
- BannerStack: iOS-style collapsible stack for non-urgent nudge banners so they + the pinned bar don't eat the chat view (JS controller with bottom-aligned peeks, overflow clip, expand/collapse on tap)
- Banner UI: bottom-only 1px border, mobile stacked body/centered buttons, default severity Info (was the bland Default), danger stays red over the tint
- BannerButton: shared wrapper so banner buttons don't repeat the class list; all banners migrated
- Test page at /test/banner-stack (listed in the Test Pages navbar)