### PR TITLE
feat(android): PTT notification states, Reply button, answer-window countdown

### DIFF
--- a/src/dotnet/Api/Constants.Audio.cs
+++ b/src/dotnet/Api/Constants.Audio.cs
@@ -80,6 +80,9 @@ public static partial class Constants
         // max rate raises the shared HAL rate and every connection gets the flood - 470Hz measured
         // against our 15Hz request - so the surplus is dropped at the platform edge.
         public static readonly TimeSpan GestureSampleMinPeriod = TimeSpan.FromMilliseconds(50);
+        // How long an accelerometer that should be delivering may stay silent before the feed
+        // stops trusting its own flag and re-asserts the shared registration.
+        public static readonly TimeSpan GestureSensorStaleTimeout = TimeSpan.FromSeconds(3);
         // Matches the wake push's FCM TTL; older wakes skip catch-up-from-start and go live.
         public static readonly TimeSpan PttStaleWakeAge = TimeSpan.FromSeconds(60);
         // Clock-fuzz allowance between a wake's startedAt and the target stream's BeginsAt.

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
@@ -128,7 +128,7 @@ public class AndroidActivitiesBackend : ActivitiesBackend
 
     // Private methods
 
-    private static void ShowImpl(ActivitySet set)
+    private void ShowImpl(ActivitySet set)
     {
         var context = Context;
         var intent = new Intent(context, typeof(AndroidActivitiesForegroundService));
@@ -144,6 +144,14 @@ public class AndroidActivitiesBackend : ActivitiesBackend
             intent.PutExtra(IntentExtras.ChatTitle, audio.Chat.Title);
             intent.PutExtra(IntentExtras.ChatPicUri, audio.Chat.PicUrl);
             intent.PutExtra(IntentExtras.ExtraChatCount, audio.Chat.ExtraChatCount);
+            // Milliseconds-from-now rather than the Moment itself: the service compares against
+            // the device wall clock, and the ServerClock stamp isn't in that domain.
+            if (audio.AnswerWindowEndsAt is { } endsAt) {
+                var remaining = endsAt - Hub.Clocks.ServerClock.Now;
+                if (remaining > TimeSpan.Zero)
+                    intent.PutExtra(
+                        IntentExtras.AnswerWindowRemainingMs, (long)remaining.TotalMilliseconds);
+            }
             break;
         case LocationActivity location:
             intent.PutExtra(IntentExtras.ChatId, location.Chat.Id.Value);

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesBackend.cs
@@ -146,6 +146,7 @@ public class AndroidActivitiesBackend : ActivitiesBackend
             intent.PutExtra(IntentExtras.ExtraChatCount, audio.Chat.ExtraChatCount);
             // Milliseconds-from-now rather than the Moment itself: the service compares against
             // the device wall clock, and the ServerClock stamp isn't in that domain.
+            intent.PutExtra(IntentExtras.IsStartGestureReady, audio.IsStartGestureReady);
             if (audio.AnswerWindowEndsAt is { } endsAt) {
                 var remaining = endsAt - Hub.Clocks.ServerClock.Now;
                 if (remaining > TimeSpan.Zero)

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
@@ -22,7 +22,7 @@ namespace ActualChat.App.Maui.Activities;
     ForegroundService.TypeMicrophone |
     ForegroundService.TypeDataSync |
     ForegroundService.TypeLocation)]
-public class AndroidActivitiesForegroundService : Service
+public sealed class AndroidActivitiesForegroundService : Service
 {
     public static class IntentExtras
     {
@@ -34,6 +34,7 @@ public class AndroidActivitiesForegroundService : Service
         public const string ExtraChatCount = nameof(ExtraChatCount);
         public const string IsPaused = nameof(IsPaused);
         public const string CanPause = nameof(CanPause);
+        public const string AnswerWindowRemainingMs = nameof(AnswerWindowRemainingMs);
         public const string UploadFileCount = nameof(UploadFileCount);
         public const string UploadBytesUploaded = nameof(UploadBytesUploaded);
         public const string UploadTotalBytes = nameof(UploadTotalBytes);
@@ -44,6 +45,8 @@ public class AndroidActivitiesForegroundService : Service
 
     public const string ActionShow = "ACTION_SHOW";
     public const string ActionStop = "ACTION_STOP";
+    public const string ActionReply = "ACTION_REPLY";
+    public const string ActionStopTalking = "ACTION_STOP_TALKING";
     private const string ChannelId = "audio_widget";
     private const string RecordingChannelId = "audio_recording";
     private const string RecordingQuietChannelId = "audio_recording_quiet";
@@ -166,16 +169,18 @@ public class AndroidActivitiesForegroundService : Service
         ReleaseMediaSession();
         base.OnDestroy();
     }
-
     public override IBinder? OnBind(Intent? intent) => null;
-
     public override StartCommandResult OnStartCommand(Intent? intent, StartCommandFlags flags, int startId)
     {
-        _requestId = RandomStringGenerator.Default.Next();
         var action = intent?.Action ?? "";
         if (action == ActionStop) {
             // The notification's Stop button - the same door the media session's OnStop takes.
             AndroidActivitiesBackend.Stop();
+            return StartCommandResult.NotSticky;
+        }
+
+        if (action is ActionReply or ActionStopTalking) {
+            TryHandleNotificationReply(isStop: action == ActionStopTalking);
             return StartCommandResult.NotSticky;
         }
 
@@ -188,6 +193,9 @@ public class AndroidActivitiesForegroundService : Service
             return StartCommandResult.NotSticky;
         }
 
+        // Reset only on Show: a reply action arriving mid-bitmap-load must not cancel the
+        // in-flight notification update it has nothing to do with.
+        _requestId = RandomStringGenerator.Default.Next();
         // A Show revives an instance whose deferred stop never reached OnDestroy - otherwise the
         // microphone re-type would stay dead for the rest of its life.
         Volatile.Write(ref _isStopping, false);
@@ -269,6 +277,7 @@ public class AndroidActivitiesForegroundService : Service
             .Build();
         _mediaSession.SetPlaybackState(playbackStateCompat);
 
+        var answerWindowRemainingMs = intent.Extras!.GetLong(IntentExtras.AnswerWindowRemainingMs, 0);
         var lastRequestId = _requestId;
         ResolveBitmapAndRun(
             chatPicUrl,
@@ -285,7 +294,8 @@ public class AndroidActivitiesForegroundService : Service
                 _lastAlbumArt = bitmap;
                 _lastLink = link;
                 SetMetadata(title, text, bitmap);
-                var notification = BuildNotification(_mediaSession, link, kind);
+                var notification = BuildNotification(
+                    _mediaSession, link, kind, title, answerWindowRemainingMs);
                 StartForeground1(notification, kind, requested);
             });
 
@@ -389,7 +399,7 @@ public class AndroidActivitiesForegroundService : Service
 
         try {
             SetMetadata(_lastTitle, GetKindText(kind), _lastAlbumArt);
-            return BuildNotification(_mediaSession, _lastLink, kind);
+            return BuildNotification(_mediaSession, _lastLink, kind, _lastTitle, 0);
         }
         catch (Exception e) {
             Log.LogWarning(e, "Couldn't relabel the notification for {Kind}", kind);
@@ -482,10 +492,11 @@ public class AndroidActivitiesForegroundService : Service
     }
 
     private Android.App.Notification BuildStartingNotification(ActivityKind kind)
+    {
         // Carries real text because the armed start (TryStartArmed) has no chat to name yet and
         // this notification is all the user sees until the backend arrives, which takes as long as
         // Blazor needs to render. A blank one reads as "PTT isn't running".
-        => new NotificationCompat.Builder(this, GetChannelId(kind))
+        var builder = new NotificationCompat.Builder(this, GetChannelId(kind))
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentTitle(kind switch {
                 ActivityKind.Armed => "Push-to-talk is on",
@@ -496,17 +507,21 @@ public class AndroidActivitiesForegroundService : Service
             })!
             .SetOngoing(true)!
             .SetOnlyAlertOnce(true)!
-            .SetVisibility(NotificationCompat.VisibilityPublic)!
-            .Build()!;
+            .SetVisibility(NotificationCompat.VisibilityPublic)!;
+        // A null link resolves to the app's launch intent - the placeholder has no chat to open.
+        if (NotificationHelper.CreateViewIntent(this, null) is { } viewIntent)
+            _ = builder.SetContentIntent(
+                PendingIntent.GetActivity(this, 3, viewIntent, PendingIntentFlags.Immutable));
+        AddReplyActions(builder, kind);
+        return builder.Build()!;
+    }
 
-    private Android.App.Notification BuildNotification(MediaSessionCompat mediaSession, string link, ActivityKind kind)
+    private Android.App.Notification BuildNotification(
+        MediaSessionCompat mediaSession, string link, ActivityKind kind,
+        string title, long answerWindowRemainingMs)
     {
         var viewIntent = NotificationHelper.CreateViewIntent(this, link);
         var viewPending = PendingIntent.GetActivity(this, 3, viewIntent, PendingIntentFlags.Immutable);
-
-        var stopIntent = new Intent(this, typeof(AndroidActivitiesForegroundService));
-        stopIntent.SetAction(ActionStop);
-        var stopPending = PendingIntent.GetService(this, 4, stopIntent, PendingIntentFlags.Immutable);
 
         var builder = new NotificationCompat.Builder(this, GetChannelId(kind))
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
@@ -517,22 +532,61 @@ public class AndroidActivitiesForegroundService : Service
             .SetOnlyAlertOnce(true)!
             // Public so an open microphone is still legible over the keyguard - that's exactly
             // when the user needs to see it, and it names only a chat they're already in.
-            .SetVisibility(NotificationCompat.VisibilityPublic)!
-            .AddAction(Android.Resource.Drawable.IcMenuCloseClearCancel, "Stop", stopPending)!;
+            .SetVisibility(NotificationCompat.VisibilityPublic)!;
+        AddReplyActions(builder, kind);
 
+        // The media template doesn't render the chronometer, so the answer window gets a
+        // standard-style notification; the media session itself stays alive for the headset button.
+        if (kind is ActivityKind.Armed && answerWindowRemainingMs > 0)
+            return builder
+                .SetContentTitle(title)!
+                .SetContentText("Flip to reply")!
+                .SetLargeIcon(_lastAlbumArt)!
+                .SetShowWhen(true)!
+                .SetUsesChronometer(true)!
+                .SetChronometerCountDown(true)!
+                .SetWhen(Java.Lang.JavaSystem.CurrentTimeMillis() + answerWindowRemainingMs)!
+                .Build()!;
+
+        var compactActions = kind is ActivityKind.Recording ? new[] { 0 } : new[] { 0, 1 };
         var mediaStyle = new AndroidX.Media.App.NotificationCompat.MediaStyle()
             .SetMediaSession(mediaSession.SessionToken)!
-            .SetShowActionsInCompactView(0)!;
+            .SetShowActionsInCompactView(compactActions)!;
         builder.SetStyle(mediaStyle);
 
         return builder.Build()!;
     }
 
+    private void AddReplyActions(NotificationCompat.Builder builder, ActivityKind kind)
+    {
+        // Reply is deliberately everywhere a mic could open: inside the answer window it's an
+        // alternative to the gesture, outside it it still resolves via the unbounded window.
+        if (kind is ActivityKind.Recording) {
+            _ = builder.AddAction(
+                Android.Resource.Drawable.IcMenuCloseClearCancel, "Stop talking",
+                GetServicePendingIntent(6, ActionStopTalking));
+            return;
+        }
+        if (kind is not (ActivityKind.Armed or ActivityKind.Listening or ActivityKind.Replaying))
+            return;
+
+        _ = builder
+            .AddAction(Android.Resource.Drawable.IcButtonSpeakNow, "Reply",
+                GetServicePendingIntent(5, ActionReply))!
+            .AddAction(Android.Resource.Drawable.IcMenuCloseClearCancel, "Stop",
+                GetServicePendingIntent(4, ActionStop));
+    }
+
+    private PendingIntent? GetServicePendingIntent(int requestCode, string action)
+    {
+        var intent = new Intent(this, typeof(AndroidActivitiesForegroundService));
+        intent.SetAction(action);
+        return PendingIntent.GetService(this, requestCode, intent, PendingIntentFlags.Immutable);
+    }
+
     private Android.App.Notification BuildLocationNotification(string chatSid, string chatTitle, int extraChatCount)
     {
-        var stopIntent = new Intent(this, typeof(AndroidActivitiesForegroundService));
-        stopIntent.SetAction(ActionStop);
-        var stopPending = PendingIntent.GetService(this, 4, stopIntent, PendingIntentFlags.Immutable);
+        var stopPending = GetServicePendingIntent(4, ActionStop);
 
         // Opening the shared chat beats opening the app, but an unparsable id must still open something.
         var link = ChatId.TryParse(chatSid, out var chatId) ? Links.Chat(chatId) : Links.Home;
@@ -591,6 +645,33 @@ public class AndroidActivitiesForegroundService : Service
         quietRecordingChannel.EnableVibration(false);
         quietRecordingChannel.LockscreenVisibility = NotificationVisibility.Public;
         manager.CreateNotificationChannel(quietRecordingChannel);
+    }
+
+    private static void TryHandleNotificationReply(bool isStop)
+    {
+        // Same shape as the headset-button path: the hold is taken synchronously inside the
+        // dispatch that Android exempted for the notification tap, which is what lets a
+        // background mic start earn the while-in-use grant.
+        try {
+            if (AppScopeAccessor.Current is not { } services)
+                return;
+
+            var hub = services.GetRequiredService<AppUIHub>();
+            var replyUI = hub.PttReplyUI;
+            // Rehearsing in the Settings practice panel must not transmit.
+            if (!isStop && hub.GestureUI.GetHeadsetButtonState().IsPracticeMode)
+                return;
+
+            var whenHandled = isStop
+                ? replyUI.StopReply()
+                : PttMicCapability.HoldWhile(() => replyUI.RequestReply(
+                    ReplyTargetResolver.UnboundedRecencyWindow, CancellationToken.None));
+            _ = BackgroundTask.Run(() => whenHandled, Log, "Notification reply action failed",
+                CancellationToken.None);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Notification reply action handling failed");
+        }
     }
 
     private static bool TryHandleHeadsetButton(HeadsetKey key, bool isDown, int repeatCount)
@@ -656,7 +737,7 @@ public class AndroidActivitiesForegroundService : Service
 
     // Nested types
 
-    private class Callback : MediaSessionCompat.Callback
+    private sealed class Callback : MediaSessionCompat.Callback
     {
         public override bool OnMediaButtonEvent(Intent? mediaButtonEvent)
         {

--- a/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Activities/AndroidActivitiesForegroundService.cs
@@ -35,6 +35,7 @@ public sealed class AndroidActivitiesForegroundService : Service
         public const string IsPaused = nameof(IsPaused);
         public const string CanPause = nameof(CanPause);
         public const string AnswerWindowRemainingMs = nameof(AnswerWindowRemainingMs);
+        public const string IsStartGestureReady = nameof(IsStartGestureReady);
         public const string UploadFileCount = nameof(UploadFileCount);
         public const string UploadBytesUploaded = nameof(UploadBytesUploaded);
         public const string UploadTotalBytes = nameof(UploadTotalBytes);
@@ -193,9 +194,12 @@ public sealed class AndroidActivitiesForegroundService : Service
             return StartCommandResult.NotSticky;
         }
 
-        // Reset only on Show: a reply action arriving mid-bitmap-load must not cancel the
-        // in-flight notification update it has nothing to do with.
-        _requestId = RandomStringGenerator.Default.Next();
+        // The chat-less armed re-raise from MainActivity.OnResume starts no bitmap load of its own,
+        // so it must not reset this: doing so aborts an in-flight one, and the placeholder it
+        // leaves behind is never replaced - the backend re-posts only when its state changes.
+        var hasChat = !intent!.Extras?.GetString(IntentExtras.ChatId).IsNullOrEmpty() ?? false;
+        if (hasChat)
+            _requestId = RandomStringGenerator.Default.Next();
         // A Show revives an instance whose deferred stop never reached OnDestroy - otherwise the
         // microphone re-type would stay dead for the rest of its life.
         Volatile.Write(ref _isStopping, false);
@@ -207,7 +211,7 @@ public sealed class AndroidActivitiesForegroundService : Service
         // Android requires StartForeground() within ~5s of StartForegroundService(). Call it up-front
         // with a placeholder so a throw while building the rich notification (unexpected kind,
         // ChatId.Parse) can't leave the service without one -> ForegroundServiceDidNotStartInTimeException.
-        StartForeground1(BuildStartingNotification(kind), kind, requested);
+        StartForeground1(GetStartingNotification(kind, hasChat), kind, requested);
         if (Volatile.Read(ref _pendingStartCount) > 0)
             Interlocked.Decrement(ref _pendingStartCount);
 
@@ -250,7 +254,7 @@ public sealed class AndroidActivitiesForegroundService : Service
             _mediaSession.SetCallback(new Callback());
         }
 
-        var text = GetKindText(kind);
+        var text = GetKindText(kind, intent.Extras!.GetBoolean(IntentExtras.IsStartGestureReady));
         var title = chatTitle;
         if (extraChatCount > 0)
             title += extraChatCount == 1 ? " (+ 1 chat)" : $" (+ {extraChatCount} chats)";
@@ -278,6 +282,7 @@ public sealed class AndroidActivitiesForegroundService : Service
         _mediaSession.SetPlaybackState(playbackStateCompat);
 
         var answerWindowRemainingMs = intent.Extras!.GetLong(IntentExtras.AnswerWindowRemainingMs, 0);
+        var isStartGestureReady = intent.Extras!.GetBoolean(IntentExtras.IsStartGestureReady);
         var lastRequestId = _requestId;
         ResolveBitmapAndRun(
             chatPicUrl,
@@ -295,7 +300,7 @@ public sealed class AndroidActivitiesForegroundService : Service
                 _lastLink = link;
                 SetMetadata(title, text, bitmap);
                 var notification = BuildNotification(
-                    _mediaSession, link, kind, title, answerWindowRemainingMs);
+                    _mediaSession, link, kind, title, answerWindowRemainingMs, isStartGestureReady);
                 StartForeground1(notification, kind, requested);
             });
 
@@ -372,12 +377,17 @@ public sealed class AndroidActivitiesForegroundService : Service
         }
     }
 
-    private static string GetKindText(ActivityKind kind)
+    private static string GetKindText(ActivityKind kind, bool isStartGestureReady)
+        // "Push-to-talk is on" was true but useless: it says a chat is armed, while what the user
+        // needs to know is whether flipping the phone right now will do anything - and outside the
+        // arming window the accelerometer is stopped, so it won't.
         => kind switch {
             ActivityKind.Recording => "Recording",
             ActivityKind.Listening => "Listening",
             ActivityKind.Replaying => "Replaying",
-            ActivityKind.Armed => "Push-to-talk is on",
+            ActivityKind.Armed => isStartGestureReady
+                ? "Flip to reply"
+                : "Push-to-talk on \u00b7 tap Reply to talk",
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
 
@@ -398,8 +408,8 @@ public sealed class AndroidActivitiesForegroundService : Service
             return null;
 
         try {
-            SetMetadata(_lastTitle, GetKindText(kind), _lastAlbumArt);
-            return BuildNotification(_mediaSession, _lastLink, kind, _lastTitle, 0);
+            SetMetadata(_lastTitle, GetKindText(kind, false), _lastAlbumArt);
+            return BuildNotification(_mediaSession, _lastLink, kind, _lastTitle, 0, false);
         }
         catch (Exception e) {
             Log.LogWarning(e, "Couldn't relabel the notification for {Kind}", kind);
@@ -491,6 +501,15 @@ public sealed class AndroidActivitiesForegroundService : Service
         }, TaskScheduler.Default);
     }
 
+    private Android.App.Notification GetStartingNotification(ActivityKind kind, bool hasChat)
+        // The bare armed re-raise (MainActivity.OnResume, re-earning the microphone type) carries no
+        // chat and returns below without building the real notification - so posting the placeholder
+        // here would replace the rendered one, and nothing would put it back: the backend re-posts
+        // only when its activity set changes, which a resume doesn't do.
+        => !hasChat && Volatile.Read(ref _lastNotification) is { } lastNotification
+            ? lastNotification
+            : BuildStartingNotification(kind);
+
     private Android.App.Notification BuildStartingNotification(ActivityKind kind)
     {
         // Carries real text because the armed start (TryStartArmed) has no chat to name yet and
@@ -499,7 +518,9 @@ public sealed class AndroidActivitiesForegroundService : Service
         var builder = new NotificationCompat.Builder(this, GetChannelId(kind))
             .SetSmallIcon(ResourceConstant.Drawable.notification_app_icon)!
             .SetContentTitle(kind switch {
-                ActivityKind.Armed => "Push-to-talk is on",
+                // Never the "Flip to reply" wording: this is raised before Blazor - and so before
+                // GestureUI - exists, so no gesture can possibly be sensed while it's on screen.
+                ActivityKind.Armed => GetKindText(ActivityKind.Armed, isStartGestureReady: false),
                 ActivityKind.Recording => "Recording",
                 ActivityKind.Uploading => "Uploading",
                 ActivityKind.SharingLocation => "Sharing live location",
@@ -518,7 +539,7 @@ public sealed class AndroidActivitiesForegroundService : Service
 
     private Android.App.Notification BuildNotification(
         MediaSessionCompat mediaSession, string link, ActivityKind kind,
-        string title, long answerWindowRemainingMs)
+        string title, long answerWindowRemainingMs, bool isStartGestureReady)
     {
         var viewIntent = NotificationHelper.CreateViewIntent(this, link);
         var viewPending = PendingIntent.GetActivity(this, 3, viewIntent, PendingIntentFlags.Immutable);
@@ -535,18 +556,24 @@ public sealed class AndroidActivitiesForegroundService : Service
             .SetVisibility(NotificationCompat.VisibilityPublic)!;
         AddReplyActions(builder, kind);
 
-        // The media template doesn't render the chronometer, so the answer window gets a
-        // standard-style notification; the media session itself stays alive for the headset button.
-        if (kind is ActivityKind.Armed && answerWindowRemainingMs > 0)
-            return builder
+        // Never MediaStyle while merely armed: the system files a transport-category notification
+        // into the media-player area, and an armed session reports Paused - so it collapses out of
+        // sight and the chat has no visible notification at all. The media session itself stays
+        // alive regardless, which is all the headset button needs. It also lets the answer window
+        // show a chronometer, which the media template doesn't render.
+        if (kind is ActivityKind.Armed) {
+            _ = builder
                 .SetContentTitle(title)!
-                .SetContentText("Flip to reply")!
-                .SetLargeIcon(_lastAlbumArt)!
-                .SetShowWhen(true)!
-                .SetUsesChronometer(true)!
-                .SetChronometerCountDown(true)!
-                .SetWhen(Java.Lang.JavaSystem.CurrentTimeMillis() + answerWindowRemainingMs)!
-                .Build()!;
+                .SetContentText(GetKindText(kind, isStartGestureReady))!
+                .SetLargeIcon(_lastAlbumArt);
+            if (isStartGestureReady && answerWindowRemainingMs > 0)
+                _ = builder
+                    .SetShowWhen(true)!
+                    .SetUsesChronometer(true)!
+                    .SetChronometerCountDown(true)!
+                    .SetWhen(Java.Lang.JavaSystem.CurrentTimeMillis() + answerWindowRemainingMs);
+            return builder.Build()!;
+        }
 
         var compactActions = kind is ActivityKind.Recording ? new[] { 0 } : new[] { 0, 1 };
         var mediaStyle = new AndroidX.Media.App.NotificationCompat.MediaStyle()

--- a/src/dotnet/App.Maui/Platforms/iOS/Activities/IosActivitiesBackend.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Activities/IosActivitiesBackend.cs
@@ -82,7 +82,7 @@ public sealed class IosActivitiesBackend : ActivitiesBackend
         }
 
         var (title, subtitle, progress) = primary switch {
-            AudioActivity audio => (audio.Chat.Title, KindLabel(audio.Kind), -1.0),
+            AudioActivity audio => (audio.Chat.Title, KindLabel(audio), -1.0),
             LocationActivity location => (
                 "Sharing live location",
                 location.Chat.ExtraChatCount > 0 ? $"{location.Chat.ExtraChatCount + 1} chats" : location.Chat.Title,
@@ -121,12 +121,17 @@ public sealed class IosActivitiesBackend : ActivitiesBackend
         center.AddNotificationRequest(request, null);
     }
 
-    private static string KindLabel(ActivityKind kind)
-        => kind switch {
+    private static string KindLabel(AudioActivity audio)
+        // Armed says whether a flip would actually do something rather than just that a chat is
+        // armed: gestures work on iOS too, and outside the arming window the accelerometer is
+        // stopped, so "push-to-talk is on" would promise one that cannot fire.
+        => audio.Kind switch {
             ActivityKind.Recording => "Recording",
             ActivityKind.Replaying => "Replaying",
             ActivityKind.Listening => "Listening",
-            ActivityKind.Armed => "Push-to-talk is on",
+            ActivityKind.Armed => audio.IsStartGestureReady
+                ? "Flip to reply"
+                : "Push-to-talk on",
             _ => "",
         };
 

--- a/src/dotnet/App.Maui/Services/MauiSensorFeed.cs
+++ b/src/dotnet/App.Maui/Services/MauiSensorFeed.cs
@@ -10,10 +10,17 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
     // check-then-set on its flag - the lock keeps the flag and the hardware from disagreeing.
     // It's held across the MAUI sensor start/stop calls, which don't block on the main thread.
     // The flag is the intended state, so on iOS it's set here, not inside the dispatch below.
+    // Accelerometer.Default is one process-wide resource, but this feed is scoped: a warm start
+    // or a headless wake scope can leave two instances alive at once. Counting the holders is
+    // what stops a dying scope's Stop() from killing the registration a live scope depends on -
+    // its own flag would stay true, so nothing would ever start it again.
+    private static int _accelerometerHolderCount;
+
     private readonly Lock _lock = new();
     private bool _isAccelerometerOn;
     private bool _isProximityOn;
     private Moment _lastSampleAt;
+    private Moment _accelerometerStartedAt;
 
     private ILogger Log => field ??= hub.LogFor(GetType());
 
@@ -22,18 +29,36 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
     public override void StartAccelerometer()
     {
         lock (_lock) {
-            if (_isAccelerometerOn || !Accelerometer.Default.IsSupported)
+            if (!Accelerometer.Default.IsSupported)
                 return;
+
+            if (_isAccelerometerOn) {
+                if (!IsAccelerometerStale(
+                        _accelerometerStartedAt, _lastSampleAt, hub.Clocks.CpuClock.Now,
+                        Constants.Audio.GestureSensorStaleTimeout))
+                    return;
+
+                // Re-asserted for every holder rather than re-counted: the shared sensor is as
+                // dead for the others as it is here, and their flags say otherwise too.
+                Log.LogWarning("The accelerometer stopped delivering - re-asserting it");
+                TryStopShared();
+                TryStartShared();
+                _lastSampleAt = default;
+                _accelerometerStartedAt = hub.Clocks.CpuClock.Now;
+                return;
+            }
 
             try {
                 Accelerometer.Default.ReadingChanged += OnReadingChanged;
-                // SensorSpeed.UI ~= 60ms/sample; clears the ~166ms bound the 500ms-window
-                // detectors need for a 4-6Hz shake.
-                Accelerometer.Default.Start(SensorSpeed.UI);
+                if (Interlocked.Increment(ref _accelerometerHolderCount) == 1)
+                    TryStartShared();
                 _isAccelerometerOn = true;
+                _lastSampleAt = default;
+                _accelerometerStartedAt = hub.Clocks.CpuClock.Now;
             }
             catch (Exception e) {
                 Accelerometer.Default.ReadingChanged -= OnReadingChanged;
+                Interlocked.Decrement(ref _accelerometerHolderCount);
                 Log.LogWarning(e, "Failed to start the accelerometer");
             }
         }
@@ -48,13 +73,35 @@ public sealed class MauiSensorFeed(AppUIHub hub) : SensorFeed
             _isAccelerometerOn = false;
             // Or a stale stamp would gate the first sample after the next start.
             _lastSampleAt = default;
+            _accelerometerStartedAt = default;
             Accelerometer.Default.ReadingChanged -= OnReadingChanged;
-            try {
-                Accelerometer.Default.Stop();
-            }
-            catch (Exception e) {
-                Log.LogWarning(e, "Failed to stop the accelerometer");
-            }
+            // Only the last holder stops the hardware - see _accelerometerHolderCount.
+            if (Interlocked.Decrement(ref _accelerometerHolderCount) == 0)
+                TryStopShared();
+        }
+    }
+
+    // Private methods
+
+    private void TryStartShared()
+    {
+        try {
+            // SensorSpeed.UI ~= 60ms/sample; clears the ~166ms bound the 500ms-window
+            // detectors need for a 4-6Hz shake.
+            Accelerometer.Default.Start(SensorSpeed.UI);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to start the accelerometer");
+        }
+    }
+
+    private void TryStopShared()
+    {
+        try {
+            Accelerometer.Default.Stop();
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to stop the accelerometer");
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
@@ -202,13 +202,20 @@
         public bool IsListening => AudioState.IsListening;
         public bool IsRecordingHere => AudioState.IsRecording;
         public bool IsParticipating => IsListening || IsRecordingHere || IsOwnVideoStreaming;
+        // Everything the panel can actually draw: someone's speech, a film strip, or own
+        // transmission with its hang-up button.
+        public bool HasRenderableActivity
+            => IsAnyoneTalking || HasRemoteStreams || IsRecordingHere
+                || IsWatchingHere || IsOwnVideoStreaming;
         public bool HasCallActivity
             // Armed PTT keeps IsListening on at all times, so for armed chats the panel needs real
             // call substance - a bare listen there is ambient state, not an activity to present.
-            => IsAnyoneTalking || HasRemoteStreams || IsRecordingHere
-                || IsWatchingHere || (IsPttArmed ? HasOngoingCall : IsListening);
+            => HasRenderableActivity || (IsPttArmed ? HasOngoingCall : IsListening);
         public bool CanJoinCall => HasCallActivity && !IsParticipating;
-        public bool IsVisible => HasCallActivity || IsSharingOwnLocation;
+        // HasOngoingCall is broader than what can be drawn - an open but silent mic satisfies it -
+        // so an armed chat gated on it alone shows a panel with nothing in it.
+        public bool IsVisible
+            => IsSharingOwnLocation || (IsPttArmed ? HasRenderableActivity : HasCallActivity);
         public bool CanShowAudioDiagnostics => IsAudioDiagnosticsEnabled && HasCallActivity;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
@@ -29,7 +29,7 @@
     protected override async Task<bool> ComputeState(CancellationToken cancellationToken) {
         var chatId = Chat.Id;
         var audioState = await ChatAudioUI.GetState(chatId).ConfigureAwait(false);
-        if (audioState.IsListening || audioState.IsRecording)
+        if (audioState.IsRecording)
             return true;
 
         var isAnyoneTalking = await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
@@ -45,6 +45,13 @@
         if (hasRemoteStreams)
             return true;
 
-        return await LocationUI.IsOwnLive(chatId, cancellationToken).ConfigureAwait(false);
+        if (await LocationUI.IsOwnLive(chatId, cancellationToken).ConfigureAwait(false))
+            return true;
+
+        // Last, because it's the only one needing the armed set: an armed chat listens at all
+        // times, so a bare listen must not open a wrapper the panel then declines to fill.
+        var pttChatIds = await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false);
+        return ChatActivityVisibility.HasActivity(
+            isPttArmed: pttChatIds.Contains(chatId), isListening: audioState.IsListening);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityVisibility.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityVisibility.cs
@@ -1,0 +1,26 @@
+namespace ActualChat.UI.Blazor.App.Components;
+
+/// <summary>
+/// Decides whether a chat has activity worth showing the activity panel for.
+/// Shared by the panel and its header wrapper, which would otherwise disagree
+/// and leave an empty wrapper on screen.
+/// </summary>
+public static class ChatActivityVisibility
+{
+    public static bool HasActivity(
+        bool isPttArmed,
+        bool isListening = false,
+        bool isRecording = false,
+        bool isAnyoneTalking = false,
+        bool isOwnVideoStreaming = false,
+        bool hasRemoteStreams = false,
+        bool isSharingOwnLocation = false)
+        // Arming a chat pins IsListening on for as long as it stays armed, so a bare listen there
+        // is ambient state rather than an activity - and the panel it would open has nothing to draw.
+        => isRecording
+            || isAnyoneTalking
+            || isOwnVideoStreaming
+            || hasRemoteStreams
+            || isSharingOwnLocation
+            || (isListening && !isPttArmed);
+}

--- a/src/dotnet/UI.Blazor.App/Services/Activities/ActivitiesBackend.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/ActivitiesBackend.cs
@@ -15,7 +15,7 @@ public class ActivitiesBackend : IDisposable
     private ActivitySet? _lastState;
     private bool? _hasEverBeenArmed;
 
-    private AppUIHub Hub { get; }
+    protected AppUIHub Hub { get; }
     private ChatAudioUI ChatAudioUI => Hub.ChatAudioUI;
     private IncomingVoiceActivityUI IncomingVoiceActivityUI => Hub.IncomingVoiceActivityUI;
     private ActivitiesUI ActivitiesUI => field ??= Hub.Services.GetRequiredService<ActivitiesUI>();

--- a/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
@@ -17,6 +17,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     private IAccounts Accounts => Hub.Accounts;
     private ChatAudioUI ChatAudioUI => Hub.ChatAudioUI;
     private IncomingVoiceActivityUI IncomingVoiceActivityUI => Hub.IncomingVoiceActivityUI;
+    private GestureUI GestureUI => Hub.GestureUI;
     private UrlMapper UrlMapper => Hub.UrlMapper;
     public bool IsDisposed => _isDisposed;
 
@@ -24,15 +25,19 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     {
         Hub = hub;
         _isAndroidHost = hub.HostInfo.AppKind == AppKind.Android;
-        if (_isAndroidHost)
+        if (_isAndroidHost) {
             IncomingVoiceActivityUI.IncomingVoiceStamped += OnIncomingVoiceStamped;
+            GestureUI.StartGestureReadyChanged += OnStartGestureReadyChanged;
+        }
     }
 
     public void Dispose()
     {
         _isDisposed = true;
-        if (_isAndroidHost)
+        if (_isAndroidHost) {
             IncomingVoiceActivityUI.IncomingVoiceStamped -= OnIncomingVoiceStamped;
+            GestureUI.StartGestureReadyChanged -= OnStartGestureReadyChanged;
+        }
     }
 
     [ComputeMethod]
@@ -42,6 +47,9 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         ActivityKind? kind = null;
         var extraChatCount = 0;
         var isPaused = false;
+        var pttChatIds = _isAndroidHost
+            ? await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false)
+            : [];
 
         // Priority: Recording > Replaying > Listening
         var recordingChatId = await ChatAudioUI.GetRecordingChatId().ConfigureAwait(false);
@@ -63,8 +71,13 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
                 }
             }
             else {
-                var listeningChatIds = await ChatAudioUI.GetListeningChatIds().ConfigureAwait(false);
-                if (!listeningChatIds.IsEmpty) {
+                // Arming keeps a chat listening for as long as it stays armed, so such a listen is
+                // ambient state - counting it as a Listening activity outranks Armed and hides the
+                // PTT state (ready / flip-to-reply / countdown) this notification exists to report.
+                var listeningChatIds = (await ChatAudioUI.GetListeningChatIds().ConfigureAwait(false))
+                    .Where(x => !pttChatIds.Contains(x))
+                    .ToList();
+                if (listeningChatIds.Count != 0) {
                     chatId = listeningChatIds.First();
                     var player = await ChatAudioUI.GetListeningPlayer(chatId, cancellationToken).ConfigureAwait(false);
                     if (player is not null) {
@@ -81,10 +94,8 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
 
         var canPause = true;
         Moment? answerWindowEndsAt = null;
+        var isStartGestureReady = false;
         if (kind is not { } vKind) {
-            var pttChatIds = _isAndroidHost
-                ? await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false)
-                : [];
             var answerWindow = _isAndroidHost
                 ? await Hub.UserSettingsUI.UserPttSettings()
                     .Get(x => x.AnswerWindow, cancellationToken)
@@ -98,6 +109,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
             chatId = armed.ChatId;
             extraChatCount = armed.ExtraChatCount;
             answerWindowEndsAt = armed.AnswerWindowEndsAt;
+            isStartGestureReady = GestureUI.IsStartGestureReady;
             canPause = false;
         }
 
@@ -105,7 +117,8 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         if (extraChatCount > 0)
             chatInfo = chatInfo with { ExtraChatCount = extraChatCount };
 
-        return new AudioActivity(vKind, chatInfo, isPaused, canPause, answerWindowEndsAt);
+        return new AudioActivity(
+            vKind, chatInfo, isPaused, canPause, answerWindowEndsAt, isStartGestureReady);
     }
 
     public static (ChatId ChatId, int ExtraChatCount, Moment? AnswerWindowEndsAt)? ResolveArmedChat(
@@ -126,6 +139,14 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     }
 
     // Private methods
+
+    private void OnStartGestureReadyChanged()
+    {
+        // Same reason as the stamps below: readiness lives in GestureUI's loop, so nothing here
+        // invalidates when a flip stops (or starts) being able to open the mic.
+        using (Invalidation.Begin())
+            _ = GetActivity(default);
+    }
 
     private void OnIncomingVoiceStamped()
     {

--- a/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
@@ -80,6 +80,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         }
 
         var canPause = true;
+        Moment? answerWindowEndsAt = null;
         if (kind is not { } vKind) {
             var pttChatIds = _isAndroidHost
                 ? await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false)
@@ -96,6 +97,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
             vKind = ActivityKind.Armed;
             chatId = armed.ChatId;
             extraChatCount = armed.ExtraChatCount;
+            answerWindowEndsAt = armed.AnswerWindowEndsAt;
             canPause = false;
         }
 
@@ -103,7 +105,24 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         if (extraChatCount > 0)
             chatInfo = chatInfo with { ExtraChatCount = extraChatCount };
 
-        return new AudioActivity(vKind, chatInfo, isPaused, canPause);
+        return new AudioActivity(vKind, chatInfo, isPaused, canPause, answerWindowEndsAt);
+    }
+
+    public static (ChatId ChatId, int ExtraChatCount, Moment? AnswerWindowEndsAt)? ResolveArmedChat(
+        IReadOnlyList<ChatId> pttChatIds,
+        IReadOnlyDictionary<ChatId, Moment> lastIncomingVoiceAt,
+        Moment now,
+        TimeSpan answerWindow)
+    {
+        if (pttChatIds.Count == 0)
+            return null;
+
+        var extraChatCount = pttChatIds.Count - 1;
+        var answer = GestureActivationPolicy.GetAnswerWindowChat(
+            pttChatIds, lastIncomingVoiceAt, now, answerWindow);
+        return answer is { } vAnswer
+            ? (vAnswer.ChatId, extraChatCount, vAnswer.At + answerWindow)
+            : (pttChatIds[0], extraChatCount, null);
     }
 
     // Private methods
@@ -116,29 +135,25 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
             _ = GetActivity(default);
     }
 
-    private (ChatId ChatId, int ExtraChatCount)? GetArmedChat(List<ChatId> pttChatIds, TimeSpan answerWindow)
+    private (ChatId ChatId, int ExtraChatCount, Moment? AnswerWindowEndsAt)? GetArmedChat(
+        List<ChatId> pttChatIds, TimeSpan answerWindow)
     {
         // Android only, and the reason is the foreground service the backend drives: Android grants
         // microphone access on the serviceType of the last startForeground call, and only if the app
         // wasn't in the background when it ran. A service first started by a wake therefore can never
         // record - so while any chat is armed the service stays up, started while the app is visible.
         // It also keeps the media session (the headset button) alive across the answer window.
-        if (pttChatIds.Count == 0)
-            return null;
-
-        var extraChatCount = pttChatIds.Count - 1;
         var now = Hub.Clocks.ServerClock.Now;
         var lastIncomingVoiceAt = IncomingVoiceActivityUI.SnapshotLastIncomingVoiceAt();
-        var answer = GestureActivationPolicy.GetAnswerWindowChat(
-            pttChatIds, lastIncomingVoiceAt, now, answerWindow);
-        if (answer is not { } vAnswer)
-            return (pttChatIds[0], extraChatCount);
+        var armed = ResolveArmedChat(pttChatIds, lastIncomingVoiceAt, now, answerWindow);
+        if (armed is not { AnswerWindowEndsAt: { } endsAt })
+            return armed;
 
         // Nothing invalidates this state when the window merely lapses, and without the
         // auto-invalidation the source would keep naming the answering chat forever.
-        var expiresIn = vAnswer.At + answerWindow - now + AnswerWindowExpiryDelay;
+        var expiresIn = endsAt - now + AnswerWindowExpiryDelay;
         Computed.GetCurrent().Invalidate(expiresIn, false);
-        return (vAnswer.ChatId, extraChatCount);
+        return armed;
     }
 
     private async Task<ActivityChatInfo> GetChatInfo(ChatId chatId)

--- a/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Activities/AudioActivitySource.cs
@@ -8,7 +8,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
 {
     private static readonly TimeSpan AnswerWindowExpiryDelay = TimeSpan.FromMilliseconds(250);
 
-    private readonly bool _isAndroidHost;
+    private readonly bool _isMauiHost;
     private bool _isDisposed;
 
     private AppUIHub Hub { get; }
@@ -24,8 +24,8 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     public AudioActivitySource(AppUIHub hub)
     {
         Hub = hub;
-        _isAndroidHost = hub.HostInfo.AppKind == AppKind.Android;
-        if (_isAndroidHost) {
+        _isMauiHost = hub.HostInfo.HostKind.IsMauiApp();
+        if (_isMauiHost) {
             IncomingVoiceActivityUI.IncomingVoiceStamped += OnIncomingVoiceStamped;
             GestureUI.StartGestureReadyChanged += OnStartGestureReadyChanged;
         }
@@ -34,7 +34,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     public void Dispose()
     {
         _isDisposed = true;
-        if (_isAndroidHost) {
+        if (_isMauiHost) {
             IncomingVoiceActivityUI.IncomingVoiceStamped -= OnIncomingVoiceStamped;
             GestureUI.StartGestureReadyChanged -= OnStartGestureReadyChanged;
         }
@@ -47,7 +47,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         ActivityKind? kind = null;
         var extraChatCount = 0;
         var isPaused = false;
-        var pttChatIds = _isAndroidHost
+        var pttChatIds = _isMauiHost
             ? await ChatAudioUI.GetPttChatIds(cancellationToken).ConfigureAwait(false)
             : [];
 
@@ -96,7 +96,7 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
         Moment? answerWindowEndsAt = null;
         var isStartGestureReady = false;
         if (kind is not { } vKind) {
-            var answerWindow = _isAndroidHost
+            var answerWindow = _isMauiHost
                 ? await Hub.UserSettingsUI.UserPttSettings()
                     .Get(x => x.AnswerWindow, cancellationToken)
                     .ConfigureAwait(false)
@@ -159,11 +159,11 @@ public class AudioActivitySource : IActivitySource, IDisposable, IHasDisposeStat
     private (ChatId ChatId, int ExtraChatCount, Moment? AnswerWindowEndsAt)? GetArmedChat(
         List<ChatId> pttChatIds, TimeSpan answerWindow)
     {
-        // Android only, and the reason is the foreground service the backend drives: Android grants
+        // MAUI hosts only. On Android it also keeps the foreground service up: Android grants
         // microphone access on the serviceType of the last startForeground call, and only if the app
-        // wasn't in the background when it ran. A service first started by a wake therefore can never
-        // record - so while any chat is armed the service stays up, started while the app is visible.
-        // It also keeps the media session (the headset button) alive across the answer window.
+        // wasn't in the background when it ran - so a service first started by a wake can never
+        // record, and while any chat is armed this keeps it (and the headset button's media session)
+        // alive. On iOS it carries the PTT state the Live Activity shows. The web has neither.
         var now = Hub.Clocks.ServerClock.Now;
         var lastIncomingVoiceAt = IncomingVoiceActivityUI.SnapshotLastIncomingVoiceAt();
         var armed = ResolveArmedChat(pttChatIds, lastIncomingVoiceAt, now, answerWindow);

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/FlipToTalkDetector.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/FlipToTalkDetector.cs
@@ -1,22 +1,21 @@
 namespace ActualChat.UI.Blazor.App.Services.Gestures;
 
 /// <summary>
-/// Fires on portrait → landscape → portrait within <see cref="FlipWindow"/>, where landscape
-/// must be held for <see cref="LandscapeDwell"/> and only gravity-dominated samples classify.
+/// Fires on portrait → landscape → portrait, where landscape must be held for at least
+/// <see cref="LandscapeDwell"/> and at most <see cref="FlipWindow"/>, dated by the return to
+/// portrait, and only gravity-dominated samples classify.
 /// Two rotations in sequence is what makes it deliberate enough to open the mic.
 /// </summary>
 public sealed class FlipToTalkDetector
 {
     public static readonly TimeSpan FlipWindow = TimeSpan.FromSeconds(2);
-    public static readonly TimeSpan LandscapeDwell = TimeSpan.FromMilliseconds(200);
+    public static readonly TimeSpan LandscapeDwell = TimeSpan.FromMilliseconds(120);
     private const float MinDominance = 0.7f;
     private const float MaxGravityDeviation = 0.3f;
 
     private GravityAxis _lastAxis;
     private Moment _lastAxisSince;
     private bool _isLandscapeFromPortrait;
-    private Moment _leftPortraitAt;
-    private bool _hasLeftPortrait;
 
     public bool Process(SensorSample sample)
     {
@@ -29,32 +28,31 @@ public sealed class FlipToTalkDetector
         if (axis == GravityAxis.None)
             return false;
 
-        if (axis == _lastAxis) {
-            if (axis == GravityAxis.X && _isLandscapeFromPortrait && !_hasLeftPortrait
-                && sample.At - _lastAxisSince >= LandscapeDwell) {
-                _hasLeftPortrait = true;
-                _leftPortraitAt = _lastAxisSince;
-            }
-
+        if (axis == _lastAxis)
             return false;
-        }
 
         var lastAxis = _lastAxis;
+        // Captured before the overwrite: the return to portrait is what dates the landscape hold.
+        // Measuring it on an intervening landscape sample instead would need one to land past the
+        // dwell, which at the ~68ms sample cadence a real quick flip (~135ms) never provides.
+        var lastAxisSince = _lastAxisSince;
         _lastAxis = axis;
         _lastAxisSince = sample.At;
         if (axis == GravityAxis.X) {
             _isLandscapeFromPortrait = lastAxis == GravityAxis.Y;
             return false;
         }
-        if (axis == GravityAxis.Y && _hasLeftPortrait && sample.At - _leftPortraitAt <= FlipWindow) {
-            Reset();
-            _lastAxis = axis;
-            _lastAxisSince = sample.At;
-            return true;
+        if (axis == GravityAxis.Y && lastAxis == GravityAxis.X && _isLandscapeFromPortrait) {
+            var dwell = sample.At - lastAxisSince;
+            if (dwell >= LandscapeDwell && dwell <= FlipWindow) {
+                Reset();
+                _lastAxis = axis;
+                _lastAxisSince = sample.At;
+                return true;
+            }
         }
 
         _isLandscapeFromPortrait = false;
-        _hasLeftPortrait = false;
         return false;
     }
 
@@ -63,7 +61,5 @@ public sealed class FlipToTalkDetector
         _lastAxis = GravityAxis.None;
         _lastAxisSince = default;
         _isLandscapeFromPortrait = false;
-        _hasLeftPortrait = false;
-        _leftPortraitAt = default;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/GestureActivationPolicy.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/GestureActivationPolicy.cs
@@ -53,6 +53,18 @@ public static class GestureActivationPolicy
         return HasAnswerWindow(pttChatIds, lastIncomingVoiceAt, now, recencyWindow);
     }
 
+    public static bool IsStartGestureReady(
+        bool mustSenseStartGestures,
+        bool isFlipToTalkEnabled,
+        bool isDoubleShakeEnabled,
+        bool isPracticeMode)
+        // What the notification must promise: not "a chat is armed", but "a flip or shake right
+        // now opens the mic". Sensing is only half of it - practice mode routes gestures away
+        // from transmitting, and with both toggles off there is no start gesture to fire.
+        => mustSenseStartGestures
+            && !isPracticeMode
+            && (isFlipToTalkEnabled || isDoubleShakeEnabled);
+
     public static bool ShouldSenseStopGesture(bool isFaceDownStopEnabled, bool isTransmitting, bool isPracticeMode)
     {
         // The playground must let the user rehearse the stop gesture even when the privacy

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/GestureUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/GestureUI.cs
@@ -21,7 +21,9 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
     private volatile bool _isPracticeMode;
     private bool _isHeadsetButtonEnabled;
     private bool _hasAnswerWindow;
+    private bool _isStartGestureReady;
     private int _sampleCount;
+    private long _lastSampleAtTicks;
     private Moment? _lastForegroundedAt;
     private TaskCompletionSource _wakeSignal = TaskCompletionSourceExt.New();
 
@@ -42,6 +44,10 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
     public SensorSample LastSample
         => _recentSamples[(_recentSampleIndex + _recentSamples.Length - 1) % _recentSamples.Length];
     public event Action<GestureEvent>? PracticeGestureDetected;
+    // Raised when a flip/shake would start meaning something (or stop meaning it), so the
+    // notification can say whether it's listening for one instead of just "PTT is on".
+    public event Action? StartGestureReadyChanged;
+    public bool IsStartGestureReady => Volatile.Read(ref _isStartGestureReady);
 
     public bool IsPracticeMode {
         get => _isPracticeMode;
@@ -173,6 +179,24 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
                     settings, pttChatIds, lastIncomingVoiceAt, now, recencyWindow, isMicOpen, isPracticeMode);
                 Volatile.Write(ref _isHeadsetButtonEnabled, buttonState.IsEnabled);
                 Volatile.Write(ref _hasAnswerWindow, buttonState.HasAnswerWindow);
+                // Availability is a device fact rather than a policy one, so it's ANDed here:
+                // a host without a working accelerometer can never fire a start gesture, and
+                // promising one in the notification is the exact lie this signal exists to stop.
+                // So is delivery: the scoped feed shares one process-wide Accelerometer.Default, so
+                // a dying scope's Stop() can kill the live scope's registration while every policy
+                // input still reads "armed" - only arriving samples prove a flip can fire.
+                var sinceLastSample = Clocks.CpuClock.Now
+                    - new Moment(Volatile.Read(ref _lastSampleAtTicks));
+                var isSensorLive = sinceLastSample <= Constants.Audio.PttIdleCheckPeriod;
+                var isStartGestureReady = Feed.IsAccelerometerAvailable
+                    && isSensorLive
+                    && GestureActivationPolicy.IsStartGestureReady(
+                        mustSenseStart, settings.IsFlipToTalkEnabled, settings.IsDoubleShakeEnabled,
+                        isPracticeMode);
+                if (Volatile.Read(ref _isStartGestureReady) != isStartGestureReady) {
+                    Volatile.Write(ref _isStartGestureReady, isStartGestureReady);
+                    StartGestureReadyChanged?.Invoke();
+                }
 
                 _recognizer.Options = new GestureOptions(
                     settings.IsFlipToTalkEnabled && mustSenseStart,
@@ -215,6 +239,12 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
         finally {
             Feed.StopAccelerometer();
             Feed.StopProximity();
+            // The sensors are down, so nothing can fire - a readiness left latched here would
+            // have the notification promising a gesture for the rest of the scope's life.
+            if (Volatile.Read(ref _isStartGestureReady)) {
+                Volatile.Write(ref _isStartGestureReady, false);
+                StartGestureReadyChanged?.Invoke();
+            }
         }
     }
 
@@ -231,6 +261,9 @@ public sealed class GestureUI : UIWorkerBase<AppUIHub>
     private void OnSample(SensorSample sample)
     {
         Interlocked.Increment(ref _sampleCount);
+        // Proof the sensor is actually delivering, which is what readiness must be built on:
+        // a stopped accelerometer still leaves every policy input saying "armed".
+        Volatile.Write(ref _lastSampleAtTicks, Clocks.CpuClock.Now.EpochOffsetTicks);
         _recentSamples[_recentSampleIndex] = sample;
         _recentSampleIndex = (_recentSampleIndex + 1) % _recentSamples.Length;
         // Logged so gesture misbehavior can be traced back to a guard-state transition on-device.

--- a/src/dotnet/UI.Blazor.App/Services/Gestures/SensorFeed.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Gestures/SensorFeed.cs
@@ -9,6 +9,14 @@ public class SensorFeed
     public event Action<SensorSample>? SampleReceived;
     public event Action<bool>? ProximityChanged;
 
+    public static bool IsAccelerometerStale(
+        Moment startedAt, Moment lastSampleAt, Moment now, TimeSpan timeout)
+        // Delivery, not the platform's own "started" flag: one process-wide accelerometer is
+        // shared by every scope, so a registration can die under a feed that still believes it
+        // owns one - and nothing would restart it. No sample yet dates from the start instead,
+        // which is what keeps a warming-up sensor from reading as dead.
+        => now - (lastSampleAt != default ? lastSampleAt : startedAt) >= timeout;
+
     public virtual bool IsAccelerometerAvailable => false;
     public virtual bool IsProximityAvailable => false;
 

--- a/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
+++ b/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
@@ -24,7 +24,8 @@ public sealed record AudioActivity(
     ActivityKind Kind,
     ActivityChatInfo Chat,
     bool IsPaused,
-    bool CanPause = true
+    bool CanPause = true,
+    Moment? AnswerWindowEndsAt = null
 ) : ActivityInfo(Kind);
 
 public sealed record LocationActivity(ActivityChatInfo Chat)

--- a/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
+++ b/src/dotnet/UI.Blazor/Services/ActivitiesUI/ActivityInfo.cs
@@ -25,7 +25,8 @@ public sealed record AudioActivity(
     ActivityChatInfo Chat,
     bool IsPaused,
     bool CanPause = true,
-    Moment? AnswerWindowEndsAt = null
+    Moment? AnswerWindowEndsAt = null,
+    bool IsStartGestureReady = false
 ) : ActivityInfo(Kind);
 
 public sealed record LocationActivity(ActivityChatInfo Chat)

--- a/tests/Chat.UI.Blazor.UnitTests/AudioActivitySourceTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/AudioActivitySourceTest.cs
@@ -1,0 +1,61 @@
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class AudioActivitySourceTest
+{
+    private static readonly Moment T0 = Moment.EpochStart + TimeSpan.FromDays(20_000);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(15);
+    private static readonly ChatId ChatA = ChatId.Parse("aaaaaaaaaaaaaaaaaaaa");
+    private static readonly ChatId ChatB = ChatId.Parse("bbbbbbbbbbbbbbbbbbbb");
+
+    [Fact]
+    public void NoArmedChatsShouldResolveToNull()
+    {
+        AudioActivitySource.ResolveArmedChat([], new Dictionary<ChatId, Moment>(), T0, Window)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ArmedWithoutIncomingVoiceShouldHaveNoAnswerWindow()
+    {
+        var resolved = AudioActivitySource.ResolveArmedChat(
+            [ChatA, ChatB], new Dictionary<ChatId, Moment>(), T0, Window);
+
+        resolved.Should().Be((ChatA, 1, (Moment?)null));
+    }
+
+    [Fact]
+    public void RecentIncomingVoiceShouldOpenAnswerWindowUntilItsEnd()
+    {
+        var at = T0 - TimeSpan.FromSeconds(5);
+        var last = new Dictionary<ChatId, Moment> { [ChatB] = at };
+
+        var resolved = AudioActivitySource.ResolveArmedChat([ChatA, ChatB], last, T0, Window);
+
+        resolved.Should().Be((ChatB, 1, (Moment?)(at + Window)),
+            "the answering chat owns the window, and it ends one answerWindow after its last voice");
+    }
+
+    [Fact]
+    public void StaleIncomingVoiceShouldNotOpenAnswerWindow()
+    {
+        var last = new Dictionary<ChatId, Moment> { [ChatB] = T0 - TimeSpan.FromSeconds(400) };
+
+        var resolved = AudioActivitySource.ResolveArmedChat([ChatA, ChatB], last, T0, Window);
+
+        resolved.Should().Be((ChatA, 1, (Moment?)null));
+    }
+
+    [Fact]
+    public void LatestSpeakerShouldWinTheAnswerWindow()
+    {
+        var atA = T0 - TimeSpan.FromSeconds(10);
+        var atB = T0 - TimeSpan.FromSeconds(2);
+        var last = new Dictionary<ChatId, Moment> { [ChatA] = atA, [ChatB] = atB };
+
+        var resolved = AudioActivitySource.ResolveArmedChat([ChatA, ChatB], last, T0, Window);
+
+        resolved.Should().Be((ChatB, 1, (Moment?)(atB + Window)));
+    }
+}

--- a/tests/Chat.UI.Blazor.UnitTests/ChatActivityPanelModelTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatActivityPanelModelTest.cs
@@ -1,0 +1,67 @@
+using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.App.Components;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class ChatActivityPanelModelTest
+{
+    [Fact]
+    public void ArmedPttChatWithNothingToShowShouldHidePanel()
+    {
+        var model = NewModel(isPttArmed: true, hasOngoingCall: true);
+
+        model.IsVisible.Should().BeFalse(
+            "an open-but-silent mic renders nothing, so the panel would be blank");
+    }
+
+    [Fact]
+    public void ArmedPttChatWithTalkerShouldShowPanel()
+        => NewModel(isPttArmed: true, hasOngoingCall: true, isAnyoneTalking: true)
+            .IsVisible.Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttChatWithRemoteStreamsShouldShowPanel()
+        => NewModel(isPttArmed: true, hasOngoingCall: true, hasRemoteStreams: true)
+            .IsVisible.Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttChatStreamingOwnVideoShouldShowPanel()
+        => NewModel(isPttArmed: true, hasOngoingCall: true, isOwnVideoStreaming: true)
+            .IsVisible.Should().BeTrue("the panel carries the hang-up button for own transmission");
+
+    [Fact]
+    public void ArmedPttChatRecordingHereShouldShowPanel()
+        => NewModel(isPttArmed: true, hasOngoingCall: true, isRecordingHere: true)
+            .IsVisible.Should().BeTrue();
+
+    [Fact]
+    public void LocationSharingShouldShowPanelEvenWithoutCallActivity()
+        => NewModel(isPttArmed: true, isSharingOwnLocation: true)
+            .IsVisible.Should().BeTrue("the panel carries the stop-sharing button");
+
+    [Fact]
+    public void UnarmedListeningChatShouldStillShowPanel()
+        => NewModel(isPttArmed: false, isListening: true)
+            .IsVisible.Should().BeTrue("a deliberate listen is an activity outside PTT arming");
+
+    private static ChatActivityPanel.Model NewModel(
+        bool isPttArmed = false,
+        bool hasOngoingCall = false,
+        bool isAnyoneTalking = false,
+        bool hasRemoteStreams = false,
+        bool isSharingOwnLocation = false,
+        bool isListening = false,
+        bool isOwnVideoStreaming = false,
+        bool isRecordingHere = false)
+        => new() {
+            AudioState = new ChatAudioState(null, isListening, false, isRecordingHere),
+            IsPttArmed = isPttArmed,
+            HasOngoingCall = hasOngoingCall,
+            IsAnyoneTalking = isAnyoneTalking,
+            HasRemoteStreams = hasRemoteStreams,
+            IsOwnVideoStreaming = isOwnVideoStreaming,
+            IsWatchingHere = false,
+            IsAudioDiagnosticsEnabled = false,
+            IsSharingOwnLocation = isSharingOwnLocation,
+        };
+}

--- a/tests/Chat.UI.Blazor.UnitTests/ChatActivityVisibilityTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatActivityVisibilityTest.cs
@@ -1,0 +1,45 @@
+using ActualChat.UI.Blazor.App.Components;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class ChatActivityVisibilityTest
+{
+    [Fact]
+    public void ArmedPttBareListenShouldNotCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isListening: true)
+            .Should().BeFalse("arming pins IsListening on, so it's ambient state, not an activity");
+
+    [Fact]
+    public void UnarmedListenShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: false, isListening: true)
+            .Should().BeTrue("a deliberate listen outside PTT arming is a real activity");
+
+    [Fact]
+    public void ArmedPttRecordingShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isRecording: true)
+            .Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttWithTalkerShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isListening: true, isAnyoneTalking: true)
+            .Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttWithOwnVideoShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isListening: true, isOwnVideoStreaming: true)
+            .Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttWithRemoteStreamsShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isListening: true, hasRemoteStreams: true)
+            .Should().BeTrue();
+
+    [Fact]
+    public void ArmedPttSharingLocationShouldCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: true, isListening: true, isSharingOwnLocation: true)
+            .Should().BeTrue();
+
+    [Fact]
+    public void IdleUnarmedChatShouldNotCountAsActivity()
+        => ChatActivityVisibility.HasActivity(isPttArmed: false).Should().BeFalse();
+}

--- a/tests/Chat.UI.Blazor.UnitTests/GestureActivationPolicyTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/GestureActivationPolicyTest.cs
@@ -202,3 +202,41 @@ public class GestureActivationPolicyTest
         GestureActivationPolicy.Route(GestureKind.None, true).Should().Be(GestureRoute.None);
     }
 }
+
+public class StartGestureReadinessTest
+{
+    [Fact]
+    public void SensedAndEnabledGestureShouldBeReady()
+        => GestureActivationPolicy.IsStartGestureReady(
+                mustSenseStartGestures: true, isFlipToTalkEnabled: true,
+                isDoubleShakeEnabled: false, isPracticeMode: false)
+            .Should().BeTrue();
+
+    [Fact]
+    public void UnsensedGestureShouldNotBeReady()
+        => GestureActivationPolicy.IsStartGestureReady(
+                mustSenseStartGestures: false, isFlipToTalkEnabled: true,
+                isDoubleShakeEnabled: true, isPracticeMode: false)
+            .Should().BeFalse("the accelerometer is stopped outside the arming window");
+
+    [Fact]
+    public void BothGestureTogglesOffShouldNotBeReady()
+        => GestureActivationPolicy.IsStartGestureReady(
+                mustSenseStartGestures: true, isFlipToTalkEnabled: false,
+                isDoubleShakeEnabled: false, isPracticeMode: false)
+            .Should().BeFalse("no start gesture exists to fire");
+
+    [Fact]
+    public void PracticeModeShouldNotBeReady()
+        => GestureActivationPolicy.IsStartGestureReady(
+                mustSenseStartGestures: true, isFlipToTalkEnabled: true,
+                isDoubleShakeEnabled: true, isPracticeMode: true)
+            .Should().BeFalse("practice mode never transmits");
+
+    [Fact]
+    public void DoubleShakeAloneShouldBeReady()
+        => GestureActivationPolicy.IsStartGestureReady(
+                mustSenseStartGestures: true, isFlipToTalkEnabled: false,
+                isDoubleShakeEnabled: true, isPracticeMode: false)
+            .Should().BeTrue();
+}

--- a/tests/Chat.UI.Blazor.UnitTests/GestureDetectorTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/GestureDetectorTest.cs
@@ -44,6 +44,19 @@ public class GestureDetectorTest
     }
 
     [Fact]
+    public void FlipFiresOnQuickRotation()
+    {
+        // Measured on-device 2026-09-01: a quick flip holds landscape ~135ms, and at the ~68ms
+        // sample cadence no landscape sample lands past the dwell - only the return dates it.
+        var d = new FlipToTalkDetector();
+        // act + assert
+        d.Process(Portrait(0)).Should().BeFalse();
+        d.Process(Landscape(68)).Should().BeFalse();
+        d.Process(Landscape(136)).Should().BeFalse();
+        d.Process(Portrait(203)).Should().BeTrue();
+    }
+
+    [Fact]
     public void FlipDoesNotFireOnHalfRotation()
     {
         // Portrait -> landscape held well past the dwell is only half a flip: without a return

--- a/tests/Chat.UI.Blazor.UnitTests/SensorFeedTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/SensorFeedTest.cs
@@ -1,0 +1,35 @@
+using ActualChat.UI.Blazor.App.Services.Gestures;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class SensorFeedTest
+{
+    private static readonly Moment T0 = Moment.EpochStart + TimeSpan.FromDays(20_000);
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(3);
+    private static Moment At(double s) => T0 + TimeSpan.FromSeconds(s);
+
+    [Fact]
+    public void JustStartedWithoutSamplesShouldNotBeStale()
+        => SensorFeed.IsAccelerometerStale(startedAt: T0, lastSampleAt: default, now: At(1), Timeout)
+            .Should().BeFalse("the sensor is still warming up");
+
+    [Fact]
+    public void StartedLongAgoWithoutSamplesShouldBeStale()
+        => SensorFeed.IsAccelerometerStale(startedAt: T0, lastSampleAt: default, now: At(5), Timeout)
+            .Should().BeTrue("a registration that never delivered is dead");
+
+    [Fact]
+    public void RecentSamplesShouldNotBeStale()
+        => SensorFeed.IsAccelerometerStale(startedAt: T0, lastSampleAt: At(9), now: At(10), Timeout)
+            .Should().BeFalse();
+
+    [Fact]
+    public void SamplesStoppedPastTimeoutShouldBeStale()
+        => SensorFeed.IsAccelerometerStale(startedAt: T0, lastSampleAt: At(4), now: At(10), Timeout)
+            .Should().BeTrue("delivery stopped even though the flag still says on");
+
+    [Fact]
+    public void SamplesShouldOutweighAnOldStart()
+        => SensorFeed.IsAccelerometerStale(startedAt: T0, lastSampleAt: At(100), now: At(101), Timeout)
+            .Should().BeFalse();
+}


### PR DESCRIPTION
## What

The Android PTT foreground notification now renders the full PTT state machine instead of a static "Push-to-talk is on", and gains actions:

- **Answer window open**: "Flip to reply — <chat>" with a native OS-ticked chronometer countdown to the window's end. Standard-style notification for this state only — the media template doesn't render a chronometer; the media session stays alive underneath so the headset button keeps working.
- **Reply** action in armed/listening/replaying states — opens the mic through the same `PttMicCapability.HoldWhile(RequestReply(unbounded))` path as the headset button, so it works outside the gesture window too (target: last speaker, else focused/sole armed chat; vibration failure cue if ambiguous). Practice mode guarded.
- **Stop talking** action while recording — ends the reply only, instead of the session-killing Stop.
- The pre-Blazor armed placeholder now opens the app on tap (it previously had no content intent at all).

## How

- `AudioActivity` carries `AnswerWindowEndsAt` (server-clock `Moment?`), resolved by the new testable `AudioActivitySource.ResolveArmedChat`; the source's existing expiry invalidation re-posts the notification when the window opens, moves, or lapses.
- `AndroidActivitiesBackend.ShowImpl` converts it to a wall-clock-domain `AnswerWindowRemainingMs` intent extra.
- `OnStartCommand` resets `_requestId` only on ActionShow, so a Reply tap can't cancel an in-flight avatar update.
- Drive-by (style hook): sealed `AndroidActivitiesForegroundService` and its nested `Callback`.

## Testing

- TDD'd `ResolveArmedChat` (5 new unit tests); all 734 `Chat.UI.Blazor.UnitTests` pass.
- `App.Maui` (net11.0-android) and `App.Server` build clean.
- **Pending**: on-device pass — countdown rendering, Reply from background/keyguard (mic grant), Stop-talking semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014coKd2vpVGa5PVvHB6Qt3c