### PR TITLE
fix(video): correct the frame size Chrome's hardware AV1 encoder declares

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/Video/av1-bitstream.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/av1-bitstream.ts
@@ -1,0 +1,372 @@
+// Chrome's hardware AV1 encoder (NVENC) writes the encoder session's maximum
+// frame size — 1920x1088 — into `max_frame_width/height` in the sequence header
+// and into `render_width/height` in the frame header, whatever resolution it was
+// configured for. Chromium's own decoder ignores both and uses the per-frame
+// coded size, so it looks right there; Gecko takes `max_frame_size` as the
+// frame's size and reports a 480x272 picture as a 1920x1088 one with the image
+// in the top-left corner. Both fields have a bit width fixed by the sequence
+// header (`frame_width_bits_minus_1`) and by the spec (16 bits for render size),
+// so correcting them is an in-place rewrite: no bit after them moves and the OBU
+// size is unchanged.
+//
+// Syntax is AV1 1.0.0 §5.5 (sequence header) and §5.9 (uncompressed frame
+// header). Every construct we have not seen a real encoder emit is a bail-out
+// rather than an untested code path — a misparsed offset would corrupt the
+// stream for every viewer, and "did not patch" only costs Gecko the rendering
+// it already gets wrong today.
+
+const OBU_SEQUENCE_HEADER = 1;
+const OBU_FRAME_HEADER = 3;
+const OBU_FRAME = 6;
+const OBU_REDUNDANT_FRAME_HEADER = 7;
+
+const KEY_FRAME = 0;
+const SELECT_SCREEN_CONTENT_TOOLS = 2;
+const SELECT_INTEGER_MV = 2;
+const RENDER_SIZE_BITS = 16;
+const MAX_LEB128_BYTES = 8;
+
+export interface Av1FrameSizes {
+    maxWidth: number;
+    maxHeight: number;
+    codedWidth: number;
+    codedHeight: number;
+    renderWidth: number;
+    renderHeight: number;
+}
+
+export function readAv1FrameSizes(data: Uint8Array): Av1FrameSizes | null {
+    const located = locateFrameSizes(data);
+    if (located === null)
+        return null;
+
+    const { sequence, frame } = located;
+
+    return {
+        maxWidth: sequence.maxWidth,
+        maxHeight: sequence.maxHeight,
+        codedWidth: frame.codedWidth,
+        codedHeight: frame.codedHeight,
+        renderWidth: frame.renderWidth,
+        renderHeight: frame.renderHeight,
+    };
+}
+
+// Rewrites `max_frame_size` and `render_size` to (width, height) in place when
+// the encoder declared something larger; `data` is left untouched and `false`
+// returned when the chunk is already correct or anything about it is
+// unrecognized. Both fields are written together or not at all — patching only
+// one would leave render_size larger than max_frame_size.
+export function normalizeAv1FrameSize(data: Uint8Array, width: number, height: number): boolean {
+    if (width <= 0 || height <= 0)
+        return false;
+
+    const located = locateFrameSizes(data);
+    if (located === null)
+        return false;
+
+    const { sequence, frame } = located;
+    // The caller's dims come from the encoder config, so a walk that drifted
+    // would have to land on exactly those two values to get past this.
+    if (frame.codedWidth !== width || frame.codedHeight !== height)
+        return false;
+    if (sequence.maxWidth < width || sequence.maxHeight < height)
+        return false;
+    if (width > 1 << sequence.widthBits || height > 1 << sequence.heightBits)
+        return false;
+
+    const patchMax = sequence.maxWidth !== width || sequence.maxHeight !== height;
+    const patchRender = frame.renderSizeCoded
+        && (frame.renderWidth !== width || frame.renderHeight !== height);
+    if (!patchMax && !patchRender)
+        return false;
+
+    if (patchMax) {
+        writeBits(sequence.payload, sequence.maxWidthBitOffset, sequence.widthBits, width - 1);
+        writeBits(sequence.payload, sequence.maxHeightBitOffset, sequence.heightBits, height - 1);
+    }
+    if (patchRender) {
+        writeBits(frame.payload, frame.renderWidthBitOffset, RENDER_SIZE_BITS, width - 1);
+        writeBits(frame.payload, frame.renderWidthBitOffset + RENDER_SIZE_BITS, RENDER_SIZE_BITS, height - 1);
+    }
+
+    return true;
+}
+
+// Private methods
+
+interface Obu {
+    type: number;
+    payload: Uint8Array;
+}
+
+interface SequenceHeader {
+    payload: Uint8Array;
+    maxWidth: number;
+    maxHeight: number;
+    maxWidthBitOffset: number;
+    maxHeightBitOffset: number;
+    widthBits: number;
+    heightBits: number;
+    reducedStillPicture: boolean;
+    frameIdNumbersPresent: boolean;
+    idLength: number;
+    forceScreenContentTools: number;
+    forceIntegerMv: number;
+    orderHintBits: number;
+    enableSuperres: boolean;
+}
+
+interface FrameSizes {
+    payload: Uint8Array;
+    codedWidth: number;
+    codedHeight: number;
+    renderWidth: number;
+    renderHeight: number;
+    renderSizeCoded: boolean;
+    renderWidthBitOffset: number;
+}
+
+class BitstreamError extends Error {}
+
+class BitReader {
+    private readonly bytes: Uint8Array;
+    private position = 0;
+
+    constructor(bytes: Uint8Array) {
+        this.bytes = bytes;
+    }
+
+    get bitPosition(): number {
+        return this.position;
+    }
+
+    f(count: number): number {
+        let value = 0;
+        for (let i = 0; i < count; i++) {
+            if (this.position >= this.bytes.length * 8)
+                throw new BitstreamError('read past end of OBU');
+
+            value = value * 2 + ((this.bytes[this.position >> 3] >> (7 - (this.position & 7))) & 1);
+            this.position++;
+        }
+
+        return value;
+    }
+
+    uvlc(): number {
+        let leadingZeros = 0;
+        while (this.f(1) === 0)
+            leadingZeros++;
+        if (leadingZeros >= 32)
+            throw new BitstreamError('uvlc out of range');
+
+        return this.f(leadingZeros) + 2 ** leadingZeros - 1;
+    }
+}
+
+function writeBits(bytes: Uint8Array, bitPosition: number, count: number, value: number): void {
+    for (let i = 0; i < count; i++) {
+        const position = bitPosition + i;
+        const mask = 1 << (7 - (position & 7));
+        if ((value >>> (count - 1 - i)) & 1)
+            bytes[position >> 3] |= mask;
+        else
+            bytes[position >> 3] &= ~mask;
+    }
+}
+
+function readLeb128(data: Uint8Array, offset: number): { value: number; length: number } | null {
+    let value = 0;
+    for (let i = 0; i < MAX_LEB128_BYTES; i++) {
+        if (offset + i >= data.length)
+            return null;
+
+        const byte = data[offset + i];
+        value += (byte & 0x7F) * 2 ** (7 * i);
+        if ((byte & 0x80) === 0)
+            return { value, length: i + 1 };
+    }
+
+    return null;
+}
+
+function readObus(data: Uint8Array): Obu[] | null {
+    const obus: Obu[] = [];
+    let offset = 0;
+    while (offset < data.length) {
+        const header = data[offset];
+        if ((header & 0x80) !== 0)
+            return null;
+
+        const type = (header >> 3) & 0xF;
+        const hasExtension = (header >> 2) & 1;
+        const hasSize = (header >> 1) & 1;
+        let payloadOffset = offset + 1 + hasExtension;
+        let size: number;
+        if (hasSize) {
+            const length = readLeb128(data, payloadOffset);
+            if (length === null)
+                return null;
+
+            size = length.value;
+            payloadOffset += length.length;
+        }
+        else
+            size = data.length - payloadOffset;
+        if (payloadOffset + size > data.length)
+            return null;
+
+        obus.push({ type, payload: data.subarray(payloadOffset, payloadOffset + size) });
+        offset = payloadOffset + size;
+    }
+
+    return obus;
+}
+
+function parseSequenceHeader(payload: Uint8Array): SequenceHeader | null {
+    const reader = new BitReader(payload);
+    reader.f(3); // seq_profile
+    reader.f(1); // still_picture
+    const reducedStillPicture = reader.f(1) === 1;
+    if (reducedStillPicture)
+        reader.f(5); // seq_level_idx[0]
+    else {
+        if (reader.f(1) === 1) { // timing_info_present_flag
+            reader.f(32); // num_units_in_display_tick
+            reader.f(32); // time_scale
+            if (reader.f(1) === 1) // equal_picture_interval
+                reader.uvlc();
+            if (reader.f(1) === 1) // decoder_model_info_present_flag
+                return null;
+        }
+        const initialDisplayDelayPresent = reader.f(1) === 1;
+        const operatingPointCount = reader.f(5) + 1;
+        for (let i = 0; i < operatingPointCount; i++) {
+            reader.f(12); // operating_point_idc
+            if (reader.f(5) > 7) // seq_level_idx
+                reader.f(1); // seq_tier
+            if (initialDisplayDelayPresent && reader.f(1) === 1)
+                reader.f(4); // initial_display_delay_minus_1
+        }
+    }
+
+    const widthBits = reader.f(4) + 1;
+    const heightBits = reader.f(4) + 1;
+    const maxWidthBitOffset = reader.bitPosition;
+    const maxWidth = reader.f(widthBits) + 1;
+    const maxHeightBitOffset = reader.bitPosition;
+    const maxHeight = reader.f(heightBits) + 1;
+    const frameIdNumbersPresent = !reducedStillPicture && reader.f(1) === 1;
+    let idLength = 0;
+    if (frameIdNumbersPresent) {
+        const deltaFrameIdLength = reader.f(4) + 2;
+        idLength = reader.f(3) + 1 + deltaFrameIdLength;
+    }
+    reader.f(3); // use_128x128_superblock, enable_filter_intra, enable_intra_edge_filter
+
+    let forceScreenContentTools = SELECT_SCREEN_CONTENT_TOOLS;
+    let forceIntegerMv = SELECT_INTEGER_MV;
+    let orderHintBits = 0;
+    if (!reducedStillPicture) {
+        reader.f(4); // enable_interintra_compound .. enable_dual_filter
+        const enableOrderHint = reader.f(1) === 1;
+        if (enableOrderHint)
+            reader.f(2); // enable_jnt_comp, enable_ref_frame_mvs
+        forceScreenContentTools = reader.f(1) === 1 // seq_choose_screen_content_tools
+            ? SELECT_SCREEN_CONTENT_TOOLS
+            : reader.f(1);
+        if (forceScreenContentTools > 0) {
+            forceIntegerMv = reader.f(1) === 1 // seq_choose_integer_mv
+                ? SELECT_INTEGER_MV
+                : reader.f(1);
+        }
+        if (enableOrderHint)
+            orderHintBits = reader.f(3) + 1;
+    }
+    const enableSuperres = reader.f(1) === 1;
+
+    return {
+        payload, maxWidth, maxHeight, maxWidthBitOffset, maxHeightBitOffset,
+        widthBits, heightBits, reducedStillPicture, frameIdNumbersPresent, idLength,
+        forceScreenContentTools, forceIntegerMv, orderHintBits, enableSuperres,
+    };
+}
+
+function parseFrameSizes(payload: Uint8Array, sequence: SequenceHeader): FrameSizes | null {
+    const reader = new BitReader(payload);
+    if (!sequence.reducedStillPicture) {
+        if (reader.f(1) === 1) // show_existing_frame
+            return null;
+        // Only a shown key frame is walked: it is the one that carries a
+        // sequence header, and its error_resilient_mode, primary_ref_frame and
+        // refresh_frame_flags are all inferred rather than coded, which keeps
+        // the walk to frame_size() short enough to be worth trusting.
+        if (reader.f(2) !== KEY_FRAME || reader.f(1) !== 1) // frame_type, show_frame
+            return null;
+    }
+
+    reader.f(1); // disable_cdf_update
+    const allowScreenContentTools = sequence.forceScreenContentTools === SELECT_SCREEN_CONTENT_TOOLS
+        ? reader.f(1)
+        : sequence.forceScreenContentTools;
+    if (allowScreenContentTools !== 0 && sequence.forceIntegerMv === SELECT_INTEGER_MV)
+        reader.f(1); // force_integer_mv
+    if (sequence.frameIdNumbersPresent)
+        reader.f(sequence.idLength); // current_frame_id
+
+    const frameSizeOverride = sequence.reducedStillPicture ? 0 : reader.f(1);
+    reader.f(sequence.orderHintBits); // order_hint
+
+    let codedWidth = sequence.maxWidth;
+    let codedHeight = sequence.maxHeight;
+    if (frameSizeOverride === 1) {
+        codedWidth = reader.f(sequence.widthBits) + 1;
+        codedHeight = reader.f(sequence.heightBits) + 1;
+    }
+    // Superres rescales the frame after frame_size(), so the caller's configured
+    // dims would no longer be the coded ones and the cross-check below breaks.
+    if (sequence.enableSuperres && reader.f(1) === 1)
+        return null;
+
+    const renderSizeCoded = reader.f(1) === 1; // render_and_frame_size_different
+    const renderWidthBitOffset = reader.bitPosition;
+    const renderWidth = renderSizeCoded ? reader.f(RENDER_SIZE_BITS) + 1 : codedWidth;
+    const renderHeight = renderSizeCoded ? reader.f(RENDER_SIZE_BITS) + 1 : codedHeight;
+
+    return {
+        payload, codedWidth, codedHeight, renderWidth, renderHeight,
+        renderSizeCoded, renderWidthBitOffset,
+    };
+}
+
+function locateFrameSizes(data: Uint8Array): { sequence: SequenceHeader; frame: FrameSizes } | null {
+    const obus = readObus(data);
+    if (obus === null)
+        return null;
+
+    // A repeated sequence header, or a redundant frame header mirroring the one
+    // we patch, would leave the copies disagreeing — nonconformant, and a
+    // decoder that reads the last copy would see the unpatched size.
+    const sequenceObus = obus.filter(obu => obu.type === OBU_SEQUENCE_HEADER);
+    const frameObus = obus.filter(obu => obu.type === OBU_FRAME || obu.type === OBU_FRAME_HEADER);
+    if (sequenceObus.length !== 1 || frameObus.length !== 1)
+        return null;
+    if (obus.some(obu => obu.type === OBU_REDUNDANT_FRAME_HEADER))
+        return null;
+
+    try {
+        const sequence = parseSequenceHeader(sequenceObus[0].payload);
+        if (sequence === null)
+            return null;
+
+        const frame = parseFrameSizes(frameObus[0].payload, sequence);
+        if (frame === null)
+            return null;
+
+        return { sequence, frame };
+    }
+    catch {
+        return null;
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/wire-send.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/wire-send.ts
@@ -8,6 +8,8 @@ import {
     type EncodedBundle,
     type RecorderStats,
 } from '../frame-envelopes';
+import { normalizeAv1FrameSize } from '../av1-bitstream';
+import { getCodecCategory } from '../codec-support';
 import type { LayerLadderController } from '../sender/layer-ladder-controller';
 
 const WIRE_QUEUE_DEPTH_EMA_ALPHA = 0.2;
@@ -204,6 +206,8 @@ export function wireSend(opts: WireSendOptions): PipeOperator<EncodedBundle, voi
                             if (id + 1 > layerCount)
                                 layerCount = id + 1;
                         }
+                        const isAv1 = getCodecCategory(
+                            top.metadata.decoderConfig?.codec ?? cur[cur.length - 1].codec) === 'av1';
                         // One backing buffer for all layers' bytes: copy each chunk
                         // into its own slice. Saves N-1 ArrayBuffer allocations per
                         // bundle (the slices stay live together until serialized).
@@ -221,6 +225,10 @@ export function wireSend(opts: WireSendOptions): PipeOperator<EncodedBundle, voi
                             const data = new Uint8Array(dataPool, dataOffset, encoded.chunk.byteLength);
                             encoded.chunk.copyTo(data);
                             dataOffset += encoded.chunk.byteLength;
+                            // Only key frames carry a sequence header; see av1-bitstream.ts
+                            // for what Chrome's hardware AV1 encoder gets wrong there.
+                            if (isAv1 && isKey)
+                                normalizeAv1FrameSize(data, encoded.encodedWidth, encoded.encodedHeight);
                             const dto: VideoStreamFrame = {
                                 offset,
                                 offsetEpoch: capturedAt.epoch,

--- a/tests/ts/unit/av1-bitstream.test.ts
+++ b/tests/ts/unit/av1-bitstream.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import {
+    normalizeAv1FrameSize,
+    readAv1FrameSizes,
+} from '../../../src/dotnet/UI.Blazor.App/Services/Video/av1-bitstream';
+import {
+    type Av1Fixture,
+    nvenc480,
+    nvenc640Delta,
+    nvencKeyFrames,
+    softwareKeyFrames,
+} from './fixtures/av1-keyframes';
+
+function decode(fixture: Av1Fixture): Uint8Array {
+    const binary = atob(fixture.base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++)
+        bytes[i] = binary.charCodeAt(i);
+
+    return bytes;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+    const result = new Uint8Array(parts.reduce((sum, p) => sum + p.length, 0));
+    let offset = 0;
+    for (const part of parts) {
+        result.set(part, offset);
+        offset += part.length;
+    }
+
+    return result;
+}
+
+// Minimal OBU splitter, independent of the module under test, for building
+// malformed streams out of a good one. Assumes obu_has_size_field, which every
+// WebCodecs encoder sets.
+function splitObus(data: Uint8Array): { type: number; bytes: Uint8Array }[] {
+    const obus: { type: number; bytes: Uint8Array }[] = [];
+    let offset = 0;
+    while (offset < data.length) {
+        const type = (data[offset] >> 3) & 0xF;
+        let cursor = offset + 1 + ((data[offset] >> 2) & 1);
+        let size = 0;
+        for (let shift = 0; ; shift += 7) {
+            const byte = data[cursor++];
+            size += (byte & 0x7F) * 2 ** shift;
+            if ((byte & 0x80) === 0)
+                break;
+        }
+
+        obus.push({ type, bytes: data.subarray(offset, cursor + size) });
+        offset = cursor + size;
+    }
+
+    return obus;
+}
+
+describe('readAv1FrameSizes', () => {
+    it.each(nvencKeyFrames)(
+        'reports the oversized max_frame_size NVENC writes at $width x $height',
+        fixture => {
+            const sizes = readAv1FrameSizes(decode(fixture));
+
+            expect(sizes).not.toBeNull();
+            expect(sizes!.codedWidth).toBe(fixture.width);
+            expect(sizes!.codedHeight).toBe(fixture.height);
+            expect(sizes!.maxWidth).toBe(1920);
+            expect(sizes!.maxHeight).toBe(1088);
+            expect(sizes!.renderWidth).toBe(1920);
+            expect(sizes!.renderHeight).toBe(1088);
+        });
+
+    it.each(softwareKeyFrames)(
+        'reports matching sizes for $encoder at $width x $height',
+        fixture => {
+            const sizes = readAv1FrameSizes(decode(fixture));
+
+            expect(sizes).not.toBeNull();
+            expect(sizes!.codedWidth).toBe(fixture.width);
+            expect(sizes!.codedHeight).toBe(fixture.height);
+            expect(sizes!.maxWidth).toBe(fixture.width);
+            expect(sizes!.maxHeight).toBe(fixture.height);
+            expect(sizes!.renderWidth).toBe(fixture.width);
+            expect(sizes!.renderHeight).toBe(fixture.height);
+        });
+
+    it('returns null for a delta frame, which carries no sequence header', () => {
+        expect(readAv1FrameSizes(decode(nvenc640Delta))).toBeNull();
+    });
+});
+
+describe('normalizeAv1FrameSize', () => {
+    it.each(nvencKeyFrames)(
+        'rewrites both size fields to $width x $height without resizing the chunk',
+        fixture => {
+            const data = decode(fixture);
+            const originalLength = data.length;
+
+            expect(normalizeAv1FrameSize(data, fixture.width, fixture.height)).toBe(true);
+
+            expect(data.length).toBe(originalLength);
+            const sizes = readAv1FrameSizes(data)!;
+            expect(sizes.maxWidth).toBe(fixture.width);
+            expect(sizes.maxHeight).toBe(fixture.height);
+            expect(sizes.codedWidth).toBe(fixture.width);
+            expect(sizes.codedHeight).toBe(fixture.height);
+            expect(sizes.renderWidth).toBe(fixture.width);
+            expect(sizes.renderHeight).toBe(fixture.height);
+        });
+
+    it.each(nvencKeyFrames)('is idempotent at $width x $height', fixture => {
+        const data = decode(fixture);
+        normalizeAv1FrameSize(data, fixture.width, fixture.height);
+        const afterFirst = Uint8Array.from(data);
+
+        expect(normalizeAv1FrameSize(data, fixture.width, fixture.height)).toBe(false);
+        expect(data).toEqual(afterFirst);
+    });
+
+    it.each(softwareKeyFrames)(
+        'leaves $encoder output at $width x $height byte-identical',
+        fixture => {
+            const data = decode(fixture);
+            const original = Uint8Array.from(data);
+
+            expect(normalizeAv1FrameSize(data, fixture.width, fixture.height)).toBe(false);
+            expect(data).toEqual(original);
+        });
+
+    it.each(nvencKeyFrames)(
+        'refuses dims that disagree with the coded size at $width x $height',
+        fixture => {
+            const data = decode(fixture);
+            const original = Uint8Array.from(data);
+
+            expect(normalizeAv1FrameSize(data, fixture.width + 2, fixture.height)).toBe(false);
+            expect(normalizeAv1FrameSize(data, fixture.width, fixture.height + 2)).toBe(false);
+            expect(data).toEqual(original);
+        });
+
+    it('refuses non-positive dims', () => {
+        const fixture = nvencKeyFrames[0];
+        const data = decode(fixture);
+        const original = Uint8Array.from(data);
+
+        expect(normalizeAv1FrameSize(data, 0, fixture.height)).toBe(false);
+        expect(normalizeAv1FrameSize(data, fixture.width, -1)).toBe(false);
+        expect(data).toEqual(original);
+    });
+
+    it('refuses a delta frame', () => {
+        const data = decode(nvenc640Delta);
+        const original = Uint8Array.from(data);
+
+        expect(normalizeAv1FrameSize(data, nvenc640Delta.width, nvenc640Delta.height)).toBe(false);
+        expect(data).toEqual(original);
+    });
+
+    it('refuses truncated and corrupt input without throwing', () => {
+        const fixture = nvencKeyFrames[0];
+        const full = decode(fixture);
+        for (const length of [0, 1, 2, 5, 12, full.length - 1]) {
+            const truncated = Uint8Array.from(full.subarray(0, length));
+            const original = Uint8Array.from(truncated);
+
+            expect(normalizeAv1FrameSize(truncated, fixture.width, fixture.height)).toBe(false);
+            expect(truncated).toEqual(original);
+        }
+
+        const corrupt = Uint8Array.from(full);
+        corrupt[0] = 0xFF; // obu_forbidden_bit set
+        expect(normalizeAv1FrameSize(corrupt, fixture.width, fixture.height)).toBe(false);
+        expect(normalizeAv1FrameSize(new Uint8Array(64), fixture.width, fixture.height)).toBe(false);
+    });
+
+    // Every other assertion here reads the result back through this module's
+    // own parser, so a matching drift in parser and writer would be invisible.
+    // These bytes were produced by a separate implementation of the spec walk
+    // and confirmed to decode at the right size in Firefox.
+    it('produces the expected bytes for a known NVENC key frame', () => {
+        const golden =
+            'EgAKDAAAAEao75D+ABDMAjJlEAAIA75D4DvgIegkCAggggEABADBABJyMw8cc2azTwWoHBJ+bF2lwd58pvEgZabrcj4nFfbO'
+            + 'zPujKbaJUIkmNfYBw9t2pfES7OrEtLP8iShcq405z3GN7iSYK1+dOZSLxsivZcg=';
+        const data = decode(nvenc480);
+
+        expect(normalizeAv1FrameSize(data, nvenc480.width, nvenc480.height)).toBe(true);
+        expect(data).toEqual(decode({ ...nvenc480, base64: golden }));
+    });
+
+    it('refuses a chunk carrying a second sequence header', () => {
+        const fixture = nvencKeyFrames[0];
+        const full = decode(fixture);
+        const obus = splitObus(full);
+        const sequence = obus.find(obu => obu.type === 1)!;
+
+        // Rebuilding the fixture from the split must reproduce it exactly,
+        // otherwise the duplicate below would be refused for being malformed
+        // rather than for carrying two sequence headers.
+        expect(concat(obus.map(obu => obu.bytes))).toEqual(full);
+
+        const duplicated = concat([...obus.map(obu => obu.bytes), sequence.bytes]);
+        const original = Uint8Array.from(duplicated);
+        expect(splitObus(duplicated).filter(obu => obu.type === 1)).toHaveLength(2);
+
+        expect(readAv1FrameSizes(duplicated)).toBeNull();
+        expect(normalizeAv1FrameSize(duplicated, fixture.width, fixture.height)).toBe(false);
+        expect(duplicated).toEqual(original);
+    });
+
+    it('touches only the two size fields', () => {
+        const fixture = nvencKeyFrames[0];
+        const data = decode(fixture);
+        const original = Uint8Array.from(data);
+
+        expect(normalizeAv1FrameSize(data, fixture.width, fixture.height)).toBe(true);
+
+        const changed: number[] = [];
+        for (let i = 0; i < data.length; i++)
+            if (data[i] !== original[i])
+                changed.push(i);
+        expect(changed.length).toBeGreaterThan(0);
+
+        // max_frame_size spans at most 3 bytes in the sequence header OBU and
+        // render_size at most 5 in the frame OBU, both of which sit in the
+        // first ~40 bytes; the tile data after them must be untouched.
+        expect(changed.length).toBeLessThanOrEqual(8);
+        expect(Math.max(...changed)).toBeLessThan(48);
+    });
+});

--- a/tests/ts/unit/fixtures/av1-keyframes.ts
+++ b/tests/ts/unit/fixtures/av1-keyframes.ts
@@ -1,0 +1,215 @@
+// AV1 keyframes captured from three encoders, base64-encoded. The Chrome
+// NVENC ones carry the defect `normalizeAv1FrameSize` repairs: their sequence
+// header declares max_frame_size 1920x1088 whatever the configured resolution
+// is. The two software encoders declare it correctly and must come through
+// untouched.
+//
+// To regenerate: in each browser, configure a `VideoEncoder` for
+// `av01.0.08M.08` at the size below with `latencyMode: 'realtime'` and the
+// stated `hardwareAcceleration`, encode a few frames of any content with
+// `keyFrame: true` on the first, and base64 the first chunk's bytes. The
+// defect is GPU-specific, so the NVENC ones need a machine whose Chrome
+// reports hardware AV1 encode.
+
+export interface Av1Fixture {
+    readonly encoder: string;
+    readonly width: number;
+    readonly height: number;
+    readonly isKeyFrame: boolean;
+    readonly base64: string;
+}
+
+export const nvenc320: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 320,
+    height: 184,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAEKrv8P+ABDMAjLCBRAACAJ+LeDv4Ifo1AgooooFAAQAwQBghFIHP16suPde5BvnqEnuWaMZBqAQwZVYMKhkLmJn'
+        + 'imGV/mgOjePjO76VW89Q0A/ruYEHsr3MXd8B4nxcZnmsDu9K7jvZqwhXrdkJ6OpfSfFH5Iq/k9VNeuNuWMrlwg31SpcOCjbS'
+        + 'kmhPdf4/LOGGRVQitS5pD/EOM5vcr8aT0d4+m3PevryoKdy5GjbyD5YECmGviRewGCcN9Zxui2oNdl5bvDr3hhxYdh6dzZ8j'
+        + 'Ts7gOr2cYYui0fNOr6NuitKKiRq5iwgWkAjXU5jLx9eYLPz/VLiofYLm8rzEVuuCraTi+fddayTbN2jJ/Q6IWBqmy9FKIrfo'
+        + 'UfPXqUfUpK1JFBSxeCHbz0X+kDwkHwhvzLPP9cYtEr5DNRS2cImUac/6qQKoLW2VsRonttQodGJ16B2nia3ADX8tXxxjIik2'
+        + 'KKG1LLKv8TY7c71Um9/QnDMv9qh8RiPJdc6diwFVrdxNgE1XUZS7O9Xy9VJ9MIXQORq58ZpDlX1fAMctFjjgDAV4jw2CvFVh'
+        + 'enHI/1vtEz+B3+0WAnjpMZlwFEpOOb7k+4RPcjdw5uD5St+LiW8f47kXEIJ5no81RiDE5ON/RZ1cHVrin+bvYdGkNJjP3CN/'
+        + 'O6zoJo+R+j0VEiQosAa8pTU1/JVzW7MFm0ASKUIylcRMU3zqNSywNyMd3Bm4bEq8NTf6Uq3Tku9gaB0rOeNnwVe4ZBnoIuHf'
+        + 'UKddYdsqX+Fc9HGwz12+/5hJ6Zs9ZNr6+AiQOXbVIA6YfYQl7LEpOw28+dNJ9i91g8fvqpWyhuzunCT4L+1yhxqnWGwA0iF4'
+        + 'Et2prp/Rga1rnbCcEZjWs0w9bHR78+qMc/HxCFEobyUN98DH+uIG+75nK2V+sOt3UWLq5ph9PMrSsoX1hTCgK2cO7dSGYFTK'
+        + '7zv2VYQ=',
+};
+
+export const nvenc640: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 640,
+    height: 360,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAEKrv8P+ABDMAjK3ChAACAT+WeDv4Ifo1AgooooFAAQAwQASclVqYUnCUK3RNCArJ+FyTdHfZHQcV/2eqBoavQP+'
+        + 'LvSULoJbPE77E9p8aIqaGaldchsxM+Pr2RioQuUBzRdiwFoEtvUhHuraCDx9VyAVCRCjl7IPOY3BMblrPHCILrEW+RGVwNWB'
+        + 'jAA7ixj3YbY0yzb/BnF2Yxb484spJqENmb0NO+culknUvq0VeQQ6WPCsY2PT23t5xxUaaU2CGrDGXATrXIKBgCgHfglH2OZg'
+        + 'T2mUabq9tu7IJtFnr4gxjNCSvPnMuRyh3YsrkU15d3xput5sVnk+QMMvqe6o7mUF50k62Uf+Q58uKKinw794hilmScairMmW'
+        + 'YY/CUFUp7vXUAoKzfOuF/4f2hrDGT7dcX3YxIxk7JtL+FciZ7HM1GzQbajECgAtnfAn2lkkurKJirBpTAeb9RxJPqWsHrHiq'
+        + 'wZTYTSW0A2a8X3dlKsCNKQHEExsqzAveYoR+haEfAed3Ai8NCVqcxeUyg3Q78hyLa+9vAKIEyF7wlp4i/ZngogK2GtZYiSd5'
+        + 'cqgYWH6Vo/cL2c9tjaMd8oTl7bavZfaeuR8gni7ZXsETry3sq6RUhUFscdq5/R+vhyg+mfGuOpT09XWPb7JJO6e2AJfWF5dJ'
+        + '1onZ21n3dPoklETstlz2Cp8oN6OGU6lFmaTFJmEAzG8a18y/dzrFWIjZ9DuKZxbNbWsQZ1xGqkf8rX1HtpHqQwcXlRIyq5di'
+        + '+9N6wTW3rGUYXIA0NsiTqRUIQlXhrzcfdL+MZGc4JfvTrLBmPaYutE730LfM5EgKGbrqT525GY1poqIG27ILR0FdW4yKETIn'
+        + 'H2subTA3ev0d9+XUNY5EphIDQx2Q5z+dsVMoYUor4fUdFfDiTWoRkmesnfuHLI4yvoUfF20z3FaPImjQNhFZRef8EZxUQkiX'
+        + 'Zxktz33sYyIjIU1mZDY7cqgIwn1dFskSACY17ekdNoWgPDF3oXKgFaT5lLoqgiq671vlxMMmI4aiZfrR4xCiw6ONsgAkSU4P'
+        + 'OS0kP7nUPAGCgVkfrvHWvWObVMpiVrYzc11RtK5yrwdDjURrpcbDUb1+81d6COatFCdQRPINl4Bay+30i/VYmkq2hJVo13HA'
+        + '8Gl+fbCePuyQmrxQ8xUf0BXPx87wzjl5E9lK3eV5geD7aL5eSJ3mKTn9NSUH8X4gZOu7GHS4cE/9ZOpcgO/+8E8LSmFvznJJ'
+        + 'Zo7ui8yIBeS6lQ4UnGguVvJZBsC8bJinJEhtDL7f9PeRKRND1o+SDMmotd5U4bjQIGoEVCA1AdK57yuLgNHC6mXfL88a/TDZ'
+        + 'j+yLojwVxGTwPnSSda/jDx5cVZBS3C5Xs5kfRBK0o7uqX5eP/HizmCY1mcQBSPycPDn6F8YgBchrmWwzrtB8hmcsBrqfqfwm'
+        + '+qcZlpIGInqpxlCmBQ0tLXAeVKVA+QDqEKXAE+UO2vFDMy0G4Pc89gNvAseO5Lv3wuPo0gmbD9urXlI5XHoioHzk/FFSLS+B'
+        + 'cRt1UpzzQskUPOZMfePBGXS8vk1TkGqITxTjfRRlvkPPkCfgRQkJZR92hsJ5ZzZ7qdCYSCmQ+Ta15jyrwx+pCDdZT/N4SYkG'
+        + 'TldEfWlEtGFdH6KuWWZVH4OXdIQeHpJOalqgNJGY9dkzALAr6+FLwnPTb3ZR+WXJlUu7FMxjZaiSx5ZVW1iY2bkPnrH0TFSR'
+        + 'vyoHkXfBdWW50wd4UuODZ35tVYaz70X8WeJNzLJYmIj1eicaWmSOc2mKJhh/NCWvzwu/QRVz5sjDuQ==',
+};
+
+export const nvenc640Delta: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 640,
+    height: 360,
+    isKeyFrame: false,
+    base64:
+        'EgAy4QUwAAwI/xAAEAAMAAgABQADAAHAAACfyzwd/BD9IjggooooFAAQAwYAhNtAuWIFzNLdexab9dnOuNmns2YfywBqI4sm'
+        + 'CcT05yhITBzOzPIOnV9LHN9GTvBkT21M0K9jbsXJ8r864sSZwe9wSSD1O2OTW/BMnhRfiz1xih8LQ7yVIPvwpFSxvA2CueQ+'
+        + 'CK1LiM2KoM1IkSonHX5LiWPH7u8/hBjKoMLAhBP483/j/5LRb20sBuYYXBKSYtbyHvaE5Rl5MoPzum0S16MWxt/oMhuKQ4Dc'
+        + '28H4TPyqSiw1HS5/l7mToicRmI7Zx+BJyw1PyzdyIecl3e1Gx7vMN3U2V2wDpwFdSXtvB4IYhUxGiQ8sneycAP6O1VaAPC5f'
+        + 'WIXWV3W9bWk2pczV+yYjDVAo3Fwv1dIPy4I/BV+xfCR2FqcSsLY2XlfNVzCbz33OMMZMpcFyPfBijXZMF2pY9vUmbcTP+16i'
+        + '/x1bakQ58k+PunIJeJPyLDibXC9DA5BuUC87KjXIssuH8OEGZYH64kCQdBghMcHs1X6jxtROQJxIziVEq47iWq4ORkPA1dg5'
+        + 'VMPSCVKQLfybmrNYybQataWYt/281plnDizHdjH9eFeRi5V7vlB6DA+FY4IUFA0Bb8h3qz1W1PlX2kt99OzzqELo+kQRqGtu'
+        + 'E6q59vwbZNNvHdhQ834ZxJ54ksEfpcWuBnb5wnhodaERfJZDbQxF6en4aO/fFwctCYsZqqNYGggK2YzLp8JtVTTV4vnu0uSA'
+        + 'snIyhIFRqAS61gqs4jhv3o8zgX0mOlQdBFrr7XG22n5oCFlL+Q6KaGcgi2X9TdNQK95dRgLceNtQ1mLF8nQcAEoIkMmnamDr'
+        + 'skhGULXJUKqlKBuCngco2l09flLKu2SWbb1JgKSSRguzXGVBfswRXbXKLv07OR+YxgcG40bbFAVPQ/J4yUQS4wVT7gOnewrD'
+        + 'feQklAe/XXil8itDuiXxtghBggZR0A==',
+};
+
+export const nvenc1280: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 1280,
+    height: 720,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAEarv8P+ABDMAjLZFBAACAn+s+Dv4Ifo1AgooooFAAQAwQASclVqYUnCUK3RNCArJ+FyTc3xRqMhS4bhuvITJuuc'
+        + 'aNCiKklIsLXpz5S933XjuIT/sUN3CByZLNM1+x4Eh3ZBpOwaVn+Gxp2wIsa7M57CEEijJBW73zaSyeCrjX+4GviqeKmowHW/'
+        + 'EFKLeLsZmN5dUTZZYU9PGPCf76RgZbDyPkK5/kOjBkJEDyxh9Ip7Eb+/TQclvS9uCpOZRjcchwcQl1jjoqYvAGxbxcS5gEka'
+        + '2MMBiiJwlFCsTtm9uyJpErMGKBv+FV/Fn4kJXe+yof6yAbU3nX/vRWclesFGvWiCZeSjWiy3JWgRHps7vDnqS9N2VB9KHfqx'
+        + '1Exzvr9M40uqbPryJ5Q4+il9clL7zFSoWJYaeMTKhJ/tPyGryIhrWgd9dM8BLu+2XUf+9CSQ5AlUeZ6i+xftt8XfnlMAdprw'
+        + 'KTW1MSRKbQR0O4EAdozFTT4HBTaKcjCDoTkEoA+n3ZJsOqvRffOcpaoJmhYdCebLxm5WAvs+QInC+fW3dxMza+vhTv694D5J'
+        + 'rF2bHvwl4NahCCWKSiIDSkZ9m637dcVmMlDsPhgicecZSODzHKTlO/OD3XFkNEFLJFsFSaOLOFJuKPObXqJRZ00vGdsQUmRG'
+        + 'QFscE4hnjayAs9ZBcIX+9v2vpyJPQnZFFwZcsQGaxjNi0ahyIMVpB+kqrDyPCEnPoF7iNB7MFCxXzHC3Uhgx9oqbPSjdZjdE'
+        + 'ixTcStc0wQNOihZhbPUShjkdAaMN1naC5/opY7X8syJ5rgJNGlBzbe9vo+qu/oJ5DfwsU42MEz/NGEc6O4usI67jMenqgAgb'
+        + 'Tf5+5MfV5+reYGmq8fooO0/3Q+k9pWYYwu6yvavZSHVdF8hgVJybClUt54FYEt7zKVTUTtjeumpnDXMtTy4HPONddl5965GF'
+        + 'jGnhwhl/AxSMqs5DJehfhzJjkFSlMfUldQZvYlpcvucuHCDWZCSdnrBv7nWekA0PbhdjMyLtaY7Tmg3vcbvecDKA9Twmiqcf'
+        + '6KqoFJRopCClkhMU18HvyikRpz/L7HgVrwYcjt4o1BEhI8Q3My3MToizBGcZOzuaNxHqM/xCnqkDWyopp0O+o1Mbq0rwHw72'
+        + 'lS2iwxx7l+BWPCYhTH12zSxDizw7rTR+AhDIszDuPXU2uGkhK7xH4986uvZHKu5CFlUqwOLMq+7w9tkOLaiA5wqfsV8NK3kF'
+        + 'EHqPPXS0Czl6Y5oUHckZL+cADtka4jgjDm+1H66VDMnKxnhF9DBni0yn0qDhiK0HM45up5Hpy7hFbh+6lTQ0ME16pF9yg3qk'
+        + 'FR/8Ug3msE6o0ncyDN3aUFnr5dD6DekMZahQOf+UTTd7QvEIWtUhlppZnGIVMzJPXR/4Kto2RT26ih++gCDULz/zXnActGhJ'
+        + 'jjYMALbSyIYka1PZS9EdNo/4NBCP7g80BWYI2dq6gLBdXh3y60GJVExLyy9QwIBPndsnhuUR3wVpAIhdrbl87NHZYPPMQ25R'
+        + 'v7u9phHh9Ra0rQ+tELa8y+djVe12GSQc13dlVQIYAvY6HPTJnXYC5OxDxVy8OaP1evn/Jxp2js9J3Y3LcKLYs2/Zo8+1FwWY'
+        + 'GJT0LYrHE0Uu2ECcb6xOgIczgdWR7F7vnryk5b5rkZ99Ubeh2pYHFJFD5AX9GHJuxvusbT1hDyVZNwcaanny3FZpYiXX7K2X'
+        + 'WY3vmXmmo33kxAmVhe6HyRu/lWp6bz6o9jVpvW3xKPJsueOmDCeuk3B3B1lMM5YZUZtwaAGw8KFNafo2zeljgrQ+TSn3nSUN'
+        + 'XuxEquxCZa5yicw6ZPqKQ3gz8eYp8xiYZnce04SWUGt/Zb5atF1t4+yGA4eENJTGKfdvmJnxVZlpGgh6RqraP4T08n/N5ZAs'
+        + 'FQMk363/WQXTcrsTW+L2+RTJVZzcFVDD25vzG0ndbYKB8dlM5fKc8GH8JHA+VSLJzvw5EG3ZnW0YB39+Pwt9DQBX6jRRhqCn'
+        + 'qzdnst4rXS/2Qk4gn1vrI1VKx2f1N8cKgKwlv5pK4lztcdnyxACPdSHWaaWlmWMsxtVLyxtDPfOnQ0s3rCN5oAjx6SEwxVrV'
+        + 'qC85STz/bgxMLCpC+TpmF82WzmDQNeRONzNoGySCIUBsadgw4OmLd6Zl3OSao5iIEe+f9P4FibuAY40nib4I6rMo3+v9r77t'
+        + 'OJA35ApXeAPcfqWQhu7UAdfXCvZvLoykezrYMryQszZVNTAZkcrDsUI6UWnP6kV2WdN7i3vYpNMHhfzcOO/ArP0LiG0wJTYA'
+        + '5dhwUcFQ4qYP41ERSPGoDfGBweiYI8BOHGCa0lXPn7ko+jQtbi61Iwk2KRPRSSAmcMjTL1IXjQosCH4B6nDe99mPZ2EZLnw0'
+        + 'EWLZA5LG49Eem9MCQPKkdGy2qpQZNXf/UfQrZ6dQMK95jE/ZGFjnrMfjtSR5IfkG48ySVL7hWwKylpeZKammCV8LW+kFi5Rg'
+        + 'vCHD6hTyGYadjcPjVsCnuPHlsK779+Tgo8L5NkraQzfjKr1nRt5kzr275FA4kmh2VfQPuQC1Oa1RhjovySin7auvUyEW5aai'
+        + 'rMrYoR7sKPr8vAFx5deJtY8cEuSVZZ1/oXGqGvpc2B+IIRsX6X/oc3nb+cQ4/A6vafKMMUgtlJ+SyU/8qW62OvP4OwUOzY3G'
+        + 'KuOiYs9vbFrcu0yxM/AJ9BeuMj6XAQYSillJxbEM9wZ+AcsDjXBQUFtNfXnRqQrA0Bt+vHclVGPnxjc7bDcQcozaWzG0uqgf'
+        + '3Yur2BhoLeolrdLqf4RfctSjha4zQ2C8q7rsWzr4F0aJf/iyAGGN0YxVu4dItl5MUcu9+sTcxTgXKhuxamMcC0oibXGzKXIb'
+        + 'sXxmyTJedkUCKVENmhdZsG4A2HYpgbnEeyju4+lbJ15lxv5djY0Q3rFKxklmrrzPMbhxOd2bYyIOvT/YKDkW6RqzM5XEMFQA'
+        + 'or6o1ZYWCNkVA4q8dbo8WHUxkWXpDMtnx4MkaBrnjChOPOhwYSBCjXWn94mYox660fd/ZH/ruZKykQ3/1BzCK3YdBDfT0Jze'
+        + 'GirhLvshNEu4hSvsSN14UEXj0nYG7db8jCIycNyuVvCPpo8prpU03SD6Tt3eynLhTCqvTzT3og01DIZ4GL2SyyAOa9qtcL/d'
+        + 'pIvkOdKMytmTNzcp5MR5dlg2JCiMd9YJ4GglFTC9NVvk0k0Eqf9CwRu61sGU4nLTQuyE6x4gXNnl3aUtrl5gYkxMcjNdbTcb'
+        + 'yRNP1v7+eXVPbZK0KLvZNWKNofcmr20uh0y0tUMXypMIo99DsztN5DL54DGOHoKjqeVfYJBaSBbxSUyFDO1NsSfY2iiThqme'
+        + 'yoClkv9lQJLcjUXZ7JHX1Iy6m4wWVjx+2BwXqE9rcBNznZxXr/VR2eINi8Z9oOGiQ3zEr7+44n5bS3KVJSO7ST4KXBHkJ3si'
+        + 'SCK1QL2UY+pb0RvaBcBqZ86rOPledM47Aqlk6XEkIxemRHO2j5x0PZO4H56S5FN6PUZtZBRGtOyoi3HQpHhV/O074XvfS7Sz'
+        + 'i+/twA==',
+};
+
+export const nvenc480: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 480,
+    height: 272,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAEarv8P+ABDMAjJlEAAIA75D4O/gh+gkCAggggEABADBABJyMw8cc2azTwWoHBJ+bF2lwd58pvEgZabrcj4nFfbO'
+        + 'zPujKbaJUIkmNfYBw9t2pfES7OrEtLP8iShcq405z3GN7iSYK1+dOZSLxsivZcg=',
+};
+
+export const nvenc960: Av1Fixture = {
+    encoder: 'Chrome NVENC (hardware)',
+    width: 960,
+    height: 544,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAEarv8P+ABDMAjKRARAACAd+h+Dv4IfopAgccccFAAQAwQASclVsQp/CYnvJNj9mp+FyTc3xTLYED6pU9Pd4uakG'
+        + 'e70QjZS0sO5CtDk+lkXN2TQp8xuo0E93mWPjuxAvlL0cXm/piYvWWecJxHv7erMduW3Opuwbt2fs2JSZIkxwgQ4bm9wG0KdO'
+        + 'p7USENizKKgNndecPN3xS6YOsIg=',
+};
+
+export const libaom480: Av1Fixture = {
+    encoder: 'Chrome libaom (software)',
+    width: 480,
+    height: 272,
+    isKeyFrame: true,
+    base64:
+        'EgAKDQAAAARHfh4A0QEBAQQyqwMQQ8ADDDDEAgkAtE7m4DSR8tKzAbuB8fnApnjC8pHcjVq8Bk/QY6ThG/zP//+Zi/Dw8OZG'
+        + 'nInCoZECY1niWEA4UKeDlb7b7TvbDcET9s3qsAkGVNGz0wb84HmYmct+Qs9QTQC+x4tk4Uu0K+tja7OPd9WfqvbdrX7kma5U'
+        + 'pvaJh0ZHmN6vSW7p/S6tn7fAboAHBUIFlMNmXWmVx6lFCaxVsQHMoOCPnA9A9nI0f66P0/pThlppdEUpTnlAP/EEd9Q1mj2c'
+        + 'oYGWG8hXrxlTCGlvhOyBxKqBF3UO46X5Twn/brRTj+4qws7EQl1PVCQfLknJ56W0c9mkmkCDKFWWsqEfqqSnqDC3DiTnRoST'
+        + '6ed8zA9fSFWFlX+In+jCqNTw0LAjTcNkhc4xdlOh0V+VarrcnFwRDKi1VS2M2VudjC9RA2rcyfpxvaC6LyVBdoxFMA682PYv'
+        + '1AcNdyjxG0y5z0OtMPsMuh2Ddh+0rz9sqsTVyxzh5Nz94a+zTXnpeUp7dxr0Ukj6U1lSv9mxc212LQ/2ChTP0OJ7rtNEYT5a'
+        + 'byVdZzol9EhwDxrvDVBA',
+};
+
+export const libaom960: Av1Fixture = {
+    encoder: 'Chrome libaom (software)',
+    width: 960,
+    height: 544,
+    isKeyFrame: true,
+    base64:
+        'EgAKDQAAACTPfw+ANEBAQEEyygQQYZkBBBBAUkmAAQAALAG1H518SSseFYSozaiUHwjqpTAkasp5ahciDSxmf7oh2+tAdMP2'
+        + 'XhJde9G+A9LwUnvVXpJ/uF9E/e6+cP3HLTuaT3txlpKV5u4/qFeE28uvEtmvmSu5uV7UDPNkVbAKrkaC/k9BpRX6ND2nE2Ee'
+        + 'olniWe0hml99dmHh3Y2oKQa6SNCwQL8B7XU/oqcKSnUB3HoBA8x68zE8H0q6UFz/qtttb+MbztyVq9rIvSB+3V5MLW7bXVqY'
+        + 'AiRENF6yYolHLpNuw8o6kXBKCXB6FeflTQSgd1ChvOVPq0RdkRtZ2xqLPs3181mU/qUPYZRh+JM5JF6dR1cj3U/sK2BCdjFy'
+        + '/XeXF/WN/uzQAsvRjVM2vEbrz9I10o+isvGG9DugAMoRO/jT2LvTnfM4xwSeF/7EtR+dfEkrHhWEqM2nxceqpb1CKot3xFtp'
+        + 'MNTnuwxqs3EUwNw0VI91LFALW2SY38jJcG+TUv7dRVxyaLRI+2B2YuxOS0nNnSSe9pvT8ZDDWRG3M0rLvhl6vVcxz8xP2L7K'
+        + 'XKMHMFZuwE8U1xcncdesam6V6I3mwgO4J69xLq6cXfvxLM0WUBwepbSU2Kn8HYkrOz9iB89QMYrQc6PfawPGBGYxThq1j0TX'
+        + '1lqYn9RIugBhRxSr+hYzc6X+8a3IlrlFEjwCUsiuzmKQyAbtKcfOZl40FDwy9GbxN+uf+uBo2zs/uuBLjMvF+ME+0vSR6FDU'
+        + 'OolR1RG86my+/StfLIs64SB2RC8XbJWOwjzM4BqA',
+};
+
+export const firefox320: Av1Fixture = {
+    encoder: 'Firefox libaom (software)',
+    width: 320,
+    height: 184,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAAQ8/t+BtfIAgDLyAhCUkAEKAAggghABZLRNcf+6E60wlzg9mCsHR6e9j2sUg//kNImgYNMx3saCkCr+Sh1jbQn9'
+        + '7ZsDqdIXHQFDQCH97PuaPt++IFXH+Sz0yzjdP8lWoKYMNhbMosTrcH23SmjSwqAyu0gtW0G025+rP8e8MP2HwtQUvq97I9We'
+        + 'QWIwkkvQJxXOhLlfxI7BRSz/dEjjlyefvbYosUNNOn0yYrw8R6pZKd/d4UJjqh37xKfnDuMnLbQBqPCSOXDZLWaIo7oLNhoE'
+        + 'CQFhtzrM9009AmLTdwrirS56oitJVDCW7Ydz7aBnqqt4igbCsRFKNq63z0Ec93J1/Y2TUV+DzjLZk3roF/mWUC5UO/oYhmMA'
+        + 'w6G+J+NttlsigbR4G+lrR+cisvykKaF51o+fEE62hklpXePl9A4N2JCP/bPV/bkAEfyM9fZaxokwc4D8+Tel9hvlgj/YiJtx'
+        + '1uL0oDRkFQCWXyYoD28hvffmyzQrlGNEFnB4fqs=',
+};
+
+export const firefox640: Av1Fixture = {
+    encoder: 'Firefox libaom (software)',
+    width: 640,
+    height: 360,
+    isKeyFrame: true,
+    base64:
+        'EgAKDAAAAAzE/2fgbXyAIDLgAhCUkAENQAggghABdLRNcdWso6v5mrgu5Os4uWRbuEW8qpJrm/fjmBlthU+K5BJ2G8iRuSBf'
+        + '7xDMG84QLH/2jPhoiL6k9x0lF95B/2YIXagLEofqe3wD8Xkpjt720o0UbYiKWB+ByT5awB7KAnUNui47Bgup/kjrUWF4kkjH'
+        + 'jmwGKoXWUUYeyLmvvrlGwo9fKa08FcTObFyBiuOtBMA50Ag+AaF95tP6rrErwDinvU6btTYfjCOZGzAkaYB7QBycHaTmSbl6'
+        + 'OzGRgQurIK3AEURZ5yeYNvg7+zPnh7qn9eMAtX2QfBexwyWRj0m+ue3ERcPRXtdS7xySAYSY2JenzYIz/pAsiLWl1/iMDCKX'
+        + 'nKNj+C4w535DL3K0wp8+tdHgtuWsbV/wNZwI9kGOOSYVbGAaSKBGblYf5zK4nSFbGH345isG2VJGUpiebGC5NgB0SHGw9XJO'
+        + '6pXx7aBWcFhb15M=',
+};
+
+export const nvencKeyFrames: readonly Av1Fixture[] = [nvenc320, nvenc640, nvenc1280, nvenc480, nvenc960];
+export const softwareKeyFrames: readonly Av1Fixture[] = [libaom480, libaom960, firefox320, firefox640];


### PR DESCRIPTION
## The defect

Chrome's **hardware** AV1 encoder (NVENC) writes the encoder session's maximum frame size — `1920x1088` — into `max_frame_width/height` in the AV1 sequence header and into `render_width/height` in the frame header, **whatever resolution it was configured for**:

```
prefer-hardware  configured  480x272  ->  seq_hdr max_frame 1920x1088
prefer-hardware  configured  960x544  ->  seq_hdr max_frame 1920x1088
prefer-software  configured  480x272  ->  seq_hdr max_frame 480x272     ✓
prefer-software  configured  960x544  ->  seq_hdr max_frame 960x544     ✓
```

The frame header is correct — `frame_size_override_flag=1`, coded size `480x272`. Chromium's decoder uses that and renders fine. **Gecko takes `max_frame_size` as the frame's size**, so the picture arrives as a `1920x1088` `VideoFrame` with the real image in the top-left corner and the rest black.

Every simulcast tier below the top is affected, and so is the top tier whenever it is smaller than 1920x1088. In Firefox this showed up as a mostly-black remote tile, and in the diagnostics modal as `L0/2 1920x1104 (tier L2)` — layer L0 carrying L2's dimensions.

## The fix

Both fields have a bit width fixed by the sequence header (`frame_width_bits_minus_1`) and by the spec (16 bits for render size), so the repair is an **in-place rewrite**: no bit after them moves, the OBU size is unchanged, no chunk rebuild.

It runs on the **sender**, in `wire-send.ts` right after `encoded.chunk.copyTo(data)` — the bytes are already in a mutable pooled buffer there, so it costs no extra copy, and `encoded.encodedWidth/encodedHeight` are the encoder config, i.e. ground truth. Gated on AV1 + key frame, so it touches 1 chunk in 90 (`KeyFramePeriod = 3s`) and non-AV1 streams pay one string comparison per bundle.

Sender-side rather than receiver-side deliberately: **both** wrong fields get corrected once for every viewer. Patching receiver-side could only fix whichever field *that* decoder happens to read — and `render_size`, the one Gecko ignores, is the field the spec says *should* drive display size.

It is a no-op when `max_frame_size` already matches, so software AV1, other GPUs and other encoders emit byte-identical output, and it self-disables if Chrome fixes NVENC.

## Why it can be trusted near live video

A wrong bit offset would write into video every viewer receives, so the offset is variable (it depends on `timing_info_present_flag`, `decoder_model_info_present_flag`, `initial_display_delay_present_flag`, the operating-point loop, and `frame_width_bits_minus_1`) and nothing sits at a fixed byte position.

- **The parser bails out rather than guessing** on every construct no real encoder was observed to emit: decoder model info, superres, non-key or non-shown frames, multi-frame temporal units, a repeated sequence header, a redundant frame header.
- **The patch is refused unless the frame header's coded size equals the caller's encoder-config dims.** A walk that drifted would have to land on exactly those two values to get through.
- Worst case is therefore "did not patch" — today's behaviour — never a corrupt stream.

## Verification

- **Bitstream**: full sequence-header + frame-header parse, and A/B against Chrome's software AV1 encoder.
- **Unit**: 35 tests over 10 real key frames from **three encoders** — Chrome NVENC (the defect), Chrome libaom and Firefox libaom (both already correct, and asserted to come through byte-identical). Covers mismatched dims, delta frames, truncation at six lengths, a set forbidden bit, all-zero input, duplicated sequence headers, idempotence, and that only ≤8 bytes change, all within the first 48 — the tile data is provably untouched.
- **Golden bytes**: the expected patched output came from a *separate* implementation of the spec walk and was confirmed to decode at the right size in Firefox, so parser and writer cannot drift together unnoticed.
- **End-to-end**: Chrome hardware-AV1 sender into Firefox 148 —

  | | before | after |
  |---|---|---|
  | Resolution row | `L0/2 1920x1104 (tier L2)` | `L2/3 1280x720 (tier L2)` |
  | remote canvas | 1920x1104, content in the corner | 1280x720, content fills it |
  | cap binding | decoder | demand |

- Full suite: **625 tests / 68 files green**; `tsc --noEmit` and `eslint` clean.

## Scope

**Rendering is all this changes.** Decode throughput (~0.85 ms/frame) and decoder latency (median ratio 1.41) measure identical before and after, interleaved and repeated — this does not explain any decoder-verdict or quality-cap behaviour.

Unrelated and **not** addressed here: Firefox's VP9 encoder is not real-time at 720p (64 ms/frame on camera-like content, ~110 ms for the full 3-tier ladder against a 33 ms budget), which is a separate finding from the same investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DyhDJwAkzWzbvH4BJV7fQ
