### PR TITLE
fix: Esc in the message editor leaves attachments staged (#1113)

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -342,8 +342,11 @@
 
     private async Task OnCancel(CancellationToken cancellationToken = default)
     {
+        // Disposing the snapshot without a Rollback is what discards the staged attachments
+        // and releases their uploads - same pair Post uses when there's nothing to send.
         await ChatEditorUI.HideRelatedEntry().WaitAsync(cancellationToken);
         await MarkupEditorRef.Clear(mustFocus: true);
+        await _attachmentListHolder.PopSnapshot().DisposeAsync();
     }
 
     private void OnContentStored(object? sender, EventArgs e) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -342,11 +342,12 @@
 
     private async Task OnCancel(CancellationToken cancellationToken = default)
     {
-        // Disposing the snapshot without a Rollback is what discards the staged attachments
-        // and releases their uploads - same pair Post uses when there's nothing to send.
+        // Popped before the awaits below, so a cancellation or a failed local-settings write
+        // can't leave the attachments staged; disposing it without a Rollback is what discards
+        // them and releases their uploads - the same pair Post uses with nothing to send.
+        await using var _ = _attachmentListHolder.PopSnapshot();
         await ChatEditorUI.HideRelatedEntry().WaitAsync(cancellationToken);
         await MarkupEditorRef.Clear(mustFocus: true);
-        await _attachmentListHolder.PopSnapshot().DisposeAsync();
     }
 
     private void OnContentStored(object? sender, EventArgs e) {


### PR DESCRIPTION
Fixes #1113.

## Root cause

`ChatMessageEditor.OnCancel` cleared the draft *text* but never the attachment list:

```csharp
private async Task OnCancel(CancellationToken cancellationToken = default)
{
    await ChatEditorUI.HideRelatedEntry().WaitAsync(cancellationToken);
    await MarkupEditorRef.Clear(mustFocus: true);
}
```

So Escape emptied the editor and left the picked files staged beneath it. Same for the X on the reply/edit banner, which reaches the same method via `CancelChatMessageEditEvent`.

## Change

Discard them with the pair `Post` already uses on its "nothing to send" path (`ChatMessageEditor.razor:220-224`) — disposing a `PopSnapshot()` without a `Rollback` drops the list and releases the uploads:

```csharp
await _attachmentListHolder.PopSnapshot().DisposeAsync();
```

Both callers are dispatcher-bound (`UIEventHub.Publish` wraps handlers in `Dispatcher.InvokeAsync`; the `Cancel` component callback runs on the dispatcher), so `PopSnapshot`'s `Dispatcher.AssertAccess()` is satisfied. And since that X already discarded the draft text, discarding attachments with it is consistent rather than a new surprise.

## Verification

Driven in the browser against a local server (Blazor Server render mode), pasting a PNG into the editor and pressing Escape — run against a **control build from the pre-fix source** and then the fix, identical steps:

| Build | After paste | After Escape |
|---|---|---|
| control (pre-fix) | `1 file` | **`1 file`** — reproduces the bug |
| fixed | `1 file` | *(cleared)* |

`.attachment-list-wrapper` goes 1 → 0 with the fix and stays at 1 without it.

No automated test: `ChatMessageEditor` has no existing bUnit harness and standing one up needs the whole `AppUIHub` DI graph, which is out of proportion to a one-line change. The browser control above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhu9rQC5JhTy8WF56NZtSv