### PR TITLE
Summarization: exclude removed entries + deferred conversation collapse

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -167,6 +167,13 @@ edited. The reason can be as short as whose decision it was.
   `Sentry`); it is the tab title itself here, not an incidental mention, but the
   exemption's rationale (brand names aren't translated) applies identically
 
+## src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+
+- L971 `public async Task RestoreNavbarSelectedGroup()`
+  — public method inside the `// Private methods` section — placement predates the
+  deferred-conversation-collapse branch and relocating it is unrelated churn.
+  NEEDS ALEX'S CALL
+
 ## src/dotnet/UI.Blazor.App/Services/LiveFoldMath.cs
 
 - L12 `public static long Advance(long lastFoldEndLid, long minVisibleLid, long streamingFloorLid, long tailFloorLid)`

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -865,7 +865,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         var dbEntries = await dbContext.ChatEntries.Where(x
                 => x.ChatId == chatId.Value
                 && x.Kind == 0
-                && x.LocalId > minLocalIdExclusive)
+                && x.LocalId > minLocalIdExclusive
+                && !x.IsRemoved)
             .OrderBy(x => x.LocalId)
             .Take(limit)
             .ToListAsync(cancellationToken)
@@ -2105,7 +2106,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         if (Invalidation.IsActive)
             return; // It just spawns other commands, so nothing to do here
 
-        var (entry, _, kind, _) = eventCommand;
+        var (entry, _, kind, oldEntry) = eventCommand;
         await ResumeContentIndexing(eventCommand, cancellationToken).ConfigureAwait(false);
 
         if (entry.IsContentStreaming)
@@ -2122,8 +2123,17 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             if (chat == null)
                 return;
 
-            if (chat.IsSummarized == false || kind == ChangeKind.Remove)
+            if (chat.IsSummarized == false)
                 return;
+
+            // Thread deletion soft-removes the parent thread-start entry via Change.Update(IsRemoved),
+            // and restore flips it back - both must refresh the covering summary.
+            var isRemovalOrRestore = kind == ChangeKind.Remove
+                || (kind == ChangeKind.Update && entry.IsRemoved != (oldEntry?.IsRemoved ?? false));
+            if (isRemovalOrRestore) {
+                await ResummarizeCoveringConversation().ConfigureAwait(false);
+                return;
+            }
 
             var endsAt = Moment.Max(entry.GetEndsAt(), Clocks.SystemClock.Now);
             await FlowHub
@@ -2143,6 +2153,31 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                         Settings.Summarization.ChatEntrySummarizationDelayQuanta)
                     .Schedule(cancellationToken)
                     .ConfigureAwait(false);
+        }
+
+        async Task ResummarizeCoveringConversation() {
+            // A removed entry must not linger in an already-persisted summary. The range isn't passed
+            // along: the flow coalesces a burst of removals and re-reads the range when it finally runs.
+            var lid = entry.LocalId;
+            var idTile = IdTileStack.LastLayer.GetTile(lid);
+            var rangeMeta = await ConversationsBackend
+                .GetRangeMeta(entry.ChatId, idTile.Range.Start, cancellationToken)
+                .ConfigureAwait(false);
+            var conversationRange = rangeMeta.ConversationLidRanges.FirstOrDefault(r => r.Contains(lid));
+            if (conversationRange.IsEmpty)
+                return;
+
+            var conversationId = ConversationId.New(entry.ChatId, conversationRange.Start);
+            var conversation = await ConversationsBackend.Get(conversationId, cancellationToken).ConfigureAwait(false);
+            if (conversation is null || !conversation.EntryLidRange.Contains(lid))
+                return; // Not persisted (e.g. a live session's synthetic range)
+
+            await FlowHub.NewResumeEvent<ConversationRefreshFlow>(conversationId.Value)
+                .WithDelay(
+                    Clocks.SystemClock.Now + Settings.Summarization.ResummarizationDelay,
+                    Settings.Summarization.ChatEntrySummarizationDelayQuanta)
+                .Schedule(cancellationToken)
+                .ConfigureAwait(false);
         }
     }
 

--- a/src/dotnet/Chat.Service/ConversationsBackend.cs
+++ b/src/dotnet/Chat.Service/ConversationsBackend.cs
@@ -327,8 +327,17 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
         var conversationId = ConversationId.New(chatId, startEntryLid);
         var entriesInfo = await GetTextEntries(chatId, entryIdRanges, cancellationToken).ConfigureAwait(false);
         var entries = entriesInfo.TextEntries;
-        if (entries.Count == 0)
+        if (entries.Count == 0) {
+            // Every entry in the range was removed - a summary of nothing must not survive, but a stale
+            // command whose range predates the conversation's growth must not delete the grown one.
+            var emptyExisting = await Get(conversationId, cancellationToken).ConfigureAwait(false);
+            if (emptyExisting is not null && emptyExisting.EndEntryLid <= endEntryLid) {
+                var removeCommand = new ConversationBackend_Change(
+                    conversationId, emptyExisting.Version, Change.Remove<ConversationDiff>());
+                await DbHub.Commander.Call(removeCommand, false, cancellationToken).ConfigureAwait(false);
+            }
             return default!;
+        }
 
         var firstEntry = entries.First();
         var lastEntry = entries.Last();
@@ -460,9 +469,12 @@ public class ConversationsBackend(IServiceProvider services) : DbServiceBase<Cha
         var textEntries = new List<ChatEntrySlim>();
         var attachments = new List<ChatEntryAttachment>();
         var attachmentCount = 0;
+        // Ranges sharing a tile fetch it more than once, so entries must be deduplicated
         var chatEntries = tiles
             .SelectMany(tile => tile.Entries)
             .Where(e => entryLidRanges.Any(r => r.Contains(e.LocalId)))
+            .DistinctBy(e => e.LocalId)
+            .OrderBy(e => e.LocalId)
             .ToArray();
         foreach (var entry in chatEntries) {
             textEntries.Add(new ChatEntrySlim(entry));

--- a/src/dotnet/Chat.Service/Flows/ConversationRefreshFlow.cs
+++ b/src/dotnet/Chat.Service/Flows/ConversationRefreshFlow.cs
@@ -1,0 +1,29 @@
+using ActualChat.Flows;
+using ActualChat.Queues;
+
+namespace ActualChat.Chat.Flows;
+
+/// <summary>
+/// Coalesces removal/restore-triggered resummarization: resume events for one conversation dedup by
+/// quantized time, so a burst of removals yields one summarizer run over the conversation's range
+/// as it exists at execution time.
+/// </summary>
+[Flow(ResumeTimeout = 60)]
+[DataContract, MessagePackObject(true)]
+public sealed partial class ConversationRefreshFlow : Flow<Unit>
+{
+    private IConversationsBackend ConversationsBackend => field ??= Services.GetRequiredService<IConversationsBackend>();
+    private ConversationId ConversationId => field ??= ConversationId.Parse(Id.Arguments);
+
+    protected override async ValueTask Resume(CancellationToken cancellationToken)
+    {
+        // Re-reading the range here rather than at enqueue time is the point: a conversation that grew
+        // or was re-summarized during the delay is refreshed as it exists now, never shrunk back.
+        var conversation = await ConversationsBackend.Get(ConversationId, cancellationToken).ConfigureAwait(false);
+        if (conversation is null)
+            return;
+
+        var summarize = new ConversationBackend_Summarize(ConversationId.ChatId, [conversation.EntryLidRange]);
+        await Services.Queues().Enqueue(summarize, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
+++ b/src/dotnet/Chat.Service/Module/ChatServiceModule.cs
@@ -197,6 +197,7 @@ public sealed class ChatServiceModule(IServiceProvider moduleServices)
             .Add<ConversationSplitMasterFlow>()
             .Add<ConversationSplitFlow>()
             .Add<LiveConversationSummaryFlow>()
+            .Add<ConversationRefreshFlow>()
             .Add<TranslationCleanupFlow>();
         if (Settings.IsChatContentItemIndexingEnabled)
             flows

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -230,8 +230,9 @@
         var hasFoldedEntries = isLive && !isVoiceOnly
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
-        // Awaited for the dependency; the value itself is read through IsConversationExpanded below.
+        // Awaited for the dependency; the values themselves are read through IsConversationExpanded below.
         await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
+        await ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(true);
         // Via ChatUI so this reads the same latched default the data layer does - the record's own
         // flag flips when a summary lands, and the two would then disagree for the session.
         var isExpanded = ChatUI.IsConversationExpanded(conversation);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -76,8 +76,9 @@
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
         var canExpand = isLive && !isVoiceOnly && rawLive is { SessionStartedAt: not null };
-        // Awaited for the dependency; the value itself is read through IsConversationExpanded below.
+        // Awaited for the dependency; the values themselves are read through IsConversationExpanded below.
         await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(true);
+        await ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(true);
         // Via ChatUI so this reads the same latched default the data layer does - the record's own
         // flag flips when a summary lands, and the two would then disagree for the session.
         var isExpanded = ChatUI.IsConversationExpanded(conversation);

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -109,9 +109,11 @@ public partial class ChatUI
     // it never fired - a whole session of 150-450ms rebuilds produced zero samples.
     private const long SlowBuildMs = 250;
 
-    private volatile ChatEntry? _audioRecordingEntry;
+    private ChatEntry? _audioRecordingEntry;
 
     private IImmutableSet<ConversationId> LastConversationExpansionOverrides { get; set; } =
+        ImmutableHashSet<ConversationId>.Empty;
+    private IImmutableSet<ConversationId> LastAutoExpandedConversations { get; set; } =
         ImmutableHashSet<ConversationId>.Empty;
 
     // Remembers each conversation's IsExpandedByDefault once its tile has been seen, so a conversation
@@ -298,6 +300,9 @@ public partial class ChatUI
         // NOTE: Changing what this requests? Review Prefetch - it warms these same calls in advance, and only
         // helps while its arguments still match the ones below.
         var startedAt = CpuTimestamp.Now;
+        // Read before the first await: everything this build later writes to the auto-expansion state
+        // is valid only for the visit it started in.
+        var autoExpansionEpoch = Volatile.Read(ref _autoExpansionEpoch);
         // Captured to detect a background stretch inside this build: GetData gates on visibility before
         // calling us, but the app can background AFTER that gate, and the in-flight RPCs below then don't
         // complete until it returns - which would land the whole background period in the live phase.
@@ -461,7 +466,8 @@ public partial class ChatUI
                     .EnsureMonotonic()
                     .ToList();
                 var navigateToId = dataQuery.Navigation.EntryLid;
-                var index = conversationRanges.AsSpan().BinarySearch(r => r.Contains(navigateToId) || r.Start > navigateToId);
+                var index = conversationRanges.AsSpan()
+                    .BinarySearch(r => r.Contains(navigateToId) || r.Start > navigateToId);
                 if (index >= 0) {
                     var conversationRange = conversationRanges[index];
                     if (conversationRange.Contains(navigateToId)) {
@@ -471,9 +477,13 @@ public partial class ChatUI
                         // later with a different one would invert the very expansion this just arranged.
                         _knownConversationDefaultExpanded.TryAdd(conversationId, false);
                         var overrides0 = ConversationExpansionOverrides.Value;
-                        var isExpanded = defaultExpanded.Contains(conversationId) ^ overrides0.Contains(conversationId);
+                        var isOverridden = overrides0.Contains(conversationId);
+                        // An auto-expanded conversation already renders expanded, and stacking an override
+                        // on it would break the "auto set implies no override" invariant the toggle relies on.
+                        var isExpanded = (defaultExpanded.Contains(conversationId) ^ isOverridden)
+                            || _autoExpandedConversations.Value.Contains(conversationId);
                         if (!isExpanded) {
-                            var newOverrides = overrides0.Contains(conversationId)
+                            var newOverrides = isOverridden
                                 ? overrides0.Remove(conversationId)
                                 : overrides0.Add(conversationId);
                             _conversationExpansionOverrides.Value = newOverrides;
@@ -510,15 +520,63 @@ public partial class ChatUI
             }
 
             var overrides = await ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
+            var autoExpanded = await AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
+            // Acquired without Lock - what decides whether this build may act on the result is the
+            // chat-id + epoch pair re-checked under Lock below, not which visit the set came from.
+            var witnessedLids = Volatile.Read(ref _witnessedLids);
+            if (!isPrefetch && witnessedLids != null) {
+                var newAutoExpansions = GetNewAutoExpansions(
+                    chatId: chatId,
+                    conversationLidRanges: chatRangeMetaList
+                        .SelectMany(m => m.ConversationLidRanges)
+                        .EnsureMonotonic(),
+                    defaultExpanded: defaultExpanded,
+                    overrides: overrides,
+                    autoExpanded: autoExpanded,
+                    isSuppressed: id => _suppressedAutoExpansions.ContainsKey(id),
+                    witnessedLids: witnessedLids,
+                    liveBlockId: liveBlockId,
+                    materializedBlockId: materializedBlockId);
+                if (newAutoExpansions.Count > 0) {
+                    // Re-read under the lock and re-check suppression: a concurrent collapse gesture
+                    // suppresses before it removes, so filtering on the fresh suppression set is what
+                    // keeps this union from resurrecting an id the user just collapsed.
+                    lock (Lock) {
+                        // ClearAutoExpansionState bumps the epoch under this same lock, so a build that
+                        // began in an earlier visit cannot resurrect that visit's auto-expansions - not
+                        // even when the user left and came back to this very chat.
+                        if (_selectedChatId.Value == chatId
+                            && autoExpansionEpoch == Volatile.Read(ref _autoExpansionEpoch)) {
+                            var updated = _autoExpandedConversations.Value.Union(
+                                newAutoExpansions.Where(id => !_suppressedAutoExpansions.ContainsKey(id)));
+                            // A gesture-path removal is lock-free by design and can race this union, so
+                            // suppress-before-remove makes subtracting suppressed ids here the self-heal.
+                            var lostRemovals = updated
+                                .Where(id => _suppressedAutoExpansions.ContainsKey(id))
+                                .ToList();
+                            if (lostRemovals.Count > 0)
+                                updated = updated.Except(lostRemovals);
+                            autoExpanded = updated;
+                            _autoExpandedConversations.Value = updated;
+                        }
+                    }
+                }
+            }
+
+            expandedConversations = defaultExpanded.SymmetricExcept(overrides).Union(autoExpanded);
             // A prefetch is a speculative background load nothing renders, so it must not consume the
-            // one-shot "just toggled" signal - the rebuild that does render would then never widen its
-            // window to the toggled conversation, and the entries it just revealed would never load.
+            // one-shot "just changed" signal - the rebuild that does render would then never widen its
+            // window to the affected conversation, and the entries it just revealed would never load.
+            // The auto set is watched alongside the overrides because auto-expansion and the toggle's
+            // auto-collapse branch never touch the overrides at all.
             if (!isPrefetch) {
-                var changedOverrides = overrides.SymmetricExcept(LastConversationExpansionOverrides)
+                var changedIds = overrides.SymmetricExcept(LastConversationExpansionOverrides)
+                    .Union(autoExpanded.SymmetricExcept(LastAutoExpandedConversations))
                     .OrderBy(c => c.StartEntryLid)
                     .ToList();
                 LastConversationExpansionOverrides = overrides;
-                if (changedOverrides.FirstOrDefault() is { } toggledId)
+                LastAutoExpandedConversations = autoExpanded;
+                if (changedIds.FirstOrDefault() is { } toggledId)
                     // Extend the data query to cover the toggled conversation's entries. It must extend,
                     // not replace: a conversation's start sits above everything it contains, so collapsing
                     // the one you're reading at the chat's tail would otherwise re-centre the window
@@ -532,7 +590,6 @@ public partial class ChatUI
                     };
             }
 
-            expandedConversations = defaultExpanded.SymmetricExcept(overrides);
             // The tail is hidden exactly while the card stands in for it - i.e. while the block renders
             // collapsed, which is the same test the fold uses. Keyed on whether the viewer had joined
             // instead, a joined viewer could not collapse the block at all: nothing left the screen.
@@ -745,6 +802,69 @@ public partial class ChatUI
         }
 
         var groupedItems = GroupAuthorMessages(items);
+
+        if (!isPrefetch) {
+            var visibleLidRange = dataQuery.VisibleLidRange;
+            // Only the has-query branch of GetChatDataQuery pins VisibleLidRange, so on a quiet visit
+            // (no query, retained data) it arrives empty - fall back to the state ChatView derives it
+            // from, or the feature never witnesses anything. Read .Value, not .Use(): a Fusion
+            // dependency on ItemVisibility would rebuild the whole chat on every scroll.
+            if (visibleLidRange.IsEmpty
+                && _itemVisibility.Value is { IsEmpty: false } itemVisibility
+                && itemVisibility.ChatId == chatId
+                && itemVisibility.MaxEntryLid >= 0)
+                // MinMessageLid (placeholders included) vs MaxEntryLid (excluded) is deliberate: a low
+                // start only over-witnesses lids the collapsedRanges filter below screens out anyway,
+                // while MaxMessageLid's synthetic tail lids would witness entries that don't exist yet
+                visibleLidRange = new Range<long>(itemVisibility.MinMessageLid, itemVisibility.MaxEntryLid + 1);
+            if (!visibleLidRange.IsEmpty) {
+                // "Rendered as a row" is not by itself proof the user saw the entry: a transitional build
+                // served from last-known range meta can leak boundary entries of a collapsed conversation
+                // into ChatItems alongside its card. So coverage is decided the way the rule decides it -
+                // from the conversation ranges, not from the item list. Live/materialized block ids are
+                // deliberately not excluded here: a participant's live entries must stay witnessable, or
+                // the conversation materialized from that block would collapse under them.
+                // No EnsureMonotonic here (unlike the rule's input): a dropped duplicate would only
+                // under-filter, and Contains checks don't need ordering
+                var collapsedRanges = chatRangeMetaList
+                    .SelectMany(m => m.ConversationLidRanges)
+                    .Where(r => {
+                        var conversationId = ConversationId.New(chatId, r.Start);
+                        return conversationId != liveBlockId
+                            && conversationId != materializedBlockId
+                            && !expandedConversations.Contains(conversationId);
+                    })
+                    .ToList();
+                // The chat-id and epoch checks live inside the lock ClearAutoExpansionState bumps the epoch
+                // under, so they are atomic with the writes below: a build that began in the previous visit
+                // to this same chat cannot witness its rows into the fresh one, resurrecting the
+                // auto-expansions the return just cleared. The loop is bounded by the visible rows and
+                // awaits nothing; LidRangeSet's own lock only ever nests underneath this one.
+                lock (Lock) {
+                    if (_selectedChatId.Value == chatId
+                        && autoExpansionEpoch == Volatile.Read(ref _autoExpansionEpoch)) {
+                        // The range is half-open - ChatView builds its end as MaxMessageLid + 1 - so End
+                        // itself is one row below the fold and must not be witnessed. Leaves come in
+                        // ascending lid order.
+                        var witnessed = _witnessedLids;
+                        if (witnessed == null) {
+                            witnessed = new LidRangeSet();
+                            // Released so the lock-free read in the auto-expansion pass sees it built
+                            Volatile.Write(ref _witnessedLids, witnessed);
+                        }
+                        foreach (var message in groupedItems.SelectMany(i => i.GetLeafMessages())) {
+                            if (message.Id >= visibleLidRange.End)
+                                break;
+
+                            if (message is ChatEntryMessage
+                                && message.Id >= visibleLidRange.Start
+                                && !collapsedRanges.Any(r => r.Contains(message.Id)))
+                                witnessed.Add(new Range<long>(message.Id, message.Id + 1));
+                        }
+                    }
+                }
+            }
+        }
 
         if (!isPrefetch) {
             var totalMs = (long)startedAt.Elapsed.TotalMilliseconds;
@@ -1368,11 +1488,11 @@ public partial class ChatUI
         if (!isRecordingInTheChat) {
             // Cleared rather than just skipped: the next session in this chat would otherwise be handed
             // this same entry back, carrying the BeginsAt and ClientUid of the one that has ended.
-            _audioRecordingEntry = null;
+            Volatile.Write(ref _audioRecordingEntry, null);
             return null;
         }
 
-        var chatEntry = _audioRecordingEntry;
+        var chatEntry = Volatile.Read(ref _audioRecordingEntry);
         if (chatEntry?.ChatId == chatId)
             return chatEntry; // Cache chat entry to enable reusing MessageView.
 
@@ -1391,7 +1511,7 @@ public partial class ChatUI
             ClientUid = Guid.NewGuid().ToString(),
         };
         // Owner.RegisterEntryByClientId(chatEntry);
-        _audioRecordingEntry = chatEntry;
+        Volatile.Write(ref _audioRecordingEntry, chatEntry);
         return chatEntry;
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -26,6 +26,11 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private readonly StoredState<IImmutableDictionary<string, ChatId>> _selectedChatIds;
     private readonly MutableState<ChatEntryId?> _highlightedEntryId;
     private readonly MutableState<IImmutableSet<ConversationId>> _conversationExpansionOverrides;
+    private readonly MutableState<IImmutableSet<ConversationId>> _autoExpandedConversations;
+    // Holds the selected chat's lids only - ClearAutoExpansionState drops it on every chat change
+    private LidRangeSet? _witnessedLids;
+    private readonly ConcurrentDictionary<ConversationId, Unit> _suppressedAutoExpansions = new();
+    private int _autoExpansionEpoch;
     private ChatId? _searchEnabledChatId;
     private List<ChatId>? _pendingSelectedChatIds = new();
 
@@ -60,6 +65,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     public IState<IImmutableDictionary<string, ChatId>> SelectedChatIds => _selectedChatIds;
     public IState<ChatEntryId?> HighlightedEntryId => _highlightedEntryId;
     public IState<IImmutableSet<ConversationId>> ConversationExpansionOverrides => _conversationExpansionOverrides;
+    public IState<IImmutableSet<ConversationId>> AutoExpandedConversations => _autoExpandedConversations;
     public Task WhenReady => _selectedChatId.WhenRead;
     public IState<ChatViewItemVisibility> ItemVisibility => _itemVisibility;
 
@@ -92,6 +98,9 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         _conversationExpansionOverrides = StateFactory.NewMutable(
             (IImmutableSet<ConversationId>)ImmutableHashSet<ConversationId>.Empty,
             StateCategories.Get(type, nameof(ConversationExpansionOverrides)));
+        _autoExpandedConversations = StateFactory.NewMutable(
+            (IImmutableSet<ConversationId>)ImmutableHashSet<ConversationId>.Empty,
+            StateCategories.Get(type, nameof(AutoExpandedConversations)));
         _itemVisibility = StateFactory.NewMutable(
             ChatViewItemVisibility.Empty,
             StateCategories.Get(type, nameof(ItemVisibility)));
@@ -458,14 +467,24 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         if (Hub.LiveBlockUI.TryCollapseOverlay(conversationId))
             return;
 
-        // Membership here flips a conversation's expansion away from its IsExpandedByDefault, so the
-        // toggle works regardless of which default (expanded/collapsed) the conversation carries.
-        var overrides = _conversationExpansionOverrides.Value;
-        var mustRemove = overrides.Contains(conversationId);
-        overrides = mustRemove
-            ? overrides.Remove(conversationId)
-            : overrides.Add(conversationId);
-        _conversationExpansionOverrides.Value = overrides;
+        // ResetReveal takes LiveBlockUI's lock, so it stays outside this one - a ChatUI -> LiveBlockUI
+        // lock edge would invert the one TryCollapseOverlay acquires in the other direction.
+        lock (Lock) {
+            var isAutoExpanded = SuppressAutoExpansion(conversationId);
+            var overrides = _conversationExpansionOverrides.Value;
+            var isOverridden = overrides.Contains(conversationId);
+            // Membership here flips a conversation's expansion away from its IsExpandedByDefault, so the
+            // toggle works regardless of which default the conversation carries. Dropping the auto entry
+            // is the whole collapse only while nothing else expands it - the latched default is written
+            // once by whoever sees the conversation first, so it can land as expanded after the rule
+            // recorded the auto-expansion, and flipping then would re-expand what just collapsed.
+            var isExpandedWithoutAuto =
+                _knownConversationDefaultExpanded.GetValueOrDefault(conversationId) ^ isOverridden;
+            if (!isAutoExpanded || isExpandedWithoutAuto)
+                _conversationExpansionOverrides.Value = isOverridden
+                    ? overrides.Remove(conversationId)
+                    : overrides.Add(conversationId);
+        }
         Hub.LiveBlockUI.ResetReveal(conversationId.ChatId);
     }
 
@@ -478,18 +497,8 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             conversation.Id,
             static (_, c) => c.IsExpandedByDefault,
             conversation);
-        return isExpandedByDefault ^ _conversationExpansionOverrides.Value.Contains(conversation.Id);
-    }
-
-    internal void EnsureConversationCollapsed(ConversationId conversationId, bool isExpandedByDefault)
-    {
-        // The caller's flag is the template's close-time value; the effective state is computed from the
-        // latched one, and keying the override off the wrong one leaves the block expanded.
-        var latched = _knownConversationDefaultExpanded.GetOrAdd(conversationId, isExpandedByDefault);
-        var overrides = _conversationExpansionOverrides.Value;
-        _conversationExpansionOverrides.Value = latched
-            ? overrides.Add(conversationId)
-            : overrides.Remove(conversationId);
+        return (isExpandedByDefault ^ _conversationExpansionOverrides.Value.Contains(conversation.Id))
+            || _autoExpandedConversations.Value.Contains(conversation.Id);
     }
 
     // This method fixes provided ChatId w/ PeerChatId.FixOwnerId, which replaces
@@ -573,6 +582,69 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         await _viewPositionStates.DisposeAsync().ConfigureAwait(false);
     }
 
+    // Protected/internal methods
+
+    internal void EnsureConversationCollapsed(ConversationId conversationId, bool isExpandedByDefault)
+    {
+        SuppressAutoExpansion(conversationId);
+        // The caller's flag is the template's close-time value; the effective state is computed from the
+        // latched one, and keying the override off the wrong one leaves the block expanded.
+        var latched = _knownConversationDefaultExpanded.GetOrAdd(conversationId, isExpandedByDefault);
+        var overrides = _conversationExpansionOverrides.Value;
+        _conversationExpansionOverrides.Value = latched
+            ? overrides.Add(conversationId)
+            : overrides.Remove(conversationId);
+    }
+
+    internal bool SuppressAutoExpansion(ConversationId conversationId)
+    {
+        // Returns whether an auto-expansion was dropped - for the toggle, that removal IS the collapse.
+        // Called on its own for ids whose IsExpandedByDefault isn't knowable: a frozen block's render id
+        // has no conversation behind it once materialized, so normalizing its override would expand it.
+        _suppressedAutoExpansions[conversationId] = default;
+        var autoExpanded = _autoExpandedConversations.Value;
+        var isAutoExpanded = autoExpanded.Contains(conversationId);
+        if (isAutoExpanded)
+            _autoExpandedConversations.Value = autoExpanded.Remove(conversationId);
+        return isAutoExpanded;
+    }
+
+    internal static List<ConversationId> GetNewAutoExpansions(
+        ChatId chatId,
+        IEnumerable<Range<long>> conversationLidRanges,
+        IImmutableSet<ConversationId> defaultExpanded,
+        IImmutableSet<ConversationId> overrides,
+        IImmutableSet<ConversationId> autoExpanded,
+        Func<ConversationId, bool> isSuppressed,
+        LidRangeSet witnessedLids,
+        ConversationId? liveBlockId,
+        ConversationId? materializedBlockId)
+    {
+        // A conversation that appeared (or grew) over rows the user has actually seen this visit must
+        // not swallow them in place; it auto-expands until the user leaves the chat. Live/materialized
+        // block ids are excluded - the live overlay machinery owns their expansion. An id carrying a
+        // manual override is excluded too: suppression dies with the visit but the override doesn't,
+        // so without this an earlier visit's deliberate collapse would be undone by later range growth.
+        var result = new List<ConversationId>();
+        foreach (var range in conversationLidRanges) {
+            var conversationId = ConversationId.New(chatId, range.Start);
+            if (conversationId == liveBlockId || conversationId == materializedBlockId)
+                continue;
+            if (autoExpanded.Contains(conversationId)
+                || isSuppressed(conversationId)
+                || overrides.Contains(conversationId))
+                continue;
+
+            var isExpanded = defaultExpanded.Contains(conversationId) ^ overrides.Contains(conversationId);
+            if (isExpanded)
+                continue;
+
+            if (witnessedLids.Intersects(range))
+                result.Add(conversationId);
+        }
+        return result;
+    }
+
     // Private methods
 
     private bool SelectChatInternal(ChatId? chatId)
@@ -590,9 +662,23 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
                 else
                     _pendingSelectedChatIds.Add(chatId);
             }
+            ClearAutoExpansionState();
             selectedChatId.Value = chatId; // "Resumes" InvalidateSelectedChatDependencies, which does the rest
             return true;
         }
+    }
+
+    private void ClearAutoExpansionState()
+    {
+        // Bumped first, and before the wipes: an in-flight build snapshots the epoch at its start, so
+        // moving it here is what tells that build its results belong to a visit that's already over -
+        // including the leave-and-return-to-the-same-chat case, where a chat-id check still matches.
+        Interlocked.Increment(ref _autoExpansionEpoch);
+        // Released, not just written under Lock: the auto-expansion pass reads this field lock-free.
+        Volatile.Write(ref _witnessedLids, null);
+        _suppressedAutoExpansions.Clear();
+        if (_autoExpandedConversations.Value.Count != 0)
+            _autoExpandedConversations.Value = ImmutableHashSet<ConversationId>.Empty;
     }
 
     private bool SelectPlaceInternal(PlaceId? placeId)

--- a/src/dotnet/UI.Blazor.App/Services/LidRangeSet.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LidRangeSet.cs
@@ -1,0 +1,63 @@
+namespace ActualChat.UI.Blazor.App.Services;
+
+/// <summary>
+/// Thread-safe accumulator of half-open <c>[Start, End)</c> lid ranges, merged on insert.
+/// </summary>
+internal sealed class LidRangeSet
+{
+    private readonly Lock _lock = new();
+    private readonly List<Range<long>> _ranges = new();
+
+    public void Add(Range<long> range)
+    {
+        if (range.IsEmptyOrNegative)
+            return;
+
+        lock (_lock) {
+            var index = -1;
+            for (var i = 0; i < _ranges.Count; i++) {
+                if (_ranges[i].End >= range.Start) {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0) {
+                _ranges.Add(range);
+                return;
+            }
+
+            if (_ranges[index].Start > range.End) {
+                _ranges.Insert(index, range);
+                return;
+            }
+
+            // Overlaps or touches _ranges[index]; absorb every subsequent range it reaches
+            var merged = _ranges[index].MinMaxWith(range);
+            var endIndex = index + 1;
+            while (endIndex < _ranges.Count && _ranges[endIndex].Start <= merged.End) {
+                merged = merged.MinMaxWith(_ranges[endIndex]);
+                endIndex++;
+            }
+            _ranges[index] = merged;
+            _ranges.RemoveRange(index + 1, endIndex - index - 1);
+        }
+    }
+
+    public bool Intersects(Range<long> range)
+    {
+        if (range.IsEmptyOrNegative)
+            return false;
+
+        lock (_lock) {
+            foreach (var r in _ranges) {
+                if (r.Start >= range.End)
+                    return false;
+                if (r.Overlaps(range))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -163,6 +163,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
                 chatState.WasAttending = false;
                 chatState.State.Value = chatState.State.Value with { WasAttending = false };
+                if (t.LiveRenderId != t.MaterializedId)
+                    Hub.ChatUI.SuppressAutoExpansion(t.LiveRenderId);
                 Hub.ChatUI.EnsureConversationCollapsed(t.MaterializedId, t.IsExpandedByDefault);
                 return true;
             }

--- a/tests/Chat.IntegrationTests/ConversationSummarizationTest.cs
+++ b/tests/Chat.IntegrationTests/ConversationSummarizationTest.cs
@@ -1,5 +1,9 @@
 using ActualChat.Chat.ML;
+using ActualChat.Chat.Module;
+using ActualChat.Module;
+using ActualChat.Queues;
 using ActualChat.Testing.Host;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ActualChat.Chat.IntegrationTests;
 
@@ -8,7 +12,7 @@ public class ConversationSummarizationTest(ChatCollection.AppHostFixture fixture
     : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
 {
     [Fact]
-    public void LimitsMentionsToKnownAuthors()
+    public void ShouldLimitMentionsToKnownAuthors()
     {
         // arrange
         var chatId = ChatId.Parse("the-actual-one");
@@ -32,7 +36,7 @@ public class ConversationSummarizationTest(ChatCollection.AppHostFixture fixture
     }
 
     [Fact]
-    public void CapsConversationSummaryOutputLength()
+    public void ShouldCapConversationSummaryOutputLength()
     {
         // arrange
         var input = new ConversationSummary(
@@ -51,22 +55,22 @@ public class ConversationSummarizationTest(ChatCollection.AppHostFixture fixture
     [Fact]
     public async Task ShouldResolveChatDialogFormatter()
     {
-        // Resolve IChatDialogFormatter — fails if registration is missing
+        // act
         var formatter = AppHost.Services.GetRequiredService<IChatDialogFormatter>();
+
+        // assert
         formatter.Should().NotBeNull();
     }
 
     [Fact]
     public async Task ShouldFormatAndSummarizeEntries()
     {
+        // arrange
         await using var tester = AppHost.NewBlazorTester(Out);
         await tester.SignInAsUniqueBob();
         var session = tester.Session;
         var commander = tester.Commander;
-
         var (chatId, _) = await tester.CreateChat(true);
-
-        // Post messages
         var messages = new[] { "Hello everyone!", "How is the project going?", "Let's discuss the roadmap." };
         var entries = new List<ChatEntry>();
         foreach (var message in messages) {
@@ -74,19 +78,180 @@ public class ConversationSummarizationTest(ChatCollection.AppHostFixture fixture
             var entry = await commander.Call(cmd);
             entries.Add(entry);
         }
-
         var textEntries = entries.Select(e => new ChatEntrySlim(e)).ToList();
 
-        // Test ChatDialogFormatter
+        // act
         var formatter = tester.AppServices.GetRequiredService<IChatDialogFormatter>();
         var formatted = await formatter.EntriesToText(textEntries);
-        foreach (var msg in messages)
-            formatted.Should().Contain(msg);
-
-        // Test ConversationSummarizer (uses stub in test env)
         var summarizer = tester.AppServices.GetRequiredService<IConversationSummarizer>();
         var result = await summarizer.Summarize(textEntries, default);
+
+        // assert
+        foreach (var msg in messages)
+            formatted.Should().Contain(msg);
         result.HasResult.Should().BeTrue();
         result.Summary.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ShouldExcludeRemovedEntriesFromListNewEntries()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var (chatId, _) = await tester.CreateChat(true);
+        var entries = await tester.CreateTextEntries(chatId, "message", 3);
+        var removedEntry = entries[1];
+        await tester.RemoveTextEntry(removedEntry.Id);
+
+        // act
+        var chatsBackend = tester.AppServices.GetRequiredService<IChatsBackend>();
+        var listed = await chatsBackend.ListNewEntries(chatId, 0, 100, default);
+
+        // assert
+        var listedLids = listed.Select(e => e.LocalId).ToArray();
+        listedLids.Should().NotContain(removedEntry.LocalId);
+        listedLids.Should().Contain(entries[0].LocalId);
+        listedLids.Should().Contain(entries[2].LocalId);
+    }
+
+    [Fact]
+    public async Task ShouldExcludeRemovedEntriesFromSummary()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var (chatId, _) = await tester.CreateChat(true);
+        var entries = await tester.CreateTextEntries(chatId, "message", 3);
+        // One-per-entry lid ranges keep async system entries (e.g. "joined") out of the count
+        var lidRanges = entries
+            .Select(e => new Range<long>(e.LocalId, e.LocalId + 1))
+            .ToArray();
+        await tester.RemoveTextEntry(entries[1].Id);
+
+        // act
+        var commander = tester.AppServices.Commander();
+        var conversation = await commander.Call(new ConversationBackend_Summarize(chatId, lidRanges));
+
+        // assert
+        conversation.MessageCount.Should().Be(2);
+        conversation.AuthorIds.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldRemoveConversationWhenAllItsEntriesAreRemoved()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var (chatId, _) = await tester.CreateChat(true);
+        var entries = await tester.CreateTextEntries(chatId, "message", 2);
+        var lidRanges = entries
+            .Select(e => new Range<long>(e.LocalId, e.LocalId + 1))
+            .ToArray();
+        var commander = tester.AppServices.Commander();
+        var conversation = await commander.Call(new ConversationBackend_Summarize(chatId, lidRanges));
+        conversation.Should().NotBeNull();
+        var conversationsBackend = tester.AppServices.GetRequiredService<IConversationsBackend>();
+
+        // act
+        foreach (var entry in entries)
+            await tester.RemoveTextEntry(entry.Id);
+        await commander.Call(new ConversationBackend_Summarize(chatId, lidRanges));
+
+        // assert
+        var removed = await conversationsBackend.Get(conversation.Id, default);
+        removed.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ShouldResummarizeConversationOnEntryRemoval()
+    {
+        // arrange
+        await using var appHost = await NewAppHost("resummarize-on-delete", options => options with {
+            UseNatsQueues = false,
+            ConfigureHost = (_, cfg) => {
+                cfg.AddInMemory<ChatSettings>((x => x.IsSummarizationEnabled, "true"));
+                cfg.AddInMemory<CoreServerSettings>((x => x.OpenAIKey, "test-key"));
+                var delayKey = $"{nameof(ChatSettings)}:{nameof(ChatSettings.Summarization)}"
+                    + $":{nameof(SummarizationSettings.ResummarizationDelay)}";
+                cfg.AddInMemoryCollection((delayKey, "00:00:01"));
+                // The flow route quantizes the delay, so the default 1-minute quanta must shrink too
+                var quantaKey = $"{nameof(ChatSettings)}:{nameof(ChatSettings.Summarization)}"
+                    + $":{nameof(SummarizationSettings.ChatEntrySummarizationDelayQuanta)}";
+                cfg.AddInMemoryCollection((quantaKey, "00:00:01"));
+            },
+            ConfigureServices = (_, services) => {
+                services.Replace(ServiceDescriptor.Singleton<IConversationSummarizer, ConversationSummarizerStub>());
+            },
+        });
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var (chatId, _) = await tester.CreateChat(true);
+        var entries = await tester.CreateTextEntries(chatId, "message", 3);
+        // Let async follow-up commands (e.g. the system "joined" entry) settle: the removal-triggered
+        // resummary walks the conversation's contiguous lid range, so a late entry would shift counts
+        await appHost.Services.Queues().WhenProcessing(TimeSpan.FromSeconds(1), default);
+        var lidRange = new Range<long>(entries[0].LocalId, entries[2].LocalId + 1);
+        var commander = tester.AppServices.Commander();
+        var conversation = await commander.Call(new ConversationBackend_Summarize(chatId, [lidRange]));
+        var baselineCount = conversation.MessageCount;
+        baselineCount.Should().BeGreaterThanOrEqualTo(3);
+        var conversationsBackend = tester.AppServices.GetRequiredService<IConversationsBackend>();
+
+        // act
+        await tester.RemoveTextEntry(entries[1].Id);
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var updated = await conversationsBackend.Get(conversation.Id, ct);
+            updated.Should().NotBeNull();
+            updated!.MessageCount.Should().Be(baselineCount - 1);
+        }, TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task ShouldResummarizeConversationOnSoftEntryRemoval()
+    {
+        // arrange
+        await using var appHost = await NewAppHost("resummarize-on-soft-delete", options => options with {
+            UseNatsQueues = false,
+            ConfigureHost = (_, cfg) => {
+                cfg.AddInMemory<ChatSettings>((x => x.IsSummarizationEnabled, "true"));
+                cfg.AddInMemory<CoreServerSettings>((x => x.OpenAIKey, "test-key"));
+                var delayKey = $"{nameof(ChatSettings)}:{nameof(ChatSettings.Summarization)}"
+                    + $":{nameof(SummarizationSettings.ResummarizationDelay)}";
+                cfg.AddInMemoryCollection((delayKey, "00:00:01"));
+                var quantaKey = $"{nameof(ChatSettings)}:{nameof(ChatSettings.Summarization)}"
+                    + $":{nameof(SummarizationSettings.ChatEntrySummarizationDelayQuanta)}";
+                cfg.AddInMemoryCollection((quantaKey, "00:00:01"));
+            },
+            ConfigureServices = (_, services) => {
+                services.Replace(ServiceDescriptor.Singleton<IConversationSummarizer, ConversationSummarizerStub>());
+            },
+        });
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var (chatId, _) = await tester.CreateChat(true);
+        var entries = await tester.CreateTextEntries(chatId, "message", 3);
+        await appHost.Services.Queues().WhenProcessing(TimeSpan.FromSeconds(1), default);
+        var lidRange = new Range<long>(entries[0].LocalId, entries[2].LocalId + 1);
+        var commander = tester.AppServices.Commander();
+        var conversation = await commander.Call(new ConversationBackend_Summarize(chatId, [lidRange]));
+        var baselineCount = conversation.MessageCount;
+        baselineCount.Should().BeGreaterThanOrEqualTo(3);
+        var conversationsBackend = tester.AppServices.GetRequiredService<IConversationsBackend>();
+
+        // act: soft-remove via Update (the thread-deletion path), not Change.Remove
+        var target = entries[1];
+        await commander.Call(new ChatsBackend_ChangeEntry(
+            target.Id, null, Change.Update(new ChatEntryDiff { IsRemoved = true })));
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var updated = await conversationsBackend.Get(conversation.Id, ct);
+            updated.Should().NotBeNull();
+            updated!.MessageCount.Should().Be(baselineCount - 1);
+        }, TimeSpan.FromSeconds(30));
     }
 }

--- a/tests/Chat.UI.Blazor.IntegrationTests/ConversationCollapseTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/ConversationCollapseTest.cs
@@ -20,7 +20,7 @@ public sealed class ConversationCollapseTest(ChatAppHostFixture fixture, ITestOu
     [InlineData(0)]
     [InlineData(30)]
     [InlineData(60)]
-    public async Task CollapsingTheLastConversationKeepsTheChatTail(int tailCount)
+    public async Task ShouldKeepChatTailWhenCollapsingTheLastConversation(int tailCount)
     {
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -71,9 +71,130 @@ public sealed class ConversationCollapseTest(ChatAppHostFixture fixture, ITestOu
             .Should().Contain(m => m.Id == entries[99].LocalId, "the expanded conversation must be loaded");
     }
 
+    [Fact]
+    public async Task ShouldKeepWitnessedEntriesExpandedWhenConversationMaterializes()
+    {
+        // arrange: the user is looking at the entries (VisibleLidRange covers them) before any
+        // conversation exists over them
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "deferred-collapse");
+        var (otherChat, _) = await Tester.CreateAndGetChat(false, "deferred-collapse-other");
+        var entries = new List<ChatEntry>();
+        for (var i = 0; i < 20; i++)
+            entries.Add(await Tester.CreateTextEntry(chat.Id, $"m-{i}"));
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var query = new ChatDataQuery(
+            new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+            -chatUI.HalfLoadLimit,
+            chatUI.HalfLoadLimit) {
+            VisibleLidRange = new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+        };
+        var before = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        before.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().Contain(m => m.Id == entries[5].LocalId, "the entries are on screen pre-materialization");
+
+        // act: a collapsed-by-default conversation materializes over the witnessed entries
+        var conversationId = await Materialize(chat.Id, entries[0], entries[9], isExpandedByDefault: false);
+
+        // assert: the entries stay rendered - the conversation is auto-expanded, not swallowed
+        await ComputedTest.When(async ct => {
+            var built = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            built.Items.SelectMany(i => i.GetLeafMessages())
+                .Should().Contain(m => m.Id == entries[5].LocalId, "witnessed entries must not collapse in place");
+            chatUI.AutoExpandedConversations.Value.Should().Contain(conversationId);
+        }, TimeSpan.FromSeconds(10));
+
+        // act: leave the chat and come back
+        chatUI.SelectChatOnNavigation(otherChat.Id);
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var fresh = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert: the conversation now renders collapsed - its entries are gone, its card is there
+        fresh.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().NotContain(m => m.Id == entries[5].LocalId, "a fresh visit renders per tier");
+        fresh.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().Contain(m => m is ConversationMessage && m.Id == conversationId.StartEntryLid);
+
+        // assert: and it stays collapsed - a collapsed conversation emits no entries, so no rebuild
+        // can re-witness the lids it covers and auto-expand it again
+        var rebuiltFresh = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        rebuiltFresh.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().NotContain(m => m.Id == entries[5].LocalId,
+                "the conversation stays collapsed across rebuilds on a fresh visit");
+    }
+
+    [Fact]
+    public async Task ShouldNotWitnessEntriesCoveredByCollapsedConversation()
+    {
+        // arrange: the conversation exists (collapsed) BEFORE the first build ever runs
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "deferred-collapse-pre");
+        var entries = new List<ChatEntry>();
+        for (var i = 0; i < 20; i++)
+            entries.Add(await Tester.CreateTextEntry(chat.Id, $"m-{i}"));
+        var conversationId = await Materialize(chat.Id, entries[0], entries[9], isExpandedByDefault: false);
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var query = new ChatDataQuery(
+            new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+            -chatUI.HalfLoadLimit,
+            chatUI.HalfLoadLimit) {
+            VisibleLidRange = new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+        };
+
+        // act: two builds - the first could only witness the visible tail, never the covered lids
+        await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        var rebuilt = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert: the conversation stays collapsed and never enters the auto set
+        rebuilt.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().NotContain(m => m.Id == entries[5].LocalId, "covered lids were never witnessed");
+        chatUI.AutoExpandedConversations.Value.Should().NotContain(conversationId);
+    }
+
+    [Fact]
+    public async Task ShouldKeepManualCollapseOfAutoExpandedConversation()
+    {
+        // arrange: same witnessed setup, conversation auto-expands
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "deferred-collapse-manual");
+        var entries = new List<ChatEntry>();
+        for (var i = 0; i < 20; i++)
+            entries.Add(await Tester.CreateTextEntry(chat.Id, $"m-{i}"));
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var query = new ChatDataQuery(
+            new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+            -chatUI.HalfLoadLimit,
+            chatUI.HalfLoadLimit) {
+            VisibleLidRange = new Range<long>(entries[0].LocalId, entries[^1].LocalId + 1),
+        };
+        await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None); // witnesses the entries
+        var conversationId = await Materialize(chat.Id, entries[0], entries[9], isExpandedByDefault: false);
+        await ComputedTest.When(async ct => {
+            var built = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            built.Items.SelectMany(i => i.GetLeafMessages())
+                .Should().Contain(m => m.Id == entries[5].LocalId, "witnessed entries must not collapse in place");
+            chatUI.AutoExpandedConversations.Value.Should().Contain(conversationId);
+        }, TimeSpan.FromSeconds(10));
+
+        // act: the user collapses it by hand
+        chatUI.ToggleExpandConversation(conversationId);
+        var collapsed = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+
+        // assert: collapsed, and it stays collapsed on the next rebuild (no auto re-add)
+        collapsed.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().NotContain(m => m.Id == entries[5].LocalId, "a manual collapse must win over auto-expansion");
+        var rebuilt = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        rebuilt.Items.SelectMany(i => i.GetLeafMessages())
+            .Should().NotContain(m => m.Id == entries[5].LocalId, "suppression must survive rebuilds");
+    }
+
     // Private methods
 
-    private async Task<ConversationId> Materialize(ChatId chatId, ChatEntry first, ChatEntry last)
+    private async Task<ConversationId> Materialize(
+        ChatId chatId, ChatEntry first, ChatEntry last, bool isExpandedByDefault = true)
     {
         var id = ConversationId.New(chatId, first.LocalId);
         var conversation = new Conversation(id) {
@@ -82,7 +203,7 @@ public sealed class ConversationCollapseTest(ChatAppHostFixture fixture, ITestOu
             Description = "d",
             EndEntryLid = last.LocalId,
             MessageCount = (int)(last.LocalId - first.LocalId + 1),
-            IsExpandedByDefault = true,
+            IsExpandedByDefault = isExpandedByDefault,
         };
         await Tester.Commander.Call(new ConversationBackend_Materialize(conversation), CancellationToken.None);
         return id;

--- a/tests/Chat.UI.Blazor.UnitTests/AutoExpansionRuleTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/AutoExpansionRuleTest.cs
@@ -1,0 +1,136 @@
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class AutoExpansionRuleTest
+{
+    private static readonly ChatId TestChatId = ChatId.Parse("aaaaaaaaaaaaaaaaaaaa");
+    private static readonly IImmutableSet<ConversationId> Empty = ImmutableHashSet<ConversationId>.Empty;
+
+    [Fact]
+    public void ShouldAutoExpandCollapsedConversationOverWitnessedLids()
+    {
+        // arrange
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        var range = new Range<long>(95, 120);
+
+        // act
+        var result = ChatUI.GetNewAutoExpansions(
+            TestChatId, [range], Empty, Empty, Empty,
+            _ => false, witnessed, null, null);
+
+        // assert
+        result.Should().Equal(ConversationId.New(TestChatId, 95));
+    }
+
+    [Fact]
+    public void ShouldSkipExpandedSuppressedAndNonWitnessedConversations()
+    {
+        // arrange
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        var witnessedRange = new Range<long>(95, 120);
+        var farRange = new Range<long>(500, 600);
+        var witnessedId = ConversationId.New(TestChatId, 95);
+
+        // act
+        var whenDefaultExpanded = ChatUI.GetNewAutoExpansions(
+            TestChatId, [witnessedRange, farRange], ImmutableHashSet.Create(witnessedId), Empty, Empty,
+            _ => false, witnessed, null, null);
+        var whenExpandedViaOverride = ChatUI.GetNewAutoExpansions(
+            TestChatId, [witnessedRange, farRange], Empty, ImmutableHashSet.Create(witnessedId), Empty,
+            _ => false, witnessed, null, null);
+        var whenSuppressed = ChatUI.GetNewAutoExpansions(
+            TestChatId, [witnessedRange, farRange], Empty, Empty, Empty,
+            id => id == witnessedId, witnessed, null, null);
+        var whenAlreadyAutoExpanded = ChatUI.GetNewAutoExpansions(
+            TestChatId, [witnessedRange, farRange], Empty, Empty, ImmutableHashSet.Create(witnessedId),
+            _ => false, witnessed, null, null);
+
+        // assert
+        whenDefaultExpanded.Should().BeEmpty();
+        whenExpandedViaOverride.Should().BeEmpty();
+        whenSuppressed.Should().BeEmpty();
+        whenAlreadyAutoExpanded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldSkipConversationWithManualOverride()
+    {
+        // arrange: a default-expanded conversation collapsed via override in an earlier visit
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        var range = new Range<long>(95, 120);
+        var id = ConversationId.New(TestChatId, 95);
+
+        // act
+        var result = ChatUI.GetNewAutoExpansions(
+            TestChatId, [range], ImmutableHashSet.Create(id), ImmutableHashSet.Create(id), Empty,
+            _ => false, witnessed, null, null);
+
+        // assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldSkipLiveAndMaterializedBlockIds()
+    {
+        // arrange
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        var range = new Range<long>(95, 120);
+        var id = ConversationId.New(TestChatId, 95);
+
+        // act
+        var whenLiveBlock = ChatUI.GetNewAutoExpansions(
+            TestChatId, [range], Empty, Empty, Empty,
+            _ => false, witnessed, id, null);
+        var whenMaterializedBlock = ChatUI.GetNewAutoExpansions(
+            TestChatId, [range], Empty, Empty, Empty,
+            _ => false, witnessed, null, id);
+
+        // assert
+        whenLiveBlock.Should().BeEmpty();
+        whenMaterializedBlock.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldReTriggerWhenRangeGrowsOverWitnessedLids()
+    {
+        // arrange
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        var grownRange = new Range<long>(50, 105);
+        var previouslyAutoExpanded = ImmutableHashSet.Create(ConversationId.New(TestChatId, 95));
+
+        // act
+        var result = ChatUI.GetNewAutoExpansions(
+            TestChatId, [grownRange], Empty, Empty, previouslyAutoExpanded,
+            _ => false, witnessed, null, null);
+
+        // assert
+        result.Should().Equal(ConversationId.New(TestChatId, 50));
+    }
+
+    [Fact]
+    public void ShouldEvaluateEachRangeIndependently()
+    {
+        // arrange
+        var witnessed = new LidRangeSet();
+        witnessed.Add(new Range<long>(100, 110));
+        witnessed.Add(new Range<long>(200, 210));
+        var suppressedRange = new Range<long>(95, 120);
+        var qualifyingRange = new Range<long>(195, 220);
+        var farRange = new Range<long>(500, 600);
+        var suppressedId = ConversationId.New(TestChatId, 95);
+
+        // act
+        var result = ChatUI.GetNewAutoExpansions(
+            TestChatId, [suppressedRange, qualifyingRange, farRange], Empty, Empty, Empty,
+            id => id == suppressedId, witnessed, null, null);
+
+        // assert
+        result.Should().Equal(ConversationId.New(TestChatId, 195));
+    }
+}

--- a/tests/Chat.UI.Blazor.UnitTests/LidRangeSetTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/LidRangeSetTest.cs
@@ -1,0 +1,75 @@
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class LidRangeSetTest
+{
+    [Fact]
+    public void ShouldMergeAdjacentAndOverlappingRanges()
+    {
+        // arrange
+        var set = new LidRangeSet();
+
+        // act
+        set.Add(new Range<long>(10, 12));
+        set.Add(new Range<long>(12, 15));
+        set.Add(new Range<long>(11, 13));
+        set.Add(new Range<long>(20, 21));
+
+        // assert
+        set.Intersects(new Range<long>(10, 15)).Should().BeTrue();
+        set.Intersects(new Range<long>(14, 16)).Should().BeTrue();
+        set.Intersects(new Range<long>(15, 20)).Should().BeFalse();
+        set.Intersects(new Range<long>(20, 25)).Should().BeTrue();
+        set.Intersects(new Range<long>(25, 30)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldIgnoreEmptyRanges()
+    {
+        // arrange
+        var set = new LidRangeSet();
+
+        // act
+        set.Add(default);
+        set.Add(new Range<long>(5, 5));
+
+        // assert
+        set.Intersects(new Range<long>(0, 100)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotIntersectWithEmptyProbe()
+    {
+        // arrange
+        var set = new LidRangeSet();
+        set.Add(new Range<long>(10, 20));
+
+        // act
+        var intersectsEmpty = set.Intersects(default);
+        var intersectsZeroWidth = set.Intersects(new Range<long>(15, 15));
+
+        // assert
+        intersectsEmpty.Should().BeFalse();
+        intersectsZeroWidth.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldBridgeSeveralRangesOnOverlappingAdd()
+    {
+        // arrange
+        var set = new LidRangeSet();
+        set.Add(new Range<long>(30, 31));
+        set.Add(new Range<long>(10, 11));
+        set.Add(new Range<long>(20, 21));
+
+        // act
+        set.Add(new Range<long>(10, 21));
+
+        // assert
+        set.Intersects(new Range<long>(11, 20)).Should().BeTrue("the gap between the bridged ranges is now witnessed");
+        set.Intersects(new Range<long>(21, 30)).Should().BeFalse("the gap before the trailing range must survive");
+        set.Intersects(new Range<long>(30, 31)).Should().BeTrue("the trailing range must not be dropped");
+        set.Intersects(new Range<long>(31, 40)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Two related summarization improvements:

## fix(chat): keep removed entries out of summaries (closes #4126)

- `ListNewEntries` skips `IsRemoved` entries, so the live and split summarization flows never feed deleted content to the LLM.
- An entry removal or restore — including `Update`-based soft removals from the thread-deletion path — re-summarizes the covering conversation through the new `ConversationRefreshFlow`, which coalesces bursts via quantized resume events and re-reads the conversation's current range at execution time (a delayed refresh can neither shrink a grown conversation nor spam one LLM call per deletion).
- A conversation whose entries are all removed is dropped, guarded against stale partial-range commands.
- `GetTextEntries` dedupes entries duplicated across range-sharing tiles.

## feat(ui): defer conversation collapse for entries on screen

A conversation summary block that appears (or grows) over entries the user is currently looking at auto-expands instead of swallowing them in place, until the user leaves the chat; the next visit renders per tier. Manual collapse wins and is suppressed from re-expansion for the visit.

- Witnessed lids come from `VisibleLidRange` with an `ItemVisibility` fallback (the query field is only set on the has-query branch), exclude effective-collapsed conversation ranges (transitional builds can leak covered boundary rows into `ChatItems`), and clear on chat switch under a visit-epoch guard.
- Auto-expansion feeds `ConversationViewState.ExpandedConversations` through the single shared expansion rule (`ChatUI.IsConversationExpanded`), and drives the same one-shot data-query widening as manual toggles.
- Live/materialized block identities stay owned by the freeze-overlay machinery.

## Testing

- 9 server integration tests (`ConversationSummarizationTest`), incl. removal-, soft-removal- and all-removed-conversation scenarios running through the real flow/queue machinery.
- 739 UI unit tests; `ConversationCollapseTest` end-to-end coverage (witnessed-stay-expanded, fresh-visit collapse, manual-collapse-sticks, covered-lids-not-witnessed), stable across 5 consecutive runs.
- Feature went through per-task spec + quality reviews plus a final high-effort `/code-review`; confirmed findings were fixed on-branch.

Pre-squash history is preserved on `feat/summarization-enhancements-bak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QgsLD7XrGeUKZRARFbfyV