### PR TITLE
test(flows): fix the flaky flow tests that keep failing slow-tests CI

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -196,3 +196,12 @@ edited. The reason can be as short as whose decision it was.
   — comment on a bit-twiddling expression — it names the bitstream field layout
   the shift-and-mask decodes, which the expression cannot carry — Alex
   Yakunin's decision: keep.
+
+## tests/Core.Server.IntegrationTests/Flows/ThrottledUpdateFlowTest.cs
+
+- L161 `: ActualChat.Testing.Host.AppHostFixture(`
+  — redundantly fully-qualified name — required: `Collections/ServerCollection.cs`
+  declares `AppHostFixture` in this very namespace, so the unqualified name binds
+  to that type and the 3-argument base call fails with CS1729.
+  `FailingThrottledUpdateFlowTest.cs` and `ResumeLatencyFlowTest.cs` qualify it
+  the same way

--- a/src/dotnet/Db/Module/DbModule.cs
+++ b/src/dotnet/Db/Module/DbModule.cs
@@ -122,15 +122,10 @@ public sealed class DbModule(IServiceProvider moduleServices)
                     operations.AddRedisOperationLogWatcher();
                 else if (dbKind == DbKind.PostgreSql)
                     operations.AddNpgsqlOperationLogWatcher();
-                // NOTE(DF):
-                // During tests execution for entire test fixture I often bump into a situation when tests fail.
-                // Usually this happens on awaiting that computed value will match the condition
-                // with using `ComputedTest.When`.
-                // But it fails when the default timeout is used.
-                // After examining log files, I found that events processing can be delayed for more than 5 seconds.
-                // So it seems that sometimes event log reader doesn't kick in on time sometimes,
-                // and that's because LocalDbLogWatcher does not signal a new event has been added.
-                // So as a temp. fix, I reduced the check period to 1s.
+                // Caps how long an event waits when LocalDbLogWatcher misses its signal (NOTE(DF, 2024-06):
+                // 5+ second delays failed `ComputedTest.When` waits). Likely obsolete: Fusion 2fbc7d0b
+                // (14.3.34) wakes the publishing host's own readers, and Flow tests passed with 60s here
+                // in 3 of 4 local runs - re-check on CI, and drop this override if it holds.
                 if (HostInfo.IsTested)
                     operations.ConfigureEventLogReader(_ => new DbEventLogReader<TDbContext>.Options() {
                         CheckPeriod = TimeSpan.FromSeconds(1).ToRandom(0.1),

--- a/src/dotnet/Flows.Service/FlowBackend.cs
+++ b/src/dotnet/Flows.Service/FlowBackend.cs
@@ -251,7 +251,9 @@ public class FlowBackend : ShardedDbServiceBase<FlowsDbContext>, IFlowBackend
                 dbFlow.Version = VersionGenerator.NextVersion(dbFlow.Version);
                 dbContext.Add(dbFlow);
 
-                // Any new flow requires a resume event
+                // Any new flow requires a resume event.
+                // NOTE(2026-08): OnResume creates a missing flow through this same path, so one
+                // created while resuming gets an extra resume - it splits a DelayQuanta=0 chain in two.
                 context.Operation.AddEvent(FlowHub.NewResumeEvent(flowId));
             }
             else { // Update

--- a/tests/Core.Server.IntegrationTests/Flows/IndexingFlowTest.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/IndexingFlowTest.cs
@@ -6,24 +6,29 @@ namespace ActualChat.Core.Server.IntegrationTests.Flows;
 
 [Collection(nameof(ServerCollection))]
 [Trait("Category", "Slow")]
-public class IndexingFlowTest(AppHostFixture fixture, ITestOutputHelper @out)
+public sealed class IndexingFlowTest(AppHostFixture fixture, ITestOutputHelper @out)
     : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
 {
-    private IndexingFlowTestContext Context { get; } = fixture.AppHost.Services.GetRequiredService<IndexingFlowTestContext>();
+    // Each batch costs a full commit -> event -> resume round-trip, ~40ms locally but up to
+    // ~800ms on a loaded CI runner, so the budget has to scale with the batch count
+    private static readonly TimeSpan BaseTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan TimeoutPerBatch = TimeSpan.FromSeconds(1);
+    private IndexingFlowTestContext Context { get; }
+        = fixture.AppHost.Services.GetRequiredService<IndexingFlowTestContext>();
 
-    [FlakyTheory("AY: Not sure why yet.", 3)]
+    [Theory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(10)]
     [InlineData(77)]
-    public async Task MustProcessAllBatches(int batchCount)
+    public async Task ShouldProcessAllBatches(int batchCount)
     {
         // arrange
         var id = RandomStringGenerator.Default.Next();
         var batchSize = 10;
         var batches = Enumerable.Range(1, batchCount)
             .Select(i => {
-                long cursor = i * batchSize;
+                var cursor = i * batchSize;
                 return new BatchIndexingResult<long> {
                     Cursor = cursor,
                     IsTailReached = false,
@@ -43,17 +48,17 @@ public class IndexingFlowTest(AppHostFixture fixture, ITestOutputHelper @out)
 
         // assert
         await TestExt.When(async () => {
-            Context.ListRemaining(id).Should().BeEmpty();
+            Context.ListRemaining(id).Should().BeEmpty("every batch must be consumed");
             var processed = Context.ListProcessed(id);
-            processed.Should().HaveCount(batchCount + 1);
+            processed.Should().HaveCount(batchCount + 1, "every batch must be processed");
             var flow = await FlowHub.TryGet<SimpleIndexingFlow>(id);
-            flow.Should().NotBeNull();
-            flow.Cursor.Should().Be((batchCount + 1) * batchSize);
-        }, TimeSpan.FromSeconds(10));
+            flow.Should().NotBeNull("the scheduled resume must create the flow");
+            flow.Cursor.Should().Be((batchCount + 1) * batchSize, "the cursor must reach the tail");
+        }, GetTimeout(batchCount));
     }
 
-    [FlakyFact("AY: Not sure why yet.", 3)]
-    public async Task MustEnd()
+    [Fact]
+    public async Task ShouldCompleteOnCompletionReason()
     {
         // arrange
         var id = RandomStringGenerator.Default.Next();
@@ -78,14 +83,14 @@ public class IndexingFlowTest(AppHostFixture fixture, ITestOutputHelper @out)
         // assert
         await TestExt.When(async () => {
             var flow = await FlowHub.TryGet<SimpleIndexingFlow>(id);
-            flow.Should().NotBeNull();
-            flow.Result.Should().Be(Result.New("Done."));
-            Context.ListRemaining(id).Should().BeEquivalentTo(batches[1..]);
-        }, TimeSpan.FromSeconds(10));
+            flow.Should().NotBeNull("the scheduled resume must create the flow");
+            flow.Result.Should().Be(Result.New("Done."), "the completion reason must end the flow");
+            Context.ListRemaining(id).Should().BeEquivalentTo(batches[1..], "the flow must stop at the first batch");
+        }, GetTimeout(batches.Length));
     }
 
-    [FlakyFact("AY: Not sure why yet.", 3)]
-    public async Task MustWaitForReindexingIfVersionIsBumped()
+    [Fact]
+    public async Task ShouldReindexOnReset()
     {
         // arrange
         var id = RandomStringGenerator.Default.Next();
@@ -112,23 +117,24 @@ public class IndexingFlowTest(AppHostFixture fixture, ITestOutputHelper @out)
             },
         ];
         Context.Add(id, batches);
+        await FlowHub.NewResumeEvent<SimpleIndexingFlow>(id).Schedule();
+        await TestExt.When(async () => {
+            var flow = await FlowHub.TryGet<SimpleIndexingFlow>(id).Require();
+            flow.DataVersion.Should().Be(1, "the flow must run at its current data version");
+        }, GetTimeout(batches.Length));
 
         // act
-        await FlowHub.NewResumeEvent<SimpleIndexingFlow>(id).Schedule();
+        await FlowHub.NewResumeEvent<SimpleIndexingFlow>(id).WithReset().Schedule();
 
         // assert
         await TestExt.When(async () => {
             var flow = await FlowHub.TryGet<SimpleIndexingFlow>(id).Require();
-            flow.DataVersion.Should().Be(1);
-        }, TimeSpan.FromSeconds(10));
-
-        // act - bump version to trigger reindex
-        await FlowHub.NewResumeEvent<SimpleIndexingFlow>(id).WithReset().Schedule();
-
-        // assert - flow should reindex (reset cursor and process again)
-        await TestExt.When(async () => {
-            var flow = await FlowHub.TryGet<SimpleIndexingFlow>(id).Require();
-            flow.Console.ToString().Should().Contain("explicit");
-        }, TimeSpan.FromSeconds(10));
+            flow.Console.ToString().Should().Contain("explicit", "the reset must restart the indexing");
+        }, GetTimeout(batches.Length));
     }
+
+    // Private methods
+
+    private static TimeSpan GetTimeout(int batchCount)
+        => BaseTimeout + (TimeoutPerBatch * batchCount);
 }

--- a/tests/Core.Server.IntegrationTests/Flows/LongThrottledUpdateFlow.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/LongThrottledUpdateFlow.cs
@@ -1,0 +1,19 @@
+using ActualChat.Flows;
+
+namespace ActualChat.Core.Server.IntegrationTests.Flows;
+
+/// <summary>
+/// A <see cref="ThrottledUpdateFlow"/> whose throttle period is long enough to never
+/// elapse mid-test - so tests asserting "the run didn't happen" can't race it.
+/// </summary>
+[Flow(DelayQuanta = 0)]
+[DataContract, MessagePackObject(true)]
+public sealed partial class LongThrottledUpdateFlow : ThrottledUpdateFlow
+{
+    protected override TimeSpan ThrottlePeriod => TimeSpan.FromMinutes(1);
+    protected override ValueTask Run(CancellationToken cancellationToken)
+    {
+        Console.Log($"Run: Target={Target}");
+        return default;
+    }
+}

--- a/tests/Core.Server.IntegrationTests/Flows/ResumeLatencyFlow.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/ResumeLatencyFlow.cs
@@ -4,16 +4,16 @@ namespace ActualChat.Core.Server.IntegrationTests.Flows;
 
 [Flow(DelayQuanta = 0)]
 [DataContract, MessagePackObject(true)]
-public partial class ResumeLatencyFlow : Flow<Unit>
+public sealed partial class ResumeLatencyFlow : Flow<Unit>
 {
     private const int ResumeCount = 5;
-
+    private static readonly TimeSpan ResumeDelay = TimeSpan.FromSeconds(1);
     [DataMember(Order = 0)]
     public int RemainingCount { get; set; }
     [DataMember(Order = 1)]
     public Moment LastResumeAt { get; set; }
     [DataMember(Order = 2)]
-    public TimeSpan MaxDelay { get; set; }
+    public TimeSpan[] Delays { get; set; } = [];
 
     protected override ValueTask Init(CancellationToken cancellationToken)
     {
@@ -28,18 +28,17 @@ public partial class ResumeLatencyFlow : Flow<Unit>
         var now = Hub.SystemNow;
         if (LastResumeAt != default) {
             var delay = now - LastResumeAt;
-            if (delay > MaxDelay)
-                MaxDelay = delay;
+            Delays = [..Delays, delay];
             Console.Log($"Resume #{ResumeCount - RemainingCount}: delay={delay.ToShortString()}");
         }
         LastResumeAt = now;
 
         if (RemainingCount > 0) {
             RemainingCount--;
-            Runtime.StageResumeIn(TimeSpan.FromSeconds(1));
+            Runtime.StageResumeIn(ResumeDelay);
         }
         else {
-            Console.Log($"Completed. MaxDelay={MaxDelay.ToShortString()}");
+            Console.Log($"Completed. Delays={Delays.Select(x => x.ToShortString()).ToDelimitedString()}");
             SetResult(default);
         }
         return default;

--- a/tests/Core.Server.IntegrationTests/Flows/ResumeLatencyFlowTest.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/ResumeLatencyFlowTest.cs
@@ -1,11 +1,12 @@
 using ActualChat.Testing.Host;
+using ActualLab.Generators;
 
 namespace ActualChat.Core.Server.IntegrationTests.Flows;
 
 [CollectionDefinition(nameof(ResumeLatencyFlowCollection))]
-public class ResumeLatencyFlowCollection : ICollectionFixture<ResumeLatencyFlowFixture>;
+public sealed class ResumeLatencyFlowCollection : ICollectionFixture<ResumeLatencyFlowFixture>;
 
-public class ResumeLatencyFlowFixture(IMessageSink messageSink) : ActualChat.Testing.Host.AppHostFixture(
+public sealed class ResumeLatencyFlowFixture(IMessageSink messageSink) : ActualChat.Testing.Host.AppHostFixture(
     "resume-latency",
     messageSink,
     TestAppHostOptions.Default with {
@@ -16,24 +17,32 @@ public class ResumeLatencyFlowFixture(IMessageSink messageSink) : ActualChat.Tes
 
 [Collection(nameof(ResumeLatencyFlowCollection))]
 [Trait("Category", "Slow")]
-public class ResumeLatencyFlowTest(ResumeLatencyFlowFixture fixture, ITestOutputHelper @out)
+public sealed class ResumeLatencyFlowTest(ResumeLatencyFlowFixture fixture, ITestOutputHelper @out)
     : SharedAppHostTestBase<ResumeLatencyFlowFixture>(fixture, @out)
 {
+    // Resumes are staged 1s ahead: one miss is a busy runner, several are a regression
+    private static readonly TimeSpan MaxTypicalDelay = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan StallDelay = TimeSpan.FromSeconds(10);
     [Fact]
-    public async Task ResumeDelayDoesNotExceed3Seconds()
+    public async Task ResumeDelaysShouldStayWithinBudget()
     {
-        var args = $"test-{Guid.NewGuid():N}";
-        await FlowHub.NewResumeEvent<ResumeLatencyFlow>(args).Schedule();
+        // arrange
+        var args = $"test-{RandomStringGenerator.Default.Next()}";
 
+        // act
+        await FlowHub.NewResumeEvent<ResumeLatencyFlow>(args).Schedule();
         await ComputedTest.When(async ct => {
             var flow = await FlowHub.TryGet<ResumeLatencyFlow>(args, ct);
-            flow.Should().NotBeNull();
-            flow.UntypedResult.Should().NotBeNull("flow should complete all 5 resumes");
+            flow.Should().NotBeNull("the scheduled resume must create the flow");
+            flow.UntypedResult.Should().NotBeNull("the flow must complete all 5 resumes");
         }, TimeSpan.FromSeconds(30));
 
+        // assert
         var completedFlow = await FlowHub.Get<ResumeLatencyFlow>(args);
         WriteLine(completedFlow.Console.ToString());
-        completedFlow.MaxDelay.Should().BeLessThan(TimeSpan.FromSeconds(3),
-            "each resume should complete within 3 seconds when DelayQuanta=0");
+        var delays = completedFlow.Delays;
+        delays.Count(x => x >= MaxTypicalDelay).Should().BeLessThanOrEqualTo(1,
+            "at most one resume may miss its budget when DelayQuanta=0");
+        delays.Max().Should().BeLessThan(StallDelay, "no resume may stall");
     }
 }

--- a/tests/Core.Server.IntegrationTests/Flows/SerializationTests.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/SerializationTests.cs
@@ -21,7 +21,7 @@ public class ResumeLatencyFlowSerializationTest(ITestOutputHelper @out)
     protected override ResumeLatencyFlow CreatePopulated() => new() {
         RemainingCount = 5,
         LastResumeAt = new Moment(new DateTime(2026, 4, 16, 12, 0, 0, DateTimeKind.Utc)),
-        MaxDelay = TimeSpan.FromMilliseconds(123),
+        Delays = [TimeSpan.FromMilliseconds(123), TimeSpan.FromSeconds(1)],
     };
 }
 

--- a/tests/Core.Server.IntegrationTests/Flows/ThrottledUpdateFlowTest.cs
+++ b/tests/Core.Server.IntegrationTests/Flows/ThrottledUpdateFlowTest.cs
@@ -1,184 +1,170 @@
 using ActualChat.Flows;
 using ActualChat.Testing.Host;
+using ActualLab.Generators;
 
 namespace ActualChat.Core.Server.IntegrationTests.Flows;
 
 [Collection(nameof(ThrottledUpdateFlowCollection))]
 [Trait("Category", "Slow")]
-public class ThrottledUpdateFlowTest(ThrottledUpdateFlowFixture fixture, ITestOutputHelper @out)
+public sealed class ThrottledUpdateFlowTest(ThrottledUpdateFlowFixture fixture, ITestOutputHelper @out)
     : SharedAppHostTestBase<ThrottledUpdateFlowFixture>(fixture, @out)
 {
     private static readonly TimeSpan ThrottlePeriod = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
     [Fact]
-    public async Task BasicTest()
+    public async Task ScheduledUpdateShouldRunFlow()
     {
-        // Arrange
-        var target = $"test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
 
-        // Act - schedule first update
+        // act
         var scheduled = await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
 
-        // Assert - should schedule since flow doesn't exist yet
-        scheduled.Should().BeTrue();
-
-        // Wait for flow to run
+        // assert
+        scheduled.Should().BeTrue("the flow doesn't exist yet");
         await ComputedTest.When(async ct => {
             var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow.Should().NotBeNull();
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
+            flow.Should().NotBeNull("the scheduled update must create the flow");
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
         }, DefaultTimeout);
     }
 
     [Fact]
-    public async Task ThrottlingTest()
+    public async Task SecondUpdateShouldBeThrottled()
     {
-        // Arrange
-        var target = $"test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
-
-        // Act - schedule first update
-        await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
-
-        // Wait for flow to run once
+        await FlowHub.TryScheduleUpdate<LongThrottledUpdateFlow>(target);
         await ComputedTest.When(async ct => {
-            var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
+            var flow = await FlowHub.TryGet<LongThrottledUpdateFlow>(args, ct);
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
         }, DefaultTimeout);
 
-        // Act - try to schedule immediately (should be throttled)
-        var scheduled = await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
+        // act
+        var scheduled = await FlowHub.TryScheduleUpdate<LongThrottledUpdateFlow>(target);
 
-        // Assert - should not schedule since throttle period hasn't elapsed
-        scheduled.Should().BeFalse();
-
-        // Get flow and verify NextRunAt is in the future
-        var flowAfter = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args);
-        flowAfter.Should().NotBeNull();
-        flowAfter!.NextRunAt.Should().BeGreaterThan(FlowHub.SystemNow);
+        // assert
+        scheduled.Should().BeFalse("the throttle period hasn't elapsed");
+        var flowAfter = await FlowHub.TryGet<LongThrottledUpdateFlow>(args);
+        flowAfter.Should().NotBeNull("the flow ran at least once");
+        flowAfter!.NextRunAt.Should().BeGreaterThan(FlowHub.SystemNow, "the next run is throttled until later");
     }
 
     [Fact]
-    public async Task MustUpdateTest()
+    public async Task MustUpdateShouldBeFalseWithinThrottlePeriod()
     {
-        // Arrange
-        var target = $"test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
 
-        // Act & Assert - new target should need update
-        var mustUpdate1 = await FlowHub.MustUpdate<SimpleThrottledUpdateFlow>(target);
-        mustUpdate1.Should().BeTrue();
-
-        // Schedule and wait for completion
-        await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
+        // act
+        var mustUpdateBeforeRun = await FlowHub.MustUpdate<LongThrottledUpdateFlow>(target);
+        await FlowHub.TryScheduleUpdate<LongThrottledUpdateFlow>(target);
         await ComputedTest.When(async ct => {
-            var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
+            var flow = await FlowHub.TryGet<LongThrottledUpdateFlow>(args, ct);
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
         }, DefaultTimeout);
+        var mustUpdateAfterRun = await FlowHub.MustUpdate<LongThrottledUpdateFlow>(target);
 
-        // Act & Assert - should not need update immediately after
-        var mustUpdate2 = await FlowHub.MustUpdate<SimpleThrottledUpdateFlow>(target);
-        mustUpdate2.Should().BeFalse();
+        // assert
+        mustUpdateBeforeRun.Should().BeTrue("the target was never updated");
+        mustUpdateAfterRun.Should().BeFalse("the throttle period hasn't elapsed");
     }
 
     [Fact]
-    public async Task ThrottledResumeIsIgnoredTest()
+    public async Task ThrottledResumeShouldBeIgnored()
     {
-        // Arrange
-        var target = $"test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
-
-        // Schedule and wait for first run
-        await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
+        await FlowHub.TryScheduleUpdate<LongThrottledUpdateFlow>(target);
         await ComputedTest.When(async ct => {
-            var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
+            var flow = await FlowHub.TryGet<LongThrottledUpdateFlow>(args, ct);
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
         }, DefaultTimeout);
 
-        // Force schedule a resume event (bypassing the TryScheduleUpdate check)
-        await FlowHub.NewResumeEvent<SimpleThrottledUpdateFlow>(args).Schedule();
-
-        // Give some time for the resume to be processed
+        // act
+        // A directly scheduled resume event bypasses the TryScheduleUpdate throttle check
+        await FlowHub.NewResumeEvent<LongThrottledUpdateFlow>(args).Schedule();
         await Task.Delay(TimeSpan.FromSeconds(1));
 
-        // Assert - SuccessCount should still be 1 (throttled resume was ignored or not run)
-        var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args);
-        flow!.SuccessCount.Should().Be(1);
-        flow.Console.ToString().Should().NotContain("Run() #2");
+        // assert
+        var flow = await FlowHub.TryGet<LongThrottledUpdateFlow>(args);
+        flow!.SuccessCount.Should().Be(1, "the throttled resume must be ignored");
+        flow.Console.ToString().Should().NotContain("Run() #2", "the throttled resume must not run");
     }
 
     [Fact]
-    public async Task RunsAfterThrottlePeriodTest()
+    public async Task FlowShouldRunAfterThrottlePeriod()
     {
-        // Arrange
-        var target = $"test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
-
-        // Schedule and wait for first run
         await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
         await ComputedTest.When(async ct => {
             var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
         }, DefaultTimeout);
 
-        // Wait for throttle period to elapse (add extra buffer for timing)
+        // act
         await Task.Delay(ThrottlePeriod + TimeSpan.FromMilliseconds(500));
-
-        // Schedule another update - should be allowed now
         var scheduled = await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
-        scheduled.Should().BeTrue();
 
-        // Wait for second run (increase timeout for this test)
+        // assert
+        scheduled.Should().BeTrue("the throttle period has elapsed");
         await ComputedTest.When(async ct => {
             var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow!.Console.ToString().Should().Contain("Run() #2 completed");
+            flow!.Console.ToString().Should().Contain("Run() #2 completed", "the second update must run");
         }, DefaultTimeout);
     }
 
     [Fact]
-    public async Task TargetPropertyTest()
+    public async Task TargetShouldSurviveArgumentsEncoding()
     {
-        // Arrange - use unique target with special characters to test encoding
-        var target = $"https://example.com/page?q=test-{Guid.NewGuid():N}";
+        // arrange
+        var target = $"https://example.com/page?q=test-{RandomStringGenerator.Default.Next()}";
         var args = ThrottledUpdateFlow.GetArguments(target);
 
-        // Act
+        // act
         await FlowHub.TryScheduleUpdate<SimpleThrottledUpdateFlow>(target);
 
-        // Wait for flow to run and verify the target was logged
+        // assert
         await ComputedTest.When(async ct => {
             var flow = await FlowHub.TryGet<SimpleThrottledUpdateFlow>(args, ct);
-            flow.Should().NotBeNull();
-            flow!.Console.ToString().Should().Contain("Run() #1 completed");
-            flow.Console.ToString().Should().Contain(target);
+            flow.Should().NotBeNull("the scheduled update must create the flow");
+            flow!.Console.ToString().Should().Contain("Run() #1 completed", "the scheduled update must run");
+            flow.Console.ToString().Should().Contain(target, "Target must decode back to the original string");
         }, DefaultTimeout);
     }
 
     [Fact]
-    public void GetArgumentsEncodesTarget()
+    public void GetArgumentsShouldEncodeTarget()
     {
-        // Arrange
+        // arrange
         var target = "https://example.com/test?foo=bar&baz=qux";
 
-        // Act
+        // act
         var args = ThrottledUpdateFlow.GetArguments(target);
 
-        // Assert
-        args.Should().NotBe(target);
-        args.FromBase64().Should().Be(target);
+        // assert
+        args.Should().NotBe(target, "the target must be encoded");
+        args.FromBase64().Should().Be(target, "the encoding must be reversible");
     }
 }
 
 [CollectionDefinition(nameof(ThrottledUpdateFlowCollection))]
-public class ThrottledUpdateFlowCollection : ICollectionFixture<ThrottledUpdateFlowFixture>;
+public sealed class ThrottledUpdateFlowCollection : ICollectionFixture<ThrottledUpdateFlowFixture>;
 
-public class ThrottledUpdateFlowFixture(IMessageSink messageSink) : ActualChat.Testing.Host.AppHostFixture(
+public sealed class ThrottledUpdateFlowFixture(IMessageSink messageSink) : ActualChat.Testing.Host.AppHostFixture(
     "throttled-update-flow",
     messageSink,
     TestAppHostOptions.Default with {
         ConfigureServices = (_, services) => {
-            services.AddFlows().Add<SimpleThrottledUpdateFlow>();
+            services.AddFlows()
+                .Add<SimpleThrottledUpdateFlow>()
+                .Add<LongThrottledUpdateFlow>();
         },
     });


### PR DESCRIPTION
Fixes the flow tests that have been failing the `Run slow tests` job across everyone's branches. In the last 12 failed runs they accounted for the majority of failures: `ThrottledUpdateFlowTest` (5), `IndexingFlowTest` (4), `ResumeLatencyFlowTest` (2), `FailingThrottledUpdateFlowTest` (1) — all of them timing-dependent, all on `dev` as well as feature branches.

## What was wrong

Each test asserted a wall-clock budget that was narrower than the runner's own noise.

**`ThrottledUpdateFlowTest`** — three tests assert that a second run did *not* happen, but shared a flow whose `ThrottlePeriod` is 2s. The test itself spends that same window on `ComputedTest.When`, event delivery and a fixed 1s `Task.Delay`. On a loaded runner the window elapsed before the forced resume was processed, the run happened, and `SuccessCount` / `MustUpdate` flipped.

**`ResumeLatencyFlowTest`** — asserted `MaxDelay < 3s` over 5 resumes staged 1s apart. A resume whose event lands after the log reader computed its next wake-up waits up to the event log check period (1s), so the normal worst case is ~2.1s — less than one poll period below the threshold. Taking the max of 5 samples multiplies the odds; CI saw 3.804s.

**`IndexingFlowTest`** — `IndexingFlow` takes one batch per resume, so 78 batches are 78 sequential commit → event → resume round-trips. That costs ~40ms per trip locally (3s total) but 250-800ms on a loaded runner, where the fixed 10s timeout only covered 12-39 of the 78 batches. `[FlakyTheory(…, 3)]` never helped: all three attempts hit the same shortfall.

## What changed

- **`LongThrottledUpdateFlow`** (1 min) now hosts the three "no second run" tests; `SimpleThrottledUpdateFlow` (2s) stays for the test that waits the period out. Budget goes from 2s to 60s against an unchanged ~3s of test overhead, with no increase in runtime — the long period is never waited on.
- **`ResumeLatencyFlow`** keeps every delay instead of just the max; the test allows one sample over the 3s budget and adds a separate 10s stall guard. A systematic slowdown still fails it, a single busy-runner moment does not.
- **`IndexingFlowTest`** timeouts scale as `10s + batchCount * 1s`; `FlakyTheory`/`FlakyFact` retries are dropped now that the cause is known and addressed.

The style hook also required `Should`-phrased test names, lowercase AAA comments, `RandomStringGenerator`, `sealed` types and `because` reasons across the touched files — hence the larger diff relative to the behavioral change.

## Verification

- All Flow tests: **52/52 passing**, five consecutive runs of the throttle tests.
- **Mutation-tested, not just green**: with `ThrottlePeriod = 0` exactly the three throttle tests fail; with the staged delay raised to 5s the latency test fails (`found 2` samples over budget). They still test what they claim to.

## Two notes, no behavior change

- **`DbModule`** — the test-only 1s event-log check period dates to 2024-06 and worked around `LocalDbLogWatcher` not signalling a newly added event. Fusion `2fbc7d0b` (shipped in 14.3.34, taken 2026-08-21) makes `DbLogWatcher.NotifyChanged` wake the publishing host's own readers — the same gap. Flow tests passed with 60s there in 3 of 4 local runs; the comment now says to re-check on CI and drop the override if that holds.
- **`FlowBackend.OnStore`** — `OnResume` reads state via `FlowHub.Get`, which materializes a missing flow through `Backend.Start`, whose Create branch schedules a kick-off resume. A flow first stored during its own resume therefore gets one extra resume right after the first commit, splitting a self-resuming `DelayQuanta=0` chain into two parallel branches. Confirmed by mutation locally and in dev logs (`LinkPreviewFlow`: `[Commit]` at 14:19:33.225, extra `[Resume]` 0.3ms later, throttled, extra commit). Measured on dev at ~3 cases/hour, mostly free — throttled flows skip it, completed ones are dropped by the `UntypedResult` check — so this PR only records the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV3CggM3EgUU5jNH7zxt61
