### PR TITLE
fix(video): one primary/secondary rule, and backdrops that survive

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanelLayoutCalculator.cs
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanelLayoutCalculator.cs
@@ -10,7 +10,9 @@ public class VideoPanelLayoutCalculator : UIWorkerBase<AppUIHub>, IComputeServic
 {
     private static readonly TimeSpan FocusDebounceDelay = TimeSpan.FromSeconds(1.5);
     private const int MaxFocusHistory = 4;
-    private const int MaxDisplaySlotsWide = 4; // focused + up to 3 on sidebar
+    // Remote slots. The equal-tile layout shows all of them at the same size plus
+    // the own-camera tile, so wide tops out at a 6-tile grid.
+    private const int MaxDisplaySlotsWide = 5; // focused + up to 4 on sidebar
     private const int MaxDisplaySlotsNarrow = 3; // focused + up to 2 on sidebar
     private readonly TaskCompletionSource _whenInitializedSource = TaskCompletionSourceExt.New();
     private readonly MutableState<VideoPanelLayout> _layout;

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -727,8 +727,12 @@ body.narrow .video-panel-content .video-track-player.item-x .video-participant-l
 body.narrow .video-panel-content .video-track-player.pip-overlay .video-participant-label {
     @apply hidden;
 }
-/* Focused video shows the participant name in the header (.c-center), hide the in-video label */
-.video-panel.expanded .video-track-player.item-focused .video-participant-label {
+/* Focused video shows the participant name in the header (.c-center), so the
+   in-video label is redundant there — but the FPS/codec readout lives inside that
+   label and the header has nowhere to show it, so hiding the label also hid the
+   readout for the one tile you most want it on. Keep the label when the debug
+   overlay is on; the duplicated name is the cheaper trade. */
+body:not(.show-fps-overlay) .video-panel.expanded .video-track-player.item-focused .video-participant-label {
     @apply hidden;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -532,7 +532,7 @@ body.hoverable .video-panel .video-panel-toolbar > button:hover,
 
 /* Blurred backdrop (§13): fills the letterbox/pillarbox bars. JS paints a
    blurred, saturated, low-res bitmap into this canvas; CSS only upscales it via
-   object-fit: cover. Hidden by default; the focused tile rule below brings it
+   object-fit: cover. Hidden by default; the primary-tile rules below bring it
    in. */
 .video-track-player canvas.remote-video-bg {
     @apply hidden;
@@ -551,11 +551,16 @@ body.hoverable .video-panel .video-panel-toolbar > button:hover,
     transition: opacity 150ms ease-out;
 }
 
-/* Blurred background canvas — only visible inside focused container,
-   fills the container behind the letterboxed main canvas. The canvas
-   renders at 64×N intrinsic resolution; CSS upscales it via object-cover
-   to fill the parent (parent has aspect-ratio matching the source). */
-.video-track-player.item-focused canvas.remote-video-bg {
+/* Blurred background canvas — visible on PRIMARY tiles, filling the container
+   behind the letterboxed main canvas. The canvas renders at 64×N intrinsic
+   resolution; CSS upscales it via object-cover to fill the parent (parent has
+   aspect-ratio matching the source).
+   The selector pairs mirror `isPrimaryTile` in tile-fit.ts: the focused tile,
+   plus every non-PiP tile in the equal layout, where they are all the same size.
+   Keep the two in step — JS deciding to paint a backdrop that CSS keeps hidden
+   shows as bare letterbox bars and a blur pipeline running for nothing. */
+.video-track-player.item-focused canvas.remote-video-bg,
+.video-panel.layout-equal .video-track-player:not(.pip-overlay) canvas.remote-video-bg {
     @apply absolute inset-0;
     @apply w-full h-full;
     @apply z-0;
@@ -568,7 +573,8 @@ body.hoverable .video-panel .video-panel-toolbar > button:hover,
     will-change: transform;
     transform: scale(1.1) rotate(var(--video-rotation, 0deg)) translateZ(0);
 }
-.video-track-player.item-focused canvas.remote-video-bg[data-rotated-video] {
+.video-track-player.item-focused canvas.remote-video-bg[data-rotated-video],
+.video-panel.layout-equal .video-track-player:not(.pip-overlay) canvas.remote-video-bg[data-rotated-video] {
     inset: auto;
     width: 100cqh;
     height: 100cqw;
@@ -576,7 +582,8 @@ body.hoverable .video-panel .video-panel-toolbar > button:hover,
     top: 50%;
     transform: translate(-50%, -50%) scale(1.1) rotate(var(--video-rotation, 0deg)) translateZ(0);
 }
-.video-track-player.item-focused canvas:not(.remote-video-bg) {
+.video-track-player.item-focused canvas:not(.remote-video-bg),
+.video-panel.layout-equal .video-track-player:not(.pip-overlay) canvas:not(.remote-video-bg) {
     @apply bg-transparent;
     z-index: 1;
 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -896,13 +896,11 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
     @apply rounded-lg border-0;
     @apply overflow-hidden;
 }
-/* Stable positions: ignore the focus-driven `order` (item-N) so tiles keep
-   their source order (sorted by stream start time in the markup) instead of
-   the active speaker jumping to the front. The speaker is shown by the ring
-   below, which moves between fixed cells rather than reshuffling them. */
-.video-panel.expanded.layout-equal .c-grid .video-track-player {
-    order: 0;
-}
+/* Tiles keep the same focus-driven `order` (item-N) they have in the sidebar
+   layout, so both layouts sort by most-recent speaker. The cost is that a tile
+   can move cell when the speaker order changes; the alternative was source
+   order here and speaker order there, which made the two layouts disagree about
+   which participant is which tile. */
 /* Active speaker highlight: any tile whose author is currently streaming audio
    (VAD-gated, includes the local user — see `.speaking` in the markup) gets a
    red ring. Drawn as an ::after overlay rather than `outline`/`border` because
@@ -925,6 +923,13 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr 1fr;
 }
+/* 5 and 6 tiles share a 3x2 grid; the 5-tile case leaves one cell empty rather
+   than stretching a tile, so every tile keeps the same aspect. */
+.video-panel.expanded.layout-equal .c-grid.tiles-5,
+.video-panel.expanded.layout-equal .c-grid.tiles-6 {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+}
 @container vp-content (orientation: portrait) {
     .video-panel.expanded.layout-equal .c-grid.tiles-2 {
         grid-template-columns: 1fr;
@@ -932,6 +937,11 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
     }
     .video-panel.expanded.layout-equal .c-grid.tiles-3 {
         grid-template-columns: 1fr;
+        grid-template-rows: repeat(3, 1fr);
+    }
+    .video-panel.expanded.layout-equal .c-grid.tiles-5,
+    .video-panel.expanded.layout-equal .c-grid.tiles-6 {
+        grid-template-columns: repeat(2, 1fr);
         grid-template-rows: repeat(3, 1fr);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -10,7 +10,7 @@ import type { Disposable } from 'disposable';
 import { DocumentEvents } from 'event-handling';
 import { Versioning } from 'versioning';
 import { type Subscription } from 'rxjs';
-import { updateCollapsedIslandAspect } from '../../Services/Video/services/tile-fit';
+import { chooseFit, isPrimaryTile, updateCollapsedIslandAspect } from '../../Services/Video/services/tile-fit';
 import type {
     PlayerWorker,
     LatencySample,
@@ -126,7 +126,7 @@ export interface RemoteStreamDiagnostics {
 interface ViewportInfo {
     cssLongSide: number;
     devicePixelRatio: number;
-    isFocused: boolean;
+    isPrimary: boolean;
     hasDimensions: boolean;
 }
 
@@ -815,9 +815,7 @@ export class VideoPlayer {
     // waiting for a new frame.
     private lastFrameW = 0;
     private lastFrameH = 0;
-    // Loss threshold: when cover would crop >COVER_LOSS_MAX of source
-    // pixels, switch to contain and paint the blurred backdrop.
-    private static readonly COVER_LOSS_MAX = 0.20;
+
 
     // Cover crops the source to fill the tile; the cropped fraction equals
     // 1 − min(frameW·tileH, frameH·tileW) / max(...). When that's small
@@ -829,16 +827,18 @@ export class VideoPlayer {
         const backend = this.renderBackend;
         const parent = this.canvas.parentElement;
         if (!parent) return;
-        const focused = parent.classList.contains('item-focused');
+        const isPrimary = isPrimaryTile(parent);
         const isMinimized = !!document.querySelector('.video-panel.collapsed');
-        if (focused)
+        // Only the truly focused tile drives the collapsed island's aspect —
+        // in the equal layout every tile is primary, and the island shows one.
+        if (parent.classList.contains('item-focused'))
             this.updateCollapsedIslandAspect();
-        if (!focused) {
+        if (!isPrimary) {
             try { backend.setFit('cover'); } catch { /* ignore */ }
             this.applyBackdrop(false);
             return;
         }
-        const fit = this.computeFocusedFit(parent);
+        const fit = this.computePrimaryFit(parent);
         if (isMinimized) {
             try { backend.setFit(fit); } catch { /* ignore */ }
             this.applyBackdrop(false);
@@ -851,10 +851,10 @@ export class VideoPlayer {
     // Dispatch a backdrop on/off decision. The bg canvas lives in the
     // worker now; backends are always told setBackdrop(null) and the
     // controller-side renderer is gated by setBgActive.
-    private applyBackdrop(focused: boolean): void {
+    private applyBackdrop(active: boolean): void {
         try { this.renderBackend.setBackdrop(null, false); } catch { /* ignore */ }
         if (this.bgBlurMode === 'off') return;
-        this.setBgActive(focused);
+        this.setBgActive(active);
     }
 
     private setBgActive(active: boolean): void {
@@ -866,18 +866,13 @@ export class VideoPlayer {
             .catch((e: unknown) => warnLog?.log('worker setBgActive failed:', e));
     }
 
-    private computeFocusedFit(parent: Element): 'cover' | 'contain' {
+    // Shared with the sender's self-preview: a viewer must not see one rule for a
+    // remote tile and another for their own. The local copy this replaced had
+    // drifted - no same-orientation shortcut, no square dead-band - so the two
+    // sides disagreed about contain on near-square sources.
+    private computePrimaryFit(parent: Element): 'cover' | 'contain' {
         const rect = parent.getBoundingClientRect();
-        const tileW = rect.width;
-        const tileH = rect.height;
-        const fw = this.lastFrameW;
-        const fh = this.lastFrameH;
-        if (fw <= 0 || fh <= 0 || tileW <= 0 || tileH <= 0)
-            return 'cover';
-        const a = fw * tileH;
-        const b = fh * tileW;
-        const cropLoss = 1 - Math.min(a, b) / Math.max(a, b);
-        return cropLoss > VideoPlayer.COVER_LOSS_MAX ? 'contain' : 'cover';
+        return chooseFit(this.lastFrameW, this.lastFrameH, rect.width, rect.height);
     }
 
     private updateCollapsedIslandAspect(): void {
@@ -1619,7 +1614,7 @@ export class VideoPlayer {
             return {
                 cssLongSide,
                 devicePixelRatio: getDevicePixelRatio(),
-                isFocused: parent?.classList.contains('item-focused') ?? false,
+                isPrimary: isPrimaryTile(parent),
                 hasDimensions: true,
             };
         }
@@ -1627,14 +1622,14 @@ export class VideoPlayer {
             return {
                 cssLongSide: 1,
                 devicePixelRatio: getDevicePixelRatio(),
-                isFocused: parent.classList.contains('item-focused'),
+                isPrimary: isPrimaryTile(parent),
                 hasDimensions: false,
             };
         if (parent?.classList.contains('pip-overlay') || parent?.classList.contains('item-x'))
             return {
                 cssLongSide: 1,
                 devicePixelRatio: getDevicePixelRatio(),
-                isFocused: false,
+                isPrimary: false,
                 hasDimensions: true,
             };
 
@@ -1706,10 +1701,11 @@ export class VideoPlayer {
 }
 
 function priorityForRenderSize(hint: ViewportInfo | null): number {
-    // The focused tile is PRIMARY; sidebar and PiP tiles are SECONDARY even if
-    // they are physically large. This keeps a screencast from competing with
-    // the same author's camera for the primary downstream budget.
-    return hint === null || hint.isFocused
+    // Primary tiles are the focused one, plus every tile in the equal layout
+    // where they are all the same size. Sidebar thumbnails and PiP tiles stay
+    // SECONDARY even when physically large, so a screencast doesn't compete
+    // with the same author's camera for the primary downstream budget.
+    return hint === null || hint.isPrimary
         ? PLAYBACK_PRIORITY_PRIMARY
         : PLAYBACK_PRIORITY_SECONDARY;
 }

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
@@ -21,8 +21,15 @@ import type {
 // on every start() would defeat the pool entirely.
 let session: PlaybackSession | null = null;
 const players = new Map<string, Player>();
-// Per-stream WebGPU bg-blur controller. Created lazily by installBgCanvas
-// or by start() (whichever lands first), disposed when the player drains.
+// Per-stream WebGPU bg-blur controller. Created lazily by installBgCanvas or by
+// start() (whichever lands first), and then kept for the life of the worker.
+//
+// It deliberately outlives the player. Main transfers the OffscreenCanvas exactly
+// once — it cannot be transferred twice and the element cannot be re-offscreened —
+// so a controller disposed on drain could never be given a surface again, and a
+// single stop/start cycle (the MSTG->canvas fallback below, or a restart after a
+// quality change) killed the backdrop permanently. Rebuilding on the same canvas
+// is not an option either: the WebGL renderers call loseContext() on dispose.
 const bgBlurControllers = new Map<string, BgBlurController>();
 
 function ensureBgBlurController(streamId: string): BgBlurController {
@@ -220,13 +227,7 @@ export const playerWorkerImpl: PlayerWorker = {
                 players.delete(opts.streamId);
                 s.unregisterStream();
             }
-            if (current === player || current === undefined) {
-                const c = bgBlurControllers.get(opts.streamId);
-                if (c === bgController) {
-                    bgBlurControllers.delete(opts.streamId);
-                    c.dispose();
-                }
-            }
+            // The bg controller is NOT torn down here — see bgBlurControllers.
             locallyStopped.delete(player);
         });
     },
@@ -349,6 +350,9 @@ export async function disposePlayerWorker(): Promise<void> {
         ]);
         players.clear();
     }
+    for (const c of bgBlurControllers.values())
+        c.dispose();
+    bgBlurControllers.clear();
     if (session) {
         session.dispose();
         session = null;

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-bg.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-bg.ts
@@ -14,7 +14,7 @@ import { BgBlurPerfTracker } from '../services/bg-blur-stats';
 import { createFbo, createProgram, createTexture, setupFullScreenQuad } from './webgl-helpers';
 import { getLogs } from 'logging';
 
-const { warnLog } = getLogs('VideoWebGPU');
+const { infoLog, warnLog } = getLogs('VideoWebGPU');
 
 const BG_CANVAS_WIDTH = 64;
 // Gaussian sigma (in target-pixel units). Picks the per-pass kernel
@@ -81,6 +81,18 @@ void main() {
 }
 `;
 
+// Shared by the ctor and the post-restore re-acquire: getContext must be asked
+// for the same attributes both times or the restored context differs from the
+// one the pipeline was built against.
+const GL_CONTEXT_ATTRS: WebGLContextAttributes = {
+    alpha: false,
+    antialias: false,
+    depth: false,
+    stencil: false,
+    premultipliedAlpha: false,
+    preserveDrawingBuffer: false,
+};
+
 export class WebGlBgRenderer {
     private gl: WebGL2RenderingContext | null = null;
     private readonly perf = new BgBlurPerfTracker('webgl');
@@ -88,10 +100,51 @@ export class WebGlBgRenderer {
     // Stored so dispose() can detach it before its own loseContext() — that call
     // dispatches the same event, and answering it would log an ordinary teardown
     // as a context loss.
-    private readonly onContextLost = (): void => {
+    private readonly onContextLost = (e: Event): void => {
+        // preventDefault is what makes the browser promise a restore. Without it
+        // `webglcontextrestored` never fires, and since the controller now outlives
+        // the player, one GPU reset meant no backdrop for the rest of the session.
+        e.preventDefault();
         warnLog?.log('WebGlBgRenderer: context lost');
         this.gl = null;
+        this.forgetGlResources();
     };
+
+    private readonly onContextRestored = (): void => {
+        if (this.isDisposed)
+            return;
+
+        const gl = this.canvas.getContext('webgl2', GL_CONTEXT_ATTRS);
+        if (!gl) {
+            warnLog?.log('WebGlBgRenderer: context restored but unavailable');
+            return;
+        }
+
+        try {
+            this.gl = gl;
+            this.initGl();
+            infoLog?.log('WebGlBgRenderer: context restored');
+        } catch (e) {
+            warnLog?.log('WebGlBgRenderer: re-init after restore failed:', e);
+            this.gl = null;
+            this.forgetGlResources();
+        }
+    };
+
+    // Every GL object died with the context. Drop the handles so nothing deletes
+    // or reuses them, and so initGl/alloc rebuild from scratch.
+    private forgetGlResources(): void {
+        this.copyProgram = null;
+        this.blurProgram = null;
+        this.positionBuffer = null;
+        this.sourceTexture = null;
+        this.pingTexture = null;
+        this.pongTexture = null;
+        this.pingFbo = null;
+        this.pongFbo = null;
+        this.allocW = 0;
+        this.allocH = 0;
+    }
 
     private copyProgram: WebGLProgram | null = null;
     private blurProgram: WebGLProgram | null = null;
@@ -112,14 +165,7 @@ export class WebGlBgRenderer {
     private uBlurRadius: WebGLUniformLocation | null = null;
 
     constructor(private readonly canvas: OffscreenCanvas) {
-        const gl = canvas.getContext('webgl2', {
-            alpha: false,
-            antialias: false,
-            depth: false,
-            stencil: false,
-            premultipliedAlpha: false,
-            preserveDrawingBuffer: false,
-        });
+        const gl = canvas.getContext('webgl2', GL_CONTEXT_ATTRS);
         if (!gl) {
             warnLog?.log('WebGlBgRenderer: webgl2 context unavailable');
             return;
@@ -128,6 +174,7 @@ export class WebGlBgRenderer {
         // Without this the renderer goes silently black on a lost context and the
         // logs give no way to tell that apart from an ordinary teardown.
         canvas.addEventListener('webglcontextlost', this.onContextLost);
+        canvas.addEventListener('webglcontextrestored', this.onContextRestored);
         try {
             this.gl = gl;
             this.initGl();
@@ -143,6 +190,7 @@ export class WebGlBgRenderer {
 
         this.isDisposed = true;
         this.canvas.removeEventListener('webglcontextlost', this.onContextLost);
+        this.canvas.removeEventListener('webglcontextrestored', this.onContextRestored);
         const gl = this.gl;
         if (!gl)
             return;

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-kawase.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/webgl-kawase.ts
@@ -24,7 +24,7 @@ import { BgBlurPerfTracker } from '../services/bg-blur-stats';
 import { createFbo, createProgram, createTexture, setupFullScreenQuad } from './webgl-helpers';
 import { getLogs } from 'logging';
 
-const { warnLog } = getLogs('VideoWebGPU');
+const { infoLog, warnLog } = getLogs('VideoWebGPU');
 
 // Matches WebGPU's `cachedLevels = 4` for blurStrength ≥ 20.
 const PYRAMID_LEVELS = 4;
@@ -101,6 +101,18 @@ void main() {
 }
 `;
 
+// Shared by the ctor and the post-restore re-acquire: getContext must be asked
+// for the same attributes both times or the restored context differs from the
+// one the pipeline was built against.
+const GL_CONTEXT_ATTRS: WebGLContextAttributes = {
+    alpha: false,
+    antialias: false,
+    depth: false,
+    stencil: false,
+    premultipliedAlpha: false,
+    preserveDrawingBuffer: false,
+};
+
 export class WebGlKawaseBgRenderer {
     private gl: WebGL2RenderingContext | null = null;
     private readonly perf = new BgBlurPerfTracker('webgl-kawase');
@@ -108,10 +120,51 @@ export class WebGlKawaseBgRenderer {
     // Stored so dispose() can detach it before its own loseContext() — that call
     // dispatches the same event, and answering it would log an ordinary teardown
     // as a context loss.
-    private readonly onContextLost = (): void => {
+    private readonly onContextLost = (e: Event): void => {
+        // preventDefault is what makes the browser promise a restore. Without it
+        // `webglcontextrestored` never fires, and since the controller now outlives
+        // the player, one GPU reset meant no backdrop for the rest of the session.
+        e.preventDefault();
         warnLog?.log('WebGlKawaseBgRenderer: context lost');
         this.gl = null;
+        this.forgetGlResources();
     };
+
+    private readonly onContextRestored = (): void => {
+        if (this.isDisposed)
+            return;
+
+        const gl = this.canvas.getContext('webgl2', GL_CONTEXT_ATTRS);
+        if (!gl) {
+            warnLog?.log('WebGlKawaseBgRenderer: context restored but unavailable');
+            return;
+        }
+
+        try {
+            this.gl = gl;
+            this.initGl();
+            infoLog?.log('WebGlKawaseBgRenderer: context restored');
+        } catch (e) {
+            warnLog?.log('WebGlKawaseBgRenderer: re-init after restore failed:', e);
+            this.gl = null;
+            this.forgetGlResources();
+        }
+    };
+
+    // Every GL object died with the context. Drop the handles so nothing deletes
+    // or reuses them, and so initGl/allocPyramid rebuild from scratch — initGl
+    // pushes into the pyramid arrays, so leaving them populated would double them.
+    private forgetGlResources(): void {
+        this.downsampleProgram = null;
+        this.upsampleProgram = null;
+        this.copyProgram = null;
+        this.positionBuffer = null;
+        this.sourceTexture = null;
+        this.pyramidTex.length = 0;
+        this.pyramidFbo.length = 0;
+        this.allocFrameW = 0;
+        this.allocFrameH = 0;
+    }
 
     private downsampleProgram: WebGLProgram | null = null;
     private upsampleProgram: WebGLProgram | null = null;
@@ -131,14 +184,7 @@ export class WebGlKawaseBgRenderer {
     private uCopyTex: WebGLUniformLocation | null = null;
 
     constructor(private readonly canvas: OffscreenCanvas) {
-        const gl = canvas.getContext('webgl2', {
-            alpha: false,
-            antialias: false,
-            depth: false,
-            stencil: false,
-            premultipliedAlpha: false,
-            preserveDrawingBuffer: false,
-        });
+        const gl = canvas.getContext('webgl2', GL_CONTEXT_ATTRS);
         if (!gl) {
             warnLog?.log('WebGlKawaseBgRenderer: webgl2 context unavailable');
             return;
@@ -147,6 +193,7 @@ export class WebGlKawaseBgRenderer {
         // Without this the renderer goes silently black on a lost context and the
         // logs give no way to tell that apart from an ordinary teardown.
         canvas.addEventListener('webglcontextlost', this.onContextLost);
+        canvas.addEventListener('webglcontextrestored', this.onContextRestored);
         try {
             this.gl = gl;
             this.initGl();
@@ -162,6 +209,7 @@ export class WebGlKawaseBgRenderer {
 
         this.isDisposed = true;
         this.canvas.removeEventListener('webglcontextlost', this.onContextLost);
+        this.canvas.removeEventListener('webglcontextrestored', this.onContextRestored);
         const gl = this.gl;
         if (!gl)
             return;

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/recorder.ts
@@ -78,6 +78,22 @@ export interface RecorderConfig {
     initialGateOpen?: boolean;
 }
 
+// Smallest size with `shape`'s aspect that still covers `box`, never larger than
+// `shape` itself. Even dimensions: odd ones make encoders pad, and the padding
+// travels as a wrong declared size.
+function scaleToAspectOf(
+    box: { width: number; height: number },
+    shape: { width: number; height: number },
+): { width: number; height: number } {
+    if (shape.width <= 0 || shape.height <= 0)
+        return shape;
+
+    const scale = Math.min(1, Math.max(box.width / shape.width, box.height / shape.height));
+    const even = (v: number): number => Math.max(2, Math.round(v * scale / 2) * 2);
+
+    return { width: even(shape.width), height: even(shape.height) };
+}
+
 export class Recorder {
     private readonly session: SenderSession;
     private abortController: AbortController | null = null;
@@ -180,7 +196,13 @@ export class Recorder {
                     const area = (s: { width: number; height: number }): number => s.width * s.height;
                     // The self-preview is not a remote viewer: shedding upper tiers for
                     // the call must not blur it, so it holds the ceiling up to its own size.
-                    const preview = this.previewSize;
+                    // Only its SCALE though - it reports a layout box, and a tile is rarely
+                    // the camera's shape. Using the box as a frame size squeezed the picture
+                    // into the tile's aspect, and since this is the ceiling every tier is
+                    // built from, the wire carried that distortion to every viewer.
+                    const preview = this.previewSize
+                        ? scaleToAspectOf(this.previewSize, normalizeSize)
+                        : null;
                     const floor = preview && area(preview) > area(activeTop) ? preview : activeTop;
                     return area(floor) < area(normalizeSize) ? floor : normalizeSize;
                 },

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/bg-canvas.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/bg-canvas.ts
@@ -260,6 +260,14 @@ class WebGlBgRenderTarget implements BgCanvasRenderTarget {
             return;
 
         const gl = this.gl;
+        // A lost context still accepts every call below and silently draws nothing,
+        // so BgCanvasRenderer.draw's catch would never fire and the backdrop would
+        // stay blank for good. Throwing is what hands it over to Canvas2D. Every GL
+        // object here is readonly and built in the ctor, so this target cannot
+        // rebuild itself — the swap IS the recovery.
+        if (gl.isContextLost())
+            throw new Error('WebGlBgRenderTarget: context lost');
+
         this.resize(width, height);
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/recorder-preview-view.ts
@@ -21,7 +21,7 @@ import {
     BG_CANVAS_WIDTH,
     BG_DRAW_INTERVAL_MS,
 } from './bg-canvas';
-import { applyRotationLayout, chooseFit, updateCollapsedIslandAspect } from './tile-fit';
+import { applyRotationLayout, chooseFit, isPrimaryTile, updateCollapsedIslandAspect } from './tile-fit';
 
 const { infoLog, warnLog } = getLogs('VideoRecorder');
 const BG_DRAW_GATE_TOLERANCE_MS = 20;
@@ -207,12 +207,12 @@ export class RecorderPreviewView {
             videoEl.closest<HTMLElement>('.video-panel'),
             frameW,
             frameH);
-        // Non-focused tiles (sidebar squares, PiP overlay during screencast)
-        // always use cover — the crop is invisible at that size and the
-        // letterbox bars would dominate the small square. Same rule the
+        // Secondary tiles (sidebar squares, PiP overlay during screencast) always
+        // use cover — the crop is invisible at that size and the letterbox bars
+        // would dominate the small square. In the equal-tile layout there are no
+        // secondary tiles, so every one gets the real decision. Same rule the
         // receiver follows in VideoPlayer.applyFitDecision.
-        const focused = parent.classList.contains('item-focused');
-        const fit = focused
+        const fit = isPrimaryTile(parent)
             ? chooseFit(frameW, frameH, parent.clientWidth, parent.clientHeight)
             : 'cover';
         if (fit !== this.currentFit) {
@@ -473,7 +473,7 @@ export class RecorderPreviewView {
     private drawBgFrame(width: number, height: number): void {
         if (!this.bgCanvasTarget)
             return;
-        if (!this.bgContainer?.classList.contains('item-focused'))
+        if (!isPrimaryTile(this.bgContainer))
             return;
 
         // Match the receiver: only paint the backdrop when contain is active.
@@ -497,7 +497,7 @@ export class RecorderPreviewView {
     private drawBgFrameFromVideo(videoEl: HTMLVideoElement): void {
         if (!this.bgCanvasTarget)
             return;
-        if (!this.bgContainer?.classList.contains('item-focused'))
+        if (!isPrimaryTile(this.bgContainer))
             return;
         if (this.currentFit !== 'contain')
             return;

--- a/src/dotnet/UI.Blazor.App/Services/Video/services/tile-fit.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/services/tile-fit.ts
@@ -6,6 +6,24 @@ import { normalizeRotationQuarter, type RotationQuarter } from 'orientation';
 
 export type Fit = 'cover' | 'contain';
 
+/** Whether a tile is a PRIMARY one: full-size, worth the contain/backdrop
+ *  treatment and the top layer of the ladder.
+ *
+ *  `item-focused` marks the primary tile in the default sidebar layout, where
+ *  everything else is a thumbnail. The equal-tile layout re-flows those same
+ *  classes into equally sized grid cells, so there `item-x` tiles are just as
+ *  large as the focused one and every tile is primary — branching on
+ *  `item-focused` alone would crop them to cover and ask for a thumbnail's
+ *  layer while showing them full size. */
+export function isPrimaryTile(tile: Element | null): boolean {
+    if (!tile) return false;
+    if (tile.classList.contains('item-focused')) return true;
+    // PiP overlays stay secondary: the equal layout hides them outright.
+    if (tile.classList.contains('pip-overlay')) return false;
+
+    return tile.closest('.video-panel.layout-equal') !== null;
+}
+
 // Loss threshold: when frame and tile orientations DIFFER (one portrait,
 // other landscape), cover-cropping more than this fraction of the source
 // pixel area triggers a switch to contain (+ blurred backdrop). 0.20 =

--- a/src/dotnet/UI.Blazor.App/Services/VideoQualityAllocator.cs
+++ b/src/dotnet/UI.Blazor.App/Services/VideoQualityAllocator.cs
@@ -13,9 +13,10 @@ public sealed record StreamAllocationRequest(
 
 /// <summary>
 /// Priority-based downstream allocator. Reserves a floor for every secondary
-/// stream first, then assigns the largest fitting spatial layer to each
-/// primary, then distributes the remainder across secondaries proportional
-/// to their <c>RenderArea</c>.
+/// stream first, splits what's left equally across the primaries and gives each
+/// the largest layer fitting its share, spends any leftover on whichever
+/// primaries can still use it, then distributes the remainder across secondaries
+/// proportional to their <c>RenderArea</c>.
 /// Output: per-stream <see cref="ReceiveQuality"/>. Streams that don't fit
 /// even at floor are omitted; the caller maps that to <see cref="ReceiveQuality.Lowest"/>.
 /// </summary>
@@ -48,12 +49,32 @@ public static class VideoQualityAllocator
 
         var primaryBudget = Math.Max(0, budgetBytesPerSec - floorBudget);
         long primariesUsed = 0;
+        // Equal shares first, so tile order doesn't decide who gets quality. The
+        // equal-tile layout makes every visible stream primary; a purely greedy
+        // pass there would hand the whole budget to whoever came first in the
+        // dictionary and leave the last tiles on the floor. With a single primary
+        // the share IS the whole budget, so the common layout is unaffected.
+        var primaryShare = primaries.Count > 0 ? primaryBudget / primaries.Count : 0;
+        var pickedRates = new Dictionary<string, long>(primaries.Count);
         foreach (var p in primaries) {
-            var (layers, rate) = PickBestFit(p, primaryBudget - primariesUsed, minimumFit: false);
+            var (layers, rate) = PickBestFit(p, primaryShare, minimumFit: false);
             if (rate < 0)
                 continue;
             result[p.StreamId] = ToReceiveQuality(layers);
+            pickedRates[p.StreamId] = rate;
             primariesUsed += rate;
+        }
+        // Then spend what the shares left over — a stream whose next layer is
+        // cheap should not be held at its share while the budget sits unused.
+        foreach (var p in primaries) {
+            var current = pickedRates.GetValueOrDefault(p.StreamId, 0L);
+            var (layers, rate) = PickBestFit(p, current + (primaryBudget - primariesUsed), minimumFit: false);
+            if (rate <= current)
+                continue;
+
+            result[p.StreamId] = ToReceiveQuality(layers);
+            pickedRates[p.StreamId] = rate;
+            primariesUsed += rate - current;
         }
 
         var remaining = Math.Max(0, budgetBytesPerSec - primariesUsed);

--- a/tests/Chat.UI.Blazor.UnitTests/VideoQualityUI/VideoQualityAllocatorTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/VideoQualityUI/VideoQualityAllocatorTest.cs
@@ -21,6 +21,33 @@ public class VideoQualityAllocatorTest
     }
 
     [Fact]
+    public void Primaries_ShareTheBudgetInsteadOfServingTheFirstOnes()
+    {
+        // The equal-tile layout makes every visible stream primary. Greedy
+        // order-based allocation gave the whole budget to the first arrivals.
+        var reqs = new[] { "A", "B", "C", "D" }.Select(id => Req(id, [100, 300, 1000])).ToArray();
+        var result = VideoQualityAllocator.Allocate(1_200, reqs, []);
+
+        foreach (var id in new[] { "A", "B", "C", "D" })
+            result[id].LayerId.Should().Be(1, $"{id} gets 300 from its 300-byte share");
+    }
+
+    [Fact]
+    public void Primaries_SpendTheLeftoverAfterEqualShares()
+    {
+        // A's share alone can't reach its top layer, but the budget B and C
+        // leave unspent can carry it there.
+        var a = Req("A", [100, 900]);
+        var b = Req("B", [100]);
+        var c = Req("C", [100]);
+        var result = VideoQualityAllocator.Allocate(1_200, [a, b, c], []);
+
+        result["A"].LayerId.Should().Be(1, "400 share + 800 unspent by B and C covers 900");
+        result["B"].LayerId.Should().Be(0);
+        result["C"].LayerId.Should().Be(0);
+    }
+
+    [Fact]
     public void Primary_HonoursLayerCountCap()
     {
         var primary = Req("P", [100, 300, 1000], layerCountCap: 1);


### PR DESCRIPTION
Follow-ups from live testing in Chrome + Firefox. Two reported symptoms turned out to share a root cause, and chasing the backdrop turned up a family of one-way latches.

## Primary vs secondary is now one rule

The equal-tile layout re-flows the sidebar layout's own tiles — the CSS says so — so `item-focused` and `item-x` survive into a grid where every cell is the same size. Everything branching on `item-focused` was wrong for five tiles out of six: fit, backdrop, and quality priority.

`isPrimaryTile` in `tile-fit.ts` answers the real question and is used by the receiver, the sender's self-preview, **and** the CSS, whose selectors now mirror it. The invariant: **primary = real cover/contain decision + backdrop + a real layer; secondary = cover, backdrop paused.**

Supporting fixes:

- **The allocator served primaries greedily in dictionary order.** Making every tile primary would have given the first tile top quality and left the last on the floor — worse than before. It now splits the primary budget into equal shares, then spends the leftover. A single primary takes the whole budget as its share, so the sidebar layout is unchanged; the 7 pre-existing allocator tests pass untouched.
- **The normalize ceiling used the self-preview's reported size as a frame size.** That value is a *layout box*: a 343x308 tile squeezed a 16:9 camera to 686x616. Since the ceiling is what every tier is built from, the wire carried that distortion to every viewer, and the self-view then looked correctly "cover" because the frame really had been reshaped. The box now picks only a scale along the source aspect. (Mine, from `d672ca92bf`.)
- **The receiver had a private copy of the fit math** that had drifted from the shared `chooseFit` — no same-orientation shortcut, no square dead-band — so a viewer could see one rule on a remote tile and another on their own.
- Remote slots 4 → 5 wide (5 remotes + own camera), 3x2 / 2x3 templates for the new counts, and both layouts now sort by most-recent speaker.

## Backdrops that survive

- **A stream restart killed the backdrop permanently.** The controller was disposed on every player drain, but main installs the OffscreenCanvas exactly once — transfer is one-shot, the element can't be re-offscreened, and `bgCanvasInstallSent` latches. The rebuilt controller had no surface and nothing could give it one. The reachable trigger is documented three lines above the disposal: the MSTG-to-canvas fallback stops and restarts the same stream, and that backend watches `item-focused` flips.
- **Neither receiver bg renderer could recover a lost WebGL context** — no `preventDefault()` on `webglcontextlost` (without it the browser never promises a restore) and no `webglcontextrestored` listener. Now that the controller outlives the player, one GPU reset meant no backdrop for the session.
- **The sender backdrop never triggered its own fallback.** `BgCanvasRenderer.draw` already swaps to Canvas2D when the WebGL target throws — but a lost context draws nothing silently and never throws. It detects and throws now.
- **The FPS/codec readout was hidden on the focused tile**, because it lives inside the participant label the header hides to avoid duplicating the name.

## Deliberately not changed

`WebGlDownscaler` already detects a lost context, disables WebGL downscale for the session and lets the pipeline re-pick Canvas2D. Its *"No preventDefault(): restoration is not wanted"* comment is a decision, not an oversight — and it's the encode path, where re-enabling a GPU path that just failed affects everyone downstream.

## Verification

- 655/655 TS unit tests, 776/776 `Chat.UI.Blazor.UnitTests` (2 new allocator tests), `tsc --noEmit` + eslint clean, npm + dotnet builds 0 errors
- Confirmed live in Chrome via CDP: the backdrop gap reproduced exactly as predicted, and the 686x616 preview surface is what pinned down the aspect bug
- **Untested:** the context-loss paths need a real GPU reset or a `WEBGL_lose_context` injection; no harness was added. The backdrop-lifecycle fix also has no unit test — the state lives in worker module scope, reachable only through a real drain, and I wasn't willing to add production API to poke it.

## Open

chrome2 receives one VP9 stream at **320x184** rather than 320x180 — a height padded to a multiple of 8, same class as `cb935eba21`. The ceiling fix may resolve it; if stripes persist on that thumbnail it's a separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DyhDJwAkzWzbvH4BJV7fQ