### PR TITLE
feat(chat): add IChats/IChatsBackend.GetTileNonComputed

### DIFF
--- a/src/dotnet/Api.Contracts/Chat/IChats.cs
+++ b/src/dotnet/Api.Contracts/Chat/IChats.cs
@@ -49,6 +49,16 @@ public interface IChats : IComputeService
         Range<long> lidTileRange,
         CancellationToken cancellationToken);
 
+    // Non computed method: for scans that walk a chat rather than render it. A scan reads a tile
+    // per 5 entries, and as a compute method each of those becomes a cached, invalidation-tracked
+    // slot - here and on the wire. This is a plain RPC call instead; the server still serves it
+    // from the GetTile cache.
+    Task<ChatTile> GetTileNonComputed(
+        Session session,
+        ChatId chatId,
+        Range<long> lidTileRange,
+        CancellationToken cancellationToken);
+
     [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]
     Task<ChatRangeMeta> GetChatRangeMeta(
         Session session,

--- a/src/dotnet/Chat.Contracts/IChatsBackend.cs
+++ b/src/dotnet/Chat.Contracts/IChatsBackend.cs
@@ -32,6 +32,15 @@ public interface IChatsBackend : IComputeService, IBackendService
         bool includeRemoved,
         CancellationToken cancellationToken);
 
+    // Non computed method: a scan reads a tile per 5 entries, so tracking each one is what makes
+    // a scan expensive - here and, once this is a distributed compute service, on the wire too.
+    // The implementation still routes through GetTile, so the result is cached on the serving node.
+    Task<ChatTile> GetTileNonComputed(
+        ChatId chatId,
+        Range<long> lidTileRange,
+        bool includeRemoved,
+        CancellationToken cancellationToken);
+
     [ComputeMethod]
     Task<ChatRangeMeta> GetChatRangeMeta(
         ChatId chatId,

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -87,6 +87,20 @@ public partial class Chats(IServiceProvider services) : IChats
         return await Backend.GetTile(chatId, lidTileRange, false, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<ChatTile> GetTileNonComputed(
+        Session session,
+        ChatId chatId,
+        Range<long> lidTileRange,
+        CancellationToken cancellationToken)
+    {
+        // Isolated so an in-process caller that happens to be a compute method doesn't pick up
+        // the permission check or the tile as dependencies - over RPC there is nothing to isolate.
+        using var _ = Computed.BeginIsolation();
+        await RequireCanRead(session, chatId, cancellationToken).ConfigureAwait(false);
+        return await Backend.GetTileNonComputed(chatId, lidTileRange, false, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     // [ComputeMethod]
     public virtual async Task<ChatContentSkeleton> GetContentPeriods(
         Session session,

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -93,12 +93,11 @@ public partial class Chats(IServiceProvider services) : IChats
         Range<long> lidTileRange,
         CancellationToken cancellationToken)
     {
-        // Isolated so an in-process caller that happens to be a compute method doesn't pick up
-        // the permission check or the tile as dependencies - over RPC there is nothing to isolate.
+        // What this method drops is the caller's dependency, not the caching - hence the isolation
+        // over Backend.GetTile rather than a call to its non-computed sibling.
         using var _ = Computed.BeginIsolation();
         await RequireCanRead(session, chatId, cancellationToken).ConfigureAwait(false);
-        return await Backend.GetTileNonComputed(chatId, lidTileRange, false, cancellationToken)
-            .ConfigureAwait(false);
+        return await Backend.GetTile(chatId, lidTileRange, false, cancellationToken).ConfigureAwait(false);
     }
 
     // [ComputeMethod]

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -390,7 +390,10 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
     }
 
     // [ComputeMethod]
-    public virtual async Task<ChatRangeMeta> GetChatRangeMeta(ChatId chatId, long lidTileStart, CancellationToken cancellationToken)
+    public virtual async Task<ChatRangeMeta> GetChatRangeMeta(
+        ChatId chatId,
+        long lidTileStart,
+        CancellationToken cancellationToken)
     {
         var tile = IdTileStack.LastLayer.AssertIsTileStart(lidTileStart);
 
@@ -743,6 +746,18 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
     }
 
     // Non-compute methods
+
+    public async Task<ChatTile> GetTileNonComputed(
+        ChatId chatId,
+        Range<long> lidTileRange,
+        bool includeRemoved,
+        CancellationToken cancellationToken)
+    {
+        // Still GetTile underneath, so the tile is read once per node and served from cache
+        // afterwards; the isolation is what keeps the caller off the dependency graph.
+        using var _ = Computed.BeginIsolation();
+        return await GetTile(chatId, lidTileRange, includeRemoved, cancellationToken).ConfigureAwait(false);
+    }
 
     // TODO: Chat and ChatFull. This method must return Chat
     // Not a [ComputeMethod]!

--- a/tests/Chat.IntegrationTests/ChatTileNonComputedTest.cs
+++ b/tests/Chat.IntegrationTests/ChatTileNonComputedTest.cs
@@ -1,0 +1,105 @@
+using ActualChat.Testing.Host;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+// GetTileNonComputed exists so a scan can read tiles without each one becoming a tracked,
+// invalidated compute slot. These tests pin exactly that: same data, no captured computed.
+
+[Collection(nameof(ChatCollection))]
+public sealed class ChatTileNonComputedTest(ChatCollection.AppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
+{
+    private ChatId TestChatId { get; } = ChatId.Parse("the-actual-one");
+
+    [Fact]
+    public async Task BackendShouldReturnTheSameTileAsGetTile()
+    {
+        // arrange
+        var chatsBackend = AppHost.Services.GetRequiredService<IChatsBackend>();
+        var tileRange = await GetTailTileRange(chatsBackend);
+
+        // act
+        var tile = await chatsBackend.GetTile(TestChatId, tileRange, false, CancellationToken.None);
+        var nonComputedTile = await chatsBackend
+            .GetTileNonComputed(TestChatId, tileRange, false, CancellationToken.None);
+
+        // assert
+        nonComputedTile.LidTileRange.Should().Be(tile.LidTileRange);
+        nonComputedTile.Entries.Select(e => e.LocalId).Should().Equal(tile.Entries.Select(e => e.LocalId));
+    }
+
+    [Fact]
+    public async Task BackendShouldCaptureNoComputed()
+    {
+        // arrange
+        var chatsBackend = AppHost.Services.GetRequiredService<IChatsBackend>();
+        var tileRange = await GetTailTileRange(chatsBackend);
+
+        // act
+        // The control: GetTile is a compute method, so it is capturable.
+        var cTile = await Computed.Capture(
+            () => chatsBackend.GetTile(TestChatId, tileRange, false, CancellationToken.None));
+        var capture = () => Computed
+            .Capture(() => chatsBackend.GetTileNonComputed(TestChatId, tileRange, false, CancellationToken.None))
+            .AsTask();
+
+        // assert
+        cTile.Value.LidTileRange.Should().Be(tileRange);
+        await capture.Should()
+            .ThrowAsync<InvalidOperationException>("a non-compute call must leave nothing to depend on");
+    }
+
+    [Fact]
+    public async Task ShouldReturnTheSameTileAsGetTile()
+    {
+        // arrange
+        await using var tester = AppHost.NewWebClientTester(Out);
+        await tester.SignInAsBob();
+        var session = tester.Session;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        await tester.AppServices.GetRequiredService<IAuthors>()
+            .EnsureJoined(session, TestChatId, CancellationToken.None);
+        var tileRange = await GetTailTileRange(chats, session);
+
+        // act
+        var tile = await chats.GetTile(session, TestChatId, tileRange, CancellationToken.None);
+        var nonComputedTile = await chats.GetTileNonComputed(session, TestChatId, tileRange, CancellationToken.None);
+
+        // assert
+        nonComputedTile.LidTileRange.Should().Be(tile.LidTileRange);
+        nonComputedTile.Entries.Select(e => e.LocalId).Should().Equal(tile.Entries.Select(e => e.LocalId));
+    }
+
+    [Fact]
+    public async Task ShouldRequireReadPermission()
+    {
+        // arrange
+        await using var tester = AppHost.NewWebClientTester(Out);
+        await tester.SignInAsBob();
+        var session = tester.Session;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var chatId = ChatId.Parse(GroupChatId.New().Value);
+        var tileRange = Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(0L).Range;
+
+        // act
+        var act = () => chats.GetTileNonComputed(session, chatId, tileRange, CancellationToken.None);
+
+        // assert
+        await act.Should()
+            .ThrowAsync<NotFoundException>("the non-compute path must run the same permission check");
+    }
+
+    // Private methods
+
+    private async Task<Range<long>> GetTailTileRange(IChatsBackend chatsBackend)
+    {
+        var lidRange = await chatsBackend.GetLidRange(TestChatId, false, CancellationToken.None);
+        return Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(Math.Max(0, lidRange.End - 1)).Range;
+    }
+
+    private async Task<Range<long>> GetTailTileRange(IChats chats, Session session)
+    {
+        var lidRange = await chats.GetIdRange(session, TestChatId, CancellationToken.None);
+        return Constants.Chat.ServerIdTileStack.FirstLayer.GetTile(Math.Max(0, lidRange.End - 1)).Range;
+    }
+}


### PR DESCRIPTION
A scan that walks a chat reads a tile per 5 entries. As compute-method calls, each of those becomes a cached, invalidation-tracked slot — and once `IChatsBackend` is a distributed compute service, an RPC-level one that holds an invalidation subscription open. A scan wants the data, not the subscription.

## What this adds

`GetTileNonComputed` as a **plain (non-compute) method on both interfaces** — the same shape as `IUploads.GetOffset`:

```csharp
// IChatsBackend
Task<ChatTile> GetTileNonComputed(
    ChatId chatId, Range<long> lidTileRange, bool includeRemoved, CancellationToken cancellationToken);

// IChats
Task<ChatTile> GetTileNonComputed(
    Session session, ChatId chatId, Range<long> lidTileRange, CancellationToken cancellationToken);
```

Because it is not a `[ComputeMethod]`, a remote call is an ordinary RPC round-trip: no client-side computed, no dependency, no invalidation subscription. The **server implementation still routes through the `GetTile` compute method**, so the tile is read once per node and served from that cache afterwards — the caching is kept, only the tracking is dropped. `Chats.GetTileNonComputed` runs the same `RequireCanRead` check as `GetTile`.

`Computed.BeginIsolation()` in both implementations covers the in-process case, where the caller may itself be a compute method; over RPC there is nothing to isolate.

## Why only the tile

The tile is the read whose key space is large enough for the tracking to matter — one slot per 5 entries, times every scanned chat. `GetIdRange` and the `*RangeMeta` methods are one slot per chat, so tracking them is cheap and they stay compute-only.

## Scope

API surface only. No call site is migrated: on the server, compute methods are usually what you want — every mesh node caches them, so repeated reads stay cheap — and the client-side scan scenarios that would use this aren't identified yet.

## Testing

`ActualChat.CI.slnf` builds clean. New `ChatTileNonComputedTest` (4 tests) pins the semantics: the non-computed call returns the same tile as `GetTile` on both the backend and the session-scoped service; `Computed.Capture` over it captures nothing (with the capturable `GetTile` as the control); and it still throws `NotFoundException` without read permission. Full Chat.IntegrationTests: 402 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMKNBeQWMpoJ8KyCVHzeVZ