### PR TITLE
fix: Android http:// deep links are silently dropped (#3289)

### DIFF
--- a/src/dotnet/Api/LocalUrl.cs
+++ b/src/dotnet/Api/LocalUrl.cs
@@ -20,42 +20,26 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
     public static LocalUrl Parse(string? s) => new(s);
 
     public static bool TryParse(string? s, Uri origin, out LocalUrl result)
-    {
-        // Drops a matching origin, then requires the remainder to be truly local
-        if (!origin.IsAbsoluteUri)
-            throw new ArgumentOutOfRangeException(nameof(origin));
+        => TryParse(s, origin, false, out result);
 
-        result = default;
-        if (s.IsNullOrEmpty())
-            return false;
-
-        // UriKind.Absolute reads "/chat" as an implicit file path on Unix, so absoluteness
-        // is decided via RelativeOrAbsolute, which answers the same way on every platform.
-        if (Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri) {
-            if (!string.Equals(uri.Scheme, origin.Scheme, StringComparison.OrdinalIgnoreCase)
-                || !string.Equals(uri.IdnHost, origin.IdnHost, StringComparison.OrdinalIgnoreCase)
-                || uri.Port != origin.Port)
-                return false;
-
-            s = uri.PathAndQuery + uri.Fragment;
-        }
-
-        var localUrl = new LocalUrl(s);
-        if (!localUrl.IsTrulyLocal())
-            return false;
-
-        result = localUrl;
-        return true;
-    }
+    // An app link reaches us on either scheme: the Android intent filter advertises http and
+    // https alike, and Android resolves a bare host tap to http. The host still has to match,
+    // so the scheme carries no authority of its own here.
+    public static bool TryParseAppLink(string? s, Uri origin, out LocalUrl result)
+        => TryParse(s, origin, true, out result);
 
     public static LocalUrl? FromAbsolute(string url, UrlMapper mapper)
     {
-        var origin = mapper.BaseUri.OriginalString.TrimEnd('/');
-        if (!url.StartsWith(origin))
+        // Absolute-only: callers pass unvalidated text (message markup, notification payloads),
+        // where a relative url names no origin to check against and must not pass as local.
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri) || !uri.IsAbsoluteUri)
             return null;
 
-        var relativeUrl = url[origin.Length..];
-        return relativeUrl;
+        // Not a ternary: the implicit string conversion would turn a null branch into LocalUrl("/")
+        if (!TryParse(url, mapper.BaseUri, out var result))
+            return null;
+
+        return result;
     }
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
@@ -128,4 +112,52 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
 
     public static LocalUrl operator +(LocalUrl left, string right)
         => new(left.Value + right);
+
+    // Private methods
+
+    private static bool TryParse(string? s, Uri origin, bool isAnyWebSchemeAllowed, out LocalUrl result)
+    {
+        // Drops a matching origin, then requires the remainder to be truly local
+        if (!origin.IsAbsoluteUri)
+            throw new ArgumentOutOfRangeException(nameof(origin));
+
+        result = default;
+        if (s.IsNullOrEmpty())
+            return false;
+
+        // UriKind.Absolute reads "/chat" as an implicit file path on Unix, so absoluteness
+        // is decided via RelativeOrAbsolute, which answers the same way on every platform.
+        if (Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri) {
+            if (!IsSameOrigin(uri, origin, isAnyWebSchemeAllowed))
+                return false;
+
+            s = uri.PathAndQuery + uri.Fragment;
+        }
+
+        var localUrl = new LocalUrl(s);
+        if (!localUrl.IsTrulyLocal())
+            return false;
+
+        result = localUrl;
+        return true;
+    }
+
+    private static bool IsSameOrigin(Uri uri, Uri origin, bool isAnyWebSchemeAllowed)
+    {
+        if (!string.Equals(uri.IdnHost, origin.IdnHost, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (string.Equals(uri.Scheme, origin.Scheme, StringComparison.OrdinalIgnoreCase))
+            return uri.Port == origin.Port;
+        if (!isAnyWebSchemeAllowed)
+            return false;
+
+        // http and https carry different default ports, so a cross-scheme match holds only when
+        // neither side names one - an explicit port belongs to a single scheme.
+        return IsWebScheme(uri.Scheme) && IsWebScheme(origin.Scheme)
+            && uri.IsDefaultPort && origin.IsDefaultPort;
+    }
+
+    private static bool IsWebScheme(string scheme)
+        => string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/dotnet/Api/LocalUrl.cs
+++ b/src/dotnet/Api/LocalUrl.cs
@@ -24,15 +24,22 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
 
     // An app link reaches us on either scheme: the Android intent filter advertises http and
     // https alike, and Android resolves a bare host tap to http. The host still has to match,
-    // so the scheme carries no authority of its own here.
+    // so the scheme carries no authority of its own here. Absolute-only: an app link always
+    // carries its origin, and a relative value would skip the host check entirely.
     public static bool TryParseAppLink(string? s, Uri origin, out LocalUrl result)
-        => TryParse(s, origin, true, out result);
+    {
+        result = default;
+        if (!IsAbsoluteUrl(s))
+            return false;
+
+        return TryParse(s, origin, true, out result);
+    }
 
     public static LocalUrl? FromAbsolute(string url, UrlMapper mapper)
     {
         // Absolute-only: callers pass unvalidated text (message markup, notification payloads),
         // where a relative url names no origin to check against and must not pass as local.
-        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri) || !uri.IsAbsoluteUri)
+        if (!IsAbsoluteUrl(url))
             return null;
 
         // Not a ternary: the implicit string conversion would turn a null branch into LocalUrl("/")
@@ -90,11 +97,13 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
 
     public string ToAbsolute(UrlMapper urlMapper)
         => urlMapper.ToAbsolute(this);
+
     public string ToAbsolute(NavigationManager nav)
         => nav.ToAbsoluteUri(Value).ToString();
 
     public DisplayUrl ToDisplayUrl(UrlMapper urlMapper)
         => new(this, ToAbsolute(urlMapper));
+
     public DisplayUrl ToDisplayUrl(NavigationManager nav)
         => new(this, ToAbsolute(nav));
 
@@ -125,8 +134,6 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
         if (s.IsNullOrEmpty())
             return false;
 
-        // UriKind.Absolute reads "/chat" as an implicit file path on Unix, so absoluteness
-        // is decided via RelativeOrAbsolute, which answers the same way on every platform.
         if (Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri) {
             if (!IsSameOrigin(uri, origin, isAnyWebSchemeAllowed))
                 return false;
@@ -160,4 +167,9 @@ public readonly partial struct LocalUrl : IStringLike<LocalUrl>, IEquatable<Loca
     private static bool IsWebScheme(string scheme)
         => string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
             || string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAbsoluteUrl(string? s)
+        // UriKind.Absolute reads "/chat" as an implicit file path on Unix, so absoluteness is
+        // decided via RelativeOrAbsolute, which answers the same way on every platform.
+        => Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri;
 }

--- a/src/dotnet/App.Maui/App.cs
+++ b/src/dotnet/App.Maui/App.cs
@@ -3,22 +3,17 @@ using Application = Microsoft.Maui.Controls.Application;
 
 namespace ActualChat.App.Maui;
 
-public class App : Application
+public class App(IServiceProvider services) : Application
 {
     public static new App Current => (App)Application.Current!;
     public static bool MustMinimizeOnQuit { get; private set; } = true;
 
-    private IServiceProvider Services { get; }
+    private IServiceProvider Services { get; } = services;
     private ILogger Log => field ??= Services.LogFor(GetType());
-
-    public App(IServiceProvider services)
-    {
-        Services = services;
-    }
 
     protected override Window CreateWindow(IActivationState? activationState)
     {
-		var window = new Window(new MainPage());
+        var window = new Window(new MainPage());
         window.Destroying += (_, _) => FlushSentryData();
         window.Title =
             MauiSettings.UseLocalhost
@@ -36,12 +31,14 @@ public class App : Application
             Log.LogWarning("OnAppLinkRequestReceived: {Uri} -> ignore (host override mode is on)", uri);
             return;
         }
-        if (!string.Equals(uri.Host, MauiSettings.Host, StringComparison.OrdinalIgnoreCase)) {
-            Log.LogWarning("OnAppLinkRequestReceived: {Uri} -> ignore (wrong host)", uri);
+        // The Android intent filter advertises http alongside https, so the link is reduced to its
+        // local part here - BaseUri is always https and would otherwise reject an http link.
+        if (!LocalUrl.TryParseAppLink(uri.ToString(), MauiSettings.BaseUri, out var localUrl)) {
+            Log.LogWarning("OnAppLinkRequestReceived: {Uri} -> ignore (wrong origin)", uri);
             return;
         }
 
-        AppNavigationQueue.EnqueueOrNavigateToUrl(uri.ToString(), AutoNavigationReason.AppLink);
+        AppNavigationQueue.EnqueueOrNavigateToUrl(localUrl.Value, AutoNavigationReason.AppLink);
     }
 
     public new void Quit()

--- a/tests/Core.UnitTests/LocalUrlTest.cs
+++ b/tests/Core.UnitTests/LocalUrlTest.cs
@@ -111,6 +111,9 @@ public class LocalUrlTest
     [InlineData("http://voxt.ai/", "/")]
     [InlineData("HTTP://VOXT.AI/chat/x", "/chat/x")]
     [InlineData("http://voxt.ai/chat?x=1#f", "/chat?x=1#f")]
+    // A spelled-out default port names the same origin, so it is not a different one
+    [InlineData("https://voxt.ai:443/chat/x", "/chat/x")]
+    [InlineData("http://voxt.ai:80/chat/x", "/chat/x")]
     public void TryParseAppLinkShouldAcceptEitherWebScheme(string value, string expected)
     {
         // arrange
@@ -130,6 +133,10 @@ public class LocalUrlTest
     [InlineData("ftp://voxt.ai/chat")] // Not a web scheme
     [InlineData("http://voxt.ai:8443/chat")] // An explicit port belongs to a single scheme
     [InlineData("//evil.example")]
+    // An app link always carries its origin - a relative value would skip the host check
+    [InlineData("/chat")]
+    [InlineData("chat")]
+    [InlineData("")]
     public void TryParseAppLinkShouldRejectEverythingElse(string value)
     {
         // arrange

--- a/tests/Core.UnitTests/LocalUrlTest.cs
+++ b/tests/Core.UnitTests/LocalUrlTest.cs
@@ -104,4 +104,77 @@ public class LocalUrlTest
         // assert
         isParsed.Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData("https://voxt.ai/chat/x", "/chat/x")]
+    [InlineData("http://voxt.ai/chat/x", "/chat/x")] // Android resolves a bare "voxt.ai" tap to http
+    [InlineData("http://voxt.ai/", "/")]
+    [InlineData("HTTP://VOXT.AI/chat/x", "/chat/x")]
+    [InlineData("http://voxt.ai/chat?x=1#f", "/chat?x=1#f")]
+    public void TryParseAppLinkShouldAcceptEitherWebScheme(string value, string expected)
+    {
+        // arrange
+        var origin = new Uri("https://voxt.ai");
+
+        // act
+        var isParsed = LocalUrl.TryParseAppLink(value, origin, out var result);
+
+        // assert
+        isParsed.Should().BeTrue("the intent filter advertises http and https alike");
+        result.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("https://evil.example/chat")]
+    [InlineData("https://voxt.ai.evil.example/chat")] // Shares the origin's prefix
+    [InlineData("ftp://voxt.ai/chat")] // Not a web scheme
+    [InlineData("http://voxt.ai:8443/chat")] // An explicit port belongs to a single scheme
+    [InlineData("//evil.example")]
+    public void TryParseAppLinkShouldRejectEverythingElse(string value)
+    {
+        // arrange
+        var origin = new Uri("https://voxt.ai");
+
+        // act
+        var isParsed = LocalUrl.TryParseAppLink(value, origin, out _);
+
+        // assert
+        isParsed.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("https://voxt.ai/chat/x", "/chat/x")]
+    [InlineData("https://VOXT.ai/chat/x", "/chat/x")]
+    [InlineData("https://voxt.ai", "/")]
+    [InlineData("https://voxt.ai/chat?x=1#f", "/chat?x=1#f")]
+    public void FromAbsoluteShouldAcceptSameOrigin(string url, string expected)
+    {
+        // arrange
+        var mapper = new UrlMapper("https://voxt.ai/");
+
+        // act
+        var localUrl = LocalUrl.FromAbsolute(url, mapper);
+
+        // assert
+        localUrl.Should().NotBeNull();
+        localUrl!.Value.Value.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("https://voxt.ai.evil.example/chat")] // Shares the origin's prefix
+    [InlineData("https://evil.example/chat")]
+    [InlineData("http://voxt.ai/chat")] // Not an app link: only TryParseAppLink relaxes the scheme
+    [InlineData("/chat")] // Absolute-only by contract - LinkPreviewUI feeds it raw message markup
+    [InlineData("chat")]
+    public void FromAbsoluteShouldRejectAnythingButSameOrigin(string url)
+    {
+        // arrange
+        var mapper = new UrlMapper("https://voxt.ai/");
+
+        // act
+        var localUrl = LocalUrl.FromAbsolute(url, mapper);
+
+        // assert
+        localUrl.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Fixes #3289.

## Root cause

`MainActivity`'s intent filter advertises **both** schemes:

```csharp
DataSchemes = ["http", "https"],
DataHost = MauiSettings.DefaultHost,
AutoVerify = true,
```

so Android legitimately hands the app `http://` links — a bare `voxt.ai` tap resolves to http. But `MauiSettings.BaseUrl` is always `"https://" + Host + "/"`, and `App.OnAppLinkRequestReceived` passed the absolute url on to `AutoNavigationUI`, which matched it with a raw string prefix in `LocalUrl.FromAbsolute`:

```csharp
var origin = mapper.BaseUri.OriginalString.TrimEnd('/');
if (!url.StartsWith(origin))
    return null;
```

`http://voxt.ai/` doesn't start with `https://voxt.ai`, so every http deep link logged `Could not get LocalUrl from url` and navigated nowhere. **We advertise a scheme we then refuse to accept.** That also answers the question on the issue ("It's weird why it's navigated to 'http://' not 'https://'") — http is expected, because we asked for it.

The quotes in the Sentry title are its structured-log rendering, not part of the value.

## Changes

**`6d590c1236` — match an origin by its parts, not a string prefix.**
`LocalUrl.TryParse` already did this correctly, so `FromAbsolute` now delegates to it instead of duplicating it badly. Besides the scheme, the old prefix match was culture-sensitive (no `StringComparison`), treated the host as case-significant, and accepted any foreign host sharing the origin's prefix (`voxt.ai.evil.example`). `FromAbsolute` keeps its absolute-only contract — `LinkPreviewUI` feeds it raw message markup, where a relative url names no origin to check against.

Adds `TryParseAppLink`, which accepts either web scheme on a matching host. Cross-scheme matching requires both sides to be on default ports, since http and https differ there. **`TryParse` stays strict** — `AuthRedirectUrl` depends on the exact scheme match, so it was deliberately not loosened.

**`37a42e4928` — the app-link path uses it**, and enqueues only the local part.

## Verification

13 new cases in `LocalUrlTest`, red before green.

**On-device (OnePlus CPH2747, USB), control build from the pre-fix sources vs. the fix, same intents:**

| Deep link | Control (pre-fix) | Fixed |
|---|---|---|
| `http://dev.voxt.ai/` | ❌ `Could not get LocalUrl` | ✅ `NavigateTo(/, AppLink)` |
| `http://dev.voxt.ai/chat/testchatid` | ❌ `Could not get LocalUrl` | ✅ `NavigateTo(/chat/testchatid)` |
| `https://dev.voxt.ai/chat/testchatid` | ✅ navigates | ✅ navigates |
| `http://dev.voxt.ai/chat/x?x=1` | — | ✅ query preserved |
| `https://dev.voxt.ai.evil.example/chat/x` | — | ✅ `ignore (wrong origin)` |

The control reproduces the reported error verbatim while https succeeds on that same build, so the failure is scheme-specific.

Unit tests: Core 699 ✅ · Users 272 ✅ (covers `AuthRedirectUrl`) · Chat 596 ✅ · Chat.UI.Blazor 774 ✅ · UI.Blazor 55 ✅ · Media 65 ✅ · Contacts 23 ✅. `App.Server` and `App.Maui` (`net11.0-android`) both build.

## Note for the reviewer

`ActualChat.CI.slnf` is broken on `dev` independently of this branch — it lists `tests/Core.Benchmarks/Core.Benchmarks.csproj`, which isn't in `ActualChat.sln`, so any `dotnet build ActualChat.CI.slnf` fails with MSB5028. I built the affected projects directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhu9rQC5JhTy8WF56NZtSv