### PR TITLE
fix(virtual-list): review pass — wheel unpin, band hand-back under the finger, idle unread badge

### DIFF
--- a/.claude/skills/virtual-list-debug/SKILL.md
+++ b/.claude/skills/virtual-list-debug/SKILL.md
@@ -216,10 +216,9 @@ reproduce iOS choosing an unscrollable target before `touchstart`: `catch-drag` 
 controller releases its lock and preserves geometry, not that the same caught gesture can resume
 native scrolling on iOS.
 
-> **Known gap:** both `rig.mjs` and `soak.mjs` still call
-> `globalThis.debugUI?.listVirtualListViolations?.(true) ?? []`, which no longer exists. The
-> `violations` column in their output is therefore **always 0** and proves nothing. The checker they
-> enable still warns to the console — read it there until those two call sites are replaced.
+> Both scripts turn the checker on and collect its console warnings over CDP themselves
+> (`Runtime.consoleAPICalled`), so the `violations` column is the checker's real verdict for the run;
+> the traces under `tmp/traces/` carry the same list as `violations`.
 
 ### 1.5 The recorder — `tools/virtual-list-rig/recorder.js`
 

--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -492,7 +492,7 @@ overscroll rows are the summary of §3.7.*
 | a scroll event past a limit, finger down | in-band → following | latch the boundary; seed `over` at the true excursion and the transform at its resisted share; each frame after: `over += Δscroll`, nudge by the resisted share | `transform` |
 | a scroll event past a limit, no finger, ordinary path | in-band → engaged | the same seed, the carry seeded from the fling's speed, then the bounce and the floor per frame | `transform` |
 | a scroll event past a limit, no finger, iOS/WebKit | in-band → engaged + momentum `arming` | seed the same band, estimate the recent native velocity, then perform the next-frame lock/FLIP handoff | `transform`, then `scrollTop` + `transform` |
-| the finger comes back inside | following → in-band | nothing: `over` and the transform are already zero | — |
+| the finger comes back inside | following → in-band | nothing under its own power: `over` and the transform are already zero. Under a limit that moved past the finger the transform still holds the curve's share, so the hand-back writes `scrollTop` by exactly that as it drops the transform — the content stays put and the drag carries on | `scrollTop` + `transform` |
 | `touchend` past the boundary, ordinary path | following → engaged | an outward release carries its speed into a bounce; each frame shows the browser's motion resisted, the carry tops it up until it turns, the floor adds only its shortfall after that; the browser's outward fling is ended by `killMomentum` | `transform` |
 | `touchend` past the boundary, iOS/WebKit | following → engaged + momentum `arming` | estimate the release speed from the recent native samples; on the next frame force the overflow lock, snap `scrollTop` to the boundary and FLIP the measured visual delta into the content transform; momentum `transform` then runs the critically damped return | `scrollTop` + `transform`, same frame; then `transform` |
 | `touchstart` during a return | engaged → following | release any takeover lock, integrate what the scroll did since the last frame, then write `scrollTop := boundary + over`, read back, and take the same delta out of the transform | `scrollTop` + `transform`, same frame |
@@ -828,7 +828,8 @@ rules:
    part only by `nudge(delta)`. During the iOS takeover the first FLIP is also a nudge, after which the
    spring owns and assigns `overscrollOffset`.
 2. **Every `scrollTop` write is named and read back.** The ordinary path writes for a catch, settle,
-   wheel/cancel/watchdog end, tiny or non-touch crossing, and the owner's `scrollTo` / clamp. The iOS
+   wheel/cancel/watchdog end, tiny or non-touch crossing, a limit that moved past a following finger,
+   and the owner's `scrollTo` / clamp. The iOS
    path additionally snaps to the boundary after forcing the overflow lock, and repeats that snap if
    native movement leaks through. Only the measured visual effect of a write is transferred into the
    transform. Anything else that wants to correct a moving view moves the scroll position or the
@@ -947,8 +948,13 @@ device pixel counts as landed. Dropping the
 transform before the write, which an earlier version did, was a step of the whole leak whenever the
 write was refused.
 
-**Ending inside the band under a finger** writes nothing and drops nothing: by the time the scroll is
-back inside, `over` has been integrated to zero and the transform with it, so letting go moves nothing.
+**Ending inside the band under a finger** writes nothing and drops nothing when the finger brought it
+back: by then `over` has been integrated to zero and the transform with it, so letting go moves nothing.
+When a limit moved past the finger instead — the page of history the pull itself asked for, arriving
+mid-pull — the transform still holds the curve's share of the pull, and dropping it was a step of that
+size on screen. The hand-back is the renumbering a catch performs: `scrollTop` is written by exactly
+that share as the transform drops, so the content stays where it is and the drag carries on. Measured
+with the soak: six such ends per run, 1-24px each, every one landing on the compensated position.
 A release from inside the band is a release, not a bounce: `engage` checks the position, and a finger
 that crossed back in and lifted — still `following`, because ending that phase waits on a scroll
 event a release does not produce — ends the excursion instead of springing at the edge it just passed.
@@ -2088,22 +2094,11 @@ can see no chats at all".
 
 ## 7. Known open issues
 
-*What is known not to be done: a load that moves the limits under a dragging finger drops the band; the
+*What is known not to be done: the
 two per-frame `scrollTop` writers are unmeasured on a device; the `auto` inset reading is verified on
 Blink only; `reanchor` holds the viewport top in both directions; a fling read through loading history
 is unmeasured; a touch that lands during the short iOS lock cannot scroll in that same gesture; and a
 long hold trips the stale-touch backstop.*
-
-- **A load that moves the limits outward under a dragging finger drops the excursion.**
-  `ScrollController.onScroll` asks `getViolatedBoundary` where the scroll is, and a limit that moved
-  past it while the finger was still pulling answers "in band" — so `endPhase(null)` runs, `over` goes
-  to zero and the band transform is discarded in one frame. Measured with the soak's 60 gestures: six
-  or seven occurrences per run, with `over` up to 180px, which is ~24px of transform vanishing in a
-  frame; the rig's `bad-ends` catches it only when the next frame happens to be outside the limits, so
-  a soak run passes or fails on timing. **It predates the translation work** — a soak against the
-  previous commit reproduces the same six occurrences and the same `bad-ends 1`. The fix is for the
-  crossing to be re-aimed rather than abandoned, the way `scrollTo`'s `reanchor` path already does it:
-  a limit that moves under an open excursion should move the latched boundary with it.
 
 - **Two things write `scrollTop` per frame, and §4.7 is about exactly that.** While an item's height
   animates, the pinned edge moves every frame, so the follow writes every frame; an expand hold does

--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -507,7 +507,7 @@ overscroll rows are the summary of §3.7.*
 | `repinEdge` called during an excursion | Pinned → awaiting overscroll end | deferred; past a boundary the measured position is not the visible one and the write would snap the bounce | — |
 | `scrollToKey` that is not the newest item | any → Placing | suppress new height animations, wait out the ones in flight, then place the item at `center` or `end` | `container.top` then `scrollTop` |
 | `scrollToKey` that *is* the newest item, end loaded | any → Pinned End | pin and re-pin, which in reverse is a follow of a few pixels or nothing at all — so a message you just posted still animates in | `scrollTop` |
-| the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop `onWheel` also clears the pin even inside the guard window | — |
+| the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop the scroll a wheel away from the edge produced clears the pin outright, even inside the guard window — but only that scroll: a wheel that scrolls nothing (a chat that fits on screen, a scroller nested in a message) leaves the pin alone | — |
 | a `data-vl-hold` control is clicked or tapped | Pinned → Free, interactive anchor set | the clicked item is what the next render holds; `keep-edge` controls leave a pinned list alone; expires after 2s | — |
 | a `data-vl-hold` control marked `data-anchor="below"` | Pinned → Free, key-addressed screen anchor set | the first content item below the control keeps its rendered position; placed only by the render that inserts content directly above that item, however many unrelated renders land first | — |
 | a `data-vl-hold` control inside a `data-vl-anchor` element | Pinned → Free, screen anchor set | the element's rendered screen position is recorded; unpinning is what gives the chain its top anchor (§3.2) | — |
@@ -713,8 +713,11 @@ The follow writes `scrollTop` again — and deliberately does **not** open that 
 never close. It is recognised the other way instead: `followBy` reports where the write landed, and
 the next scroll event standing on that exact value is dropped whole, while the first event anywhere
 else is the user's. So the guard proper is only open after a genuine jump — opening a chat, a
-`scrollToKey`, a re-centre — where suppressing the handler is what we want. `onWheel` remains the
-escape hatch on desktop.
+`scrollToKey`, a re-centre — where suppressing the handler is what we want. A wheel away from the edge
+remains the escape hatch on desktop: `onWheel` only notes it, and the scroll it produces inside
+`WheelAwayWindowMs` (300ms) drops the pin whatever the guard says. Noting rather than dropping is what
+keeps a wheel that scrolls nothing — a chat that fits on screen, a scroller nested in a message — from
+leaving the list unpinned with nothing to put the pin back until the next render's clamp.
 
 #### Stranded recovery
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -316,7 +316,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         }
 
         ChatUI.SetItemVisibility(itemVisibility);
-        var isUserPresent = ChatUI.IsUserPresent();
+        var isUserPresent = ChatUI.IsUserPresent(Chat.Id);
         if (itemVisibility.IsEndAnchorVisible) {
             _lastEndAnchorVisibleAt = CpuTimestamp.Now;
             if (isUserPresent)
@@ -348,7 +348,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         // messages that arrived meanwhile - which the badge no longer shows (ChatUI.IsReadingTail).
         // The interaction that ends the stretch catches it up, before that interaction can take the
         // user anywhere the count would surface.
-        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent())
+        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent(Chat.Id))
             return;
 
         var itemVisibility = ItemVisibility.Value;
@@ -412,7 +412,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 // count never rises for the chat being watched. The !IsEmpty guard keeps a retained
                 // pinned flag from marking anything read while no items are actually rendered.
                 var itemVisibility = ItemVisibility.Value;
-                if (itemVisibility.IsPinnedToEnd && !itemVisibility.IsEmpty && ChatUI.IsUserPresent())
+                if (itemVisibility.IsPinnedToEnd && !itemVisibility.IsEmpty && ChatUI.IsUserPresent(Chat.Id))
                     UpdateReadPosition(lastEntryLid);
                 continue;
             }
@@ -840,7 +840,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (items.Count == 0)
             return false; // Not loaded yet or wrong load range
 
-        if (!ChatUI.IsUserPresent()) {
+        if (!ChatUI.IsUserPresent(Chat.Id)) {
             DebugLog?.LogDebug("TryUpdateShownReadEntryLid: the user isn't at the screen");
             return false;
         }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -120,6 +120,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _shownReadEntryLid.Value = readPosition.EntryLid;
             if (_viewPositionLease.Resource.Value.EntryLid is 0 && readPosition.EntryLid > 0)
                 _viewPositionLease.Resource.Value = readPosition;
+            Hub.UserActivityUI.LastPresentAt.Updated += OnPresenceUpdated;
             _whenInitializedSource.TrySetResult();
             ChatSwitchTracer.Mark("ChatView.OnInitializedAsync: WhenInitialized SET",
                 $"readEntryLid={readPosition.EntryLid}");
@@ -169,6 +170,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         _readPositionLease.DisposeSilently();
         ChatUI.ResetItemVisibility(Chat.Id);
         Nav.LocationChanged -= OnLocationChanged;
+        Hub.UserActivityUI.LastPresentAt.Updated -= OnPresenceUpdated;
         _isHoverMenuDisposed = true;
         if (_hoverMenuJsRefTask is { IsCompletedSuccessfully: true } jsRefTask)
             _ = jsRefTask.Result.DisposeSilentlyAsync("dispose");
@@ -318,7 +320,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         if (itemVisibility.IsEndAnchorVisible) {
             _lastEndAnchorVisibleAt = CpuTimestamp.Now;
             if (isUserPresent)
-                _ = UpdateReadPositionToTheLastId(Chat.Id);
+                _ = UpdateReadPositionToTheLastId();
         }
         else if (isUserPresent)
             UpdateReadPosition(itemVisibility.MaxEntryLid);
@@ -328,17 +330,32 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             var entryId = itemVisibility.MaxMessageLid;
             _viewPositionLease.Resource.Value = new ReadPosition(Chat.Id, entryId);
         }
-        return;
+    }
 
-        async Task UpdateReadPositionToTheLastId(ChatId chatId)
-        {
-            var chatInfo = await ChatUI.Get(chatId, DisposeToken).ConfigureAwait(true);
-            var lastId = chatInfo?.News?.TextEntryLidRange.End - 1;
-            if (lastId is not > 0)
-                return;
+    private async Task UpdateReadPositionToTheLastId()
+    {
+        var chatInfo = await ChatUI.Get(Chat.Id, DisposeToken).ConfigureAwait(true);
+        var lastId = chatInfo?.News?.TextEntryLidRange.End - 1;
+        if (lastId is not > 0)
+            return;
 
-            UpdateReadPosition(lastId.Value);
-        }
+        UpdateReadPosition(lastId.Value);
+    }
+
+    private void OnPresenceUpdated(IState state, StateEventKind eventKind)
+    {
+        // The read position waits for presence, so an idle stretch at the tail leaves it behind the
+        // messages that arrived meanwhile - which the badge no longer shows (ChatUI.IsReadingTail).
+        // The interaction that ends the stretch catches it up, before that interaction can take the
+        // user anywhere the count would surface.
+        if (eventKind != StateEventKind.Updated || !ChatUI.IsUserPresent())
+            return;
+
+        var itemVisibility = ItemVisibility.Value;
+        if (!itemVisibility.IsPinnedToEnd || itemVisibility.IsEmpty)
+            return;
+
+        _ = UpdateReadPositionToTheLastId();
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -39,6 +39,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private IAccounts Accounts => Hub.Accounts;
     private BrowserInfo BrowserInfo => Hub.BrowserInfo;
     private UserActivityUI UserActivityUI => Hub.UserActivityUI;
+    private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
     private NotificationsUI NotificationsUI => Hub.NotificationsUI;
     private IAvatars Avatars => Hub.Avatars;
     private IAuthors Authors => Hub.Authors;
@@ -336,15 +337,24 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         // anything for three minutes used to watch it count up. What keeps hiding it honest is
         // ChatView advancing the read position on the interaction that ends the idle stretch, so what
         // the badge hides is read before it could show anywhere else. A hidden document still counts
-        // as not reading.
+        // as not reading - unless the user is in this chat's live conversation, which goes on with the
+        // screen untouched, or off.
         var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);
-        return lastPresentAt != Moment.MinValue;
+        if (lastPresentAt != Moment.MinValue)
+            return true;
+
+        return await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
     }
 
     // The non-reactive half of IsReadingTail, for the JS-driven callbacks that can't await:
     // the document is visible and the user interacted recently enough to still be at the screen.
     public bool IsUserPresent()
         => UserActivityUI.LastPresentAt.Value + Constants.Chat.ReadingGracePeriod > Clocks.CpuClock.Now;
+
+    // Presence for reading one chat: the input above, or being in that chat's live conversation -
+    // listening and recording are the interaction there, whatever the pointer and the screen do.
+    public bool IsUserPresent(ChatId chatId)
+        => IsUserPresent() || LiveSessionUI.IsInLiveConversation(chatId);
 
     [ComputeMethod(ConsolidationDelay = 0.3)]
     public virtual async Task<bool> IsUnreadByOthers(

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -324,8 +324,6 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     [ComputeMethod(ConsolidationDelay = 0.25)]
     public virtual async Task<bool> IsReadingTail(ChatId chatId, CancellationToken cancellationToken)
     {
-        // Must stay in sync with what actually advances the read position (ChatView) - suppressing
-        // the unread badge for a chat whose read position isn't moving would hide real unread messages.
         if (!await IsSelected(chatId).ConfigureAwait(false))
             return false;
 
@@ -333,14 +331,14 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         if (itemVisibility.ChatId != chatId || !itemVisibility.IsPinnedToEnd)
             return false;
 
+        // Not the reading grace period the read position waits for: the chat on screen, pinned to
+        // its tail, has nothing to tell the user through a badge, and a listener who had not touched
+        // anything for three minutes used to watch it count up. What keeps hiding it honest is
+        // ChatView advancing the read position on the interaction that ends the idle stretch, so what
+        // the badge hides is read before it could show anywhere else. A hidden document still counts
+        // as not reading.
         var lastPresentAt = await UserActivityUI.LastPresentAt.Use(cancellationToken).ConfigureAwait(false);
-        var readingUntil = lastPresentAt + Constants.Chat.ReadingGracePeriod;
-        var now = Clocks.CpuClock.Now;
-        if (readingUntil <= now)
-            return false;
-
-        Computed.GetCurrent().Invalidate(readingUntil - now);
-        return true;
+        return lastPresentAt != Moment.MinValue;
     }
 
     // The non-reactive half of IsReadingTail, for the JS-driven callbacks that can't await:

--- a/src/dotnet/UI.Blazor.App/Services/ChatVideoUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatVideoUI.cs
@@ -90,6 +90,9 @@ public partial class ChatVideoUI : UIWorkerBase<AppUIHub>, IComputeService, INot
     public virtual async Task<ChatId?> GetWatchingChatId(CancellationToken cancellationToken = default)
         => await _watchingChatId.Use(cancellationToken).ConfigureAwait(false);
 
+    // The non-reactive form of GetWatchingChatId, for callbacks that can't await.
+    public ChatId? WatchingChatId => _watchingChatId.Value;
+
     [ComputeMethod]
     public virtual async Task<bool> IsWatching(ChatId chatId, CancellationToken cancellationToken = default)
         => await GetWatchingChatId(cancellationToken).ConfigureAwait(false) == chatId;

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -153,6 +153,16 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         return await ChatVideoUI.IsWatching(chatId, cancellationToken).ConfigureAwait(false);
     }
 
+    // The non-reactive form of AmIInLiveConversation, for callbacks that can't await.
+    public bool IsInLiveConversation(ChatId chatId)
+    {
+        var activeChats = ActiveChatsUI.ActiveChats.Value;
+        if (activeChats.TryGetValue(chatId, out var activeChat) && (activeChat.IsListening || activeChat.IsRecording))
+            return true;
+
+        return ChatVideoUI.WatchingChatId == chatId;
+    }
+
     public Task SetParticipation(
         ChatId chatId,
         ParticipationKind kind,

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -29,6 +29,8 @@ const UpdateViewportIntervalMs = 64;
 const UpdateVisibilityIntervalMs = 250;
 const ScrollSettleMs = 200;
 const ProgrammaticScrollGuardMs = DeviceInfo.isMobile ? 250 : 100;
+// How long a wheel away from the pinned edge waits for the scroll it produces before it is forgotten.
+const WheelAwayWindowMs = 300;
 const SmoothScrollMs = 500;
 const EdgeEpsilon = 4;
 const VisibilityEpsilon = 4;
@@ -213,6 +215,7 @@ export class InfiniteList extends VirtualList {
     private pinnedEdge: VirtualListEdge | null = null;
     private endAnchorSize = 0;
     private lastProgrammaticScrollAt = 0;
+    private wheelAwayAt = 0;
     private isWatchingStillness = false;
     private isAwaitingOverscrollEnd = false;
     private isNearSkeleton = false;
@@ -1685,14 +1688,25 @@ export class InfiniteList extends VirtualList {
         this.turnOffIsScrollingDebounced();
         if (!event.isTrusted)
             return;
+        // A wheel away from the pinned edge is the user's however its scroll lands - inside the guard
+        // window as often as not, while content is resizing and re-pinning - and it drops the pin
+        // outright, since the position it lands on may still read as the edge. But only on the scroll
+        // it produced: a wheel that scrolls nothing - a chat that fits on screen, a scroller nested in a
+        // message - has not left the edge, and a pin dropped there had nothing to put it back until the
+        // next render's clamp.
+        const isWheelAway = performance.now() - this.wheelAwayAt < WheelAwayWindowMs;
         // The scroll a re-pin or a re-centre just wrote isn't the user moving, and reading it as one
         // would drop the very pin that produced it.
-        if (performance.now() - this.lastProgrammaticScrollAt < ProgrammaticScrollGuardMs)
+        if (!isWheelAway && performance.now() - this.lastProgrammaticScrollAt < ProgrammaticScrollGuardMs)
             return;
 
+        this.wheelAwayAt = 0;
         this.interactiveAnchor = null;
         this.releaseScreenAnchor();
-        this.updatePinnedEdge();
+        if (isWheelAway)
+            this.setPinnedEdge(null);
+        else
+            this.updatePinnedEdge();
         this.updateViewportThrottled();
     };
 
@@ -1710,9 +1724,8 @@ export class InfiniteList extends VirtualList {
         this.updateVisibilityThrottled();
     };
 
-    // A wheel gesture says the user wants to leave the edge even when the scroll it produces lands
-    // inside the programmatic-scroll guard - which it routinely does while content is resizing and
-    // re-pinning. Without this the pin survives and the next re-pin drags the view back.
+    // A wheel gesture away from the pinned edge says the user wants to leave it; onScroll acts on that
+    // when the scroll it produces arrives, whether or not that scroll lands inside the guard window.
     private onWheel = (event: WheelEvent): void => {
         // Momentum scrolling on mobile also arrives as wheel events; there onScroll is enough. A
         // ctrl+wheel is a pinch-zoom, which doesn't scroll the list at all.
@@ -1723,7 +1736,7 @@ export class InfiniteList extends VirtualList {
             ? event.deltaY < 0
             : event.deltaY > 0;
         if (isAwayFromEdge)
-            this.setPinnedEdge(null);
+            this.wheelAwayAt = performance.now();
     };
 
     private readonly turnOffIsScrollingDebounced = debounce(() => this.turnOffIsScrolling(), ScrollSettleMs);

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -429,10 +429,14 @@ export class ScrollController {
 
         const boundary = this.getViolatedBoundary(scrollTop);
         if (boundary === null) {
-            // Back inside under its own power; `over` has been integrated to zero and the transform
-            // with it, so there is nothing to hand back.
+            // Back inside. Under its own power `over` has been integrated to zero and the transform
+            // with it, so the write below is a no-op. Under a limit that moved past the finger - the
+            // page of history the pull itself asked for, arriving mid-pull - the transform still holds
+            // the curve's share of the pull, and dropping it is a step of that size on screen. Handed
+            // back at the position that keeps the content where it is instead: the renumbering a catch
+            // performs, so the drag carries on from there with nothing owed.
             if (this.phase === 'following')
-                this.endPhase(null);
+                this.endPhase(scrollTop - this.overscrollOffset);
 
             return;
         }


### PR DESCRIPTION
Review pass over `InfiniteList` / `VirtualList` and their use cases (chat view, right-panel media/files/links lists, log list), on top of #4344. Each confirmed defect is its own commit.

## What was exercised (checker on, no warnings anywhere)
- History reads with `?vlloaddelay=300` (24 × 700px steps), a 6000px jump into unloaded history, a 20000px jump towards the end from history, `?n=<lid>` navigation, an unread open (new-messages line + first unread mid-viewport), a message arriving while the reader is 1500px up (view did not move), an own message sent while scrolled up (jumped to the end), conversation block expand/collapse (expand holds the control; collapse at the chat end lands the card flush), the right-panel media/files/links lists, and the touch rig: soak (60 gestures) plus the full matrix on the long chat (lock) and the short chat (lock / nolock / takeover) — all PASS.

## Fixed
1. **Wheel-unpin without a scroll.** `onWheel` dropped the End pin on the wheel event itself, so a wheel that scrolls nothing (a chat that fits on screen, a scroller nested in a message) left the list unpinned with nothing to put the pin back. The wheel now notes the intent and the scroll it produces within 300ms drops the pin, guard window or not. Verified both ways in the browser.
2. **Band dropped under a still-down finger** (docs §7, first open issue). When the page of history a pull asked for arrived mid-pull, the scroll read as in band and `endPhase(null)` discarded the transform: a 1–24px step, six times per soak run. The hand-back now writes `scrollTop` by exactly the transform it drops (the renumbering a catch performs), so the content stays put and the drag carries on. An in-page probe over the soak shows all six such ends landing on the compensated position; the judge stays clean. Removed from the known open issues.
3. **Unread badge counting up while pinned at the tail** (reported for prod, reproduced on dev). Presence is pointer/key/visibility with a 3-minute reading grace (`Constants.Chat.ReadingGracePeriod`); an idle listener pinned at the tail lost both the read-position advance and the `IsReadingTail` badge gate, and watched the badge go 1, 2, … with the list flush at the end. Two commits:
   - `IsReadingTail` no longer waits on the grace period (a hidden document still counts as not reading), and `ChatView` catches the read position up on the interaction that ends the idle stretch, so what the badge hides is read before it can surface elsewhere.
   - Being in the chat's live conversation — listening, recording, or watching — counts as being present in that chat, whatever the input says (`ChatUI.IsUserPresent(chatId)`): the read position keeps advancing for a live participant, and the badge stays off for them even with the document hidden. The grace period keeps its original meaning for everyone else.
4. `virtual-list-debug` skill: the rig's `violations` column is real (stale note removed).

`docs/ui/virtual-list.md` updated for 1 and 2.

## How to test manually

**1. Wheel-unpin (desktop Chrome/Edge)**
- Open a chat short enough to fit on screen (a new chat with two or three messages) and stay at the bottom. In DevTools, `document.querySelector('.chat-view').hasAttribute('data-sticky-end')` is `true`.
- Roll the mouse wheel up once — nothing scrolls. The attribute must stay `true`. Have another account post a message: it appears immediately, flush above the editor. Before the fix the attribute flipped to `false` on the wheel and the new message could take up to a couple of seconds to be pulled into view.
- On a long chat: wheel up → the attribute goes `false` (the pin is dropped on the scroll the wheel produced); scroll back down to the end → it returns to `true`.

**2. Band hand-back under the finger (touch)**
- On a phone, or DevTools device emulation with touch on, open a chat with a lot of history and append `?vlloaddelay=1500` to the URL so history loads slowly.
- Scroll to the top of what is loaded, then pull down past the first message and *hold the finger there* while the next page arrives (~1.5s). The content under the finger must not step or twitch when the page lands; it fills in above and the drag simply continues. Before the fix it stepped by a few pixels (up to ~24px) the moment the page arrived.
- Mechanical check: `node tools/virtual-list-rig/soak.mjs 60 9223` against a Chrome started with `ai chrome*2` and a long chat open — expect `PASS`.

**3. Unread badge while idle at the tail**
- Open a chat and stay at the bottom. Do not touch the mouse, keyboard or screen for more than 3 minutes, keeping the tab visible.
- Have another account post a message. The chat-list badge and the tab title count must not increase (before: badge `1`, then `2` with each message, with the list still flush at the end).
- Press any key or move the mouse, then switch to another chat: the chat you left shows no unread badge (the read position caught up on that interaction). Hiding the tab instead (switch to another browser tab) still lets the badge show, as intended.
- Live conversation variant: have someone record in the chat, click "Join muted" (or record yourself), then leave the device alone for over 3 minutes while the transcript keeps arriving. No badge while you are in it, and switching to another chat afterwards — without touching anything first, e.g. via a notification or a script `location.assign` — leaves no badge either: a live participant's read position keeps advancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ng2LK65p44ysTh7xLZbfF
