### PR TITLE
fix(video): review follow-ups from the WebCodecs branch

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -566,6 +566,7 @@ export class VideoRecorder {
     private workerSourceUsesClone = false;
 
     // Listeners.
+    private previewSizesByView = new Map<object, { width: number; height: number }>();
     private previewFrameListeners = new Set<PreviewFrameListener>();
     private previewPresentationListeners = new Set<PreviewPresentationListener>();
     private stateChangeListeners = new Set<(state: VideoRecordingState) => void>();
@@ -835,10 +836,36 @@ export class VideoRecorder {
         return this.isScreenCasting;
     }
 
-    /** Device pixels the self-preview occupies. The ceiling honours it, so shedding
-     *  upper tiers for remote viewers doesn't blur the local preview. */
-    public setPreviewSize(width: number, height: number): void {
-        void this.worker?.setPreviewSize(Math.round(width), Math.round(height), rpcNoWait);
+    /** Device pixels the self-preview occupies, keyed by the view reporting it. The
+     *  ceiling honours the largest: several surfaces attach at once (the join modal
+     *  overlaps the call tile during the transition), and a small one reporting last
+     *  must not blur the big one. Pass 0 or drop the view to withdraw a size. */
+    public setPreviewSize(view: object, width: number, height: number): void {
+        const w = Math.round(width);
+        const h = Math.round(height);
+        if (w > 0 && h > 0)
+            this.previewSizesByView.set(view, { width: w, height: h });
+        else
+            this.previewSizesByView.delete(view);
+
+        this.sendPreviewSize();
+    }
+
+    public clearPreviewSize(view: object): void {
+        if (this.previewSizesByView.delete(view))
+            this.sendPreviewSize();
+    }
+
+    private sendPreviewSize(): void {
+        let width = 0;
+        let height = 0;
+        for (const size of this.previewSizesByView.values()) {
+            if (size.width * size.height > width * height) {
+                width = size.width;
+                height = size.height;
+            }
+        }
+        void this.worker?.setPreviewSize(width, height, rpcNoWait);
     }
 
     public addPreviewFrameListener(cb: PreviewFrameListener): () => void {

--- a/src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/codec-support.ts
@@ -790,19 +790,26 @@ export interface EncoderRung {
 
 // Why each codec sits where it does in software:
 //  • VP9  — first: the floor every client already decodes, 3.75ms/frame at 720p.
-//  • AV1  — off: it compresses better, but 29.7ms/frame at 720p on one of the
-//           fastest machines available leaves nothing for a 33ms budget.
-//           Hardware AV1 is unaffected and stays at the top of the ladder.
-//  • H264 — hardware only: the slowest encoder measured anywhere (6.69ms at 480p
-//           on a Galaxy SM-S948U1 vs 1.17ms hardware) and compresses worst.
+//  • H264 — behind its own hardware rung: 6.69ms/frame at 480p on a Galaxy
+//           SM-S948U1 against 1.17ms for that device's hardware path, and it
+//           compresses worst of the four.
+//  • AV1  — last of all: it compresses best, but 29.7ms/frame at 720p on one of
+//           the fastest machines available leaves nothing for a 33ms budget.
 //  • HEVC — hardware only: Chromium ships no software HEVC encoder at all.
+//
+// The two trailing software rungs sit below every alternative, so neither is
+// chosen while anything better qualifies. They are in the ladder rather than
+// removed because the preferred-codec setting only reorders rungs that already
+// qualified — a codec absent here cannot be forced at all — and because they are
+// the last resort on a device that offers nothing else.
 const ENCODER_LADDER: readonly EncoderRung[] = [
     { category: 'av1',  accel: 'prefer-hardware' },
     { category: 'vp9',  accel: 'prefer-hardware' },
     { category: 'hevc', accel: 'prefer-hardware' },
     { category: 'vp9',  accel: 'prefer-software' },
-    // { category: 'av1',  accel: 'prefer-software' },
     { category: 'h264', accel: 'prefer-hardware' },
+    { category: 'h264', accel: 'prefer-software' },
+    { category: 'av1',  accel: 'prefer-software' },
 ];
 
 // Firefox drops the MPEG rungs entirely: its H.264 encoder runs ~18 frames

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/encoded-frame-buffer.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/encoded-frame-buffer.ts
@@ -152,6 +152,14 @@ export class EncodedFrameBuffer {
 
         for (let i = 0; i < kfIndex; i++)
             this.disposeChunk(this.chunks[i]);
+        // Stamp the survivor before the splice: `traceDrops(ReceiverEncodedBuffer)`
+        // downstream blames any index gap it finds uncovered on the buffer, so an
+        // intentional catch-up would be counted twice - once here, and once as a
+        // buffer failure on a ratio that feeds the DOWNLINK verdict.
+        const survivor = this.chunks[kfIndex];
+        for (let i = 0; i < kfIndex; i++)
+            survivor.dropTrace.push(FrameDropStage.ReceiverSkipToLive);
+
         this.chunks.splice(0, kfIndex);
         this.nextSkipAllowedAtMs = now + SKIP_TO_LIVE_COOLDOWN_MS;
         this.countDrops(FrameDropStage.ReceiverSkipToLive, kfIndex);

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -161,7 +161,7 @@ export class RecorderPreviewView {
         const parent = this.options.videoEl.parentElement;
         const rect = (parent ?? this.options.videoEl).getBoundingClientRect();
         const dpr = globalThis.devicePixelRatio || 1;
-        this.attachedRecorder?.setPreviewSize(rect.width * dpr, rect.height * dpr);
+        this.attachedRecorder?.setPreviewSize(this, rect.width * dpr, rect.height * dpr);
     }
 
     private applyRotationAndFit(): void {
@@ -422,6 +422,7 @@ export class RecorderPreviewView {
             this.unsubscribeFrames();
             this.unsubscribeFrames = null;
         }
+        this.attachedRecorder.clearPreviewSize(this);
         this.attachedRecorder = null;
         this.attachedTrack = null;
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/webgpu/blur.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/webgpu/blur.ts
@@ -17,6 +17,7 @@
 import { WebGPUManager } from './manager';
 import { BgBlurPerfTracker } from '../services/bg-blur-stats';
 import { getLogs } from 'logging';
+import { WebCodecsCompat, type FrameSource } from 'web-codecs-compat/init';
 
 const { infoLog, warnLog } = getLogs('VideoWebGPU');
 
@@ -1096,8 +1097,17 @@ export class BgBlurRenderer {
     // Returns true if the blur ran, false if WebGPU isn't ready yet (or
     // initialization failed permanently). Caller does NOT lose ownership of
     // `frame`.
-    render(frame: VideoFrame, blurStrength = 4): boolean {
+    render(frame: FrameSource, blurStrength = 4): boolean {
         if (this.initFailed)
+            return false;
+        // WebGPU's importExternalTexture takes a native VideoFrame and nothing else,
+        // so a polyfilled realm (which hands the tap an ImageBitmap) has no path
+        // here. The realm test comes first because at level `full` the VideoFrame
+        // global IS the polyfill class, so instanceof would wave a plain object
+        // through. The controller just leaves the backdrop unpainted, as before init.
+        if (WebCodecsCompat.isPolyfilledRealm
+            || typeof VideoFrame === 'undefined'
+            || !(frame instanceof VideoFrame))
             return false;
 
         if (!this.ctx) {

--- a/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
@@ -18,6 +18,10 @@ export class ImageSkeleton extends LitElement {
     private _isRetrying = false;
     // The src whose retries were exhausted; tracked by value so a new src retries.
     private _failedSrc: string | null = null;
+    // Attempts already spent on the current src, so a decode failure after a
+    // successful fetch resumes the backoff instead of restarting it. Single-entry:
+    // cleared whenever a different src starts retrying.
+    private _attemptsBySrc = new Map<string, number>();
 
     @property() src: string;
     @property() thumbnailSrc: string;
@@ -113,12 +117,19 @@ export class ImageSkeleton extends LitElement {
         if (this._isRetrying || this._failedSrc === this.src)
             return;
 
+        // A 200 carrying bytes the decoder rejects fires `error` AFTER a successful
+        // fetch, which re-enters here. Resuming the attempt count rather than
+        // restarting it is what keeps that from becoming a delay-free fetch loop:
+        // the src is reachable, so only the backoff can slow it down.
+        let attempt = this._attemptsBySrc.get(this.src) ?? 0;
+        this._attemptsBySrc.clear();
         this._isRetrying = true;
         this._imageState = 'skeleton';
         this.applyState();
         const isSubDomain = this.isSubDomain(this.src);
         try {
-            for (let attempt = 0; attempt < RetryCount; attempt++) {
+            for (; attempt < RetryCount; attempt++) {
+                this._attemptsBySrc.set(this.src, attempt + 1);
                 if (attempt >= 1) {
                     const delay = Math.min(MaxRetryDelay, Math.pow(2, attempt - 1));
                     await delayAsync(delay * 1000);
@@ -134,7 +145,11 @@ export class ImageSkeleton extends LitElement {
                 const image = this._imageRef.value;
                 if (image) {
                     const url = URL.createObjectURL(blob);
-                    image.addEventListener('load', () => URL.revokeObjectURL(url), { once: true });
+                    // Revoke on either outcome: undecodable bytes never fire `load`,
+                    // so a load-only listener leaks the URL on every failed attempt.
+                    const revoke = (): void => URL.revokeObjectURL(url);
+                    image.addEventListener('load', revoke, { once: true });
+                    image.addEventListener('error', revoke, { once: true });
                     image.src = url;
                 }
 
@@ -142,6 +157,7 @@ export class ImageSkeleton extends LitElement {
             }
 
             this._failedSrc = this.src;
+            this._attemptsBySrc.delete(this.src);
             if (this._imageRef.value)
                 this._imageRef.value.src = this.src;
         } finally {

--- a/src/nodejs/src/web-codecs-compat/init.ts
+++ b/src/nodejs/src/web-codecs-compat/init.ts
@@ -139,8 +139,14 @@ export class WebCodecsCompat {
     /** Records the level for this realm. Nothing is fetched until a component that
      *  the level actually affects asks for {@link whenReadyFor}. */
     static init(config: WebCodecsCompatConfig): void {
-        if (this._config && config.level !== this._config.level) {
-            warnLog?.log(`init: already at '${this._config.level}', ignoring '${config.level}'`);
+        // SharedSettings re-pushes its whole snapshot on every change, so this runs
+        // again on every server-clock tick. Re-applying is not harmless: a load that
+        // failed drops `_level` to 'none' while `_config.level` still says 'full',
+        // and re-applying would restore 'full' with no classes behind it.
+        if (this._config) {
+            if (config.level !== this._config.level)
+                warnLog?.log(`init: already at '${this._config.level}', ignoring '${config.level}'`);
+
             return;
         }
 

--- a/tests/ts/unit/encoder-ladder.test.ts
+++ b/tests/ts/unit/encoder-ladder.test.ts
@@ -48,18 +48,19 @@ describe('encoder ladder', () => {
         codecInfo('h264', true, true),
     ];
 
-    it('ranks every hardware rung ahead of the software ones', () => {
+    it('ranks the full ladder hardware-first, with the two slow software rungs last', () => {
         expect(pick(everything()))
-            .toEqual(['hw-av1', 'hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264']);
+            .toEqual(['hw-av1', 'hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264', 'sw-h264', 'sw-av1']);
     });
 
-    // VP9 is the only software rung: it is the floor every client must decode
-    // anyway, and it is the only one that holds a 30fps budget. Software AV1 costs
-    // 29.7ms/frame at 720p on a fast desktop, software H.264 was the slowest
-    // encoder seen on any device, and Chromium has no software HEVC at all.
-    it('offers only VP9 in software', () => {
+    // VP9 is the only software rung that holds a 30fps budget, so it leads. H.264 and
+    // AV1 follow in cost order and sit below every hardware alternative - never chosen
+    // while anything better qualifies, but present so the preferred-codec setting can
+    // reach them and so a software-only device still has a last resort. Chromium has
+    // no software HEVC encoder at all.
+    it('offers VP9, then H.264, then AV1 in software, and nothing else', () => {
         expect(getEncoderLadder().filter(r => r.accel === 'prefer-software').map(r => r.category))
-            .toEqual(['vp9']);
+            .toEqual(['vp9', 'h264', 'av1']);
     });
 
     it('prefers software VP9 over hardware H.264', () => {
@@ -71,16 +72,16 @@ describe('encoder ladder', () => {
             codecInfo('h264', true, true),
         ];
 
-        expect(pick(infos)).toEqual(['hw-hevc', 'sw-vp9', 'hw-h264']);
+        expect(pick(infos)).toEqual(['hw-hevc', 'sw-vp9', 'hw-h264', 'sw-h264', 'sw-av1']);
     });
 
     it('drops every MPEG rung on Firefox', () => {
         mocks.deviceInfo.isFirefox = true;
 
-        expect(pick(everything())).toEqual(['hw-av1', 'hw-vp9', 'sw-vp9']);
+        expect(pick(everything())).toEqual(['hw-av1', 'hw-vp9', 'sw-vp9', 'sw-av1']);
     });
 
-    it('leaves Firefox on software VP9 by default', () => {
+    it('leaves Firefox on software VP9 by default, with AV1 last', () => {
         mocks.deviceInfo.isFirefox = true;
         const measured = [
             codecInfo('av1', false, true),
@@ -88,13 +89,13 @@ describe('encoder ladder', () => {
             codecInfo('h264', false, true),  // excluded on Firefox anyway
         ];
 
-        expect(pick(measured)).toEqual(['sw-vp9']);
+        expect(pick(measured)).toEqual(['sw-vp9', 'sw-av1']);
     });
 
     it('drops a codec the audience cannot decode', () => {
         const allowed = new Set<CodecInfo['category']>(['vp9', 'h264']);
 
-        expect(pick(everything(), allowed)).toEqual(['hw-vp9', 'sw-vp9', 'hw-h264']);
+        expect(pick(everything(), allowed)).toEqual(['hw-vp9', 'sw-vp9', 'hw-h264', 'sw-h264']);
     });
 
     it('drops a codec measured as too slow for a call', () => {
@@ -102,14 +103,14 @@ describe('encoder ladder', () => {
         // survives - the case Firefox's H.264 hits in practice.
         const infos = everything().map(i => i.category === 'av1' ? { ...i, realtime: false } : i);
 
-        expect(pick(infos)).toEqual(['hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264']);
+        expect(pick(infos)).toEqual(['hw-vp9', 'hw-hevc', 'sw-vp9', 'hw-h264', 'sw-h264']);
     });
 
     it('lets the debug preference outrank the ladder, but not conjure a codec', () => {
         expect(pick(everything(), null, 'h264')[0]).toBe('hw-h264');
         // vp9 is not in the audience set, so preferring it changes nothing.
         const allowed = new Set<CodecInfo['category']>(['av1']);
-        expect(pick(everything(), allowed, 'vp9')).toEqual(['hw-av1']);
+        expect(pick(everything(), allowed, 'vp9')).toEqual(['hw-av1', 'sw-av1']);
     });
 
     it('drops a codec with no usable encoder at all', () => {
@@ -117,13 +118,13 @@ describe('encoder ladder', () => {
             .toEqual(['sw-vp9']);
     });
 
-    // Software-only AV1 or H.264 is not a candidate on any platform.
-    it('will not fall back to software AV1 or software H.264', () => {
+    // Both are candidates now, as last resorts, in the ladder's cost order.
+    it('falls back to software H.264 before software AV1', () => {
         const softwareOnly = [
             codecInfo('av1', false, true),
             codecInfo('h264', false, true),
         ];
 
-        expect(pick(softwareOnly)).toEqual([]);
+        expect(pick(softwareOnly)).toEqual(['sw-h264', 'sw-av1']);
     });
 });

--- a/tests/ts/unit/operators/encoded-buffer.test.ts
+++ b/tests/ts/unit/operators/encoded-buffer.test.ts
@@ -320,6 +320,29 @@ describe('EncodedFrameBuffer skip-to-live', () => {
         expect(stats.dropTrace.get(FrameDropStage.ReceiverSkipToLive)).toBe(9);
     });
 
+    it('stamps skipped chunks onto the survivor so the buffer is not blamed for them', () => {
+        const stats = createEmptyPlayerStats();
+        const buffer = new EncodedFrameBuffer({
+            targetSpanMs: 100,
+            frameDurationMs: 33.333,
+            stats,
+            skipToLiveSpanMs: 300,
+            nowFn: () => 0,
+        });
+
+        buffer.push(mkChunk({ timeMs: 0, isKeyFrame: true, stats }));
+        for (let i = 1; i <= 8; i++)
+            buffer.push(mkChunk({ timeMs: 33 * i, isKeyFrame: false, stats }));
+        const kf2 = mkChunk({ timeMs: 297, isKeyFrame: true, stats });
+        buffer.push(kf2);
+
+        // Without this the index gap reaches traceDrops(ReceiverEncodedBuffer)
+        // uncovered, and an intentional catch-up reads as a buffer failure on a
+        // ratio that feeds the downlink verdict.
+        expect(kf2.dropTrace).toEqual(
+            Array.from({ length: 9 }, () => FrameDropStage.ReceiverSkipToLive));
+    });
+
     it('does not skip when there is no newer keyframe to land on', () => {
         const stats = createEmptyPlayerStats();
         const buffer = new EncodedFrameBuffer({

--- a/tests/ts/unit/web-codecs-compat/init.test.ts
+++ b/tests/ts/unit/web-codecs-compat/init.test.ts
@@ -44,6 +44,20 @@ describe('WebCodecsCompat.resolveLevel', () => {
         expect(WebCodecsCompat.resolveLevel('full')).toBe('full');
         expect(WebCodecsCompat.resolveLevel('vp9')).toBe('vp9');
     });
+
+    it('ignores a repeated init, so a failed load is not re-armed', async () => {
+        const { WebCodecsCompat } = await freshCompat();
+        WebCodecsCompat.init({ level: 'full', baseUrl: '/dist/libav' });
+        expect(WebCodecsCompat.level).toBe('full');
+
+        // SharedSettings re-pushes its whole snapshot on every change, so this is
+        // what runs on every server-clock tick. Standing in for a failed load,
+        // which drops the level to 'none' while _config still says 'full'.
+        (WebCodecsCompat as unknown as { _level: string })._level = 'none';
+        WebCodecsCompat.init({ level: 'full', baseUrl: '/dist/libav' });
+
+        expect(WebCodecsCompat.level).toBe('none');
+    });
 });
 
 describe('WebCodecsCompat.affects', () => {


### PR DESCRIPTION
Follow-ups from a post-merge review of `26762786a3..014c642989` (the WebCodecs polyfill branch). Every finding below was verified against the code before fixing.

## The one that matters

**`don't blame the buffer for skip-to-live catch-up`** — the receive-side twin of the encoder back-pressure bug fixed in `ee7559711f`. `trySkipToLive` counts its drops into the stats histogram but leaves the surviving chunk's envelope trace untouched, so `traceDrops(ReceiverEncodedBuffer)` re-blames the gap as a buffer failure.

It is latent today — `ComputeAggregateReceiveDropRatio` counts only `ReceiverPull` — but that ratio already feeds `ClassifyDownlink` as `serverPathDropRatio`, under a TODO to *"split dropTrace stages 31-34+61-62 from 63-64"*. Stage 62 is `ReceiverEncodedBuffer`. When that TODO lands, a viewer joining behind the live edge reads as downlink loss through the same stateless `dropVerdict` gate we just fixed on the sender.

## The rest

- **software H.264 and AV1 restored, ranked last** — the preferred-codec debug setting only reorders rungs that already qualified, so a codec absent from the ladder cannot be forced at all. Both now sit below every hardware alternative in cost order (H.264 6.69ms/frame at 480p, AV1 29.7ms at 720p): never chosen while anything better qualifies, but reachable by the setting and available as a last resort on a device that offers nothing else.
- **failed polyfill load no longer re-arms itself** — `load()`'s failure drops `_level` to `'none'` but leaves `_config.level` at `'full'`; SharedSettings re-pushes its snapshot on every server-clock tick, and the guard let the matching level through, restoring `'full'` with no classes behind it.
- **preview ceiling sized by the largest attached view** — two `RecorderPreviewView` instances reported into one `Recorder.previewSize`, so a small surface reporting last re-blurred the focused view.
- **WebGPU backdrop bails on polyfilled frames** — the one bg renderer left on `VideoFrame` when the others took `FrameSource`; bivariance hid it from tsc.
- **image retry loop no longer restarts on a decode failure** — a 200 with undecodable bytes re-entered at attempt 0 with no backoff, leaking a blob URL per cycle. Pre-existing, not introduced by the branch.

## Verification

- 655/655 TS unit tests (2 new), `tsc --noEmit` clean, eslint clean, npm + dotnet build 0 errors
- Both new tests negative-checked: reverting each fix makes its test fail
- No C# changed

## Not fixed, needs a decision

Removing the Firefox timer pump (`e69cde7ef7`) also removed the only pump that ticks in a hidden tab — rVFC is Firefox's production capture path and does not fire while hidden, and `keepAlivePeriodMs` is 0 for camera. But `detectCaptureStall` already excuses a backgrounded tab, so the codebase's stance is that a hidden tab is not expected to capture. The asymmetry is that Chromium's MSTP keeps flowing while hidden and Firefox's rVFC does not. Wants a real backgrounded-Firefox measurement before anyone touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DyhDJwAkzWzbvH4BJV7fQ