### PR TITLE
fix(video): trim the encoder ladder to measured winners, exempt encoder startup from the deficit

### DIFF
--- a/docs/live-video/03-codecs-and-layers.md
+++ b/docs/live-video/03-codecs-and-layers.md
@@ -11,8 +11,8 @@ File: `src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts`.
 `detectSupportedCodecs(width, height)` probes one representative encoder per
 category to keep startup cheap. Categories:
 
-- **AV1** (`av01.*`) — preferred where hardware exists; software AV1 is used
-  too, but not on phones.
+- **AV1** (`av01.*`) — hardware only. Preferred where that hardware exists;
+  the software encoder is not a ladder rung anywhere.
 - **HEVC** (`hev1.*` / `hvc1.*`) — hardware only; Chromium ships no software
   HEVC encoder, and Firefox ships none at all.
 - **VP9** (`vp09.*`) — the negotiation floor (see below).
@@ -69,10 +69,14 @@ floor.
 
 Selection walks an explicit ladder over (codec, acceleration) pairs, best-first:
 
-    hw-AV1 > hw-VP9 > hw-HEVC > sw-AV1 > sw-VP9 > hw-H.264 > sw-H.264
+    hw-AV1 > hw-VP9 > hw-HEVC > sw-VP9 > hw-H.264
 
-Software HEVC is absent (Chromium has none); software AV1 is withheld on phones.
-Firefox drops both MPEG rungs. `listCodecCandidatesByEfficiency` filters that
+VP9 is the only software rung, because it is also the floor every client must
+be able to decode. Software HEVC does not exist in Chromium; software AV1 and
+software H.264 were both measured and dropped — see
+[codec-performance.md](./codec-performance.md). Firefox drops both MPEG rungs.
+
+`listCodecCandidatesByEfficiency` filters that
 ladder to what the *audience* can decode, drops anything with `realtime: false`,
 and honours the "prefer encode codec" debug override. `getFallbackCodecs` runs
 only when nothing qualifies at all, returning the same ladder order without

--- a/docs/live-video/08-quality-control.md
+++ b/docs/live-video/08-quality-control.md
@@ -193,8 +193,12 @@ clamps now rather than at the next 5 s interval.
 ### What composes the layer count
 
 1. **`EncodingCap`** — driven by `RecorderStats.EncodeDeficitEma`, the
-   *throughput deficit* `1 − bundlesEncodedPerSec / framesCapturedPerSec`
-   (`0` = the encoder keeps pace, `1` = it emits nothing). Deficit above
+   *throughput deficit* `1 − bundlesEncodedPerSec / framesOfferedPerSec`
+   (`0` = the encoder keeps pace, `1` = it emits nothing). The denominator is
+   frames *offered* to the encoder, not captured, so deliberate fps pacing does
+   not read as falling behind; and ticks before the encoder's first output are
+   exempt for a bounded grace period, since an encoder still starting up scores
+   a full `1` (see `EncodeDeficitTicker`). Deficit above
    `EncBadDeficit = 0.20` for 2 ticks demotes; below `EncOkDeficit = 0.05` for
    5 ticks promotes. In between is a **dead band**: the bad streak clears but
    the good streak only *decays by one*, so a single transient excursion can't

--- a/docs/live-video/README.md
+++ b/docs/live-video/README.md
@@ -19,6 +19,7 @@ from current source code under `src/`.
 | 9 | [09-diagnostics.md](./09-diagnostics.md) | Meters, diagnostics modal, debug overrides, tunable constants |
 | 10 | [10-glossary.md](./10-glossary.md) | Glossary of types, files, and abbreviations |
 | 11 | [11-buffering-and-av-sync.md](./11-buffering-and-av-sync.md) | "One buffer per side" goal vs. current shape; A/V sync (wired but disabled) |
+| — | [codec-performance.md](./codec-performance.md) | Measured encode cost and codec support per device — the evidence behind the encoder ladder |
 
 ## Top-level architecture
 

--- a/docs/live-video/codec-performance.md
+++ b/docs/live-video/codec-performance.md
@@ -1,0 +1,220 @@
+# Codec performance — measured
+
+Every number here was measured on a real device through WebCodecs, not taken
+from a spec sheet or a vendor claim. It is the evidence behind
+[`ENCODER_LADDER`](../../src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts)
+and the codec policy in [03-codecs-and-layers.md](./03-codecs-and-layers.md).
+
+Measured 2026-08-30/31. Re-measure when a device, browser or codec set changes —
+several results here contradict what the same platforms were assumed to do.
+
+## How to read the numbers
+
+**ms/frame is encode time only.** Frames are decoded and held in advance, so
+decode never enters the timed window. Each configuration runs a warm-up pass,
+then the counters reset and the measured pass is timed from the first
+`encode()` to the resolved `flush()`. Three runs, minimum taken.
+
+**The warm-up is not optional.** Hardware encoders spend ~215 ms initialising
+on first use, which is most of a short run: without a warm-up every codec and
+resolution measures the same and the result is meaningless. Two separate bugs
+in this repo came from measuring an encoder mid-startup — the realtime probe
+and the sender's throughput deficit — so treat any "they're all identical"
+result as a broken harness rather than a finding.
+
+**Budget is 33 ms/frame at 30 fps.** Nothing measured on any device comes
+close, even in software. Simulcast does not multiply that by the tier count
+either: encode time scales *sub*-linearly with pixels here — on the hardware
+paths 480p costs ~two thirds of 720p for 44% of the pixels — so summing all
+three measured
+resolutions comes to ~2x the 1080p tier alone, and the app's real
+W1280/W640/W320 ladder is smaller still. Ample room either way.
+
+**kbps is what the encoder actually produced**, against the target passed in
+`bitrate`. It is worth watching: several encoders miss badly in both
+directions.
+
+**Content differs between the desktop and phone runs.** Desktop used a real
+1080p camera clip (`WIN_20260831…mp4`), lanczos-resized to each resolution.
+The phones used generated frames — a moving-bar pattern over a gradient with a
+noise band — because ATS blocks plain HTTP from the app WebView and streaming
+the clip in as base64 stalled on the usbmux transport. **Phone-to-phone is
+directly comparable; phone-to-desktop is not.** Fixing this properly means
+shipping the clips in the app's `wwwroot` so they are same-origin.
+
+## Capability matrix
+
+What each engine reports for `VideoEncoder.isConfigSupported`, probing
+`prefer-hardware` and `prefer-software` independently.
+
+| | AV1 | HEVC | VP9 | H.264 |
+|---|---|---|---|---|
+| **Chrome / Windows** (RTX 3090) | hw + sw | hw only | **sw only** | hw + sw |
+| **Firefox / Windows** | sw only | **none** | sw only | sw only, *not real-time* |
+| **iPhone 13 Pro** (WKWebView) | **none** | hw + sw | hw + sw | hw + sw |
+| **Galaxy SM-S948U1** (WebView 151) | sw only | **hw only** | sw only | hw + sw |
+
+No two platforms agree. The only codec every engine can encode is VP9, which
+is why it is the negotiation floor.
+
+**The Chromium rows are GPU-dependent, not engine-wide.** "VP9 sw only" and
+"HEVC hw only" describe what that machine's GPU exposes through Chromium, and a
+different adapter answers differently — which is the whole reason detection
+probes each device rather than keying off the browser. The Firefox and WebKit
+rows are engine limits and do generalise.
+
+**The `hardwareAcceleration` hint means different things per engine.** On
+Chromium the answers are real — an unsupported mode is a genuine gap. On
+WebKit they are not: HEVC and VP9 measure identically under both modes (2.98 vs
+3.05, 2.27 vs 2.30 at 480p), so WebKit is answering "supported" without
+distinguishing. Only H.264 differs there. The echoed `config.hardwareAcceleration`
+is worthless everywhere — it mirrors the request — which is why detection asks
+each mode separately and believes only the `supported` flag.
+
+## Desktop — Chrome, Windows
+
+Real camera clip, 90 frames, 30-frame warm-up. Targets: 800 kbps at 480p,
+1.8 Mbps at 720p, 3.5 Mbps at 1080p.
+
+| codec / profile | 480p hw | 480p sw | 720p hw | 720p sw | 1080p hw | 1080p sw |
+|---|---|---|---|---|---|---|
+| AV1 Main L4.0 `av01.0.08M.08` | 0.86 | 1.21 | 1.26 | 1.68 | 2.18 | 2.76 |
+| AV1 Main L3.0 `av01.0.05M.08` | 0.83 | 1.21 | 1.27 | 1.64 | 1.99 | 2.83 |
+| HEVC Main L4.0 `hev1.1.6.L120.B0` | 0.79 | — | 1.19 | — | 2.14 | — |
+| HEVC Main L3.1 `hev1.1.6.L93.B0` | 0.82 | — | 1.20 | — | 2.12 | — |
+| VP9 P0 L4.1 `vp09.00.41.08` | — | 1.71 | — | 1.97 | — | 3.33 |
+| VP9 P0 L3.1 `vp09.00.31.08` | — | 1.64 | — | 2.00 | — | 3.31 |
+| H.264 CBP `avc1.42E01F` / `42E028` | 0.87 | 0.77 | 1.32 | 1.01 | 2.15 | 2.06 |
+
+Achieved bitrate, hw / sw: AV1 699/123, HEVC 475/—, VP9 —/550, H.264 511/94 at
+480p. The **software encoders undershoot the target badly** — H.264 software
+produced 94 kbps against an 800 kbps target — so their apparent speed advantage
+at 480p is partly them doing less work at worse quality. Compare within an
+acceleration mode, not across. Hardware HEVC undershoots too (475 against 800),
+which is the usual quality/rate-control trade and not a fault; hardware AV1 at
+699 is the closest to the target.
+
+## iPhone 13 Pro — WKWebView (Voxt Dev build)
+
+Generated frames, 40 frames, 15-frame warm-up.
+
+| codec / profile | 480p hw | 480p sw | 720p hw | 720p sw |
+|---|---|---|---|---|
+| AV1 (both profiles) | unsupported | unsupported | unsupported | unsupported |
+| HEVC Main L4.0 | 2.98 | 3.05 | 4.97 | 5.03 |
+| HEVC Main L3.1 | 3.10 | 3.05 | 5.03 | 5.03 |
+| VP9 P0 L4.1 | **2.27** | 2.30 | **3.88** | 3.98 |
+| VP9 P0 L3.1 | 2.35 | 2.38 | 4.05 | 4.10 |
+| H.264 CBP | 1.95 | 2.25 | 4.60 | 7.28 |
+
+Achieved: HEVC 765 / VP9 720 / H.264 827 kbps at 480p (target 800); HEVC 1291 /
+VP9 1556 / H.264 1288 at 720p (target 1800).
+
+**VP9 encodes on iOS**, contradicting the common assumption that Apple has no
+VP9 encoder — verified by a full encode round-trip (12/12 chunks) in both
+acceleration modes, not just by `isConfigSupported`. At 720p it is the fastest
+of the three. **AV1 is absent entirely** on the A15.
+
+Decode, verified by round-trip with no `description` supplied:
+
+| | result |
+|---|---|
+| VP9 | 10/10 frames |
+| H.264 CBP | 10/10 frames |
+| HEVC | fails — genuinely needs a description |
+| AV1 | not advertised |
+
+That HEVC result is the rule `canConfigureWithoutDescription` encodes, confirmed
+on a third engine.
+
+## Galaxy SM-S948U1 — Android WebView 151.0.7922.199 (Voxt Dev build)
+
+Same harness and content as the iPhone, so these two tables compare directly.
+
+| codec / profile | 480p hw | 480p sw | 720p hw | 720p sw |
+|---|---|---|---|---|
+| AV1 Main L4.0 | unsupported | 2.36 | unsupported | 4.44 |
+| AV1 Main L3.0 | unsupported | 2.41 | unsupported | 4.65 |
+| HEVC Main L4.0 | **1.51** | unsupported | **2.55** | unsupported |
+| HEVC Main L3.1 | 1.44 | unsupported | 2.55 | unsupported |
+| VP9 P0 L4.1 | unsupported | 2.18 | unsupported | 3.75 |
+| VP9 P0 L3.1 | unsupported | 2.89 | unsupported | 3.86 |
+| H.264 CBP | **1.17** | 6.69 | **2.43** | 8.59 |
+
+Achieved at 720p against an 1800 kbps target: HEVC 2114, H.264 2509 (hw),
+AV1 1724 (sw), VP9 1840 (sw).
+
+Two things worth carrying forward. **The Android hardware encoders overshoot
+the bitrate target by 17–39%**, while its software encoders hit it — the ladder
+sizes tiers assuming the target is respected. And **software H.264 is the
+slowest encoder measured on any device** (6.69 ms at 480p against 1.17 ms for
+the same device's hardware path) while compressing worst of the four; that
+measurement is why it is no longer a ladder rung.
+
+## Firefox / Windows — latency, not throughput
+
+Firefox was measured for first-output latency rather than the full matrix,
+because that is what disqualifies it.
+
+| codec | first output | steady-state depth | verdict |
+|---|---|---|---|
+| H.264 (every `latencyMode`) | **18 frames** | stays ~18 behind | **not real-time** |
+| VP8 | 1 frame | 0 | fine |
+| VP9 | 1 frame | 0 | fine |
+| AV1 | 1 frame | 0 | fine |
+
+Firefox's H.264 encoder never catches up — it is ~18 frames behind for the
+whole stream, roughly 600 ms of added latency, and no configuration changes it.
+This is what `probeEncoderLatencyFrames` measures and what removes H.264 from
+Firefox's ladder. Firefox also ships **no HEVC encoder at all**.
+
+Decode round-trip with no description: VP9, H.264 and AV1 all 10/10.
+
+For contrast, Chromium's hardware encoders emit their first chunk after ~7
+frames / ~215 ms and then track submissions exactly — a startup cost, not a
+deficit. Charging that startup to the codec is precisely the bug that
+disqualified three working codecs on Chromium.
+
+## What the ladder does with all this
+
+```
+hw-AV1 > hw-VP9 > hw-HEVC > sw-VP9 > hw-H.264
+```
+
+Software AV1 and software H.264 are deliberately absent. Software H.264 is the
+slowest thing measured anywhere and compresses worst of the four. Software AV1
+is the narrower call: on the Galaxy — the one device offering both — it is ~18%
+slower than software VP9 at 720p (4.44 vs 3.75 ms) while producing *fewer* bits
+(1724 vs 1840 kbps), and ~8% slower at 480p. So it buys a CPU loss for no reach
+VP9 does not already have, VP9 being the floor every client must decode anyway.
+Software HEVC does not exist in Chromium. Firefox drops both MPEG rungs.
+
+Resulting choice per device, verified against each one's real detected
+capabilities:
+
+| device | chosen | why |
+|---|---|---|
+| Chrome / Windows | hw-AV1 | rung 1, available |
+| Firefox / Windows | sw-VP9 | no hardware encoder at all; MPEG rungs dropped |
+| iPhone 13 Pro | hw-VP9 | no AV1 encoder; VP9 also fastest at 720p |
+| Galaxy SM-S948U1 | hw-HEVC | no hardware AV1 or VP9 |
+
+Codec **level** (L4.0 vs L3.0/L3.1) makes no measurable difference on any
+device, so the ladder string and the detection probe string differing in level
+costs nothing.
+
+## Reproducing this
+
+The harness is a self-contained script that generates or decodes frames, runs
+the matrix, and leaves the result in `globalThis.__bench`.
+
+- **Desktop**: serve the clips over a local HTTP server and open the harness
+  page in the browser under test.
+- **Android**: `adb forward tcp:9334 localabstract:webview_devtools_remote_<pid>`,
+  then drive `Runtime.evaluate` over flat CDP. The app's WebView is inspectable
+  in the dev build.
+- **iOS**: `ios_webkit_debug_proxy -c <udid>:9222`, then wrap every command in
+  `Target.sendMessageToTarget` — iOS speaks the target-wrapped WebKit protocol,
+  not flat CDP, and `awaitPromise` is not honoured, so the script must park its
+  result in a global and be polled. The app must be **foregrounded**, or `/json`
+  returns an empty list that looks exactly like Web Inspector being off.

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -46,6 +46,7 @@ import { BrowserInfo } from '../../../UI.Blazor/Services/BrowserInfo/browser-inf
 import { ConnectivityUI } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
 import { SharedSettings } from 'shared-settings';
 import { SharedSettingsWorkerSync } from 'shared-settings-worker';
+import { EncodeDeficitTicker } from '../../Services/Video/throughput-deficit-ticker';
 import {
     detectSupportedCodecs,
     FLOOR_CATEGORY,
@@ -2726,7 +2727,8 @@ export class VideoRecorder {
     // slow keyframe would otherwise pop the classifier; α=0.3 gives a
     // ~3-tick half-life at 1 Hz polling.
     private static readonly EncodeDeficitEmaAlpha = 0.3;
-    private encodeDeficitEma = 0;
+    private readonly encodeDeficitTicker =
+        new EncodeDeficitTicker(VideoRecorder.EncodeDeficitEmaAlpha);
     private senderDropRatioEma = 0;
     // Per-tick instantaneous rates for every cumulative counter the modal /
     // overlay surfaces. Computed at the recorder-health-monitor boundary
@@ -2751,7 +2753,7 @@ export class VideoRecorder {
         this.stopRecorderHealthMonitor();
         this.lastRecorderHealthStats = null;
         this.lastRecorderHealthWasPeerConnected = false;
-        this.encodeDeficitEma = 0;
+        this.encodeDeficitTicker.reset();
         this.senderDropRatioEma = 0;
         this.capturedPerSec = 0;
         this.bundlesPerSec = 0;
@@ -2913,16 +2915,12 @@ export class VideoRecorder {
             // emitting at the offered rate registers 0 here; deficit only grows
             // when encoder emit rate actually falls behind. QC uses this to
             // decide whether to demote a spatial layer.
+            // Startup is not a deficit — see EncodeDeficitTicker.
             if (previous) {
-                const encDelta = Math.max(0, stats.bundlesEncoded - previous.bundlesEncoded);
-                const capDelta = Math.max(0, stats.framesOffered - previous.framesOffered);
-                if (capDelta > 0) {
-                    const throughputRatio = Math.min(1, encDelta / capDelta);
-                    const deficit = 1 - throughputRatio;
-                    this.encodeDeficitEma =
-                        VideoRecorder.EncodeDeficitEmaAlpha * deficit
-                        + (1 - VideoRecorder.EncodeDeficitEmaAlpha) * this.encodeDeficitEma;
-                }
+                this.encodeDeficitTicker.tick(
+                    stats.bundlesEncoded,
+                    Math.max(0, stats.bundlesEncoded - previous.bundlesEncoded),
+                    Math.max(0, stats.framesOffered - previous.framesOffered));
             }
 
             this.lastRecorderHealthStats = {
@@ -2943,7 +2941,7 @@ export class VideoRecorder {
             }
             await this.blazorRef.invokeMethodAsync(
                 'OnRecorderStats',
-                this.encodeDeficitEma,
+                this.encodeDeficitTicker.value,
                 this.senderDropRatioEma,
                 stats.wireLastAckAgeMs,
                 isPeerConnected,

--- a/src/dotnet/UI.Blazor.App/Services/EncodingCap.cs
+++ b/src/dotnet/UI.Blazor.App/Services/EncodingCap.cs
@@ -3,7 +3,7 @@ namespace ActualChat.UI.Blazor.App.Services;
 public sealed record EncodingCapConfig(
     // Thresholds match the THROUGHPUT-DEFICIT semantic of
     // `RecorderStats.EncodeDeficitEma` (range 0..1, deficit = 1 -
-    // bundlesEncoded/framesCaptured per-second EMA). Bad = sustained
+    // bundlesEncoded/framesOffered per-second EMA). Bad = sustained
     // encoder underrun, Good = within a few-% margin of source rate.
     // Demote layers when underrun persists `BadStreak` ticks.
     double EncodeDeficitBad = 0.20,

--- a/src/dotnet/UI.Blazor.App/Services/SenderHealthClassifier.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SenderHealthClassifier.cs
@@ -5,8 +5,8 @@ namespace ActualChat.UI.Blazor.App.Services;
 public sealed record SenderHealthThresholds(
     // `EncodeDeficit*` thresholds match the THROUGHPUT-DEFICIT semantic of
     // `RecorderStats.EncodeDeficitEma` (range 0..1, 0 = encoder keeps up
-    // with capture, 1 = encoder emits nothing). Bad = sustained deficit
-    // (encoder produces fewer bundles than captured); Good = within a
+    // with the frames offered to it, 1 = encoder emits nothing). Bad =
+    // sustained deficit (fewer bundles than frames offered); Good = within a
     // few-% margin. Background allows a wider miss because the tab
     // itself is throttled and source rate is naturally lower.
     double EncodeDeficitBadForeground = 0.15,

--- a/src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts
@@ -1,7 +1,6 @@
 import { getLogs } from 'logging';
 import { kbpsToBitsPerSecond } from 'app-constants';
 import { DeviceInfo } from 'device-info';
-import { SharedSettings } from 'shared-settings';
 import { isDecoderCodecProven, isEncoderCodecProven } from './codec-proof';
 import { closeEncodedChunk } from './frame-envelopes';
 
@@ -775,9 +774,18 @@ export function detectSupportedDecoderCodecs(): Promise<string[]> {
 // Baseline at a small size is the narrowest thing that answers it.
 // Encoder preference, best-first, over (category, acceleration) pairs rather
 // than categories: whether a codec is worth using depends on which encoder is
-// behind it. Software HEVC is absent because Chromium has none. Software AV1
-// sits behind every hardware rung and is gated further — see below. Anything
-// not listed here is never chosen as an encoder.
+// behind it.
+//
+// Only one software rung survives, and it is VP9. Software H.264 is the slowest
+// encoder measured anywhere - 6.69ms/frame at 480p on a Galaxy SM-S948U1
+// against 1.17ms for that device's hardware path - while compressing worst of
+// the four. Software AV1 is the closer call: at matched bitrate on the one
+// device that offers both it runs ~18% slower than software VP9 (4.44ms vs
+// 3.75ms at 720p), and VP9 is the floor every client already has to decode, so
+// the extra cost buys nothing. Software HEVC does not exist in Chromium at all.
+// Numbers in docs/live-video/codec-performance.md.
+//
+// Anything not listed here is never chosen as an encoder.
 export interface EncoderRung {
     category: CodecCategory;
     accel: HardwareAcceleration;
@@ -787,39 +795,17 @@ const ENCODER_LADDER: readonly EncoderRung[] = [
     { category: 'av1',  accel: 'prefer-hardware' },
     { category: 'vp9',  accel: 'prefer-hardware' },
     { category: 'hevc', accel: 'prefer-hardware' },
-    { category: 'av1',  accel: 'prefer-software' },
     { category: 'vp9',  accel: 'prefer-software' },
     { category: 'h264', accel: 'prefer-hardware' },
-    { category: 'h264', accel: 'prefer-software' },
 ];
-
-// Software AV1 is the most expensive rung on the ladder, so it is kept off
-// phones: the user agent settles it for browsers, and appKind for the MAUI app,
-// whose WebView doesn't always say "mobile". Desktop is fine either way. It
-// still ranks below every hardware encoder.
-function allowsSoftwareAv1(): boolean {
-    if (DeviceInfo.isMobile)
-        return false;
-
-    // From SharedSettings, not BrowserInfo: this module also runs inside the
-    // recorder worker, which has no BrowserInfo, and SharedSettings is the
-    // channel the main thread already mirrors into workers.
-    const { appKind } = SharedSettings.current;
-    return appKind !== 'Ios' && appKind !== 'Android';
-}
 
 // Firefox drops the MPEG rungs entirely: its H.264 encoder runs ~18 frames
 // behind (the realtime probe already rejects it) and it ships no HEVC encoder,
 // so offering either only wastes a probe.
 export function getEncoderLadder(): readonly EncoderRung[] {
-    return ENCODER_LADDER.filter(rung => {
-        if (DeviceInfo.isFirefox && (rung.category === 'h264' || rung.category === 'hevc'))
-            return false;
-        if (rung.category === 'av1' && rung.accel === 'prefer-software')
-            return allowsSoftwareAv1();
-
-        return true;
-    });
+    return DeviceInfo.isFirefox
+        ? ENCODER_LADDER.filter(rung => rung.category !== 'h264' && rung.category !== 'hevc')
+        : ENCODER_LADDER;
 }
 
 // Which acceleration modes this codec was actually accepted with.

--- a/src/dotnet/UI.Blazor.App/Services/Video/throughput-deficit-ticker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/throughput-deficit-ticker.ts
@@ -25,3 +25,59 @@ export class ThroughputDeficitTicker {
         this._value = 0;
     }
 }
+
+// Encoder-side deficit. Same ratio as above, but silence before the encoder's
+// first output is startup rather than a deficit: an encoder that has emitted
+// nothing scores 1.0, and two such ticks are enough to latch the sender-health
+// classifier Bad, which then takes ten clean ticks to clear while QC is free to
+// demote a layer. The monitor starts when the worker is asked to start, so its
+// opening ticks span camera attach, worker spin-up and encoder configuration -
+// frames are already being offered and nothing has come back yet. This is not a
+// codec buffering frames: even Firefox emits its first VP9 or AV1 chunk after a
+// single frame.
+//
+// The decoder side gets this for free by subtracting `decoderQueueSize` from
+// arrived chunks, so its in-flight frames never count as missing; the encoder
+// has no equivalent exact counter, hence the explicit startup handling.
+//
+// The grace period is bounded: an encoder that never produces anything must
+// still read as broken rather than perfect.
+export class EncodeDeficitTicker {
+    private readonly inner: ThroughputDeficitTicker;
+    private started = false;
+    private silentTicks = 0;
+
+    constructor(alpha: number, private readonly graceTicks = 3) {
+        this.inner = new ThroughputDeficitTicker(alpha);
+    }
+
+    public get value(): number {
+        return this.inner.value;
+    }
+
+    public tick(outputTotal: number, outputDelta: number, inputDelta: number): number {
+        // No frames offered means no signal, so such a tick must neither charge
+        // a deficit nor spend the grace period. The health monitor starts when
+        // the worker is asked to start, not when frames begin to flow, so on a
+        // slow camera attach these come first and would otherwise exhaust the
+        // grace before the encoder had ever been handed anything.
+        if (inputDelta <= 0)
+            return this.inner.value;
+        if (!this.started && outputTotal <= 0 && ++this.silentTicks <= this.graceTicks)
+            return this.inner.value;
+        if (!this.started && outputTotal > 0) {
+            // The first window with output in it also spans the startup gap,
+            // so it sets the baseline instead of smoothing a partial window in.
+            this.started = true;
+            return this.inner.value;
+        }
+
+        return this.inner.tick(outputDelta, inputDelta);
+    }
+
+    public reset(): void {
+        this.inner.reset();
+        this.started = false;
+        this.silentTicks = 0;
+    }
+}

--- a/src/dotnet/UI.Blazor/Services/BrowserInfo/browser-info.ts
+++ b/src/dotnet/UI.Blazor/Services/BrowserInfo/browser-info.ts
@@ -6,7 +6,6 @@ import { ScreenSize } from '../ScreenSize/screen-size';
 import { getLogs } from 'logging';
 import { DocumentEvents } from 'event-handling';
 import { Theme, ThemeInfo } from 'theme';
-import { SharedSettings } from 'shared-settings';
 import { LocalizationUI, UILanguageInfo } from 'localization-ui';
 
 const { infoLog } = getLogs('BrowserInfo');
@@ -37,8 +36,6 @@ export class BrowserInfo {
         infoLog?.log(`initializing`);
         this.backendRef = backendRef1;
         this.hostKind = hostKind;
-        // Mirrored to workers, which have no BrowserInfo of their own.
-        SharedSettings.update({ hostKind, appKind });
         this.appKind = appKind;
         this.utcOffset = new Date().getTimezoneOffset();
         this.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/nodejs/src/shared-settings.ts
+++ b/src/nodejs/src/shared-settings.ts
@@ -21,11 +21,6 @@ export interface SharedSettingsSnapshot {
     // Device-pose angle, degrees CW from natural portrait, quantized to 10-degree steps
     // to avoid excessive worker updates.
     deviceOrientationAngle?: number;
-    // BrowserInfo.hostKind / appKind. Mirrored here because workers have no
-    // BrowserInfo: codec policy needs to know whether this is the MAUI app and
-    // on which platform, and workers are where the encoder actually runs.
-    hostKind?: string;
-    appKind?: string;
 }
 
 let current: SharedSettingsSnapshot = {

--- a/tests/Streaming.IntegrationTests/LiveAudioBackendRedisStateTest.cs
+++ b/tests/Streaming.IntegrationTests/LiveAudioBackendRedisStateTest.cs
@@ -171,7 +171,7 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
         var sessionId = $"session-{Guid.NewGuid():N}";
         var codecs = new ApiArray<string>(["av1", "h264"]);
 
-        await liveBackend.RegisterMember(chatId, sessionId, codecs, CancellationToken.None);
+        await liveBackend.RegisterMember(chatId, sessionId, codecs, false, CancellationToken.None);
 
         var redisEntries = await ReadRedisHash<VideoStreamMemberInfo>("live-video:members", chatId);
         redisEntries.Should().ContainKey(sessionId);
@@ -185,7 +185,7 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
         var sessionId = $"session-{Guid.NewGuid():N}";
 
         await liveBackend.RegisterMember(chatId, sessionId,
-            new ApiArray<string>(["av1", "h264"]), CancellationToken.None);
+            new ApiArray<string>(["av1", "h264"]), false, CancellationToken.None);
         await liveBackend.UnregisterMember(chatId, sessionId, CancellationToken.None);
 
         var redisEntries = await ReadRedisHash<VideoStreamMemberInfo>("live-video:members", chatId);
@@ -208,7 +208,7 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
         // Register a member
         var sessionId = $"session-{Guid.NewGuid():N}";
         var codecs = new ApiArray<string>(["h264"]);
-        await liveBackend.RegisterMember(chatId, sessionId, codecs, CancellationToken.None);
+        await liveBackend.RegisterMember(chatId, sessionId, codecs, false, CancellationToken.None);
 
         // Verify Redis has the data
         (await ReadRedisHash<VideoStreamInfo>("live-video:streams", chatId)).Should().NotBeEmpty();
@@ -250,7 +250,7 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
         // Register a member that only supports h264
         var sessionId = $"session-{Guid.NewGuid():N}";
         await liveBackend.RegisterMember(chatId, sessionId,
-            new ApiArray<string>(["h264"]), CancellationToken.None);
+            new ApiArray<string>(["h264"]), false, CancellationToken.None);
 
         // Computed should be invalidated
         computed.IsConsistent().Should().BeFalse("registering member should invalidate codec computed");
@@ -303,7 +303,7 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
         // Register a member
         var sessionId = $"session-{Guid.NewGuid():N}";
         await liveBackend.RegisterMember(chatId, sessionId,
-            new ApiArray<string>(["h264", "av1"]), CancellationToken.None);
+            new ApiArray<string>(["h264", "av1"]), false, CancellationToken.None);
 
         // Simulate shard switch: invalidate ALL compute methods
         using (Invalidation.Begin()) {
@@ -341,11 +341,11 @@ public class LiveAudioBackendRedisStateTest(AppHostFixture fixture, ITestOutputH
 
         // Member A supports everything
         await liveBackend.RegisterMember(chatId, $"session-{Guid.NewGuid():N}",
-            new ApiArray<string>(["av1", "hevc", "vp9", "h264"]), CancellationToken.None);
+            new ApiArray<string>(["av1", "hevc", "vp9", "h264"]), false, CancellationToken.None);
 
         // Member B only supports vp9 + h264
         await liveBackend.RegisterMember(chatId, $"session-{Guid.NewGuid():N}",
-            new ApiArray<string>(["vp9", "h264"]), CancellationToken.None);
+            new ApiArray<string>(["vp9", "h264"]), false, CancellationToken.None);
 
         var codecs = await liveBackend.GetSupportedCodecs(chatId, CancellationToken.None);
         codecs.Should().BeEquivalentTo(new[] { "vp9", "h264" },

--- a/tests/ts/unit/encoder-ladder.test.ts
+++ b/tests/ts/unit/encoder-ladder.test.ts
@@ -1,13 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ deviceInfo: { isFirefox: false, isMobile: false } }));
+const mocks = vi.hoisted(() => ({ deviceInfo: { isFirefox: false } }));
 vi.mock('device-info', () => ({ DeviceInfo: mocks.deviceInfo }));
-
-let sharedSettings: typeof import('shared-settings').SharedSettings | undefined;
-
-function setHost(hostKind: string, appKind: string): void {
-    sharedSettings?.update({ hostKind, appKind });
-}
 
 import {
     getEncoderLadder,
@@ -43,13 +37,9 @@ function pick(
 }
 
 describe('encoder ladder', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
         mocks.deviceInfo.isFirefox = false;
-        mocks.deviceInfo.isMobile = false;
-        sharedSettings ??= (await import('shared-settings')).SharedSettings;
-        setHost('WebServer', 'Unknown');
     });
-    afterEach(() => vi.unstubAllGlobals());
 
     const everything = (): CodecInfo[] => [
         codecInfo('av1', true, true),
@@ -58,110 +48,68 @@ describe('encoder ladder', () => {
         codecInfo('h264', true, true),
     ];
 
-    it('puts every hardware rung ahead of every software one', () => {
+    it('ranks every hardware rung ahead of the one software rung', () => {
         expect(pick(everything()))
-            .toEqual(['hw-av1', 'hw-vp9', 'hw-hevc', 'sw-av1', 'sw-vp9', 'hw-h264', 'sw-h264']);
+            .toEqual(['hw-av1', 'hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264']);
     });
 
-    it('never offers software HEVC — Chromium has no such encoder', () => {
+    // VP9 is the only codec worth encoding in software: it is the floor every
+    // client must decode anyway, software AV1 measured ~18% slower than it at
+    // 720p for no extra reach, software H.264 was the slowest encoder seen on
+    // any device, and Chromium has no software HEVC at all.
+    it('offers exactly one software rung, and it is VP9', () => {
         expect(getEncoderLadder().filter(r => r.accel === 'prefer-software').map(r => r.category))
-            .not.toContain('hevc');
+            .toEqual(['vp9']);
     });
 
-    // Software AV1 is the most expensive rung, so it is spent only where there
-    // is CPU headroom for it.
-    it('withholds software AV1 on mobile', () => {
-        mocks.deviceInfo.isMobile = true;
-
-        expect(pick(everything())).not.toContain('sw-av1');
-    });
-
-    it('withholds software AV1 on the phone MAUI apps only', () => {
-        // The MAUI WebView doesn't always report a mobile user agent, so appKind
-        // is what settles it there. Desktop MAUI is as capable as the browser.
-        for (const appKind of ['Ios', 'Android']) {
-            setHost('MauiApp', appKind);
-            expect(pick(everything())).not.toContain('sw-av1');
-        }
-        for (const appKind of ['MacOS', 'Windows']) {
-            setHost('MauiApp', appKind);
-            expect(pick(everything())).toContain('sw-av1');
-        }
-    });
-
-    // The machine this was measured on: no VP9 hardware encoder, no HEVC
-    // software encoder. Software VP9 must still outrank hardware H.264.
     it('prefers software VP9 over hardware H.264', () => {
+        // The Galaxy's split: HEVC hardware-only, VP9 and AV1 software-only.
         const infos = [
-            codecInfo('av1', false, true),   // sw-only AV1 is not a rung
+            codecInfo('av1', false, true),
             codecInfo('vp9', false, true),
             codecInfo('hevc', true, false),
             codecInfo('h264', true, true),
         ];
 
-        expect(pick(infos)).toEqual(['hw-hevc', 'sw-av1', 'sw-vp9', 'hw-h264', 'sw-h264']);
+        expect(pick(infos)).toEqual(['hw-hevc', 'sw-vp9', 'hw-h264']);
     });
 
-    // Firefox has no HEVC encoder and its H.264 runs ~18 frames behind, so
-    // offering either only wastes a probe. VP9 is what it lands on — the floor.
     it('drops every MPEG rung on Firefox', () => {
         mocks.deviceInfo.isFirefox = true;
-        const all = [
-            codecInfo('av1', true, true),
-            codecInfo('vp9', true, true),
-            codecInfo('hevc', true, true),
-            codecInfo('h264', true, true),
-        ];
 
-        expect(getEncoderLadder().map(r => r.category)).not.toContain('h264');
-        expect(getEncoderLadder().map(r => r.category)).not.toContain('hevc');
-        expect(pick(all)).toEqual(['hw-av1', 'hw-vp9', 'sw-av1', 'sw-vp9']);
+        expect(pick(everything())).toEqual(['hw-av1', 'hw-vp9', 'sw-vp9']);
     });
 
-    it('leaves desktop Firefox on software AV1 when it reports no hardware encoder', () => {
+    it('leaves Firefox on software VP9, which is all it can encode in real time', () => {
         mocks.deviceInfo.isFirefox = true;
         const measured = [
-            codecInfo('av1', false, true),   // sw-only: not a rung
+            codecInfo('av1', false, true),   // software AV1 is not a rung
             codecInfo('vp9', false, true),
             codecInfo('h264', false, true),  // excluded on Firefox anyway
         ];
 
-        expect(pick(measured)).toEqual(['sw-av1', 'sw-vp9']);
-    });
-
-    it('reads host identity from SharedSettings when none is passed', async () => {
-        const { SharedSettings } = await import('shared-settings');
-        SharedSettings.update({ hostKind: 'MauiApp', appKind: 'Android' });
-
-        expect(getEncoderLadder().map(r => `${r.accel}-${r.category}`))
-            .not.toContain('prefer-software-av1');
-
-        SharedSettings.update({ hostKind: 'MauiApp', appKind: 'MacOS' });
-        expect(getEncoderLadder().map(r => `${r.accel}-${r.category}`))
-            .toContain('prefer-software-av1');
-
-        SharedSettings.update({ hostKind: 'WebServer', appKind: 'Unknown' });
+        expect(pick(measured)).toEqual(['sw-vp9']);
     });
 
     it('drops a codec the audience cannot decode', () => {
         const allowed = new Set<CodecInfo['category']>(['vp9', 'h264']);
 
-        expect(pick(everything(), allowed)).toEqual(['hw-vp9', 'sw-vp9', 'hw-h264', 'sw-h264']);
+        expect(pick(everything(), allowed)).toEqual(['hw-vp9', 'sw-vp9', 'hw-h264']);
     });
 
     it('drops a codec measured as too slow for a call', () => {
-        // A codec measured as too slow: realtime === false, so no rung of
-        // it survives - the case Firefox's H.264 hits in practice.
+        // A codec measured as too slow: realtime === false, so no rung of it
+        // survives - the case Firefox's H.264 hits in practice.
         const infos = everything().map(i => i.category === 'av1' ? { ...i, realtime: false } : i);
 
-        expect(pick(infos)).toEqual(['hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264', 'sw-h264']);
+        expect(pick(infos)).toEqual(['hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264']);
     });
 
     it('lets the debug preference outrank the ladder, but not conjure a codec', () => {
         expect(pick(everything(), null, 'h264')[0]).toBe('hw-h264');
         // vp9 is not in the audience set, so preferring it changes nothing.
         const allowed = new Set<CodecInfo['category']>(['av1']);
-        expect(pick(everything(), allowed, 'vp9')).toEqual(['hw-av1', 'sw-av1']);
+        expect(pick(everything(), allowed, 'vp9')).toEqual(['hw-av1']);
     });
 
     it('drops a codec with no usable encoder at all', () => {
@@ -169,10 +117,13 @@ describe('encoder ladder', () => {
             .toEqual(['sw-vp9']);
     });
 
-    it('falls to software VP9 on a mobile browser with no hardware encoder', () => {
-        mocks.deviceInfo.isMobile = true;
+    // Software-only AV1 or H.264 is no longer a candidate on any platform.
+    it('will not fall back to software AV1 or software H.264', () => {
+        const softwareOnly = [
+            codecInfo('av1', false, true),
+            codecInfo('h264', false, true),
+        ];
 
-        expect(pick([codecInfo('av1', false, true), codecInfo('vp9', false, true)]))
-            .toEqual(['sw-vp9']);
+        expect(pick(softwareOnly)).toEqual([]);
     });
 });

--- a/tests/ts/unit/throughput-deficit-ticker.test.ts
+++ b/tests/ts/unit/throughput-deficit-ticker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ThroughputDeficitTicker } from
+import { EncodeDeficitTicker, ThroughputDeficitTicker } from
     '../../../src/dotnet/UI.Blazor.App/Services/Video/throughput-deficit-ticker';
 
 describe('ThroughputDeficitTicker', () => {
@@ -114,5 +114,76 @@ describe('decode-deficit with in-flight subtraction', () => {
         for (let i = 1; i <= 40; i++)
             lossy.push({ chunksReceived: i * 10, framesDecoded: i * 8, decoderQueueSize: 0 });
         expect(runEffective(lossy)).toBeGreaterThan(0.1);
+    });
+});
+
+describe('EncodeDeficitTicker', () => {
+    // The reported symptom: the health monitor starts when the worker is
+    // asked to start, so the opening ticks span camera attach and encoder
+    // configuration. They scored a full deficit and latched the sender-health
+    // classifier Bad (α=0.3 reaches ~0.51 in two ticks, past the 0.15
+    // threshold) before the encoder had done anything wrong.
+    it('stays at 0 while the encoder is still producing its first bundle', () => {
+        const t = new EncodeDeficitTicker(0.3);
+
+        t.tick(0, 0, 30);
+        t.tick(0, 0, 30);
+
+        expect(t.value).toBe(0);
+    });
+
+    it('does not charge the window that spans the startup gap', () => {
+        const t = new EncodeDeficitTicker(0.3);
+
+        t.tick(0, 0, 30);
+        t.tick(5, 5, 30); // first output: 5 of 30, but 25 were pre-first-chunk
+
+        expect(t.value).toBe(0);
+    });
+
+    it('measures normally once the encoder is warm', () => {
+        const t = new EncodeDeficitTicker(0.3);
+        t.tick(0, 0, 30);
+        t.tick(5, 5, 30);
+
+        t.tick(35, 30, 30);
+        expect(t.value).toBe(0);
+
+        t.tick(50, 15, 30); // half the offered frames
+        expect(t.value).toBeCloseTo(0.15, 5);
+    });
+
+    // The health monitor starts when the worker is asked to start, not when
+    // frames begin flowing, so no-input ticks come first on a slow camera
+    // attach. Spending grace on them exhausted it before the encoder was ever
+    // handed a frame, which resurrected the very bug this class exists to fix.
+    it('does not spend the grace period on ticks with no frames offered', () => {
+        const t = new EncodeDeficitTicker(0.3, 3);
+
+        for (let i = 0; i < 10; i++) t.tick(0, 0, 0);  // camera not up yet
+        t.tick(0, 0, 30);                              // frames flow, encoder still silent
+        t.tick(0, 0, 30);
+
+        expect(t.value).toBe(0);
+    });
+
+    // The grace period is bounded, or a dead encoder would read as perfect.
+    it('reports a full deficit for an encoder that never produces anything', () => {
+        const t = new EncodeDeficitTicker(0.3, 3);
+
+        for (let i = 0; i < 8; i++) t.tick(0, 0, 30);
+
+        expect(t.value).toBeGreaterThan(0.15);
+    });
+
+    it('resets its startup state', () => {
+        const t = new EncodeDeficitTicker(0.3, 3);
+        for (let i = 0; i < 8; i++) t.tick(0, 0, 30);
+        expect(t.value).toBeGreaterThan(0.15);
+
+        t.reset();
+        t.tick(0, 0, 30);
+
+        expect(t.value).toBe(0);
     });
 });


### PR DESCRIPTION
Follow-up to the codec-negotiation work, from measurements taken on real
devices plus a review pass. Three commits.

## Drop the software AV1 and software H.264 rungs

The encoder ladder is now:

    hw-AV1 > hw-VP9 > hw-HEVC > sw-VP9 > hw-H.264

Firefox additionally drops both MPEG rungs, leaving it hw-AV1 > hw-VP9 >
sw-VP9 — and since it has no hardware encoder at all, software VP9 rather
than the software AV1 it was picking before.

Software H.264 was the slowest encoder measured on any device: 6.69 ms/frame
at 480p on a Galaxy SM-S948U1 against 1.17 ms for that device's hardware
path, while compressing worst of the four. Software AV1 is the narrower
call — on the one device offering both it runs ~18% slower than software VP9
at 720p (4.44 vs 3.75 ms) while producing fewer bits (1724 vs 1840 kbps) —
so the rung bought a CPU loss for no reach VP9 didn't already have, VP9
being the floor every client must be able to decode anyway.

Neither phone's choice changes: the iPhone still takes hw-VP9 (no AV1
encoder on the A15), the Galaxy still takes hw-HEVC, both verified against
their real detected capabilities. This also retires the mobile/appKind gate
on software AV1 and the `hostKind`/`appKind` mirror into `SharedSettings`,
which that gate was the only reader of.

## Stop counting encoder startup as a throughput deficit

Reported from Firefox on AV1: `def=1% q=0.6 rs=0 bad=[deficit 2/10]`
appearing almost instantly — a healthy encoder already latched Bad.

The deficit is `1 - bundlesEncoded/framesOffered`, EMA-smoothed at α=0.3.
Nothing exempted startup, so an encoder that hadn't emitted yet scored a
full 1.0; two such ticks put the EMA past the 0.15 threshold with
`BadStreakRequired = 2`, and it then took ten clean ticks to live down —
with the quality controller free to demote a spatial layer meanwhile.

This isn't a codec buffering frames (Firefox emits its first VP9 and AV1
chunk after one frame). The health monitor starts when the worker is *asked*
to start, so its first ticks span camera attach, worker spin-up and encoder
configuration. Handled explicitly in a new `EncodeDeficitTicker`; the grace
period is bounded, so an encoder that never produces anything still reads as
broken rather than perfect, and a tick with no frames offered neither
charges a deficit nor spends grace.

Also fixes the `ILiveVideoBackend.RegisterMember` call sites in
`Streaming.IntegrationTests` that the `isAdmin` parameter broke — that
project sits outside the solution filter used earlier, so it reached `dev`
uncompilable.

## Record the measured codec performance per device

New `docs/live-video/codec-performance.md`: the encode matrix for
Chrome/Windows, an iPhone 13 Pro and a Galaxy SM-S948U1, Firefox's
first-output latency, the capability matrix, and what the ladder picks on
each device and why. Several results contradict what those platforms were
assumed to do — iOS *does* encode VP9, Apple has no AV1 encoder, Android has
no hardware VP9, and Firefox has no HEVC encoder at all — so the doc leads
with how the numbers were taken and what makes them comparable.

## Verification

`tsc --noEmit`, `lint:all`, 590 vitest unit tests, `dotnet build
ActualChat.CI.slnf` and `dotnet build tests/Streaming.IntegrationTests` all
green. Codec choices verified on device against each platform's real
detected capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9bqJidRkGDe6YrHVertp5
