### PR TITLE
fix(virtual-list): short-chat tail unreachable, and skeletons under a live conversation

### DIFF
--- a/.claude/skills/virtual-list-debug/SKILL.md
+++ b/.claude/skills/virtual-list-debug/SKILL.md
@@ -216,10 +216,9 @@ reproduce iOS choosing an unscrollable target before `touchstart`: `catch-drag` 
 controller releases its lock and preserves geometry, not that the same caught gesture can resume
 native scrolling on iOS.
 
-> **Known gap:** both `rig.mjs` and `soak.mjs` still call
-> `globalThis.debugUI?.listVirtualListViolations?.(true) ?? []`, which no longer exists. The
-> `violations` column in their output is therefore **always 0** and proves nothing. The checker they
-> enable still warns to the console — read it there until those two call sites are replaced.
+> Both scripts turn the checker on and collect its console warnings over CDP themselves
+> (`Runtime.consoleAPICalled`), so the `violations` column is the checker's real verdict for the run;
+> the traces under `tmp/traces/` carry the same list as `violations`.
 
 ### 1.5 The recorder — `tools/virtual-list-rig/recorder.js`
 

--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -492,7 +492,7 @@ overscroll rows are the summary of §3.7.*
 | a scroll event past a limit, finger down | in-band → following | latch the boundary; seed `over` at the true excursion and the transform at its resisted share; each frame after: `over += Δscroll`, nudge by the resisted share | `transform` |
 | a scroll event past a limit, no finger, ordinary path | in-band → engaged | the same seed, the carry seeded from the fling's speed, then the bounce and the floor per frame | `transform` |
 | a scroll event past a limit, no finger, iOS/WebKit | in-band → engaged + momentum `arming` | seed the same band, estimate the recent native velocity, then perform the next-frame lock/FLIP handoff | `transform`, then `scrollTop` + `transform` |
-| the finger comes back inside | following → in-band | nothing: `over` and the transform are already zero | — |
+| the finger comes back inside | following → in-band | nothing under its own power: `over` and the transform are already zero. Under a limit that moved past the finger the transform still holds the curve's share, so the hand-back writes `scrollTop` by exactly that as it drops the transform — the content stays put and the drag carries on | `scrollTop` + `transform` |
 | `touchend` past the boundary, ordinary path | following → engaged | an outward release carries its speed into a bounce; each frame shows the browser's motion resisted, the carry tops it up until it turns, the floor adds only its shortfall after that; the browser's outward fling is ended by `killMomentum` | `transform` |
 | `touchend` past the boundary, iOS/WebKit | following → engaged + momentum `arming` | estimate the release speed from the recent native samples; on the next frame force the overflow lock, snap `scrollTop` to the boundary and FLIP the measured visual delta into the content transform; momentum `transform` then runs the critically damped return | `scrollTop` + `transform`, same frame; then `transform` |
 | `touchstart` during a return | engaged → following | release any takeover lock, integrate what the scroll did since the last frame, then write `scrollTop := boundary + over`, read back, and take the same delta out of the transform | `scrollTop` + `transform`, same frame |
@@ -828,7 +828,8 @@ rules:
    part only by `nudge(delta)`. During the iOS takeover the first FLIP is also a nudge, after which the
    spring owns and assigns `overscrollOffset`.
 2. **Every `scrollTop` write is named and read back.** The ordinary path writes for a catch, settle,
-   wheel/cancel/watchdog end, tiny or non-touch crossing, and the owner's `scrollTo` / clamp. The iOS
+   wheel/cancel/watchdog end, tiny or non-touch crossing, a limit that moved past a following finger,
+   and the owner's `scrollTo` / clamp. The iOS
    path additionally snaps to the boundary after forcing the overflow lock, and repeats that snap if
    native movement leaks through. Only the measured visual effect of a write is transferred into the
    transform. Anything else that wants to correct a moving view moves the scroll position or the
@@ -947,8 +948,13 @@ device pixel counts as landed. Dropping the
 transform before the write, which an earlier version did, was a step of the whole leak whenever the
 write was refused.
 
-**Ending inside the band under a finger** writes nothing and drops nothing: by the time the scroll is
-back inside, `over` has been integrated to zero and the transform with it, so letting go moves nothing.
+**Ending inside the band under a finger** writes nothing and drops nothing when the finger brought it
+back: by then `over` has been integrated to zero and the transform with it, so letting go moves nothing.
+When a limit moved past the finger instead — the page of history the pull itself asked for, arriving
+mid-pull — the transform still holds the curve's share of the pull, and dropping it was a step of that
+size on screen. The hand-back is the renumbering a catch performs: `scrollTop` is written by exactly
+that share as the transform drops, so the content stays where it is and the drag carries on. Measured
+with the soak: six such ends per run, 1-24px each, every one landing on the compensated position.
 A release from inside the band is a release, not a bounce: `engage` checks the position, and a finger
 that crossed back in and lifted — still `following`, because ending that phase waits on a scroll
 event a release does not produce — ends the excursion instead of springing at the edge it just passed.
@@ -2088,22 +2094,11 @@ can see no chats at all".
 
 ## 7. Known open issues
 
-*What is known not to be done: a load that moves the limits under a dragging finger drops the band; the
+*What is known not to be done: the
 two per-frame `scrollTop` writers are unmeasured on a device; the `auto` inset reading is verified on
 Blink only; `reanchor` holds the viewport top in both directions; a fling read through loading history
 is unmeasured; a touch that lands during the short iOS lock cannot scroll in that same gesture; and a
 long hold trips the stale-touch backstop.*
-
-- **A load that moves the limits outward under a dragging finger drops the excursion.**
-  `ScrollController.onScroll` asks `getViolatedBoundary` where the scroll is, and a limit that moved
-  past it while the finger was still pulling answers "in band" — so `endPhase(null)` runs, `over` goes
-  to zero and the band transform is discarded in one frame. Measured with the soak's 60 gestures: six
-  or seven occurrences per run, with `over` up to 180px, which is ~24px of transform vanishing in a
-  frame; the rig's `bad-ends` catches it only when the next frame happens to be outside the limits, so
-  a soak run passes or fails on timing. **It predates the translation work** — a soak against the
-  previous commit reproduces the same six occurrences and the same `bad-ends 1`. The fix is for the
-  crossing to be re-aimed rather than abandoned, the way `scrollTo`'s `reanchor` path already does it:
-  a limit that moves under an open excursion should move the latched boundary with it.
 
 - **Two things write `scrollTop` per frame, and §4.7 is about exactly that.** While an item's height
   animates, the pinned edge moves every frame, so the follow writes every frame; an expand hold does

--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -50,9 +50,10 @@ in a later section looks loaded — most of them are.*
   of the container, sized from the model, standing in for the unloaded range. In `InfiniteList` its
   size is a stub that means nothing exact; in `FiniteList` it covers the unloaded range precisely. It
   also holds the skeletons and is what the load-trigger observer watches.
-- **end anchor** — *`endAnchorRef`, `.c-end-anchor`.* A blank `<li>` after the last item that keeps the
-  newest message clear of the message editor overlapping the list. Nothing to do with `reanchor` or
-  with scroll anchoring, despite the name.
+- **end anchor** — *`endAnchorRef`, `.c-end-anchor`.* A blank `<li>` right after the last item, before
+  the end spacer, that keeps the newest message clear of the message editor overlapping the list. The
+  bottom limit honours as much of it as fits (`honouredEndAnchorSize`); the rest is its **slack**
+  (`endAnchorSlack`). Nothing to do with `reanchor` or with scroll anchoring, despite the name.
 
 ### The two position terms
 
@@ -168,9 +169,10 @@ in a later section looks loaded — most of them are.*
 - **reappearance** — *`recentlyRemoved`, `ReappearanceMs`.* A key that leaves a render and comes back
   inside 1.5s. It looks exactly like an insertion to the diff, because the render it is diffed against
   does not contain it, but the user was reading it a moment ago — so it does not animate.
-- **chain fitting** — *`isChainWithinViewport`, `updateChainFitting`.* "Both ends loaded, and the whole
-  conversation is shorter than the viewport." A special case with its own resting place and its own
-  hysteresis, not a coincidence the general rules happen to handle.
+- **honoured anchor** — *`honouredEndAnchorSize`, `endAnchorSlack`.* How much of the end anchor the
+  bottom limit adds: the whole of it once the content overflows the viewport by the anchor's height,
+  less around one viewport, so a conversation that fits is never scrolled past its first message
+  (§3.8). There is no "fits on screen" flag; the rule is continuous.
 - **near-skeleton** — *`isNearSkeleton`.* A spacer is on screen or within 200px of it — i.e. the user
   is looking at a hole, which relaxes the heuristics that otherwise avoid a data query.
 - **reveal** — *`reveal`, `startRevealWatch`, `c-initially-hidden`.* The wrapper stays
@@ -1211,9 +1213,9 @@ carrying an inset of `base - 66.26px` — and after it, with every inline inset 
 ### 3.8 Spacers, the end anchor, and the conversation that fits on screen
 
 *The spacers reserve scroll space, hold the skeletons, and trigger loading. The end anchor is blank
-space under the newest message that the bottom limit adds explicitly. A conversation shorter than the
-viewport is a special case: its band inverts, so it rests with its first message at the top and the
-anchor is not honoured.*
+space under the newest message that the bottom limit adds explicitly — as much of it as fits, so a
+conversation around one viewport is never scrolled past its first message for the sake of blank space
+under its last.*
 
 **The spacers** do three jobs at once, and it is worth seeing all three:
 
@@ -1245,58 +1247,70 @@ viewport above the chain that fades in after three seconds to suggest you can pu
 message. It is rendered only when the list opts in *and* the very first item is loaded, and it is
 `position: absolute`, so it contributes nothing to any measurement.
 
-**The end anchor** is a blank `<li class="c-end-anchor">` after the last item, whose job is to keep the
-newest message clear of the message editor that overlaps the bottom of the list. Its height is CSS —
+**The end anchor** is a blank `<li class="c-end-anchor">` right after the last item, whose job is to keep
+the newest message clear of the message editor that overlaps the bottom of the list. Its height is CSS —
 4px normally, 48px on a narrow screen, 80px when a listening-activity or audio-panel header is up —
 and JS *measures* it through a `ResizeObserver` rather than being told, so a layout change that alters
-it needs no code change. It sits *after* the items, so `chainEnd` does not include it and the bottom
-limit adds it explicitly:
+it needs no code change. It sits *after* the items and *before* the end spacer, so `chainEnd` does not
+include it and the bottom limit adds it explicitly — as much of it as is honoured:
 
 ```ts
-max = chainEnd + endAnchorSize - clientHeight
+max = chainEnd + honouredEndAnchorSize - clientHeight
 ```
 
 — "scroll far enough that the bottom of content-plus-anchor meets the bottom of the viewport".
 
-#### Why a conversation that fits on screen is an exception
+The order matters. The End pin aims at this element (`measureEdgeTarget`), and when the end of the data
+stops being known the end spacer grows to `spacerSize` (1500px). Placed behind the spacer, the anchor
+would take an End-pinned list a spacer's height down with it on that render — the newest messages at
+the top of the viewport and skeletons filling the rest, which is exactly what a viewer of a live
+conversation used to see. Ahead of the spacer it stays with the content, and the skeletons stay below
+the fold where scrolling past the loaded content is supposed to find them.
+
+#### Why a conversation around one viewport honours less of the anchor
 
 Take a fully loaded chat whose content is 200px, in a 578px viewport, with a 48px anchor:
 
 - `min = chainStart` — there is nothing above the first message to scroll to
 - `max = chainStart + 200 + 48 − 578 = chainStart − 330`
 
-`max` is 330px *below* `min`: an inverted band. And read literally, that position puts the chain's top
-330px above the viewport top — the only messages in the chat pushed off the top of the screen, with
-`min` forbidding any scroll back to them.
+`max` is 330px *below* `min`: an inverted band, which the End default resolves to `min = max`, so the
+conversation rests bottom-aligned with its anchor honoured and its first message well below the top.
+That is fine. Now let the content be 560px: `max = chainStart + 30`, which read literally puts the first
+message 30px above the viewport top with `min` forbidding any scroll back to it — the only messages in
+the chat pushed off the top of a list that cannot scroll back, for the sake of blank space under them.
 
 It is not hypothetical, because the list is pinned to End and `repinEdge` measures exactly this: the
-end anchor's bottom against the viewport's bottom, scrolling to make them flush. With short content,
-"flush" *is* that position.
+end anchor's bottom against the viewport's bottom, scrolling to make them flush.
 
-So both places that could take you there cap at `chainStart` — the chain's top at the viewport top:
+So the anchor is honoured only as far as it fits, and the limit is built from that part of it:
 
 ```ts
-if (this.isChainWithinViewport)            // computeScrollLimits
-    max = Math.min(max, this.chainStart);
-
-return this.isChainWithinViewport          // repinEdge.measureTarget
-    ? Math.min(target, this.chainStart) : target;
+honouredEndAnchorSize = min(endAnchorSize, |clientHeight − chainSize|)   // both ends loaded
+max = chainEnd + honouredEndAnchorSize − clientHeight
 ```
 
-A conversation that fits is therefore shown from its first message, and the anchor is not honoured at
-all — there is nothing to keep clear of the editor when the content never reaches it.
+Below one viewport that honours as much of the anchor as the slack above the chain allows, which caps
+`max` at `chainStart` — the first message at the top. Above it the honoured part grows with the
+overflow, so the limit runs continuously through the crossing: from `chainStart` at exactly one
+viewport to the full `chainEnd + endAnchorSize − clientHeight` once the content overflows by the
+anchor's height. A live transcript sitting at one viewport and growing and shrinking by a line follows
+two pixels per pixel there and never jumps by the anchor's height — and no content is ever beyond the
+reachable limit. The rule this replaced was a "fits on screen" flag with 64px of hysteresis that capped
+`max` at `chainStart` while set: it did jump at the exit, it hid up to 64px plus the anchor of the
+newest messages while the chain sat inside the band — a short chat that grew past the viewport by a
+message or two could not be scrolled to its end — and it was never re-evaluated on a viewport resize.
 
-Two conditions on it. It requires **both** ends loaded (`hasVeryFirstItem && hasVeryLastItem`) — "fits
-on screen" means nothing about a partially loaded window that happens to be short. And it has
-hysteresis: entered at `chainSize <= clientHeight`, left only above `clientHeight + ChainFittingExitPx`
-(64px), because crossing that boundary adds or removes a whole `endAnchorSize` of scroll range — a live
-transcript sitting at exactly one viewport and growing and shrinking by a line would otherwise toggle
-it on every measure and jump 48px each time.
+`measureEdgeTarget` applies the same cap to the End target, and only while something is capped, so a
+model a pixel short cannot stop the re-pin from landing flush on the DOM measure. The rule requires
+**both** ends loaded (`hasVeryFirstItem && hasVeryLastItem`) — "fits on screen" means nothing about a
+partially loaded window that happens to be short — and honours the whole anchor otherwise.
 
-The same case leaks into three other places, and all are deliberate: a chain that fits counts as being
-at the End edge for pinning, however far the anchor says it is; it counts as "the newest message is
-visible" for read tracking; and the initial reveal asks only that its first item is not clipped off the
-top. Without the first two an End-pinned list would settle on Start and stop following new messages
+What the anchor is short of at the limit is its **slack** (`endAnchorSlack`), and three places read
+the end through it, all deliberate: the list counts as at the End edge for pinning when the anchor's
+bottom is within the slack of the viewport bottom; the same test says "the newest message is visible"
+for read tracking; and the initial reveal accepts the End edge with the anchor its slack below the
+fold. Without the first two an End-pinned list would settle on Start and stop following new messages
 until the conversation outgrew the viewport.
 
 ### 3.9 Re-anchoring

--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -507,7 +507,7 @@ overscroll rows are the summary of §3.7.*
 | `repinEdge` called during an excursion | Pinned → awaiting overscroll end | deferred; past a boundary the measured position is not the visible one and the write would snap the bounce | — |
 | `scrollToKey` that is not the newest item | any → Placing | suppress new height animations, wait out the ones in flight, then place the item at `center` or `end` | `container.top` then `scrollTop` |
 | `scrollToKey` that *is* the newest item, end loaded | any → Pinned End | pin and re-pin, which in reverse is a follow of a few pixels or nothing at all — so a message you just posted still animates in | `scrollTop` |
-| the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop `onWheel` also clears the pin even inside the guard window | — |
+| the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop the scroll a wheel away from the edge produced clears the pin outright, even inside the guard window — but only that scroll: a wheel that scrolls nothing (a chat that fits on screen, a scroller nested in a message) leaves the pin alone | — |
 | a `data-vl-hold` control is clicked or tapped | Pinned → Free, interactive anchor set | the clicked item is what the next render holds; `keep-edge` controls leave a pinned list alone; expires after 2s | — |
 | a `data-vl-hold` control marked `data-anchor="below"` | Pinned → Free, key-addressed screen anchor set | the first content item below the control keeps its rendered position; placed only by the render that inserts content directly above that item, however many unrelated renders land first | — |
 | a `data-vl-hold` control inside a `data-vl-anchor` element | Pinned → Free, screen anchor set | the element's rendered screen position is recorded; unpinning is what gives the chain its top anchor (§3.2) | — |
@@ -713,8 +713,11 @@ The follow writes `scrollTop` again — and deliberately does **not** open that 
 never close. It is recognised the other way instead: `followBy` reports where the write landed, and
 the next scroll event standing on that exact value is dropped whole, while the first event anywhere
 else is the user's. So the guard proper is only open after a genuine jump — opening a chat, a
-`scrollToKey`, a re-centre — where suppressing the handler is what we want. `onWheel` remains the
-escape hatch on desktop.
+`scrollToKey`, a re-centre — where suppressing the handler is what we want. A wheel away from the edge
+remains the escape hatch on desktop: `onWheel` only notes it, and the scroll it produces inside
+`WheelAwayWindowMs` (300ms) drops the pin whatever the guard says. Noting rather than dropping is what
+keeps a wheel that scrolls nothing — a chat that fits on screen, a scroller nested in a message — from
+leaving the list unpinned with nothing to put the pin back until the next render's clamp.
 
 #### Stranded recovery
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -316,7 +316,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         }
 
         ChatUI.SetItemVisibility(itemVisibility);
-        var isUserPresent = ChatUI.IsUserPresent();
+        var isUserPresent = ChatUI.IsUserPresent(Chat.Id);
         if (itemVisibility.IsEndAnchorVisible) {
             _lastEndAnchorVisibleAt = CpuTimestamp.Now;
             if (isUserPresent)
@@ -348,7 +348,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         // messages that arrived meanwhile - which the badge no longer shows (ChatUI.IsReadingTail).
         // The interaction that ends the stretch catches it up, before that interaction can take the
         // user anywhere the count would surface.
-        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent())
+        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent(Chat.Id))
             return;
 
         var itemVisibility = ItemVisibility.Value;
@@ -412,7 +412,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 // count never rises for the chat being watched. The !IsEmpty guard keeps a retained
                 // pinned flag from marking anything read while no items are actually rendered.
                 var itemVisibility = ItemVisibility.Value;
-                if (itemVisibility.IsPinnedToEnd && !itemVisibility.IsEmpty && ChatUI.IsUserPresent())
+                if (itemVisibility.IsPinnedToEnd && !itemVisibility.IsEmpty && ChatUI.IsUserPresent(Chat.Id))
                     UpdateReadPosition(lastEntryLid);
                 continue;
             }
@@ -840,7 +840,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (items.Count == 0)
             return false; // Not loaded yet or wrong load range
 
-        if (!ChatUI.IsUserPresent()) {
+        if (!ChatUI.IsUserPresent(Chat.Id)) {
             DebugLog?.LogDebug("TryUpdateShownReadEntryLid: the user isn't at the screen");
             return false;
         }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -120,6 +120,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _shownReadEntryLid.Value = readPosition.EntryLid;
             if (_viewPositionLease.Resource.Value.EntryLid is 0 && readPosition.EntryLid > 0)
                 _viewPositionLease.Resource.Value = readPosition;
+            Hub.UserActivityUI.LastPresentAt.Updated += OnPresenceUpdated;
             _whenInitializedSource.TrySetResult();
             ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: WhenInitialized SET",
                 $"readEntryLid={readPosition.EntryLid}");
@@ -169,6 +170,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         _readPositionLease.DisposeSilently();
         ChatUI.ResetItemVisibility(Chat.Id);
         Nav.LocationChanged -= OnLocationChanged;
+        Hub.UserActivityUI.LastPresentAt.Updated -= OnPresenceUpdated;
         _isHoverMenuDisposed = true;
         if (_hoverMenuJsRefTask is { IsCompletedSuccessfully: true } jsRefTask)
             _ = jsRefTask.Result.DisposeSilentlyAsync("dispose");
@@ -318,7 +320,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (itemVisibility.IsEndAnchorVisible) {
             _lastEndAnchorVisibleAt = CpuTimestamp.Now;
             if (isUserPresent)
-                _ = UpdateReadPositionToTheLastId(Chat.Id);
+                _ = UpdateReadPositionToTheLastId();
         }
         else if (isUserPresent)
             UpdateReadPosition(itemVisibility.MaxEntryLid);
@@ -328,17 +330,32 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             var entryId = itemVisibility.MaxMessageLid;
             _viewPositionLease.Resource.Value = new ReadPosition(Chat.Id, entryId);
         }
-        return;
+    }
 
-        async Task UpdateReadPositionToTheLastId(ChatId chatId)
-        {
-            var chatInfo = await ChatUI.Get(chatId, DisposeToken).ConfigureAwait(true);
-            var lastId = chatInfo?.News?.TextEntryLidRange.End - 1;
-            if (lastId is not > 0)
-                return;
+    private async Task UpdateReadPositionToTheLastId()
+    {
+        var chatInfo = await ChatUI.Get(Chat.Id, DisposeToken).ConfigureAwait(true);
+        var lastId = chatInfo?.News?.TextEntryLidRange.End - 1;
+        if (lastId is not > 0)
+            return;
 
-            UpdateReadPosition(lastId.Value);
-        }
+        UpdateReadPosition(lastId.Value);
+    }
+
+    private void OnPresenceUpdated(IState state, StateEventKind eventKind)
+    {
+        // The read position waits for presence, so an idle stretch at the tail leaves it behind the
+        // messages that arrived meanwhile - which the badge no longer shows (ChatUI.IsReadingTail).
+        // The interaction that ends the stretch catches it up, before that interaction can take the
+        // user anywhere the count would surface.
+        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent())
+            return;
+
+        var itemVisibility = ItemVisibility.Value;
+        if (!itemVisibility.IsPinnedToEnd || itemVisibility.IsEmpty)
+            return;
+
+        _ = UpdateReadPositionToTheLastId();
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -652,6 +652,11 @@ public partial class ChatUI
         var chatSendingMessagesWrapper = new IgnoreComputeArg<ChatSendingMessagesAccessor>(chatSendingMessages);
         var tiles = new List<VirtualListTile<ChatMessage>>();
         var hasVeryFirstItem = idTiles.Count > 0 && idTiles[0].Start <= chatLidRange.Start;
+        // The loaded window reaching the chat's last entry has nothing after it, whatever the range meta
+        // said: served stale, it can still name a next id tile, and an End-pinned list pays for that
+        // "more after" with a spacer of skeletons under the newest message.
+        if (idTiles.Count > 0 && idTiles[^1].End >= chatLidRange.End)
+            hasMoreAfter = false;
         var prevMessage = hasVeryFirstItem ? ChatMessage.Welcome(chatId) : null;
         var alreadyAddedConversationHeaders = new HashSet<ConversationId>();
         var alreadyAddedConversationCards = new HashSet<ConversationId>();

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -39,6 +39,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private IAccounts Accounts => Hub.Accounts;
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
     private UserActivityUI UserActivityUI => Hub.UserActivityUI;
+    private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
     private NotificationsUI NotificationsUI => Hub.NotificationsUI;
     private IAvatars Avatars => Hub.Avatars;
     private IAuthors Authors => Hub.Authors;
@@ -336,15 +337,24 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         // anything for three minutes used to watch it count up. What keeps hiding it honest is
         // ChatView advancing the read position on the interaction that ends the idle stretch, so what
         // the badge hides is read before it could show anywhere else. A hidden document still counts
-        // as not reading.
+        // as not reading - unless the user is in this chat's live conversation, which goes on with the
+        // screen untouched, or off.
         var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);
-        return lastPresentAt != Moment.MinValue;
+        if (lastPresentAt != Moment.MinValue)
+            return true;
+
+        return await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
     }
 
     // The non-reactive half of IsReadingTail, for the JS-driven callbacks that can't await:
     // the document is visible and the user interacted recently enough to still be at the screen.
     public bool IsUserPresent()
         => UserActivityUI.LastPresentAt.Value + Constants.Chat.ReadingGracePeriod > Clocks.CpuClock.Now;
+
+    // Presence for reading one chat: the input above, or being in that chat's live conversation -
+    // listening and recording are the interaction there, whatever the pointer and the screen do.
+    public bool IsUserPresent(ChatId chatId)
+        => IsUserPresent() || LiveSessionUI.IsInLiveConversation(chatId);
 
     [ComputeMethod(ConsolidationDelay = 0.3)]
     public virtual async Task<bool> IsUnreadByOthers(

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -324,8 +324,6 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     [ComputeMethod(ConsolidationDelay = 0.25)]
     public virtual async Task<bool> IsReadingTail(ChatId chatId, CancellationToken cancellationToken)
     {
-        // Must stay in sync with what actually advances the read position (ChatView) - suppressing
-        // the unread badge for a chat whose read position isn't moving would hide real unread messages.
         if (!await IsSelected(chatId).ConfigureAwait(false))
             return false;
 
@@ -333,14 +331,14 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         if (itemVisibility.ChatId != chatId || !itemVisibility.IsPinnedToEnd)
             return false;
 
+        // Not the reading grace period the read position waits for: the chat on screen, pinned to
+        // its tail, has nothing to tell the user through a badge, and a listener who had not touched
+        // anything for three minutes used to watch it count up. What keeps hiding it honest is
+        // ChatView advancing the read position on the interaction that ends the idle stretch, so what
+        // the badge hides is read before it could show anywhere else. A hidden document still counts
+        // as not reading.
         var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);
-        var readingUntil = lastPresentAt + Constants.Chat.ReadingGracePeriod;
-        var now = Clocks.CpuClock.Now;
-        if (readingUntil <= now)
-            return false;
-
-        Computed.GetCurrent().Invalidate(readingUntil - now);
-        return true;
+        return lastPresentAt != Moment.MinValue;
     }
 
     // The non-reactive half of IsReadingTail, for the JS-driven callbacks that can't await:

--- a/src/dotnet/UI.Blazor.App/Services/ChatVideoUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatVideoUI.cs
@@ -90,6 +90,9 @@ public partial class ChatVideoUI : UIWorkerBase<AppUIHub>, IComputeService, INot
     public virtual async Task<ChatId?> GetWatchingChatId(CancellationToken cancellationToken = default)
         => await _watchingChatId.Use(cancellationToken).ConfigureAwait(false);
 
+    // The non-reactive form of GetWatchingChatId, for callbacks that can't await.
+    public ChatId? WatchingChatId => _watchingChatId.Value;
+
     [ComputeMethod]
     public virtual async Task<bool> IsWatching(ChatId chatId, CancellationToken cancellationToken = default)
         => await GetWatchingChatId(cancellationToken).ConfigureAwait(false) == chatId;

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -153,6 +153,16 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         return await ChatVideoUI.IsWatching(chatId, cancellationToken).ConfigureAwait(false);
     }
 
+    // The non-reactive form of AmIInLiveConversation, for callbacks that can't await.
+    public bool IsInLiveConversation(ChatId chatId)
+    {
+        var activeChats = ActiveChatsUI.ActiveChats.Value;
+        if (activeChats.TryGetValue(chatId, out var activeChat) && (activeChat.IsListening || activeChat.IsRecording))
+            return true;
+
+        return ChatVideoUI.WatchingChatId == chatId;
+    }
+
     public Task SetParticipation(
         ChatId chatId,
         ParticipationKind kind,

--- a/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
@@ -101,16 +101,19 @@
                 }
             }
 
-            <li @key="@VirtualListSpecialKeys.EndSpacer"
-                class="c-spacer-end">
-                <VirtualListSkeletonView SkeletonCount="@endSkeletonCount" Skeleton="@Skeleton" SkeletonBatch="@SkeletonBatch"/>
-            </li>
-
             @* In-flow end marker right after the content: visible only when scrolled to the newest,
-               which drives sticky-end detection (top-to-bottom layout, no reverse rendering). *@
+               which drives sticky-end detection (top-to-bottom layout, no reverse rendering). It has
+               to precede the end spacer: the End pin aims at this element, and behind the spacer it
+               would drag an End-pinned list a spacer's height down into the skeletons whenever the
+               end of the data stops being known. *@
             <li @key="@VirtualListSpecialKeys.EndAnchor"
                 class="c-end-anchor">
                 &nbsp;
+            </li>
+
+            <li @key="@VirtualListSpecialKeys.EndSpacer"
+                class="c-spacer-end">
+                <VirtualListSkeletonView SkeletonCount="@endSkeletonCount" Skeleton="@Skeleton" SkeletonBatch="@SkeletonBatch"/>
             </li>
 
         </ul>

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -82,10 +82,6 @@ const QuietStillFrames = 3;
 // it is shifted back - tens of thousands of messages, and the shift itself is free because it only
 // happens at a standstill.
 const RecentreReservePercent = 20;
-// Leaving "the whole conversation fits on screen" costs a jump of the end anchor's whole height, so a
-// chain hovering at exactly one viewport - a transcript growing and shrinking by a line - must not
-// toggle it on every measure.
-const ChainFittingExitPx = 64;
 const InteractiveAnchorTtlMs = 2000;
 // A WASM render can arrive several seconds after its click; the screen anchor has to survive until
 // that replacement DOM exists, while its shorter active hold starts only once placement begins.
@@ -256,7 +252,6 @@ export class InfiniteList extends VirtualList {
     private isAwaitingJump = false;
     private isInitiallyPlaced = false;
     private isApplyingRender = false;
-    private isChainWithinViewport = false;
     private mustRecentre = false;
     private lastWrapperSize = 0;
     private handledScrollToKey: string | null = null;
@@ -780,7 +775,6 @@ export class InfiniteList extends VirtualList {
     }
 
     private applyLayout(reason: string): void {
-        this.updateChainFitting();
         // Re-read every time rather than trusted from construction: the clamp depends on
         // devicePixelRatio, which changes when the window moves to another display or the page is
         // zoomed, and a stale value here is a chain drawn nowhere near its scroll position.
@@ -962,18 +956,26 @@ export class InfiniteList extends VirtualList {
         return this.renderState.hasVeryLastItem ? 0 : this.spacerSize;
     }
 
-    // Whether the whole conversation is loaded and short enough to show at once - both edges on screen
-    // together, so the view has one correct resting place with the first item at the top.
-    private updateChainFitting(): void {
+    // How much of the end anchor the bottom limit honours. The anchor keeps the newest message clear of
+    // the editor, but a whole conversation that fits on screen has nothing to keep clear of anything,
+    // and honouring it there pushes the first message off the top of a list that cannot scroll back. So
+    // around one viewport it is honoured only as far as it fits: below that size, as much as the slack
+    // above the chain allows; above it, growing with the overflow. The limit is continuous through the
+    // crossing, so a transcript growing and shrinking by a line there follows rather than jumps by the
+    // anchor's height - which is what the hysteresis this replaces was for, at the price of hiding up
+    // to its own width of the newest content.
+    private get honouredEndAnchorSize(): number {
         const rs = this.renderState;
-        if (!rs.hasVeryFirstItem || !rs.hasVeryLastItem || this.items.length === 0) {
-            this.isChainWithinViewport = false;
-            return;
-        }
+        if (!rs.hasVeryFirstItem || !rs.hasVeryLastItem || this.items.length === 0)
+            return this.endAnchorSize;
 
-        const limit = this.ref.clientHeight;
-        this.isChainWithinViewport =
-            this.chainSize <= (this.isChainWithinViewport ? limit + ChainFittingExitPx : limit);
+        return Math.min(this.endAnchorSize, Math.abs(this.ref.clientHeight - this.chainSize));
+    }
+
+    // What the anchor is short of at the bottom limit: the newest content is flush with the end there
+    // while the anchor's bottom hangs that far below the fold.
+    private get endAnchorSlack(): number {
+        return this.endAnchorSize - this.honouredEndAnchorSize;
     }
 
     private applyRenderIntent(rs: VirtualListRenderState): void {
@@ -1089,12 +1091,11 @@ export class InfiniteList extends VirtualList {
             return;
         }
 
-        // A chain that fits on screen rests with its first item at the top, which leaves the end anchor
-        // hanging below the fold - so the end is reached there by construction, however far the anchor
-        // says it is. Without this an End-edge list would settle on Start and stop following new
-        // messages until the conversation outgrew the viewport.
+        // Around one viewport the bottom limit leaves the anchor's slack hanging below the fold, so the
+        // end is reached with the anchor that far out. Without this an End-edge list would settle on
+        // Start and stop following new messages until the conversation outgrew the viewport.
         const isAtEnd = rs.hasVeryLastItem
-            && (this.isChainWithinViewport || (this.distanceToEndEdge() ?? Infinity) <= EdgeEpsilon);
+            && (this.distanceToEndEdge() ?? Infinity) <= this.endAnchorSlack + EdgeEpsilon;
         // Leaving the far edge for this one is a claim about where the reader is, and a window that
         // can't see its last item has no basis for it - while distanceToStartEdge has no lower bound, so
         // a chain hanging below the viewport top satisfies it as readily as one flush with it. A
@@ -1178,9 +1179,13 @@ export class InfiniteList extends VirtualList {
             }
         }
         const target = clamp(scrollOffset + delta, 0, maxScrollOffset);
-        // Same cap as computeScrollLimits: the end anchor must not push the first message off the top
-        // of a conversation that fits on screen.
-        return this.isChainWithinViewport ? Math.min(target, this.chainStart) : target;
+        // Same cap as computeScrollLimits: only the honoured part of the anchor may pull the view past
+        // the newest content. Left to the DOM measure where nothing is capped, so a model a pixel short
+        // cannot stop the re-pin from landing flush.
+        const honoured = this.honouredEndAnchorSize;
+        return edge === VirtualListEdge.End && honoured < this.endAnchorSize
+            ? Math.min(target, this.chainEnd + honoured - this.ref.clientHeight)
+            : target;
     }
 
     // A follow moves the position the user is at, so it moves the scroll position - the term the
@@ -1463,13 +1468,8 @@ export class InfiniteList extends VirtualList {
         // the scroller enforces itself can't rubber-band. Blank space below the newest item is now
         // unreachable only because this says so, the same way the top is.
         let max = rs.hasVeryLastItem
-            ? this.chainEnd + this.endAnchorSize - this.ref.clientHeight
+            ? this.chainEnd + this.honouredEndAnchorSize - this.ref.clientHeight
             : this.chainEnd + this.maxOverscroll - this.ref.clientHeight;
-        // The end anchor is blank space under the newest message, sized to keep it clear of the editor.
-        // A whole conversation that fits on screen has nothing to keep clear of anything, and honouring
-        // the anchor there scrolls the first message off the top of a list that cannot scroll back.
-        if (this.isChainWithinViewport)
-            max = Math.min(max, this.chainStart);
         if (min > max) {
             if (this.defaultEdge === VirtualListEdge.End)
                 min = max;
@@ -2084,12 +2084,11 @@ export class InfiniteList extends VirtualList {
         // Never true while the tab is in the background: the list stays flush at its edge there, and the
         // chat view reads this flag as "the user is looking at the newest message" to advance the read
         // position - so reporting it would mark messages read that nobody has seen.
-        // A conversation that fits on screen rests with its first item at the top, which leaves the end
-        // anchor's blank space hanging below the fold - the newest message is on screen all the same,
-        // and without this it would never be marked read.
+        // Around one viewport the bottom limit leaves the anchor's slack below the fold - the newest
+        // message is on screen all the same, and without this it would never be marked read.
         const isEndAnchorVisible = !document.hidden
             && this.renderState.hasVeryLastItem
-            && (this.isChainWithinViewport || (this.distanceToEndEdge() ?? Infinity) <= EdgeEpsilon);
+            && (this.distanceToEndEdge() ?? Infinity) <= this.endAnchorSlack + EdgeEpsilon;
         // A level signal for the badge gate: stays true while the list follows its end edge, even
         // when a streaming expansion momentarily pushes the anchor out before the follow catches up.
         const isPinnedToEnd = isEndAnchorVisible || this.pinnedEdge === VirtualListEdge.End;
@@ -2324,13 +2323,9 @@ export class InfiniteList extends VirtualList {
             return rect.height > 0 && rect.bottom > viewRect.top && rect.top < viewRect.bottom;
         }
 
-        // Fitting on screen means reaching neither edge, and the slack below the top is where it rests -
-        // so this asks only that the first item isn't clipped off the top.
-        if (this.isChainWithinViewport)
-            return this.distanceToStartEdge() <= RevealEpsilon;
-
+        // At the end the anchor rests its slack below the fold, so that is where "flush" is.
         return this.defaultEdge === VirtualListEdge.End
-            ? Math.abs(this.distanceToEndEdge() ?? Infinity) <= RevealEpsilon
+            ? Math.abs((this.distanceToEndEdge() ?? Infinity) - this.endAnchorSlack) <= RevealEpsilon
             : Math.abs(this.distanceToStartEdge()) <= RevealEpsilon;
     }
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -29,6 +29,8 @@ const UpdateViewportIntervalMs = 64;
 const UpdateVisibilityIntervalMs = 250;
 const ScrollSettleMs = 200;
 const ProgrammaticScrollGuardMs = DeviceInfo.isMobile ? 250 : 100;
+// How long a wheel away from the pinned edge waits for the scroll it produces before it is forgotten.
+const WheelAwayWindowMs = 300;
 const SmoothScrollMs = 500;
 const EdgeEpsilon = 4;
 const VisibilityEpsilon = 4;
@@ -213,6 +215,7 @@ export class InfiniteList extends VirtualList {
     private pinnedEdge: VirtualListEdge | null = null;
     private endAnchorSize = 0;
     private lastProgrammaticScrollAt = 0;
+    private wheelAwayAt = 0;
     private isWatchingStillness = false;
     private isAwaitingOverscrollEnd = false;
     private isNearSkeleton = false;
@@ -1685,14 +1688,25 @@ export class InfiniteList extends VirtualList {
         this.turnOffIsScrollingDebounced();
         if (!event.isTrusted)
             return;
+        // A wheel away from the pinned edge is the user's however its scroll lands - inside the guard
+        // window as often as not, while content is resizing and re-pinning - and it drops the pin
+        // outright, since the position it lands on may still read as the edge. But only on the scroll
+        // it produced: a wheel that scrolls nothing - a chat that fits on screen, a scroller nested in a
+        // message - has not left the edge, and a pin dropped there had nothing to put it back until the
+        // next render's clamp.
+        const isWheelAway = performance.now() - this.wheelAwayAt < WheelAwayWindowMs;
         // The scroll a re-pin or a re-centre just wrote isn't the user moving, and reading it as one
         // would drop the very pin that produced it.
-        if (performance.now() - this.lastProgrammaticScrollAt < ProgrammaticScrollGuardMs)
+        if (!isWheelAway && performance.now() - this.lastProgrammaticScrollAt < ProgrammaticScrollGuardMs)
             return;
 
+        this.wheelAwayAt = 0;
         this.interactiveAnchor = null;
         this.releaseScreenAnchor();
-        this.updatePinnedEdge();
+        if (isWheelAway)
+            this.setPinnedEdge(null);
+        else
+            this.updatePinnedEdge();
         this.updateViewportThrottled();
     };
 
@@ -1710,9 +1724,8 @@ export class InfiniteList extends VirtualList {
         this.updateVisibilityThrottled();
     };
 
-    // A wheel gesture says the user wants to leave the edge even when the scroll it produces lands
-    // inside the programmatic-scroll guard - which it routinely does while content is resizing and
-    // re-pinning. Without this the pin survives and the next re-pin drags the view back.
+    // A wheel gesture away from the pinned edge says the user wants to leave it; onScroll acts on that
+    // when the scroll it produces arrives, whether or not that scroll lands inside the guard window.
     private onWheel = (event: WheelEvent): void => {
         // Momentum scrolling on mobile also arrives as wheel events; there onScroll is enough. A
         // ctrl+wheel is a pinch-zoom, which doesn't scroll the list at all.
@@ -1723,7 +1736,7 @@ export class InfiniteList extends VirtualList {
             ? event.deltaY < 0
             : event.deltaY > 0;
         if (isAwayFromEdge)
-            this.setPinnedEdge(null);
+            this.wheelAwayAt = performance.now();
     };
 
     private readonly turnOffIsScrollingDebounced = debounce(() => this.turnOffIsScrolling(), ScrollSettleMs);

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -429,10 +429,14 @@ export class ScrollController {
 
         const boundary = this.getViolatedBoundary(scrollTop);
         if (boundary === null) {
-            // Back inside under its own power; `over` has been integrated to zero and the transform
-            // with it, so there is nothing to hand back.
+            // Back inside. Under its own power `over` has been integrated to zero and the transform
+            // with it, so the write below is a no-op. Under a limit that moved past the finger - the
+            // page of history the pull itself asked for, arriving mid-pull - the transform still holds
+            // the curve's share of the pull, and dropping it is a step of that size on screen. Handed
+            // back at the position that keeps the content where it is instead: the renumbering a catch
+            // performs, so the drag carries on from there with nothing owed.
             if (this.phase === 'following')
-                this.endPhase(null);
+                this.endPhase(scrollTop - this.overscrollOffset);
 
             return;
         }


### PR DESCRIPTION
Two chat-view list bugs, each fixed in its own commit, plus a data-side backstop for the first.

## 1. Skeletons under a live conversation at the end of the chat

**Mechanism.** The End pin aims at the end anchor `<li>`, and the anchor was rendered *behind* the end spacer. Any render in which `HasVeryLastItem` flips to false grows the spacer to 1500px between the newest message and the anchor, and `repinEdge('render')` follows the anchor down: newest messages at the top, skeletons filling the rest — the screenshot exactly. Once the view sits on skeletons the list issues a query, which is what defeats ChatView's `query.IsNone` stale-tail guard, so the state could persist.

**Fix.** `InfiniteList.razor`: the anchor now precedes the spacer, as its own comment said it should. Reproduced mechanically on `the-actual-one` by faking `hasVeryLastItem=false` + `applyLayout` + `repinEdge`: with the old order the last item moved 1548px up and the skeletons covered the viewport; with the new order nothing moves and the spacer sits below the fold.

**Backstop.** `ChatUI.Tiles`: a loaded window whose last id tile reaches the chat's fresh id range end has nothing after it, whatever the (possibly serve-stale) range meta says — symmetric with how `hasVeryFirstItem` is already decided. The live run on local did show `staleTail=True` rebuilds on a non-joined viewer.

## 2. A short chat that grows past the viewport cannot be scrolled to its end

**Mechanism.** "Fits on screen" was a flag with 64px of hysteresis that capped the bottom limit at `chainStart` while set. Inside the band the cap hid up to 64px plus the anchor of the newest messages, and the flag was never re-evaluated on a viewport resize (a keyboard opening on a chat that had fit left it stuck the same way).

**Fix.** `infinite-list.ts`: the limit adds only as much of the anchor as fits — all of it once the content overflows the viewport by the anchor's height, less around one viewport, growing with the overflow. That is continuous through the crossing, so nothing jumps and nothing is ever beyond the reachable limit; the hysteresis and the flag are gone, and edge pinning / read tracking / initial reveal read the end through the anchor's slack. Verified by sweeping the viewport height through the band on a narrow layout (48px anchor): the last message never drops below the fold, the range opens at 2px per px of overflow, the anchor returns in full at overflow = 48.

`docs/ui/virtual-list.md` §3.8 and the glossary describe the new rule and the anchor order.

## How to test manually

**Short chat that outgrows the viewport (bug 2)**
1. Create a new group chat (or open any chat with only a handful of messages) and stay at the bottom.
2. Post messages (from this or another account) until the content is a little taller than the viewport — one or two lines past the fold is the interesting zone. Before the fix the last line(s) could not be scrolled into view; now the list follows and the last message is always reachable.
3. Faster variant: open a short chat that fits, then shrink the browser window height (or, on a phone, open the keyboard) so the content overflows by less than ~60px. Before: the bottom of the last message is cut off and the list won't scroll. After: the last message stays flush above the editor.
4. Repeat at phone width (`body.narrow`, 48px end anchor) — that is where the hidden band was largest.
5. Optional: `debugUI.showVirtualListOverlay(true)` in the console shows the green `]` pinned-end marker throughout.

**Skeletons under a live conversation (bug 1)**
- Real scenario (3 users): two accounts record in the same chat (`ai chrome*2 --fake-media` gives fake mics; sign in with `debugUI.signIn('+1 555 555 555X')`), a third opens the chat without joining and stays pinned at the bottom. Watch the live block at the end of the chat for a few minutes: no skeleton rows may appear under it and the newest lines must stay flush with the editor.
- Deterministic check (any chat, scrolled to the bottom, DevTools console) — this is the exact render the bug needed:
  ```js
  const il = [...InfiniteList.instances][0];
  il.requestData = async () => {};                       // keep Blazor from re-rendering during the check
  il.renderState = { ...il.renderState, hasVeryLastItem: false };
  il.applyLayout('test'); il.repinEdge('test');
  ```
  Expected: nothing moves; the 1500px skeleton spacer is below the fold (scroll down to see it). Before the fix the last message jumped ~1500px up and skeletons filled the viewport. Reload the page to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ng2LK65p44ysTh7xLZbfF
