### PR TITLE
feat(audio): burst-scoped listening focus for Android Auto

### DIFF
--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -31,6 +31,8 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     private AudioEngines AudioEngines => field ??= Hub.Services.GetRequiredService<AudioEngines>();
     private ILogger Log => field ??= Hub.LogFor(GetType());
 
+    public override bool IsSuspended => _isSuspended || IsInterrupted;
+
     public AppleAudioFocusUI(AppUIHub hub)
     {
         Hub = hub;
@@ -414,6 +416,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     {
         private readonly Dictionary<AudioFocusMode, Dictionary<AudioFocusRequester, Scope>> _byMode = new() {
             [AudioFocusMode.Tune] = new(),
+            [AudioFocusMode.Listening] = new(),
             [AudioFocusMode.Playback] = new(),
             [AudioFocusMode.Recording] = new(),
         };

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioEngines.cs
@@ -5,7 +5,7 @@ using Foundation;
 
 namespace ActualChat.App.Maui.Audio;
 
-public class AudioEngines : ProcessorBase
+public sealed class AudioEngines : ProcessorBase
 {
     // A tune is a one-off sound, so its engine only has to outlive a burst of them.
     private static readonly TimeSpan TuneIdleReleaseDelay = TimeSpan.FromSeconds(1);
@@ -15,12 +15,12 @@ public class AudioEngines : ProcessorBase
 
     private readonly Disposable<NSObject> _configurationChangeSubscription;
 
+    private AppUIHub Hub { get; }
+    private ILogger Log => field ??= Hub.LogFor(GetType());
+
     public AudioEngine Tunes { get; }
     public AudioEngine Playback { get; }
     public AudioEngine Recording { get; }
-
-    private AppUIHub Hub { get; }
-    private ILogger Log => field ??= Hub.LogFor(GetType());
 
     public AudioEngines(AppUIHub hub)
     {
@@ -51,10 +51,10 @@ public class AudioEngines : ProcessorBase
         Recording.Pause();
     }
 
-    // Apple's contract after a media-services reset: the engines are invalid and have to be
-    // recreated, not restarted. Releasing them is what makes the next use build fresh ones.
     public void Release()
     {
+        // Apple's contract after a media-services reset: the engines are invalid and have to be
+        // recreated, not restarted. Releasing them is what makes the next use build fresh ones.
         Tunes.Release();
         Playback.Release();
         Recording.Release();
@@ -66,7 +66,7 @@ public class AudioEngines : ProcessorBase
         // revives the ones that still have a live consumer.
         if (mode >= AudioFocusMode.Tune)
             Tunes.Resume();
-        if (mode >= AudioFocusMode.Playback)
+        if (mode >= AudioFocusMode.Listening)
             Playback.Resume();
         if (mode >= AudioFocusMode.Recording)
             Recording.Resume();
@@ -78,11 +78,13 @@ public class AudioEngines : ProcessorBase
         // engine that stopped itself also needs its output graph and player nodes restored.
         if (mode >= AudioFocusMode.Tune)
             Tunes.Reconnect();
-        if (mode >= AudioFocusMode.Playback)
+        if (mode >= AudioFocusMode.Listening)
             Playback.Reconnect();
         if (mode >= AudioFocusMode.Recording)
             Recording.Reconnect();
     }
+
+    // Private methods
 
     private void OnConfigurationChange(object? sender, NSNotificationEventArgs e)
         => Log.LogInformation("Audio engine configuration change");

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -303,7 +303,8 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         // moves playback only, so iOS leaves a headset that arrived mid-recording unheard.
         var input = ApplyPreferredInput(portOverride is AVAudioSessionPortOverride.None);
         Log.LogInformation(
-            "ApplyOutputRoute: mode={Mode}, sessionMode={SessionMode}, {Outputs} -> {Override} -> {Result}, input={Input}",
+            "ApplyOutputRoute: mode={Mode}, sessionMode={SessionMode}, "
+            + "{Outputs} -> {Override} -> {Result}, input={Input}",
             mode,
             session.Mode,
             Describe(outputs),
@@ -382,7 +383,7 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
             session.SetPreferredIOBufferDuration(Constants.Audio.OpusFrameDuration.TotalSeconds, out var error);
             error.Assert("Failed to set preferred IO buffer duration");
         }
-        else if (mode is AudioFocusMode.Playback)
+        else if (mode is AudioFocusMode.Playback or AudioFocusMode.Listening)
             session.SetCategory(AVAudioSessionCategory.Playback).Assert($"{mode}: failed to set category");
         else
             session.SetCategory(AVAudioSessionCategory.Ambient).Assert($"{mode}: failed to set category");

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusHelper.cs
@@ -61,6 +61,11 @@ public sealed class AndroidAudioFocusHelper : IDisposable
         // Playback needs no microphone, and the communication route drops a BT peer to SCO - a virtual call.
         => RequestFocus(AudioFocus.Gain, AudioUsageKind.Media, AudioContentType.Speech);
 
+    public Task<bool> RequestFocusForListening()
+        // Transient, not Gain: this focus lives only while someone's speech is actually playing,
+        // so whatever it pauses - music, navigation - auto-resumes once the utterance ends.
+        => RequestFocus(AudioFocus.GainTransient, AudioUsageKind.Media, AudioContentType.Speech);
+
     public Task<bool> RequestFocusForNotification()
         => RequestFocus(
             AudioFocus.GainTransientMayDuck,

--- a/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Audio/AndroidAudioFocusUI.cs
@@ -94,6 +94,7 @@ public sealed class AndroidAudioFocusUI : MauiAudioFocusUI
         var success = await Task.Run(() => mode switch {
                 AudioFocusMode.Recording => _focusHelper.RequestFocusForCall(useCommunicationRoute),
                 AudioFocusMode.Playback => _focusHelper.RequestFocusForPlayback(),
+                AudioFocusMode.Listening => _focusHelper.RequestFocusForListening(),
                 AudioFocusMode.Tune => _focusHelper.RequestFocusForNotification(),
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported audio focus mode"),
             }, CancellationToken.None)

--- a/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiAudioFocusUI.cs
@@ -14,6 +14,7 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
     protected AppUIHub Hub { get; } = hub;
     protected ILogger Log => field ??= Hub.LogFor(GetType());
     public override AudioFocusMode ActiveMode => _lastAudioFocusHolder?.Mode ?? AudioFocusMode.Tune;
+    public override bool IsSuspended => _lastAudioFocusHolder?.IsSuspended ?? false;
 
     public override async Task<AudioFocusScope?> TryAcquire(AudioFocusRequester requester)
     {
@@ -23,8 +24,15 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
         Log.LogInformation("Trying to acquire audio focus: {Kind}", requester.Kind);
         if (_lastAudioFocusHolder is not null && !_lastAudioFocusHolder.IsSuspended) {
             if (_lastAudioFocusHolder.Scopes.TryGetValue(requester, out var scope)) {
-                Log.LogInformation("Already have audio focus");
-                return scope;
+                if (!scope.IsDisposed) {
+                    Log.LogInformation("Already have audio focus");
+                    return scope;
+                }
+
+                // Its Release is queued behind this very lock; handing it back would let that
+                // release tear down whatever the caller starts next.
+                Log.LogInformation("Dropping disposed scope {Scope} ({Mode})", scope, requester.Kind);
+                _lastAudioFocusHolder.Scopes.Remove(requester);
             }
 
             if (!FocusModeHasChanged(_lastAudioFocusHolder, requester)) {
@@ -76,7 +84,7 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 
     // Private methods
 
-    private async Task ReleaseAudioFocus(AudioFocusRequester requester)
+    private async Task ReleaseAudioFocus(AudioFocusRequester requester, Scope scope)
     {
         using var releaser = await OperationLock.Lock(CancellationToken.None).ConfigureAwait(false);
         releaser.MarkLockedLocally();
@@ -84,8 +92,13 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
         if (_lastAudioFocusHolder is null)
             return;
 
-        if (!_lastAudioFocusHolder.Scopes.Remove(requester))
+        // Identity check, not a bare Remove: a late release for a superseded scope must not
+        // evict the live scope that replaced it under the same requester.
+        if (!_lastAudioFocusHolder.Scopes.TryGetValue(requester, out var existing)
+            || !ReferenceEquals(existing, scope))
             return;
+
+        _lastAudioFocusHolder.Scopes.Remove(requester);
 
         if (_lastAudioFocusHolder.Scopes.Count == 0) {
             _lastAudioFocusHolder.Handle.Release();
@@ -207,7 +220,17 @@ public abstract class MauiAudioFocusUI(AppUIHub hub) : AudioFocusUI
 
     private sealed class Scope(MauiAudioFocusUI owner, AudioFocusRequester requester) : AudioFocusScope
     {
+        private int _isDisposed;
+
+        // Set before the Release is queued, so a TryAcquire winning the lock sees it's on its way out.
+        public bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
         public override void Dispose()
-            => _ = owner.ReleaseAudioFocus(requester);
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+                return;
+
+            _ = owner.ReleaseAudioFocus(requester, this);
+        }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.Players.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.Players.cs
@@ -7,17 +7,24 @@ public partial class ChatAudioUI
 {
     private static TimeSpan RestorePreviousPlaybackStateDelay { get; } = TimeSpan.FromMilliseconds(250);
 
-    private volatile ImmutableDictionary<(ChatId ChatId, ChatPlayerKind PlayerKind), ChatPlayer> _players =
+    private ImmutableDictionary<(ChatId ChatId, ChatPlayerKind PlayerKind), ChatPlayer> _players =
         ImmutableDictionary<(ChatId ChatId, ChatPlayerKind PlayerKind), ChatPlayer>.Empty;
     private readonly ConcurrentDictionary<ChatId, Moment> _listeningCatchUpAnchors = new();
     private ImmutableHashSet<ChatId> _listeningChatsBeforeReplay = ImmutableHashSet<ChatId>.Empty;
     private readonly MutableState<ReplayState?> _replayState;
     private readonly AudioFocusRequester _audioFocusRequester;
+    private readonly AudioFocusRequester _listeningFocusRequester;
     private AudioFocusScope? _audioFocusScope;
+    private AudioFocusScope? _listeningFocusScope;
     private int _audioFocusDenialCount;
+    // MutableState, not a plain flag: ShouldHoldListeningFocus reads it, and a focus-driven pause
+    // must keep that compute's hold/retry signal alive - a non-reactive read would freeze it.
+    private readonly MutableState<bool> _isListeningPausedByFocus;
 
-    // Advances on every refused acquisition - the state sync answers those by dropping the state.
-    public int AudioFocusDenialCount => Volatile.Read(ref _audioFocusDenialCount);
+    public int AudioFocusDenialCount
+        // Advances on every refused acquisition, listening bursts included: an advance inside a
+        // PTT wake window is what makes PttSessionCore fall back to a notification.
+        => Volatile.Read(ref _audioFocusDenialCount);
 
     // Compute methods
 
@@ -87,7 +94,8 @@ public partial class ChatAudioUI
         }
 
         var speed = ReplaySettings.Value.Speed;
-        DebugLog?.LogInformation("StartReplay: chatId={ChatId}, startAt={StartAt}, rewindOffset={RewindOffset}, speed={Speed}",
+        DebugLog?.LogInformation(
+            "StartReplay: chatId={ChatId}, startAt={StartAt}, rewindOffset={RewindOffset}, speed={Speed}",
             chatId, startAt, rewindOffset, speed);
 
         StopReplay();
@@ -138,7 +146,8 @@ public partial class ChatAudioUI
     public async Task<AudioFocusScope?> TryAcquireAudioFocus(string? reason = "")
     {
         if (_audioFocusScope is not null && !_audioFocusScope.IsSuspended) {
-            Log.LogInformation("Already have audio focus {Scope}. Request reason: '{Reason}'", _audioFocusScope, reason);
+            Log.LogInformation(
+                "Already have audio focus {Scope}. Request reason: '{Reason}'", _audioFocusScope, reason);
             return _audioFocusScope;
         }
 
@@ -154,6 +163,40 @@ public partial class ChatAudioUI
         _audioFocusScope = null;
     }
 
+    public async Task AcquireListeningFocus()
+    {
+        if (_listeningFocusScope is not null)
+            return; // Live, or suspended with its restore handler pending - either way, no re-request
+
+        if (AudioFocusUI.IsSuspended) {
+            // Another requester's focus is lost right now (e.g. a call over a paused replay).
+            // A renew from here would be denied, and a denied renew wipes that requester's
+            // pending restore - so hold playback instead and let the next transition retry.
+            PauseListeningPlayers();
+            return;
+        }
+
+        _listeningFocusScope = await AudioFocusUI.TryAcquire(_listeningFocusRequester).ConfigureAwait(false);
+        if (_listeningFocusScope is null) {
+            // No SetListeningState(false) here: a denial - e.g. during a real phone call - is
+            // transient, and the armed listening intent is exactly what retries on the next stream.
+            // Playback pauses too: a denied transient focus doesn't mute an AudioTrack, and chat
+            // speech must not play over whoever holds the focus.
+            Interlocked.Increment(ref _audioFocusDenialCount);
+            PauseListeningPlayers();
+            Log.LogWarning("AcquireListeningFocus: failed to gain audio focus");
+            return;
+        }
+
+        ResumeListeningPlayersPausedByFocus();
+    }
+
+    public void ReleaseListeningFocus()
+    {
+        _listeningFocusScope?.Dispose();
+        _listeningFocusScope = null;
+    }
+
     // Private player lifecycle methods
 
     private ChatPlayer GetOrCreatePlayer(ChatId chatId, ChatPlayerKind playerKind)
@@ -162,17 +205,21 @@ public partial class ChatAudioUI
         ChatPlayer newPlayer;
         lock (Lock) {
             var player = _players.GetValueOrDefault((chatId, playerKind));
-            if (player != null) {
-                DebugLog?.LogInformation("GetOrCreatePlayer: returning existing {PlayerKind} player for {ChatId}", playerKind, chatId);
+            if (player is not null) {
+                DebugLog?.LogInformation(
+                    "GetOrCreatePlayer: returning existing {PlayerKind} player for {ChatId}", playerKind, chatId);
                 return player;
             }
-            DebugLog?.LogInformation("GetOrCreatePlayer: creating new {PlayerKind} player for {ChatId}", playerKind, chatId);
+
+            DebugLog?.LogInformation(
+                "GetOrCreatePlayer: creating new {PlayerKind} player for {ChatId}", playerKind, chatId);
             newPlayer = playerKind switch {
                 ChatPlayerKind.Listening => new ChatListeningPlayer(Hub, chatId),
                 ChatPlayerKind.Replaying => new ChatReplayPlayer(Hub, chatId),
                 _ => throw new ArgumentOutOfRangeException(nameof(playerKind), playerKind, null),
             };
-            _players = _players.Add((chatId, playerKind), newPlayer);
+            // Publication for StopAllPlayers' lock-free read.
+            Volatile.Write(ref _players, _players.Add((chatId, playerKind), newPlayer));
         }
         if (playerKind is ChatPlayerKind.Replaying)
             using (Invalidation.Begin())
@@ -200,8 +247,8 @@ public partial class ChatAudioUI
             .Collect(ApiConstants.Concurrency.Unlimited);
 
     private Task StopAllPlayers()
-        // ReSharper disable once InconsistentlySynchronizedField
-        => _players
+        // Pairs with the Volatile.Write publication in GetOrCreatePlayer.
+        => Volatile.Read(ref _players)
             .Select(kv => StopPlayer(kv.Key.ChatId, kv.Key.PlayerKind))
             .Collect(ApiConstants.Concurrency.Unlimited);
 
@@ -251,6 +298,8 @@ public partial class ChatAudioUI
 
     private AudioFocusRestoreHandler? OnAudioFocusLost(bool mayRecover, bool canDuck)
     {
+        // Listening deliberately survives this: it holds no Playback focus anymore - incoming
+        // speech runs on the transient Listening scope, which recovers on its own per utterance.
         Log.LogInformation("OnAudioFocusLost: mayRecover={MayRecover}, canDuck={CanDuck}", mayRecover, canDuck);
         if (canDuck)
             return null; // Do not stop players. We don't support ducking so far, so just let it play, do nothing.
@@ -258,7 +307,6 @@ public partial class ChatAudioUI
         if (!mayRecover)
             _audioFocusScope = null;
 
-        _ = ClearListeningChats();
         var replayState = _replayState.Value;
         if (replayState is null || replayState.PausedAt.HasValue)
             return null;
@@ -273,6 +321,7 @@ public partial class ChatAudioUI
             if (chatReplayer is null)
                 return null;
         }
+
         PauseReplay(pausedAt);
         Log.LogInformation("OnAudioFocusLost: paused replayer for #{ChatId}", replayState.ChatId);
 
@@ -289,5 +338,43 @@ public partial class ChatAudioUI
                 Log.LogInformation("OnAudioFocusRestore: resumed replayer for #{ChatId}", currentState.ChatId);
             }
         };
+    }
+
+    private AudioFocusRestoreHandler? OnListeningFocusLost(bool mayRecover, bool canDuck)
+    {
+        // Listening stays armed on any loss; only playback is silenced, since a lost focus doesn't
+        // mute an AudioTrack and in-flight speech must not play over whoever took the focus.
+        Log.LogInformation("OnListeningFocusLost: mayRecover={MayRecover}, canDuck={CanDuck}", mayRecover, canDuck);
+        if (canDuck)
+            return null;
+
+        PauseListeningPlayers();
+        if (mayRecover) {
+            // The scope survives: the platform request stays registered, so the recover callback
+            // unsuspends it and this handler brings the paused players back.
+            return ResumeListeningPlayersPausedByFocus;
+        }
+
+        // A permanent loss never recovers - the scope would pin a dead platform request, so it
+        // goes now; ManageListeningFocusBursts re-acquires from scratch on the next stream.
+        ReleaseListeningFocus();
+        return null;
+    }
+
+    private void PauseListeningPlayers()
+    {
+        _isListeningPausedByFocus.Value = true;
+        foreach (var player in Volatile.Read(ref _players).Values.OfType<ChatListeningPlayer>())
+            player.Pause();
+    }
+
+    private void ResumeListeningPlayersPausedByFocus()
+    {
+        if (!_isListeningPausedByFocus.Value)
+            return;
+
+        _isListeningPausedByFocus.Value = false;
+        foreach (var player in Volatile.Read(ref _players).Values.OfType<ChatListeningPlayer>())
+            _ = player.Resume();
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -7,6 +7,9 @@ public partial class ChatAudioUI
 {
     private static readonly TimeSpan Epsilon = TimeSpan.FromMilliseconds(50);
     private static readonly TimeSpan MinListeningPlayerPlayDurationToConsiderHealthy = TimeSpan.FromSeconds(10);
+    // Long enough to bridge the gap between consecutive utterances of one conversation, so music
+    // isn't bounced on every pause in speech; short enough that it comes back in a real lull.
+    private static readonly TimeSpan ListeningFocusLinger = TimeSpan.FromSeconds(4);
     private static readonly int MaxStopRecordingTryCount = 3;
     private static readonly TimeSpan DiagnosticsTimeout = TimeSpan.FromSeconds(5);
 
@@ -21,6 +24,7 @@ public partial class ChatAudioUI
             AsyncChain.From(InvalidateReplayDependencies),
             AsyncChain.From(PushRecordingState),
             AsyncChain.From(StartStopListeningPlayers),
+            AsyncChain.From(ManageListeningFocusBursts),
             AsyncChain.From(StartStopReplayingPlayers),
             AsyncChain.From(StopReplayWhenRecordingStarts),
             AsyncChain.From(StopListeningWhenIdle),
@@ -365,14 +369,9 @@ public partial class ChatAudioUI
                 }
 
                 if (!addedChatIds.IsEmpty) {
-                    var audioFocusScope = await TryAcquireAudioFocus("Listening players").ConfigureAwait(false);
-                    if (audioFocusScope is null) {
-                        Log.LogWarning("ManageListeningPlayers: failed to gain audio focus");
-                        // Can't acquire focus; stop the newly requested chats
-                        foreach (var chatId in addedChatIds)
-                            await SetListeningState(chatId, false).ConfigureAwait(false);
-                        continue;
-                    }
+                    // No focus here: listening no longer owns one while idle. ManageListeningFocusBursts
+                    // takes a transient focus per incoming stream, so other apps' audio keeps playing
+                    // in the silence between utterances.
                     if (lastChatIds.IsEmpty)
                         _ = TuneUI.Play(Tune.StartListening);
                     foreach (var chatId in addedChatIds)
@@ -381,12 +380,8 @@ public partial class ChatAudioUI
                             cancellationToken);
                 }
 
-                if (newChatIds.IsEmpty && !lastChatIds.IsEmpty) {
+                if (newChatIds.IsEmpty && !lastChatIds.IsEmpty)
                     _ = TuneUI.Play(Tune.StopListening);
-                    // Release audio focus only if replay is also not active
-                    if (_replayState.Value is null)
-                        TryReleaseAudioFocus();
-                }
 
                 lastChatIds = newChatIds;
             }
@@ -452,6 +447,40 @@ public partial class ChatAudioUI
         }
     }
 
+    private async Task ManageListeningFocusBursts(CancellationToken cancellationToken)
+    {
+        // Playback itself doesn't wait for this focus: the acquire rides on the same server-side
+        // stream flag that starts the track, so it lands around the first frames. A denial is
+        // logged and retried on the next stream - it never disarms listening.
+        await WhenEnabled.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // A restart after a mid-hold crash would otherwise park in the wait below with the scope
+        // still held, keeping other apps' audio paused until the next burst cycle releases it.
+        ReleaseListeningFocus();
+        var cMustHold = await Computed
+            .Capture(() => ShouldHoldListeningFocus(cancellationToken), cancellationToken)
+            .ConfigureAwait(false);
+        while (true) {
+            cMustHold = await cMustHold.When(x => x, cancellationToken).ConfigureAwait(false);
+            await AcquireListeningFocus().ConfigureAwait(false);
+            while (true) {
+                cMustHold = await cMustHold.When(x => !x, cancellationToken).ConfigureAwait(false);
+                using var lingerCts = cancellationToken.CreateLinkedTokenSource();
+                lingerCts.CancelAfter(ListeningFocusLinger);
+                try {
+                    cMustHold = await cMustHold.When(x => x, lingerCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                    break; // The linger elapsed with no new stream - time to hand the focus back
+                }
+
+                // A new stream arrived within the linger; the scope may be gone if focus was lost
+                // mid-burst, and re-acquiring is exactly how the burst model recovers from that.
+                await AcquireListeningFocus().ConfigureAwait(false);
+            }
+            ReleaseListeningFocus();
+        }
+    }
+
     private async Task StartStopReplayingPlayers(CancellationToken cancellationToken)
     {
         await WhenEnabled.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -476,10 +505,8 @@ public partial class ChatAudioUI
                         foreach (var chatId in toRestore)
                             await SetListeningState(chatId, true).ConfigureAwait(false);
 
-                        // Release audio focus if no listening either
-                        var listeningChatIds = await GetListeningChatIds().ConfigureAwait(false);
-                        if (listeningChatIds.IsEmpty)
-                            TryReleaseAudioFocus();
+                        // Listening runs on its own transient focus now, so replay's ends with replay
+                        TryReleaseAudioFocus();
                     }
                     lastState = null;
                     continue;

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.cs
@@ -30,6 +30,8 @@ public partial class ChatAudioUI : UIWorkerBase<AppUIHub>, IComputeService, INot
     private IAuthors Authors => Hub.Authors;
     private LiveStreamUI LiveStreamUI => Hub.LiveStreamUI;
     private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
+    private ConnectivityUI ConnectivityUI => Hub.ConnectivityUI;
+    private IncomingVoiceActivityUI IncomingVoiceActivityUI => Hub.IncomingVoiceActivityUI;
     private ActiveChatsUI ActiveChatsUI => Hub.ActiveChatsUI;
     private IAudioInitializer AudioInitializer => Hub.AudioInitializer;
     private AudioFocusUI AudioFocusUI => Hub.AudioFocusUI;
@@ -89,6 +91,10 @@ public partial class ChatAudioUI : UIWorkerBase<AppUIHub>, IComputeService, INot
                 Category = StateCategories.Get(type, nameof(IsPttEnabledOnDevice)),
             });
         _audioFocusRequester = new AudioFocusRequester(AudioFocusMode.Playback, OnAudioFocusLost);
+        _listeningFocusRequester = new AudioFocusRequester(AudioFocusMode.Listening, OnListeningFocusLost);
+        _isListeningPausedByFocus = stateFactory.NewMutable(
+            false,
+            StateCategories.Get(type, nameof(ShouldHoldListeningFocus)));
     }
 
     void INotifyInitialized.Initialized()
@@ -191,9 +197,52 @@ public partial class ChatAudioUI : UIWorkerBase<AppUIHub>, IComputeService, INot
             .SilentAwait();
     }
 
+    [ComputeMethod]
+    public virtual async Task<bool> ShouldHoldListeningFocus(CancellationToken cancellationToken)
+    {
+        var chatIds = await GetListeningChatIds().ConfigureAwait(false);
+        // A focus-driven pause must not look like a user pause: suppressing these chats would
+        // freeze the hold/retry signal exactly while it's needed to re-acquire and resume them.
+        var isPausedByFocus = await _isListeningPausedByFocus.Use(cancellationToken).ConfigureAwait(false);
+        foreach (var chatId in chatIds) {
+            var playback = (await GetListeningPlayer(chatId, cancellationToken).ConfigureAwait(false))?.Playback;
+            if (playback is not null
+                && !isPausedByFocus
+                && await playback.IsPaused.Use(cancellationToken).ConfigureAwait(false))
+                continue; // The user paused this chat's audio, so its streams must not touch the focus
+
+            // Local playback is the authority on audibility: a wake catch-up plays past the live
+            // edge - or entirely after it - and the focus has to cover what's actually audible.
+            if (playback is not null && await playback.IsPlaying.Use(cancellationToken).ConfigureAwait(false))
+                return true;
+
+            // The live-edge hint leads the first decoded frames, pausing the music before speech starts
+            if (await HasIncomingRealtimeAudio(chatId, cancellationToken).ConfigureAwait(false))
+                return true;
+        }
+
+        return false;
+    }
+
+    [ComputeMethod]
+    public virtual async Task<bool> HasIncomingRealtimeAudio(ChatId chatId, CancellationToken cancellationToken)
+    {
+        // Guarded like LiveStreamUI's own compute methods: with the peer down the last server
+        // value is unreliable, and a flag frozen at true would hold the focus for the whole outage.
+        var isConnected = await ConnectivityUI.IsConnected.Use(cancellationToken).ConfigureAwait(false);
+        if (!isConnected)
+            return false;
+
+        // Own-author-filtered: the user's own recording must not grab the listening focus
+        return await IncomingVoiceActivityUI.HasIncomingVoice(chatId, cancellationToken).ConfigureAwait(false);
+    }
+
     [ComputeMethod] // Synced
     public virtual Task<ImmutableHashSet<ChatId>> GetListeningChatIds()
-        => Task.FromResult(ActiveChatsUI.ActiveChats.Value.Where(c => c.IsListening).Select(c => c.ChatId).ToImmutableHashSet());
+        => Task.FromResult(ActiveChatsUI.ActiveChats.Value
+            .Where(c => c.IsListening)
+            .Select(c => c.ChatId)
+            .ToImmutableHashSet());
 
     public ValueTask SetListeningState(ChatId chatId, bool mustListen)
     {

--- a/src/dotnet/UI.Blazor.App/Services/IncomingVoiceActivityUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/IncomingVoiceActivityUI.cs
@@ -81,19 +81,9 @@ public class IncomingVoiceActivityUI(AppUIHub hub)
         return snapshot;
     }
 
-    protected override Task OnRun(CancellationToken cancellationToken)
-    {
-        var retryDelays = RetryDelaySeq.Exp(0.1, 1);
-        return AsyncChain.From(TrackArmedChats)
-            .Log(LogLevel.Debug, Log)
-            .RetryForever(retryDelays, Log)
-            .RunIsolated(cancellationToken);
-    }
-
-    // Protected/internal methods
-
+    // Public so the listening-focus burst manager can share the own-author-filtered signal
     [ComputeMethod]
-    protected virtual async Task<bool> HasIncomingVoice(ChatId chatId, CancellationToken cancellationToken)
+    public virtual async Task<bool> HasIncomingVoice(ChatId chatId, CancellationToken cancellationToken)
     {
         var authorIds = await LiveStreamUI.GetAudioStreamingAuthorIds(chatId, cancellationToken).ConfigureAwait(false);
         if (authorIds.Count == 0)
@@ -102,6 +92,15 @@ public class IncomingVoiceActivityUI(AppUIHub hub)
         var ownAuthor = await Authors.GetOwn(Session, chatId, cancellationToken).ConfigureAwait(false);
         var ownAuthorId = ownAuthor?.Id ?? default;
         return authorIds.Any(id => id != ownAuthorId);
+    }
+
+    protected override Task OnRun(CancellationToken cancellationToken)
+    {
+        var retryDelays = RetryDelaySeq.Exp(0.1, 1);
+        return AsyncChain.From(TrackArmedChats)
+            .Log(LogLevel.Debug, Log)
+            .RetryForever(retryDelays, Log)
+            .RunIsolated(cancellationToken);
     }
 
     // Private methods

--- a/src/dotnet/UI.Blazor.App/Services/Playback/ChatListeningPlayer.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Playback/ChatListeningPlayer.cs
@@ -12,10 +12,9 @@ public sealed class ChatListeningPlayer : ChatPlayer
         => PlayerKind = ChatPlayerKind.Listening;
 
     public override void Pause()
-    {
-        _ = Playback.Pause(CancellationToken.None);
-        ChatAudioUI.TryReleaseAudioFocus();
-    }
+        // No focus release: IsPaused makes ShouldHoldListeningFocus skip this chat, so the burst
+        // manager hands the focus back after its linger - streams still arriving or not.
+        => _ = Playback.Pause(CancellationToken.None);
 
     public override async Task Resume()
     {
@@ -25,9 +24,9 @@ public sealed class ChatListeningPlayer : ChatPlayer
             return;
         }
 
-        if (!await ChatAudioUI.TryAcquireAudioFocusForResume(this).ConfigureAwait(false))
-            return;
-
+        // No direct focus acquire: the resumed playback flips ShouldHoldListeningFocus, and the
+        // burst manager takes the focus from there - a direct grab here leaked it when nothing
+        // was streaming, since only a completed burst cycle ever releases it.
         _ = Playback.Resume(default);
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/PttSessionCore.cs
+++ b/src/dotnet/UI.Blazor.App/Services/PttSessionCore.cs
@@ -142,8 +142,8 @@ public sealed class PttSessionCore(AppUIHub hub) : IDisposable
     public void WatchAudioFocus(
         int baselineDenialCount, ChatId chatId, PttPlatform platform, Func<Task> onDenied)
         => _ = BackgroundTask.Run(async () => {
-            // A denial makes ChatAudioUI.StateSync drop the replay/listening state it was just
-            // given, and nothing throws - so the wake would end in silence instead of a fallback.
+            // A denial drops replay state and pauses listening playback, and nothing throws -
+            // so the wake would end in silence instead of a fallback.
             try {
                 for (var i = 0; i < AudioFocusChecks; i++) {
                     await Task.Delay(AudioFocusCheckPeriod, _disposeCts.Token).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
+++ b/src/dotnet/UI.Blazor/Services/AudioFocusUI.cs
@@ -1,9 +1,12 @@
 namespace ActualChat.UI.Blazor.Services;
 
 /// <summary>
-/// Defines the type of audio activity for focus management.
+/// Defines the type of audio activity for focus management. Ordered by precedence:
+/// when several requesters are active, the highest mode wins. Listening is a transient
+/// per-utterance grab for incoming realtime speech, so other apps' audio resumes in the
+/// gaps; Playback is a user-initiated replay that holds focus for its whole duration.
 /// </summary>
-public enum AudioFocusMode { Tune, Playback, Recording }
+public enum AudioFocusMode { Tune, Listening, Playback, Recording }
 
 public delegate void AudioFocusRestoreHandler();
 
@@ -40,6 +43,10 @@ public abstract class AudioFocusScope : IDisposable
 public class AudioFocusUI : ProcessorBase
 {
     public virtual AudioFocusMode ActiveMode => AudioFocusMode.Tune;
+    public virtual bool IsSuspended
+        // True while the held focus is lost to another app and awaiting its recover callback.
+        // Requesting focus in that state is harmful: a denied renew wipes the pending restores.
+        => false;
     public virtual bool IsCommunicationFocus
         // Whether the focus we hold actually took the communication route. ActiveMode no longer
         // implies it: a recording under car projection asks for Media usage and stays in Normal.
@@ -79,7 +86,7 @@ public class AudioFocusUI : ProcessorBase
 
     // Nested types
 
-    private class FakeScope : AudioFocusScope
+    private sealed class FakeScope : AudioFocusScope
     {
         public static readonly FakeScope Instance = new();
 


### PR DESCRIPTION
## Problem

With Android Auto connected, realtime speech was inaudible and stayed dead: listening held a permanent media audio focus for its whole armed life (silencing car music/nav even in silence), and any focus loss ran `ClearListeningChats()` with no restore path — one focus blip from the car killed listening until manually re-enabled.

## Change

**Burst-scoped listening focus.** Idle listening holds no focus at all; focus exists only while incoming speech is audible.

- New `AudioFocusMode.Listening` → Android `GainTransient` + Media, so paused music/nav auto-resumes; Apple maps it like Playback (engines, session category).
- `ShouldHoldListeningFocus` drives acquire/release (+4s linger between utterances):
  - local playback is the authority on audibility (covers PTT catch-up tails that trail the live edge);
  - the server live-edge hint pre-acquires before first frames — own-author-filtered via `IncomingVoiceActivityUI.HasIncomingVoice` (made public) and `ConnectivityUI.IsConnected`-guarded so an outage can't latch the hold;
  - user-paused chats are excluded, so the media-notification Pause stops the focus bouncing.
- Focus loss/denial **pauses** the listening players and keeps the intent armed: transient loss resumes via the recover callback, permanent loss re-acquires on the next stream. No more play-over-a-call, no more dead listening.
- `MauiAudioFocusUI` hardening: disposed-scope guard (ported from `AppleAudioFocusUI`), identity-checked release, and an `IsSuspended` guard so an auto-acquire during someone else's suspension can't wipe a paused replay's restore handler.
- Replay and recording focus behavior unchanged.

## In-car behavior

| Situation | Focus | Music/nav |
|---|---|---|
| Listening armed, silence | none | plays |
| Incoming speech | transient | pauses, resumes ≤4s after speech ends |
| Focus stolen | intent kept | next utterance re-acquires |

## Testing

- Reviewed via /code-review (10 findings, all addressed in this commit).
- Needs a device pass in a real car: speech duck-in over Spotify, notification Pause mid-conversation, record-then-silence resume, phone call while listening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD3F1k18c9CwwdLmF2Eoya