### PR TITLE
fix(notifications): make banner clearing actually reach the device

### DIFF
--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -367,12 +367,19 @@ public static partial class Constants
             public const string ImageUrl = "imageUrl";
             public const string Messages = "messages";
             public const string Timestamp = "timestamp";
+            // The user's whole active banner set at send time, so a client rendering this push can
+            // also close what is no longer active. Version orders the snapshots: pushes can arrive
+            // out of order, and an older one must never undo a newer one's prune.
+            public const string ActiveTags = "activeTags";
+            public const string ActiveVersion = "activeVersion";
             public const string DismissedIds = "dismissedIds";
             public const string DismissedTags = "dismissedTags";
             public const string Silent = "silent";
 
             public static readonly string[] ValidKeys = {
-                AuthorId, Body, ChatId, ChatEntryId, DismissedIds, DismissedTags, GroupTitle, LastEntryLocalId, Icon, ImageUrl, Kind, Link, Messages, NotificationId, SenderName, Silent, Tag, Title, Timestamp
+                ActiveTags, ActiveVersion, AuthorId, Body, ChatId, ChatEntryId, DismissedIds,
+                DismissedTags, GroupTitle, LastEntryLocalId, Icon, ImageUrl, Kind, Link, Messages,
+                NotificationId, SenderName, Silent, Tag, Title, Timestamp,
             };
 
             public static bool IsValidKey(string key)
@@ -438,6 +445,9 @@ public static partial class Constants
         // retrying it forever only grows the blob.
         public static readonly TimeSpan PendingDismissalTtl = TimeSpan.FromDays(1);
         public const int MaxPendingDismissals = 256;
+        // The active-tag snapshot's share of the push payload. A snapshot that doesn't fit is
+        // omitted rather than truncated: a partial one would prune banners that are still active.
+        public const int MaxActiveTagsBytes = 1024;
         // Read-position advances are frequent (~1/s while scrolling); the read-reconcile event
         // is collapsed to one per (user, chat) per this window via a delay-bucketed event uuid.
         // This bounds the background-banner dismissal lag on other devices (in-app is instant).

--- a/src/dotnet/Api/Notifications/NotificationExt.cs
+++ b/src/dotnet/Api/Notifications/NotificationExt.cs
@@ -2,12 +2,11 @@ namespace ActualChat.Notifications;
 
 public static class NotificationExt
 {
-    // The device push tag: the OS replaces a shown banner by tag, so the tag must map 1:1 to the
-    // server-side notification identity or dismissal-by-tag closes the wrong banners.
-    // Individually-seen kinds (mention, attention, reaction) tag by their entry — each keeps its
-    // own banner; chat-coalescing kinds share one banner per chat. Shared by the FCM send path,
-    // the dismissal path and the client-side reconciler so all derive the same tag.
     public static string? GetPushTag(this Notification notification)
+        // The OS replaces a shown banner by tag, so this must map 1:1 to the server-side identity
+        // or dismissal-by-tag closes the wrong banners. Individually-seen kinds (mention,
+        // attention, reaction) tag by entry and keep their own banner; chat-coalescing kinds share
+        // one per chat. The send, dismissal and reconcile paths all derive the tag from here.
         => notification switch {
             ChatEntryNotification n => n.EntryId.Value,
             // A call's ring and its dismissal must collapse onto a banner of their own —
@@ -16,9 +15,19 @@ public static class NotificationExt
             _ => notification.GetChatTag(),
         };
 
-    // The chat a notification belongs to, as a tag (one value per chat). Returns null for
-    // non-chat notifications.
+    public static NotificationDismissMode GetDismissMode(NotificationKind kind)
+        // What Notification.DismissMode says, for a caller holding only a kind - a push payload on
+        // a client. NotificationDismissModeTest asserts the two agree for every kind.
+        => kind switch {
+            NotificationKind.Message or NotificationKind.Reply or NotificationKind.Thread
+                or NotificationKind.Mention or NotificationKind.Attention
+                or NotificationKind.Conversation => NotificationDismissMode.OnRead,
+            NotificationKind.Reaction => NotificationDismissMode.OnView,
+            _ => NotificationDismissMode.Explicit,
+        };
+
     public static string? GetChatTag(this Notification notification)
+        // The chat a notification belongs to, one value per chat; null for non-chat kinds.
         => notification switch {
             ConversationNotification n => n.ChatId.Value,
             ChatEntryRelatedNotification n => n.ChatId.Value,
@@ -31,11 +40,10 @@ public static class NotificationExt
     public static ChatId? GetChatId(this Notification notification)
         => ChatId.TryParse(notification.GetChatTag() ?? "", out var chatId) ? chatId : null;
 
-    // The in-app deep link a notification points at (entry if it has one, else the chat).
-    // Mirrors the link the FCM send path builds; used by the client reconciler to create a
-    // missing notification with a working tap target.
     public static LocalUrl GetChatLink(this Notification notification)
     {
+        // Mirrors the link the FCM send path builds, so a notification the client reconciler
+        // re-creates gets the same tap target: its entry if it has one, else the chat.
         var entryId = notification switch {
             ConversationNotification n => (ChatEntryId?)ChatEntryId.New(n.ChatId, n.StartEntryLid),
             ChatEntryRelatedNotification n when n.EntryLid > 0 => (ChatEntryId?)n.StartEntryId,

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/AndroidDeviceNotifications.cs
@@ -23,7 +23,10 @@ public class AndroidDeviceNotifications : IDeviceNotifications
         var shown = notificationManager?.ActiveNotifications;
         if (shown != null)
             foreach (var statusBarNotification in shown) {
-                var tag = statusBarNotification.Tag;
+                // Only banners this app posted for a push tag are the active set's to prune: the
+                // tray also holds the foreground-service, upload, attention and microphone
+                // notifications, none of which is ever an active tag.
+                var tag = NotificationHelper.GetPushBannerTag(statusBarNotification.Notification!);
                 if (tag.IsNullOrEmpty())
                     continue;
                 if (!activeTags.Contains(tag))

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/ChatAttentionService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/ChatAttentionService.cs
@@ -66,6 +66,11 @@ public sealed class ChatAttentionService
     public void Clear(ChatId chatId, long chatPosition)
         => DispatchOnNonMainThread(() => ClearInternal(chatId, chatPosition));
 
+    public void Dismiss(IReadOnlyCollection<ChatId> chatIds)
+        // The server already decided these chats are handled, so the positions they were asked at
+        // no longer matter - and the alarm re-posts the banners until the requests are gone.
+        => DispatchOnNonMainThread(() => DismissInternal(chatIds));
+
     public void OnHandleIntent(Intent intent)
     {
         var action = intent.Action;
@@ -108,6 +113,23 @@ public sealed class ChatAttentionService
         }
         if (!ReferenceEquals(originalState, state))
             DoJob(state ?? State.None);
+    }
+
+    private void DismissInternal(IReadOnlyCollection<ChatId> chatIds)
+    {
+        // A whole push worth of dismissals at once: one state read and one Notify pass, instead of
+        // cancelling and re-posting every surviving banner once per dismissed chat.
+        var originalState = GetState();
+        if (originalState is null)
+            return;
+
+        var requests = originalState.Requests.Where(c => !chatIds.Contains(c.ChatId)).ToArray();
+        if (requests.Length == originalState.Requests.Length)
+            return;
+
+        var state = requests.Length > 0 ? new State(UtcNow, requests) : null;
+        SetState(state);
+        DoJob(state ?? State.None);
     }
 
     private void OnAlarmTriggered()

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
@@ -9,6 +9,8 @@ using Firebase.Analytics;
 using Firebase.Messaging;
 using DeviceType = ActualChat.Notifications.DeviceType;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
+using NotificationDismissMode = ActualChat.Notifications.NotificationDismissMode;
+using NotificationExt = ActualChat.Notifications.NotificationExt;
 
 namespace ActualChat.App.Maui;
 
@@ -88,6 +90,7 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
             var notificationManager = NotificationManagerCompat.From(this)!;
             foreach (var tag in data.DismissedTags)
                 notificationManager.Cancel(tag, 0);
+            ClearAttentionRequests(data.DismissedTags);
             ClearForegroundCallRings(data.DismissedTags);
 
             return;
@@ -111,7 +114,7 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
             return;
 
         var chatId = data.ChatId;
-        if (chatId is not null && ShouldSuppressForDevice(chatId, data.EntryLocalId))
+        if (chatId is not null && ShouldSuppressForDevice(chatId, data.EntryLocalId, data.NotificationKind))
             return;
 
         ShowChatMessageNotification(data);
@@ -119,7 +122,7 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
 
     // Private methods
 
-    private static bool ShouldSuppressForDevice(ChatId chatId, long entryLid)
+    private static bool ShouldSuppressForDevice(ChatId chatId, long entryLid, NotificationKind kind)
     {
         // Fail-open: this runs on background deliveries too, where the Blazor scope may be disposed
         // and the scoped-service calls throw - a failed check must never suppress a message or
@@ -139,7 +142,9 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
             // Skip if this device has already read past the notification's entry. Uses the cached
             // read position (non-blocking) — it's fresher than the server's debounced cursor. If
             // there's no cached value (the chat was never opened here), don't suppress.
-            if (entryLid > 0) {
+            // Only for kinds a read actually clears: a reaction anchors at the recipient's own
+            // message, so its entry is read the moment it was sent and this would drop every one.
+            if (entryLid > 0 && NotificationExt.GetDismissMode(kind) == NotificationDismissMode.OnRead) {
                 var chatUI = scopedServices.GetRequiredService<ChatUI>();
                 // GetExisting can return an instance whose first computation is still in flight;
                 // touching its output then throws "Wrong Computed.State: Computing."
@@ -158,6 +163,19 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
             Log.LogWarning(e, "ShouldSuppressForDevice failed for chat #{ChatId}; showing the notification", chatId);
             return false;
         }
+    }
+
+    private static void ClearAttentionRequests(IReadOnlyList<string> dismissedTags)
+    {
+        // An attention banner is posted under ChatAttentionService's own tag, so cancelling the
+        // dismissed one doesn't touch it - and nothing else would, unless this device's app happens
+        // to be running with that chat open.
+        var chatIds = dismissedTags
+            .Select(tag => ChatId.TryParse(tag, allowNull: true))
+            .SkipNullItems()
+            .ToList();
+        if (chatIds.Count > 0)
+            ChatAttentionService.Instance.Dismiss(chatIds);
     }
 
     private static void ClearForegroundCallRings(IReadOnlyList<string> dismissedTags)

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/FirebaseMessagingService.cs
@@ -167,12 +167,14 @@ public sealed class FirebaseMessagingService : Firebase.Messaging.FirebaseMessag
 
     private static void ClearAttentionRequests(IReadOnlyList<string> dismissedTags)
     {
-        // An attention banner is posted under ChatAttentionService's own tag, so cancelling the
-        // dismissed one doesn't touch it - and nothing else would, unless this device's app happens
-        // to be running with that chat open.
+        // An attention banner lives under ChatAttentionService's own tag, so cancelling the dismissed
+        // one never touches it. Attention tags by entry, so the tag is usually an entry id.
         var chatIds = dismissedTags
-            .Select(tag => ChatId.TryParse(tag, allowNull: true))
+            .Select(tag => ChatEntryId.TryParse(tag, out var entryId)
+                ? entryId.ChatId
+                : ChatId.TryParse(tag, allowNull: true))
             .SkipNullItems()
+            .Distinct()
             .ToList();
         if (chatIds.Count > 0)
             ChatAttentionService.Instance.Dismiss(chatIds);

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/IncomingCallNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/IncomingCallNotifications.cs
@@ -114,6 +114,7 @@ public static class IncomingCallNotifications
             .SetFullScreenIntent(fullScreenPendingIntent, true)!
             .SetTimeoutAfter((long)RingTimeout.TotalMilliseconds)!
             .SetStyle(callStyle)!;
+        NotificationHelper.MarkAsPushBanner(builder, tag);
         NotificationManagerCompat.From(Context)!.Notify(tag, 0, builder.Build());
     }
 

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
@@ -88,8 +88,19 @@ public static class NotificationHelper
         // unmasked copy of it.
         if (largeImage != null && style is not NotificationCompat.MessagingStyle)
             builder.SetLargeIcon(largeImage);
+        MarkAsPushBanner(builder, tag);
         NotificationManagerCompat.From(context)!.Notify(tag, 0, builder.Build());
     }
+
+    public static void MarkAsPushBanner(NotificationCompat.Builder builder, string tag)
+    {
+        var extras = new Android.OS.Bundle();
+        extras.PutString(Constants.PushTagExtra, tag);
+        _ = builder.AddExtras(extras);
+    }
+
+    public static string? GetPushBannerTag(Android.App.Notification notification)
+        => notification.Extras?.GetString(Constants.PushTagExtra);
 
     public static Bitmap? GetImage(string imageUrl)
         => imageUrl.IsNullOrEmpty()
@@ -291,6 +302,10 @@ public static class NotificationHelper
 
     public static class Constants
     {
+        // Marks a banner this app posted for a server-side push tag, so the reconcilers can tell
+        // ours from the foreground-service, upload, attention and microphone notifications that
+        // share the tray and must never be pruned by an active-set diff.
+        public const string PushTagExtra = "voxt.pushTag";
         public const string DefaultChannelId = "default_channel";
         public const string AttentionChannelId = "internal_attention_channel";
         public const string ActivityUploadChannelId = "activity_upload";

--- a/src/dotnet/App.Maui/Platforms/iOS/AppDelegate.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/AppDelegate.cs
@@ -68,16 +68,17 @@ public class AppDelegate : MauiUIApplicationDelegate, IMessagingDelegate
 
     // Silent dismissal pushes (content-available, no alert) are delivered here, not to the
     // Plugin.Firebase NotificationReceived event — that only fires for foreground alert pushes.
-    // iOS applies aps.badge from the payload automatically; we only drop the dismissed banners.
+    // The badge does not ride this one - a background aps may carry only content-available, and
+    // iOS ignores a badge next to it - so SendBadge sends the count as its own alert push.
     [Export("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
     public void DidReceiveRemoteNotification(
         UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler)
     {
         try {
-            var dismissedTags = (userInfo[new NSString(Constants.Notification.MessageDataKeys.DismissedTags)] as NSString)?.ToString();
-            if (!dismissedTags.IsNullOrEmpty()) {
-                var tags = dismissedTags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                RemoveDeliveredNotifications(tags);
+            var dismissedIds = GetValue(userInfo, Constants.Notification.MessageDataKeys.DismissedIds);
+            var dismissedTags = GetValue(userInfo, Constants.Notification.MessageDataKeys.DismissedTags);
+            if (!dismissedIds.IsNullOrEmpty() || !dismissedTags.IsNullOrEmpty()) {
+                RemoveDeliveredNotifications(Split(dismissedIds), Split(dismissedTags));
                 completionHandler(UIBackgroundFetchResult.NewData);
                 return;
             }
@@ -85,6 +86,7 @@ public class AppDelegate : MauiUIApplicationDelegate, IMessagingDelegate
         catch (Exception e) {
             Log.LogError(e, "DidReceiveRemoteNotification failed");
         }
+
         completionHandler(UIBackgroundFetchResult.NoData);
     }
 
@@ -104,16 +106,44 @@ public class AppDelegate : MauiUIApplicationDelegate, IMessagingDelegate
 
     // Private methods
 
-    // Removes delivered notifications whose thread (= chat tag) is being dismissed.
-    private static void RemoveDeliveredNotifications(IReadOnlyCollection<string> dismissedTags)
+    private static void RemoveDeliveredNotifications(
+        IReadOnlyCollection<string> dismissedIds,
+        IReadOnlyCollection<string> dismissedTags)
         => UNUserNotificationCenter.Current.GetDeliveredNotifications(delivered => {
             var toRemove = delivered
-                .Where(n => dismissedTags.Contains(n.Request.Content.ThreadIdentifier))
+                .Where(n => IsDismissed(n, dismissedIds, dismissedTags))
                 .Select(n => n.Request.Identifier)
                 .ToArray();
             if (toRemove.Length > 0)
                 UNUserNotificationCenter.Current.RemoveDeliveredNotifications(toRemove);
         });
+
+    private static bool IsDismissed(
+        UNNotification notification,
+        IReadOnlyCollection<string> dismissedIds,
+        IReadOnlyCollection<string> dismissedTags)
+    {
+        // The id identifies the banner exactly. The thread id is the whole chat, so matching on it
+        // takes that chat's live mentions down with an ordinary message dismissal, and never equals
+        // the entry-derived tag a mention or reaction is dismissed by - it is the fallback only for
+        // a banner delivered without an id.
+        var notificationId = GetValue(notification.Request.Content.UserInfo,
+            Constants.Notification.MessageDataKeys.NotificationId);
+        return notificationId.IsNullOrEmpty()
+            ? dismissedTags.Contains(notification.Request.Content.ThreadIdentifier)
+            : dismissedIds.Contains(notificationId);
+    }
+
+    private static string GetValue(NSDictionary userInfo, string key)
+    {
+        var nsKey = new NSString(key);
+        return userInfo.ContainsKey(nsKey) ? (userInfo[nsKey] as NSString)?.ToString() ?? "" : "";
+    }
+
+    private static string[] Split(string? value)
+        => value.IsNullOrEmpty()
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     private static void RegisterBadgeNotifications()
         => UNUserNotificationCenter.Current.RequestAuthorization(

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -24,10 +24,11 @@ public class FirebaseMessagingClient(
         Notification notification,
         IReadOnlyCollection<Symbol> deviceIds,
         bool? enableDataCollection,
-        int badgeCount,
+        UserNotificationInfo info,
         bool isSilent,
         CancellationToken cancellationToken)
     {
+        var badgeCount = info.Items.Count;
         var notificationId = notification.Id;
         var kind = notification.Kind;
         var title = notification.Title;
@@ -91,6 +92,16 @@ public class FirebaseMessagingClient(
         };
         if (lastEntryLocalId > 0)
             data.Add(Constants.Notification.MessageDataKeys.LastEntryLocalId, lastEntryLocalId.ToString());
+        // The whole active set, so a client rendering this banner can close what is no longer
+        // active - the one clearing path that needs no background push at all, and so the only one
+        // Doze and the standby buckets can't hold. Omitted whole when it doesn't fit its share:
+        // a truncated snapshot reads as "these are all that are active" and prunes live banners.
+        var activeTags = string.Join(',', info.Items.Select(n => n.GetPushTag()).SkipNullItems().Distinct());
+        if (!activeTags.IsNullOrEmpty()
+            && Encoding.UTF8.GetByteCount(activeTags) <= Constants.Notification.MaxActiveTagsBytes) {
+            data.Add(Constants.Notification.MessageDataKeys.ActiveTags, activeTags);
+            data.Add(Constants.Notification.MessageDataKeys.ActiveVersion, info.Version.ToString());
+        }
         // Common data, so these ride inside the 4KB APNs budget - hence omitted when empty.
         if (chatNotification is not null && !chatNotification.SenderName.IsNullOrEmpty()) {
             data.Add(Constants.Notification.MessageDataKeys.SenderName, chatNotification.SenderName);

--- a/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/FirebaseMessagingClient.cs
@@ -165,8 +165,60 @@ public class FirebaseMessagingClient(
         await HandleBatchResponse(batchResponse, deviceIds, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task SendDismissal(
+    public async Task<IReadOnlyCollection<PendingDismissal>> SendDismissal(
         IReadOnlyCollection<PendingDismissal> dismissals,
+        IReadOnlyCollection<Symbol> deviceIds,
+        int badgeCount,
+        CancellationToken cancellationToken)
+    {
+        if (deviceIds.Count == 0)
+            return [];
+
+        var sent = new List<PendingDismissal>();
+        foreach (var chunk in ChunkDismissals(dismissals)) {
+            var data = new Dictionary<string, string>() {
+                {
+                    Constants.Notification.MessageDataKeys.DismissedIds,
+                    string.Join(',', chunk.Dismissals.Select(x => x.Id.Value))
+                },
+                { Constants.Notification.MessageDataKeys.DismissedTags, string.Join(',', chunk.Tags) },
+            };
+            var multicastMessage = new MulticastMessage {
+                Tokens = deviceIds.Select(id => id.Value).ToList(),
+                Data = data,
+                Android = new AndroidConfig {
+                    Data = data,
+                    // Doze holds this one, but only until the device wakes: measured at ~0.57s
+                    // after it leaves Doze, which High would buy with an FCM cold start.
+                    Priority = Priority.Normal,
+                    TimeToLive = TimeSpan.FromDays(1),
+                },
+                Apns = new ApnsConfig {
+                    Headers = new Dictionary<string, string>() {
+                        // A silent push: it only updates the badge and lets the app drop dismissed notifications.
+                        ["apns-push-type"] = "background",
+                        ["apns-priority"] = "5",
+                    },
+                    Aps = new Aps {
+                        // No Badge here: a background notification's aps may carry only
+                        // content-available, and iOS ignores a badge sent alongside it - measured,
+                        // banners cleared while the count stayed put. SendBadge carries it instead.
+                        ContentAvailable = true,
+                    },
+                },
+            };
+            var batchResponse = await FirebaseMessaging
+                .SendEachForMulticastAsync(multicastMessage, cancellationToken)
+                .ConfigureAwait(false);
+            await HandleBatchResponse(batchResponse, deviceIds, cancellationToken).ConfigureAwait(false);
+            if (IsAccepted(batchResponse))
+                sent.AddRange(chunk.Dismissals);
+        }
+
+        return sent;
+    }
+
+    public async Task SendBadge(
         IReadOnlyCollection<Symbol> deviceIds,
         int badgeCount,
         CancellationToken cancellationToken)
@@ -174,36 +226,20 @@ public class FirebaseMessagingClient(
         if (deviceIds.Count == 0)
             return;
 
-        var dismissedIds = dismissals.Select(x => x.Id.Value);
-        // Only chat/entry-derived tags are emitted: a client closes every notification sharing
-        // a tag, so the non-chat "topic" fallback must never be a dismissal tag.
-        var dismissedTags = dismissals
-            .Select(x => x.Tag)
-            .Where(tag => !tag.IsNullOrEmpty())
-            .Distinct();
-        var data = new Dictionary<string, string>() {
-            { Constants.Notification.MessageDataKeys.DismissedIds, string.Join(',', dismissedIds) },
-            { Constants.Notification.MessageDataKeys.DismissedTags, string.Join(',', dismissedTags) },
-        };
         var multicastMessage = new MulticastMessage {
             Tokens = deviceIds.Select(id => id.Value).ToList(),
-            Data = data,
-            Android = new AndroidConfig {
-                Data = data,
-                // Normal, not High: nothing here is worth waking the device out of Doze. High would
-                // cold-start a dead app on the 10s foreground-broadcast ANR budget and, being
-                // non-notifying, spend the high-priority allowance real notifications need.
-                Priority = Priority.Normal,
-                TimeToLive = TimeSpan.FromDays(1),
-            },
             Apns = new ApnsConfig {
                 Headers = new Dictionary<string, string>() {
-                    // A silent push: it only updates the badge and lets the app drop dismissed notifications.
-                    ["apns-push-type"] = "background",
+                    // "alert" is the push type for anything that triggers an alert, badge or sound,
+                    // and badge-only is one of those. It matters: "background" is the throttled
+                    // budget this exists to get out of. With no alert body and no mutable-content
+                    // iOS applies the count itself - no banner, no app wake, no service extension.
+                    ["apns-push-type"] = "alert",
                     ["apns-priority"] = "5",
+                    // A burst of reads is one badge value, not a queue of them.
+                    ["apns-collapse-id"] = "badge",
                 },
                 Aps = new Aps {
-                    ContentAvailable = true,
                     Badge = badgeCount,
                 },
             },
@@ -253,6 +289,48 @@ public class FirebaseMessagingClient(
             chatId, batchResponse.SuccessCount, deviceIds.Count);
         await HandleBatchResponse(batchResponse, deviceIds, cancellationToken).ConfigureAwait(false);
     }
+
+    // Protected/internal methods
+
+    // It's internal to be accessible from tests
+    internal static List<DismissalChunk> ChunkDismissals(IReadOnlyCollection<PendingDismissal> dismissals)
+    {
+        // Over the FCM payload limit the whole message is rejected, taking every dismissal in it
+        // down. A chunk pays for both keys it emits - one id per dismissal, one tag per distinct
+        // tag - so the two stay consistent and a rejected chunk leaves exactly its own owed.
+        var budget = MaxFcmPayloadBytes - FcmPayloadMargin
+            - Encoding.UTF8.GetByteCount(Constants.Notification.MessageDataKeys.DismissedIds)
+            - Encoding.UTF8.GetByteCount(Constants.Notification.MessageDataKeys.DismissedTags);
+        var chunks = new List<DismissalChunk>();
+        // Only chat/entry-derived tags are emitted: a client closes every notification sharing
+        // a tag, so the non-chat "topic" fallback must never be a dismissal tag. An untagged
+        // dismissal closes no banner, but its id still refreshes the badge.
+        var items = dismissals.Where(x => x.Tag.IsNullOrEmpty()).ToList();
+        var tags = new List<string>();
+        var size = items.Sum(IdSize);
+        foreach (var group in dismissals.Where(x => !x.Tag.IsNullOrEmpty()).GroupBy(x => x.Tag)) {
+            var groupSize = Encoding.UTF8.GetByteCount(group.Key) + 1 + group.Sum(IdSize);
+            if (tags.Count > 0 && size + groupSize > budget) {
+                chunks.Add(new DismissalChunk(items, tags));
+                items = [];
+                tags = [];
+                size = 0;
+            }
+            items.AddRange(group);
+            tags.Add(group.Key);
+            size += groupSize;
+        }
+        if (items.Count > 0 || tags.Count > 0)
+            chunks.Add(new DismissalChunk(items, tags));
+
+        return chunks;
+
+        static int IdSize(PendingDismissal dismissal)
+            // + the ',' separator
+            => Encoding.UTF8.GetByteCount(dismissal.Id.Value) + 1;
+    }
+
+    // Private methods
 
     private async Task HandleBatchResponse(
         BatchResponse batchResponse,
@@ -305,4 +383,17 @@ public class FirebaseMessagingClient(
                     responseGroup.Key, responseGroup.Count(), errorContent);
             }
     }
+
+    private static bool IsAccepted(BatchResponse batchResponse)
+        // An unregistered token isn't a failure worth retrying - that device is gone and gets removed.
+        => batchResponse.Responses.All(x =>
+            x.IsSuccess
+            || x.Exception.MessagingErrorCode
+                is MessagingErrorCode.Unregistered or MessagingErrorCode.SenderIdMismatch);
+
+    // Nested types
+
+    internal sealed record DismissalChunk(
+        IReadOnlyList<PendingDismissal> Dismissals,
+        IReadOnlyList<string> Tags);
 }

--- a/src/dotnet/Notifications.Service/IFirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/IFirebaseMessagingClient.cs
@@ -10,8 +10,17 @@ public interface IFirebaseMessagingClient
         bool isSilent,
         CancellationToken cancellationToken);
 
-    Task SendDismissal(
+    // Returns the dismissals FCM accepted: one it rejected stays owed, so the converge flow retries
+    // it instead of losing the banner it was supposed to close.
+    Task<IReadOnlyCollection<PendingDismissal>> SendDismissal(
         IReadOnlyCollection<PendingDismissal> dismissals,
+        IReadOnlyCollection<Symbol> deviceIds,
+        int badgeCount,
+        CancellationToken cancellationToken);
+
+    // iOS only, and deliberately separate from the dismissal it accompanies: the badge rides an
+    // alert push, which lands even when the background push carrying the removal is throttled.
+    Task SendBadge(
         IReadOnlyCollection<Symbol> deviceIds,
         int badgeCount,
         CancellationToken cancellationToken);

--- a/src/dotnet/Notifications.Service/IFirebaseMessagingClient.cs
+++ b/src/dotnet/Notifications.Service/IFirebaseMessagingClient.cs
@@ -2,11 +2,13 @@ namespace ActualChat.Notifications;
 
 public interface IFirebaseMessagingClient
 {
+    // Takes the whole active set, not just its count: the push carries the badge and, when it
+    // fits, the active tags a client prunes its stale banners against.
     Task SendMessage(
         Notification notification,
         IReadOnlyCollection<Symbol> deviceIds,
         bool? enableDataCollection,
-        int badgeCount,
+        UserNotificationInfo info,
         bool isSilent,
         CancellationToken cancellationToken);
 

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -959,7 +959,7 @@ public class NotificationsBackend(IServiceProvider services)
             + "IsSilent={IsSilent}, DeviceIds#={DeviceIdCount}",
             entryId, userId, notification.Id, command.IsSilent, deviceIds.Count);
         await FirebaseMessagingClient
-            .SendMessage(notification, deviceIds, isAdmin, info.Items.Count, command.IsSilent, cancellationToken)
+            .SendMessage(notification, deviceIds, isAdmin, info, command.IsSilent, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -1009,13 +1009,28 @@ public class NotificationsBackend(IServiceProvider services)
             DebugLog?.LogDebug("OnConverge: sending. UserId={UserId}, Pending#={Count}, DeviceIds#={DeviceIdCount}",
                 userId, sendable.Count, deviceIds.Count);
             // No devices to send to still counts as done - otherwise a user with none accumulates
-            // entries no send could ever consume. A throwing send leaves them standing to retry.
-            if (deviceIds.Count > 0)
-                // Badge recomputed from current state at delivery (see OnPush).
+            // entries no send could ever consume. Anything else is done only once it's out: FCM
+            // reports a rejected push in the batch response rather than throwing, so clearing what
+            // was merely attempted loses the dismissal for good.
+            if (deviceIds.Count == 0)
+                doneIds.AddRange(sendable.Select(x => x.Id));
+            else {
+                // The badge goes on its own alert push to iOS, and unconditionally: the removal
+                // below rides a background push that the system may hold for a long time, and a
+                // count that lags by an hour is the part the user sees from the home screen.
+                var iosDeviceIds = devices
+                    .Where(d => d.DeviceType == DeviceType.iOSApp)
+                    .Select(d => d.DeviceId)
+                    .ToList();
                 await FirebaseMessagingClient
+                    .SendBadge(iosDeviceIds, info.Items.Count, cancellationToken)
+                    .ConfigureAwait(false);
+                // Badge recomputed from current state at delivery (see OnPush).
+                var sent = await FirebaseMessagingClient
                     .SendDismissal(sendable, deviceIds, info.Items.Count, cancellationToken)
                     .ConfigureAwait(false);
-            doneIds.AddRange(sendable.Select(x => x.Id));
+                doneIds.AddRange(sent.Select(x => x.Id));
+            }
         }
 
         if (doneIds.Count > 0)

--- a/src/swift/VoxtNotificationService/Service/NotificationService.swift
+++ b/src/swift/VoxtNotificationService/Service/NotificationService.swift
@@ -134,9 +134,10 @@ final class NotificationService: UNNotificationServiceExtension {
         iconData: Data
     ) -> INSendMessageIntent? {
         guard !headline.isEmpty else { return nil }
-        // The thread id is the chat tag the server groups banners under, and AppDelegate's
-        // dismissal path matches delivered notifications on it. updating(from:) rewrites the
-        // thread id from the conversation id, so these two must be the same string.
+        // The thread id is the chat tag the server groups banners under, and updating(from:)
+        // rewrites it from the conversation id, so these two must be the same string. AppDelegate
+        // dismisses by notification id rather than by this, and updating(from:) does preserve
+        // userInfo - measured on device - so that id survives to the delivered banner.
         let conversationId = content.threadIdentifier.isEmpty
             ? (content.userInfo[chatIdKey] as? String ?? "")
             : content.threadIdentifier

--- a/src/swift/VoxtNotificationService/Service/NotificationService.swift
+++ b/src/swift/VoxtNotificationService/Service/NotificationService.swift
@@ -11,6 +11,12 @@ final class NotificationService: UNNotificationServiceExtension {
     private static let chatIdKey = "chatId"
     private static let senderNameKey = "senderName"
     private static let groupTitleKey = "groupTitle"
+    private static let tagKey = "tag"
+    private static let activeTagsKey = "activeTags"
+    private static let activeVersionKey = "activeVersion"
+    // Highest active-set version this extension has pruned against. Its own container, not the
+    // app group: nothing else reads it, and the appex has no group entitlement.
+    private static let lastPrunedVersionKey = "voxt.lastPrunedActiveVersion"
     // The system allows 30s, but a banner that lands seconds late is worse than an iconless
     // one - and these are 128px avatars, so a slow fetch means the network is gone anyway.
     private static let downloadTimeout: TimeInterval = 5
@@ -37,6 +43,11 @@ final class NotificationService: UNNotificationServiceExtension {
         self.contentHandler = contentHandler
         bestAttempt = content
         lock.unlock()
+
+        // Started before the icon download and deliberately not awaited: closing stale banners is
+        // local and must not be lost to a slow network, and the new banner is shown by the system
+        // after the handler returns either way.
+        Self.pruneStaleBanners(from: content)
 
         guard let iconUrl = Self.iconUrl(of: content) else {
             deliver(content)
@@ -82,6 +93,43 @@ final class NotificationService: UNNotificationServiceExtension {
         bestAttempt = nil
         lock.unlock()
         handler?(content)
+    }
+
+    // Closes the banners the server no longer lists as active. This is the only clearing path that
+    // needs no background push, so it is the one Doze and the standby buckets cannot hold - but it
+    // only runs when a new alert arrives, so it supplements the dismissal push rather than
+    // replacing it.
+    private static func pruneStaleBanners(from content: UNMutableNotificationContent) {
+        guard let rawTags = content.userInfo[activeTagsKey] as? String,
+              let rawVersion = content.userInfo[activeVersionKey] as? String,
+              let version = Int64(rawVersion)
+        else { return }
+
+        // Pushes can arrive out of order, and an active set is a snapshot, not a delta: applying an
+        // older one would close banners a newer one had already accounted for.
+        let defaults = UserDefaults.standard
+        guard version > (defaults.object(forKey: lastPrunedVersionKey) as? Int64 ?? 0) else {
+            log.info("Skipping stale active set \(version, privacy: .public)")
+            return
+        }
+        defaults.set(version, forKey: lastPrunedVersionKey)
+
+        let activeTags = Set(rawTags.split(separator: ",").map(String.init))
+        UNUserNotificationCenter.current().getDeliveredNotifications { delivered in
+            // Only banners carrying our own tag key are the active set's to close: the tray also
+            // holds locally posted notifications, which the server has never heard of.
+            let stale = delivered
+                .filter {
+                    guard let tag = $0.request.content.userInfo[tagKey] as? String, !tag.isEmpty
+                    else { return false }
+                    return !activeTags.contains(tag)
+                }
+                .map(\.request.identifier)
+            guard !stale.isEmpty else { return }
+
+            log.info("Pruning \(stale.count, privacy: .public) stale banner(s)")
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: stale)
+        }
     }
 
     private static func iconUrl(of content: UNMutableNotificationContent) -> URL? {

--- a/tests/Notifications.IntegrationTests/CallNotificationTagTests.cs
+++ b/tests/Notifications.IntegrationTests/CallNotificationTagTests.cs
@@ -17,6 +17,26 @@ public class CallNotificationTagTests(ITestOutputHelper @out) : TestBase(@out)
     }
 
     [Fact]
+    public void AttentionPushTagIsEntryScopedNotChatScoped()
+    {
+        // arrange
+        // AttentionNotification extends ChatEntryNotification, so it tags by entry like a mention.
+        // The Android dismissal path has to map that back to a chat to clear ChatAttentionService's
+        // request, and an entry tag does not parse as a ChatId - which is the trap this pins.
+        var entryId = ChatEntryId.New(TestChatId, 7);
+        var attention = AttentionNotification.New(TestUserId, entryId);
+
+        // act
+        var tag = attention.GetPushTag();
+
+        // assert
+        tag.Should().Be(entryId.Value);
+        ChatId.TryParse(tag, out _).Should().BeFalse("an entry tag is not a chat id");
+        ChatEntryId.TryParse(tag, out var parsed).Should().BeTrue();
+        parsed.ChatId.Should().Be(TestChatId);
+    }
+
+    [Fact]
     public void DismissalSharesRingTag()
     {
         var conversationId = ConversationId.New(TestChatId, 2067);

--- a/tests/Notifications.IntegrationTests/DismissalPayloadChunkTest.cs
+++ b/tests/Notifications.IntegrationTests/DismissalPayloadChunkTest.cs
@@ -1,0 +1,85 @@
+using System.Text;
+
+namespace ActualChat.Notifications.IntegrationTests;
+
+public class DismissalPayloadChunkTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private const int MaxPayloadBytes = 4096 - 512;
+    private static readonly UserId TestUserId = UserId.New();
+    private static readonly Moment QueuedAt = Moment.EpochStart;
+
+    [Fact]
+    public void ShouldKeepEveryChunkUnderTheFcmPayloadLimit()
+    {
+        // arrange
+        var dismissals = ManyDismissals();
+
+        // act
+        var chunks = FirebaseMessagingClient.ChunkDismissals(dismissals);
+
+        // assert
+        chunks.Count.Should().BeGreaterThan(1, "256 dismissals don't fit a single 4KB FCM payload");
+        foreach (var chunk in chunks) {
+            var ids = string.Join(',', chunk.Dismissals.Select(x => x.Id.Value));
+            var payload = Encoding.UTF8.GetByteCount(ids)
+                + Encoding.UTF8.GetByteCount(string.Join(',', chunk.Tags));
+            payload.Should().BeLessThan(MaxPayloadBytes, "both keys ride in the same payload");
+        }
+    }
+
+    [Fact]
+    public void ShouldChunkWithoutLosingOrDuplicatingADismissal()
+    {
+        // arrange
+        var dismissals = ManyDismissals();
+
+        // act
+        var chunks = FirebaseMessagingClient.ChunkDismissals(dismissals);
+
+        // assert
+        chunks.SelectMany(c => c.Dismissals).Should().BeEquivalentTo(dismissals);
+    }
+
+    [Fact]
+    public void ShouldSendOneChunkWhenEveryTagFits()
+    {
+        // arrange
+        var dismissals = new[] { NewDismissal("s-a-b"), NewDismissal("s-c-d") };
+
+        // act
+        var chunks = FirebaseMessagingClient.ChunkDismissals(dismissals);
+
+        // assert
+        chunks.Should().ContainSingle().Which.Tags.Should().BeEquivalentTo("s-a-b", "s-c-d");
+    }
+
+    [Fact]
+    public void ShouldCarryASharedTagOnlyOnce()
+    {
+        // arrange
+        var dismissals = new[] { NewDismissal("s-a-b"), NewDismissal("s-a-b"), NewDismissal("") };
+
+        // act
+        var chunks = FirebaseMessagingClient.ChunkDismissals(dismissals);
+
+        // assert
+        var chunk = chunks.Should().ContainSingle().Subject;
+        chunk.Tags.Should().ContainSingle().Which.Should().Be("s-a-b");
+        chunk.Dismissals.Should().HaveCount(3, "an untagged dismissal still refreshes the badge");
+    }
+
+    [Fact]
+    public void ShouldProduceNoChunksForNoDismissals()
+        => FirebaseMessagingClient.ChunkDismissals([]).Should().BeEmpty();
+
+    // Private methods
+
+    private static List<PendingDismissal> ManyDismissals()
+        => Enumerable
+            .Range(0, Constants.Notification.MaxPendingDismissals)
+            .Select(i => NewDismissal($"s-{i:D19}-{i:D19}"))
+            .ToList();
+
+    private static PendingDismissal NewDismissal(string tag)
+        => new(NotificationId.New(TestUserId, NotificationKind.Message, "key-" + tag), tag, QueuedAt);
+}

--- a/tests/Notifications.IntegrationTests/NotificationDeliveryTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationDeliveryTest.cs
@@ -321,6 +321,38 @@ public class NotificationDeliveryTest(AppHostFixture fixture, ITestOutputHelper 
         };
     }
 
+    [Fact]
+    public async Task RenderPushShouldCarryTheWholeActiveSet()
+    {
+        // arrange
+        var alice = await Tester.SignInAsAlice();
+        var bob = await Tester.SignInAsBob();
+        var (chat1, _) = await Tester.CreateChat(false, "Snapshot chat 1");
+        var (chat2, _) = await Tester.CreateChat(false, "Snapshot chat 2");
+        await Tester.InviteToChat(chat1, alice);
+        await Tester.InviteToChat(chat2, alice);
+        var deviceId = await RegisterDevice(alice.Id);
+        Sink.Clear();
+
+        // act
+        await Tester.SignIn(bob);
+        await Tester.CreateTextEntry(chat1, "First");
+        await Tester.CreateTextEntry(chat2, "Second");
+
+        // assert
+        // The snapshot is what lets a client close banners for chats this push isn't about, so it
+        // has to name every active tag - not just the one being rendered.
+        await TestExt.When(() => {
+            var push = Sink.Messages
+                .LastOrDefault(m => !m.IsDismissal && m.DeviceIds.Contains(deviceId)
+                    && m.ActiveTags.Count > 1);
+            push.Should().NotBeNull();
+            push!.ActiveTags.Should().BeEquivalentTo([chat1.Value, chat2.Value]);
+            push.ActiveVersion.Should().BePositive("a client orders snapshots by it");
+            return Task.CompletedTask;
+        }, TimeSpan.FromSeconds(30));
+    }
+
     private async Task<Symbol> RegisterDevice(UserId userId)
     {
         var deviceId = new Symbol("test-device-" + userId.Value);

--- a/tests/Notifications.IntegrationTests/NotificationDismissModeTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationDismissModeTest.cs
@@ -116,6 +116,34 @@ public sealed class NotificationDismissModeTest(AppHostFixture fixture, ITestOut
             "a kind that declares no mode must not be cleared by a read position it has no anchor for");
     }
 
+    [Fact]
+    public void KindDismissModeShouldMatchTheInstanceProperty()
+    {
+        // arrange
+        // A client holds only the push payload's kind, so NotificationExt.GetDismissMode restates
+        // per kind what the types declare per instance. The two drifting apart is what made every
+        // reaction banner vanish on Android, so it is asserted rather than assumed.
+        var entryId = ChatEntryId.New(TestChatId, 1);
+        var userId = UserId.New();
+        var conversationId = ConversationId.New(TestChatId, 1);
+        Notification[] notifications = [
+            MessageNotification.New(userId, TestChatId, 1),
+            ReplyNotification.New(userId, TestChatId, 1),
+            ThreadNotification.New(userId, TestChatId, 1),
+            MentionNotification.New(userId, entryId),
+            AttentionNotification.New(userId, entryId),
+            ReactionNotification.New(userId, entryId),
+            ConversationNotification.New(userId, conversationId, 2),
+            CallNotification.New(userId, conversationId, default, false),
+            InvitationNotification.New(userId, TestChatId),
+        ];
+
+        // act & assert
+        foreach (var notification in notifications)
+            NotificationExt.GetDismissMode(notification.Kind).Should().Be(notification.DismissMode,
+                because: $"{notification.Kind} must resolve the same either way");
+    }
+
     // Private methods
 
     private Task SetReadPosition(UserId userId, ChatId chatId, long entryLid)

--- a/tests/Notifications.IntegrationTests/NotificationDismissalReliabilityTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationDismissalReliabilityTest.cs
@@ -55,6 +55,74 @@ public sealed class NotificationDismissalReliabilityTest(AppHostFixture fixture,
         afterRetry.PendingDismissals.Should().BeEmpty("the retry sent it");
     }
 
+    [Fact]
+    public async Task DismissalRejectedByFcmShouldStayOwed()
+    {
+        // arrange
+        var (alice, notification, _) = await SetUpNotifiedAlice("Pending dismissal — rejected send");
+        Sink.RejectDismissalCount = int.MaxValue;
+
+        // act
+        await Commander.Call(new NotificationsBackend_Dismiss(notification.Id));
+
+        // assert
+        // FCM reports a rejected push in the batch response instead of throwing, so the send
+        // completes normally. Waiting on the observed rejection (rather than polling the blob)
+        // keeps this off the race with the converge event the dismissal queues.
+        await TestExt.When(() => Sink.RejectedDismissals.Should().BeGreaterThan(0),
+            TimeSpan.FromSeconds(10));
+
+        // act 2 — the retry NotificationConvergeFlow performs
+        Sink.Clear();
+        Sink.RejectDismissalCount = 0;
+        await Commander.Call(new NotificationsBackend_Converge(alice.Id));
+
+        // assert 2
+        // Nothing but PendingDismissals can re-derive this - the notification is gone from Items -
+        // so a rejected send that cleared it would leave the banner up for good.
+        Sink.Messages.Should().Contain(
+            m => m.IsDismissal && m.DismissedIds.Contains(notification.Id),
+            "a dismissal FCM rejected must be re-sent, not dropped");
+    }
+
+    [Fact]
+    public async Task DismissalShouldSendTheBadgeToIosOnItsOwnPush()
+    {
+        // arrange
+        var alice = await Tester.SignInAsAlice();
+        var bob = await Tester.SignInAsBob();
+        var (chatId, _) = await Tester.CreateChat(false, "Badge push chat");
+        await Tester.InviteToChat(chatId, alice);
+        var iosDeviceId = new Symbol("test-ios-" + alice.Id.Value);
+        var webDeviceId = new Symbol("test-web-" + alice.Id.Value);
+        await Commander.Call(new NotificationsBackend_RegisterDevice(
+            alice.Id, iosDeviceId, DeviceType.iOSApp, Symbol.Empty));
+        await Commander.Call(new NotificationsBackend_RegisterDevice(
+            alice.Id, webDeviceId, DeviceType.WebBrowser, Symbol.Empty));
+        Sink.Clear();
+
+        await Tester.SignIn(bob);
+        await Tester.CreateTextEntry(chatId, "Hi Alice");
+        Notification notification = null!;
+        await TestExt.When(async () => {
+            var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+            notification = info.Items.Should().ContainSingle().Subject;
+        }, TimeSpan.FromSeconds(10));
+
+        // act
+        await Commander.Call(new NotificationsBackend_Dismiss(notification.Id));
+
+        // assert
+        // The badge rides an alert push so it lands even when the background push carrying the
+        // removal is held - and only iOS has one, so nothing else should be woken for it.
+        await TestExt.When(() => {
+            var badge = Sink.Badges.Should().ContainSingle().Subject;
+            badge.DeviceIds.Should().Equal([iosDeviceId]);
+            badge.BadgeCount.Should().Be(0);
+            return Task.CompletedTask;
+        }, TimeSpan.FromSeconds(10));
+    }
+
     // Private methods
 
     private async Task<(AccountFull Alice, Notification Notification, Symbol DeviceId)> SetUpNotifiedAlice(

--- a/tests/Testing.Host/FirebaseMessagingTestSink.cs
+++ b/tests/Testing.Host/FirebaseMessagingTestSink.cs
@@ -10,6 +10,8 @@ public sealed record FirebaseSentMessage(
     int BadgeCount,
     bool IsSilent = false)
 {
+    public IReadOnlyList<string> ActiveTags { get; init; } = [];
+    public long ActiveVersion { get; init; }
     public bool IsDismissal => Notification == null;
 }
 
@@ -55,13 +57,17 @@ public sealed class FirebaseMessagingTestSink(ILogger<FirebaseMessagingTestSink>
         Notification notification,
         IReadOnlyCollection<Symbol> deviceIds,
         bool? enableDataCollection,
-        int badgeCount,
+        UserNotificationInfo info,
         bool isSilent,
         CancellationToken cancellationToken)
     {
+        var badgeCount = info.Items.Count;
         log.LogInformation("SendMessage: {NotificationId} -> {DeviceCount} device(s), badge={Badge}, silent={IsSilent}",
             notification.Id, deviceIds.Count, badgeCount, isSilent);
-        Add(new FirebaseSentMessage(notification, [], [..deviceIds], badgeCount, isSilent));
+        Add(new FirebaseSentMessage(notification, [], [..deviceIds], badgeCount, isSilent) {
+            ActiveTags = [..info.Items.Select(n => n.GetPushTag()).SkipNullItems().Distinct()],
+            ActiveVersion = info.Version,
+        });
         return Task.CompletedTask;
     }
 

--- a/tests/Testing.Host/FirebaseMessagingTestSink.cs
+++ b/tests/Testing.Host/FirebaseMessagingTestSink.cs
@@ -13,6 +13,8 @@ public sealed record FirebaseSentMessage(
     public bool IsDismissal => Notification == null;
 }
 
+public sealed record FirebaseBadgeMessage(IReadOnlyList<Symbol> DeviceIds, int BadgeCount);
+
 public sealed record FirebaseWakeMessage(
     ChatId ChatId,
     AuthorId AuthorId,
@@ -25,18 +27,28 @@ public sealed class FirebaseMessagingTestSink(ILogger<FirebaseMessagingTestSink>
 {
     private readonly ConcurrentQueue<FirebaseSentMessage> _messages = new();
     private readonly ConcurrentQueue<FirebaseWakeMessage> _wakes = new();
+    private readonly ConcurrentQueue<FirebaseBadgeMessage> _badges = new();
+    private int _rejectedDismissals;
 
     public IReadOnlyList<FirebaseSentMessage> Messages => _messages.ToArray();
     public IReadOnlyList<FirebaseWakeMessage> Wakes => _wakes.ToArray();
+    public IReadOnlyList<FirebaseBadgeMessage> Badges => _badges.ToArray();
     // Makes the next N dismissal sends throw, so a test can assert that a failed send leaves the
     // dismissal owed rather than losing it.
     public int FailDismissalCount { get; set; }
+    // Makes the next N dismissal sends accept nothing instead of throwing - how FCM reports a
+    // rejected push.
+    public int RejectDismissalCount { get; set; }
+    // Lets a test wait for the rejection instead of racing the converge the dismissal queues.
+    public int RejectedDismissals => Volatile.Read(ref _rejectedDismissals);
     public event Action<FirebaseSentMessage>? Sent;
 
     public void Clear()
     {
         _messages.Clear();
         _wakes.Clear();
+        _badges.Clear();
+        Interlocked.Exchange(ref _rejectedDismissals, 0);
     }
 
     public Task SendMessage(
@@ -53,7 +65,7 @@ public sealed class FirebaseMessagingTestSink(ILogger<FirebaseMessagingTestSink>
         return Task.CompletedTask;
     }
 
-    public Task SendDismissal(
+    public Task<IReadOnlyCollection<PendingDismissal>> SendDismissal(
         IReadOnlyCollection<PendingDismissal> dismissals,
         IReadOnlyCollection<Symbol> deviceIds,
         int badgeCount,
@@ -64,10 +76,27 @@ public sealed class FirebaseMessagingTestSink(ILogger<FirebaseMessagingTestSink>
             log.LogInformation("SendDismissal: injected failure");
             throw new InvalidOperationException("Injected dismissal failure.");
         }
+        if (RejectDismissalCount > 0) {
+            RejectDismissalCount--;
+            Interlocked.Increment(ref _rejectedDismissals);
+            log.LogInformation("SendDismissal: injected rejection");
+            return Task.FromResult<IReadOnlyCollection<PendingDismissal>>([]);
+        }
 
         log.LogInformation("SendDismissal: {Count} id(s) -> {DeviceCount} device(s), badge={Badge}",
             dismissals.Count, deviceIds.Count, badgeCount);
         Add(new FirebaseSentMessage(null, [..dismissals.Select(x => x.Id)], [..deviceIds], badgeCount));
+        return Task.FromResult<IReadOnlyCollection<PendingDismissal>>([..dismissals]);
+    }
+
+    public Task SendBadge(
+        IReadOnlyCollection<Symbol> deviceIds,
+        int badgeCount,
+        CancellationToken cancellationToken)
+    {
+        log.LogInformation("SendBadge: {DeviceCount} device(s), badge={Badge}", deviceIds.Count, badgeCount);
+        if (deviceIds.Count > 0)
+            _badges.Enqueue(new FirebaseBadgeMessage([..deviceIds], badgeCount));
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Banners outliving the read that should have closed them. Four independent causes, found by tracing the push end to end on a real Android phone and a real iPhone.

### What's in here

**`fix(android): fix banner clearing on the device`**
- **Every reaction notification was suppressed before it was shown.** `ShouldSuppressForDevice` drops a push whose entry the device has read past, and a reaction anchors at the recipient's *own* message — so the condition was always true. This is the client-side half of what `4a3dc34266` fixed on the server: it gave `IsRead` a `DismissMode` gate; this check, the same positional test against the same anchor, never got one.
- **Attention banners were unreachable by any dismissal** — posted under `ChatAttentionService`'s own tag, so `Cancel(tag, 0)` never matched, and a 15-minute alarm re-posted them.
- **The reconciler cancelled notifications that were never its to cancel** — every shown notification whose tag was missing from the active set, which includes the foreground-service, upload, microphone and attention notifications.

**`fix(ios): match dismissals by notification id, not thread`** — `ThreadIdentifier` is always the chat, while dismissed tags are push tags (entry-derived for mentions/reactions, `call-` prefixed for rings). So mention, reaction and call dismissals matched nothing, while a message dismissal matched the whole thread and took that chat's live mentions with it.

**`fix(notifications): make the dismissal push land where it is aimed`** — a rejected send was marked done and lost forever; the payload had no size budget (over 4KB FCM rejects the whole message); the badge rode a background push iOS won't apply it from, and now goes as its own alert push.

**`feat(notifications): prune stale banners from the push that renders the next one`** — the render push carries the active set so the iOS extension can close what's no longer in it. This is the only clearing path no delivery budget applies to.

### Verified on device

- Android: reaction push anchored below the read position now shows, while a message push at the same entry is still suppressed — the guard is scoped, not removed.
- iOS: `updating(from: intent)` preserves `userInfo` (measured in the extension on two real pushes), so dismissal matching runs on the exact id path.
- End to end: reaction → banner → server dismissal → banner cancelled, id and tag both present.
- 189/189 notification tests, solution builds clean.

### Deliberately not changed

The dismissal push **stays at normal FCM priority**. Raising it was tried and measured instead: Doze holds it, but only until the device wakes — 568/571/572 ms from leaving Doze to delivery across three runs. High would buy that half second with the FCM cold start that made these pushes an ANR source.

Reaction clearing is **not** touched. `OnView` + `SeenNotificationDismisser` is correct: a read position advancing means you read *newer* messages, which says nothing about an older reacted one.

### Not verified

The active-set prune and the badge push are server-side and can't be exercised until this is deployed — dev runs the old server, so its payloads carry neither.

Two things found while testing that are **not** fixed here:
- iOS silently drops every dismissal when Background App Refresh is off (`dasd` answers `pushDisallowed` / `Decision: AMNP`), with no signal to the user. Nothing reads `BackgroundRefreshStatus` today.
- `SeenNotificationDismisser` has no foreground guard, so in principle a backgrounded app could still report an entry as "seen". Not observed: the one case tested cleared correctly, from a desktop client with the entry genuinely on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdU3DRpfco7w37mgEkT6od
