### PR TITLE
fix(markup): stop exponential backtracking on unbalanced style tokens

### DIFF
--- a/src/dotnet/Api/Chat/Markup/Internal/MemoParser.cs
+++ b/src/dotnet/Api/Chat/Markup/Internal/MemoParser.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using Pidgin;
+
+namespace ActualChat.Chat;
+
+// The wrapped parser must fail without consuming input, which every text block does: its first
+// element is a Try'd alternative, and once that matched the rest of it can't fail. A replayed
+// failure consumes nothing, so a parser that could fail after consuming would replay differently.
+
+/// <summary>
+/// Caches the wrapped parser's outcome per input position for the length of one parse scope,
+/// so a suffix parsed once under one enclosing span isn't parsed again under another.
+/// </summary>
+internal sealed class MemoParser(Parser<char, Markup> parser) : Parser<char, Markup>
+{
+    private readonly int _index = ParseMemo.NextParserIndex();
+
+    public override bool TryParse(
+        ref ParseState<char> state,
+        ref PooledList<Expected<char>> expecteds,
+        [MaybeNullWhen(false)] out Markup result)
+    {
+        var memo = ParseMemo.TryGetTable(_index);
+        if (memo == null)
+            return parser.TryParse(ref state, ref expecteds, out result);
+
+        var start = state.Location;
+        if (memo.TryGetValue(start, out var entry)) {
+            result = entry.Result;
+            if (result == null)
+                return false;
+
+            state.LookAhead(entry.Length);
+            state.Advance(entry.Length);
+            return true;
+        }
+
+        var isParsed = parser.TryParse(ref state, ref expecteds, out result);
+        memo[start] = isParsed ? (result, checked((int)(state.Location - start))) : (null, 0);
+        return isParsed;
+    }
+}

--- a/src/dotnet/Api/Chat/Markup/Internal/ParseBudget.cs
+++ b/src/dotnet/Api/Chat/Markup/Internal/ParseBudget.cs
@@ -1,0 +1,28 @@
+namespace ActualChat.Chat;
+
+// A parse is synchronous and runs on one thread, so the budget is a thread-static counter: Pidgin's
+// parse state has no slot for it. The nested parses a document makes (paragraph and quote bodies,
+// table cells) draw from the budget of the parse that started them, since they are part of it.
+
+/// <summary>
+/// Bounds how many alternatives one <see cref="MarkupParser"/> parse may try;
+/// <see cref="SafeOneOfParser{T}"/> spends a step per invocation.
+/// </summary>
+internal static class ParseBudget
+{
+    [ThreadStatic]
+    private static int _remaining;
+
+    public static int Remaining => _remaining;
+
+    public static void Reset(int steps)
+        => _remaining = steps;
+
+    public static void Spend()
+    {
+        if (--_remaining < 0)
+            throw new ParseBudgetExceededException();
+    }
+}
+
+internal sealed class ParseBudgetExceededException : Exception;

--- a/src/dotnet/Api/Chat/Markup/Internal/ParseMemo.cs
+++ b/src/dotnet/Api/Chat/Markup/Internal/ParseMemo.cs
@@ -1,0 +1,65 @@
+namespace ActualChat.Chat;
+
+// A scope lives for one parse: ParseRaw opens the outermost one, and every nested parse of a
+// paragraph, header, quote or table cell opens its own, since positions in its text mean nothing
+// in the enclosing one. A parse is synchronous and runs on one thread, so the scopes are
+// thread-static and pooled per thread - a warm thread allocates nothing here per parse.
+
+/// <summary>
+/// The per-parse tables behind <see cref="MemoParser"/>: one per parser, keyed by input position.
+/// </summary>
+internal static class ParseMemo
+{
+    private static int _parserCount;
+    [ThreadStatic]
+    private static Scope? _current;
+    [ThreadStatic]
+    private static Stack<Scope>? _pool;
+
+    public static int NextParserIndex()
+        => Interlocked.Increment(ref _parserCount) - 1;
+
+    public static void Push()
+    {
+        var pool = _pool ??= new Stack<Scope>();
+        var scope = pool.Count > 0 ? pool.Pop() : new Scope();
+        scope.Parent = _current;
+        _current = scope;
+    }
+
+    public static void Pop()
+    {
+        var scope = _current!;
+        _current = scope.Parent;
+        scope.Clear();
+        _pool!.Push(scope);
+    }
+
+    // Null outside of a scope, which makes a MemoParser used there a pass-through
+    public static Dictionary<long, (Markup? Result, int Length)>? TryGetTable(int parserIndex)
+        => _current?.GetTable(parserIndex);
+
+    // Nested types
+
+    private sealed class Scope
+    {
+        private Dictionary<long, (Markup? Result, int Length)>?[] _tables = [];
+
+        public Scope? Parent { get; set; }
+
+        public Dictionary<long, (Markup? Result, int Length)> GetTable(int parserIndex)
+        {
+            if (parserIndex >= _tables.Length)
+                Array.Resize(ref _tables, Math.Max(parserIndex + 1, 2 * _tables.Length));
+
+            return _tables[parserIndex] ??= new Dictionary<long, (Markup? Result, int Length)>();
+        }
+
+        public void Clear()
+        {
+            foreach (var table in _tables)
+                table?.Clear();
+            Parent = null;
+        }
+    }
+}

--- a/src/dotnet/Api/Chat/Markup/Internal/SafeOneOfParser.cs
+++ b/src/dotnet/Api/Chat/Markup/Internal/SafeOneOfParser.cs
@@ -19,6 +19,7 @@ internal sealed class SafeOneOfParser<T>(Parser<char, T>[] parsers) : Parser<cha
         ref PooledList<Expected<char>> expecteds,
         [MaybeNullWhen(false)] out T result)
     {
+        ParseBudget.Spend();
         foreach (var parser in parsers) {
             if (parser.TryParse(ref state, ref expecteds, out result))
                 return true;

--- a/src/dotnet/Api/Chat/Markup/MarkupParser.cs
+++ b/src/dotnet/Api/Chat/Markup/MarkupParser.cs
@@ -18,6 +18,7 @@ public sealed partial class MarkupParser : IMarkupParser
     public bool UseUnparsedTextMarkup { get; init; }
     public bool MustSimplify { get; init; } = true;
     public bool AllowIncompleteMarkup { get; init; }
+    public int? StepBudget { get; init; }
 
     public Markup Parse(string text)
     {
@@ -25,7 +26,7 @@ public sealed partial class MarkupParser : IMarkupParser
         if (MustSimplify && IsPlainText(text))
             return new ParagraphMarkup(new PlainTextMarkup(text));
 
-        var markup = ParseRaw(text, UseUnparsedTextMarkup, AllowIncompleteMarkup);
+        var markup = ParseRaw(text, UseUnparsedTextMarkup, AllowIncompleteMarkup, StepBudget);
         if (MustSimplify)
             markup = markup.Simplify();
 
@@ -35,7 +36,8 @@ public sealed partial class MarkupParser : IMarkupParser
     public static Markup ParseRaw(
         string text,
         bool useUnparsedTextMarkup = false,
-        bool allowIncompleteMarkup = false)
+        bool allowIncompleteMarkup = false,
+        int? stepBudget = null)
     {
         if (text.IsNullOrEmpty())
             return EmptyResult;
@@ -49,9 +51,43 @@ public sealed partial class MarkupParser : IMarkupParser
             (false, true) => IncompleteMarkup,
             (true, true) => IncompleteWithUnparsedMarkup,
         };
-        var result = parser.Parse(text, ParserConfiguration);
+        ParseBudget.Reset(stepBudget ?? GetDefaultStepBudget(text.Length));
+        ParseMemo.Push();
+        try {
+            var result = parser.Parse(text, ParserConfiguration);
+            return result.Success ? result.Value : EmptyResult;
+        }
+        catch (ParseBudgetExceededException) {
+            // A backtracking grammar has inputs it can't finish in any useful time, so the budget is
+            // what bounds a parse. Past it the message is text - and the same text everywhere, because
+            // the budget depends on nothing but the message.
+            var textMarkupKind = useUnparsedTextMarkup ? TextMarkupKind.Unparsed : TextMarkupKind.Plain;
+            return new ParagraphMarkup(TextMarkup.New(textMarkupKind, text, true));
+        }
+        finally {
+            ParseMemo.Pop();
+        }
+    }
 
-        return result.Success ? result.Value : EmptyResult;
+    // Measured over the benchmark corpus: prose spends under one step per character, a table or a
+    // list about two, a run of block quotes under thirty, and a two-character message a dozen.
+    // RegularMessagesShouldStayFarBelowTheStepBudget in MarkupParserTest keeps the margin honest.
+    internal const int StepBudgetBase = 2_000;
+    internal const int StepBudgetPerChar = 200;
+
+    private static int GetDefaultStepBudget(int textLength)
+        => StepBudgetBase + StepBudgetPerChar * textLength;
+
+    private static Markup ParseNested(Parser<char, Markup> parser, string text)
+    {
+        // The nested text has positions of its own, so it gets a memo scope of its own
+        ParseMemo.Push();
+        try {
+            return parser.ParseOrThrow(text, ParserConfiguration);
+        }
+        finally {
+            ParseMemo.Pop();
+        }
     }
 
     // A bound on the scan below, not a tuning knob: a failing scan stops at the first special char,
@@ -275,6 +311,15 @@ public sealed partial class MarkupParser : IMarkupParser
     private static readonly Parser<char, Markup> StraySpecialText =
         CharRun.String(IsSpecialChar, 1).ToTextMarkup(TextMarkupKind.Plain, false);
 
+    // A divider-style run of style tokens ("**********") is text. Without this every token in the run
+    // opens a span that can't close, and "***bi***" is the longest run with a meaning.
+    private const int MinStyleTokenRunLength = 4;
+    private static readonly Parser<char, Markup> StyleTokenRunText =
+        SafeTryOneOf(
+            CharRun.String(c => c == '*', MinStyleTokenRunLength),
+            CharRun.String(c => c == '|', MinStyleTokenRunLength))
+            .ToTextMarkup(TextMarkupKind.Plain, false);
+
     // Code block
     private static readonly Parser<char, string> CodeBlockWithLanguageStart =
         CodeBlockToken.Then(CharRun.String(IsIdChar).Before(EndOfLine)); // Language
@@ -487,21 +532,26 @@ public sealed partial class MarkupParser : IMarkupParser
             // this list is tried at every element, so each nesting level cost a rent/return pair.
             // The order is exactly what the nested form tried, and every alternative backtracks.
             Parser<char, Markup>[] inlineElements = [
-                boldMarkup, italicMarkup, spoilerMarkup,
+                StyleTokenRunText, boldMarkup, italicMarkup, spoilerMarkup,
                 NamedMention, UnnamedMention, preformattedText, WwwUrl, Email, Hashtag, NonWhitespaceText,
             ];
 
+            // Both text blocks are memoized by position: a stylized span recurses into TextBlock, so
+            // without the memo an unbalanced run of tokens re-parsed the same suffix once per way of
+            // pairing the tokens before it - exponential in the run's length. A memo hit costs one
+            // dictionary lookup, and the result is the same because a text block's parse depends on
+            // nothing but where it starts.
             // Text block for single-line content (list items) - no newlines allowed
-            var textBlockSingleLine =
+            var textBlockSingleLine = new MemoParser(
                 SafeTryOneOf([.. inlineElements, StraySpecialText])
                     .AtLeastOnceSingleLineMarkup()
-                    .Debug("<TextSingleLine>");
+                    .Debug("<TextSingleLine>"));
 
             // Text block (includes inline newlines for multi-line styled text in paragraphs)
-            TextBlock =
+            TextBlock = new MemoParser(
                 SafeTryOneOf([.. inlineElements, InlineNewLine])
                     .AtLeastOnceInlineMarkup()
-                    .Debug("<Text>");
+                    .Debug("<Text>"));
 
             // List block (list items use single-line text block - no newlines within items)
             var unorderedListItem =
@@ -620,7 +670,7 @@ public sealed partial class MarkupParser : IMarkupParser
         private Markup BuildBlockQuote(string firstLine, IEnumerable<string> restLines, int contentQuoteLevel)
         {
             var content = firstLine + string.Concat(restLines);
-            return new BlockQuoteMarkup(GetDocument(contentQuoteLevel).ParseOrThrow(content, ParserConfiguration));
+            return new BlockQuoteMarkup(ParseNested(GetDocument(contentQuoteLevel), content));
         }
 
         private static Markup BuildBlockSequence(
@@ -670,11 +720,11 @@ public sealed partial class MarkupParser : IMarkupParser
         {
             // Concatenate all content (restParts already include newlines)
             var content = firstLine + string.Concat(restParts);
-            return new ParagraphMarkup(inlineParser.ParseOrThrow(content, ParserConfiguration));
+            return new ParagraphMarkup(ParseNested(inlineParser, content));
         }
 
         private static Markup BuildHeader(int level, string line, Parser<char, Markup> inlineParser)
-            => new HeaderMarkup(level, inlineParser.ParseOrThrow(line, ParserConfiguration));
+            => new HeaderMarkup(level, ParseNested(inlineParser, line));
 
         private static Markup? TryBuildTable(
             string headerLine,
@@ -697,7 +747,7 @@ public sealed partial class MarkupParser : IMarkupParser
             var cells = new TableCellMarkup[columnCount];
             for (var i = 0; i < columnCount; i++) {
                 var cellText = i < cellTexts.Count ? cellTexts[i] : "";
-                cells[i] = new TableCellMarkup(inlineParser.ParseOrThrow(cellText, ParserConfiguration));
+                cells[i] = new TableCellMarkup(ParseNested(inlineParser, cellText));
             }
 
             return new TableRowMarkup(cells);

--- a/src/dotnet/Core/Text/StringExt.cs
+++ b/src/dotnet/Core/Text/StringExt.cs
@@ -14,7 +14,7 @@ public static partial class StringExt
     [GeneratedRegex(@"([a-z0-9])([A-Z])")]
     private static partial Regex CamelCaseRegexFactory();
 
-    [GeneratedRegex(@"([^\r\n]*)(?:\r?\n)", RegexOptions.ExplicitCapture)]
+    [GeneratedRegex(@"(?<line>[^\r\n]*)\r?\n", RegexOptions.ExplicitCapture)]
     private static partial Regex NewLineRegexFactory();
 
     [GeneratedRegex(@"\s*(\S+)\s*$")]
@@ -196,7 +196,7 @@ public static partial class StringExt
         for (var index = 0; index < text.Length;) {
             var match = NewLineRegex.Match(text, index);
             if (match.Success)
-                yield return (match.Groups[1].Value, true);
+                yield return (match.Groups["line"].Value, true);
             else {
                 yield return (text[index..], false);
                 yield break;

--- a/tests/Chat.UnitTests/MarkupParserTest.cs
+++ b/tests/Chat.UnitTests/MarkupParserTest.cs
@@ -2032,7 +2032,136 @@ code
             .Which.Text.Should().Be(text);
     }
 
+    [Fact]
+    public void LongAsteriskRunShouldParseAsPlainText()
+    {
+        // A pasted e-mail divider; before the fix this parse never returned (exponential backtracking).
+        // arrange
+        var text = $"resubmit. {new string('*', 106)} on fund claim\nActivity/Project Name: X";
+
+        // act
+        var markup = ParseWithWatchdog(new MarkupParser(), text);
+
+        // assert
+        FormatNormalized(markup).Should().Be(text);
+        ContainsStylized(markup).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("*a ", 60)]
+    [InlineData("**a ", 40)]
+    [InlineData("a*", 60)]
+    [InlineData("||a ", 60)]
+    [InlineData("*", 200)]
+    [InlineData("**", 100)]
+    public void UnbalancedStyleTokensShouldParseInBoundedTime(string unit, int count)
+    {
+        // arrange
+        var text = string.Concat(Enumerable.Repeat(unit, count));
+
+        // act
+        var markup = ParseWithWatchdog(new MarkupParser(), text);
+
+        // assert
+        FormatNormalized(markup).Should().Be(text);
+    }
+
+    [Fact]
+    public void ExhaustedStepBudgetShouldFallBackToPlainText()
+    {
+        // arrange
+        var text = "**bold** and *italic*\nnext line";
+        var parser = new MarkupParser { StepBudget = 1 };
+
+        // act
+        var markup = parser.Parse(text);
+
+        // assert
+        ContainsStylized(new MarkupParser().Parse(text)).Should().BeTrue("the default budget must parse this");
+        ContainsStylized(markup).Should().BeFalse();
+        FormatNormalized(markup).Should().Be(text);
+        var seq = markup.Should().BeOfType<ParagraphMarkup>()
+            .Which.Content.Should().BeOfType<MarkupSeq>().Subject;
+        seq.Items.Should().AllSatisfy(x => (x is PlainTextMarkup or NewLineMarkup).Should().BeTrue());
+    }
+
+    [Fact]
+    public void RegularMessagesShouldStayFarBelowTheStepBudget()
+    {
+        // arrange
+        // The margin is how many times the budget exceeds what the text spends. Unbalanced style
+        // tokens are the most expensive shape the memoized grammar has, so they get the smallest one.
+        var texts = new (string Text, int Margin)[] {
+            ("ok", 4),
+            ("Quick update: the release build is green, p95 is 89 ms (down from 143).", 4),
+            (string.Concat(Enumerable.Repeat("**bold** *it* ||sp|| `c` @u:id https://x.y/z #tag ", 50)), 4),
+            (string.Concat(Enumerable.Repeat("**a *b ||c|| d* e** ", 50)), 4),
+            ("| a | b |\n| --- | --- |\n" + string.Concat(Enumerable.Repeat("| **x** | *y* |\n", 100)), 4),
+            (string.Concat(Enumerable.Repeat("- **a** *b* `c` d\n", 100)), 4),
+            (string.Concat(Enumerable.Repeat("> **q** *w*\n", 100)), 4),
+            (string.Concat(Enumerable.Repeat("*a ", 200)), 2),
+            (string.Concat(Enumerable.Repeat("**a ", 200)), 2),
+        };
+
+        // act & assert
+        foreach (var (text, margin) in texts) {
+            var budget = MarkupParser.StepBudgetBase + MarkupParser.StepBudgetPerChar * text.Length;
+            MarkupParser.ParseRaw(text, true, false, int.MaxValue);
+            var spent = int.MaxValue - ParseBudget.Remaining;
+            WriteLine($"{spent} steps for {text.Length} chars: {text[..Math.Min(40, text.Length)]}");
+            (margin * spent).Should().BeLessThan(budget, "a message must stay far below the budget: {0}", text);
+        }
+    }
+
+    [Fact]
+    public void StylizedSpansShouldNestThreeLevelsDeep()
+    {
+        // act
+        var p = Parse<ParagraphMarkup>("**a *b ||c|| b* a**");
+
+        // assert
+        var bold = p.Content.Should().BeOfType<StylizedMarkup>().Subject;
+        bold.Style.Should().Be(TextStyle.Bold);
+        var italic = bold.Content.Should().BeOfType<MarkupSeq>()
+            .Which.Items.OfType<StylizedMarkup>().Single();
+        italic.Style.Should().Be(TextStyle.Italic);
+        var spoiler = italic.Content.Should().BeOfType<MarkupSeq>()
+            .Which.Items.OfType<StylizedMarkup>().Single();
+        spoiler.Style.Should().Be(TextStyle.Spoiler);
+    }
+
     // Helpers
+
+    private static readonly TimeSpan WatchdogTimeout = TimeSpan.FromSeconds(5);
+
+    private static Markup ParseWithWatchdog(MarkupParser parser, string text)
+    {
+        Markup? markup = null;
+        Exception? error = null;
+        var thread = new Thread(() => {
+            try {
+                markup = parser.Parse(text);
+            }
+            catch (Exception e) {
+                error = e;
+            }
+        }) { IsBackground = true };
+        thread.Start();
+        thread.Join(WatchdogTimeout).Should().BeTrue("the parse must finish within {0}", WatchdogTimeout);
+        error.Should().BeNull();
+        return markup!;
+    }
+
+    private static string FormatNormalized(Markup markup)
+        => MarkupFormatter.Default.Format(markup).Replace("\r\n", "\n");
+
+    private static bool ContainsStylized(Markup markup)
+        => markup switch {
+            StylizedMarkup => true,
+            MarkupSeq seq => seq.Items.Any(ContainsStylized),
+            ParagraphMarkup p => ContainsStylized(p.Content),
+            _ => false,
+        };
 
     private static string CellText(TableRowMarkup row, int index)
         => MarkupFormatter.Default.Format(row.Cells[index].Content);

--- a/tests/Core.UnitTests/Text/StringExtTest.cs
+++ b/tests/Core.UnitTests/Text/StringExtTest.cs
@@ -32,4 +32,14 @@ public class StringExtTest
     [InlineData("a\r\nb", "  ", "  a\r\n  b")]
     public void IndentTest(string source, string indent, string expected)
         => source.Indent(indent).Should().Be(expected);
+
+    [Fact]
+    public void ParseLinesShouldKeepEveryLine()
+    {
+        // act
+        var lines = "first\nsecond\r\n\nlast".ParseLines().ToArray();
+
+        // assert
+        lines.Should().Equal(("first", true), ("second", true), ("", true), ("last", false));
+    }
 }


### PR DESCRIPTION
## Why

Production CPU has been pinned since Aug 26. A user pasted an e-mail with a 106-asterisk divider line into chat `VCmaZX6h1z`; every `ChatsBackend_ChangeEntry` for it parses the content in `PrepareTextEntryForSave` and never returns. Each retry burned one more core until the liveness probe restarted the pod (7 and 13 restarts on the two pods). The message was never persisted.

Root cause: the markup grammar recurses from a stylized span back into `TextBlock` with every alternative in `Try`, so an unbalanced run of style tokens re-parses the same suffix once per way of pairing the tokens before it. Measured locally: `*` × 36 takes 7.5 s and every 4 extra characters cost 4×. The shape is the same in v2.15, so this is a latent bug, not a regression of the 2.16 parser work.

## What

- **`MemoParser` + `ParseMemo`**: each text block's outcome is cached per input position for the length of a parse scope. The inline parse becomes linear with identical output (a text block's parse depends only on where it starts). Nested parses of paragraphs, headers, quotes and table cells open their own scope.
- **`StyleTokenRunText`**: a run of 4+ `*` or `|` is plain text, so a divider line never opens spans that can't close. `***bi***` (3) keeps working.
- **`ParseBudget`**: a thread-static step counter spent in `SafeOneOfParser`, `2000 + 200 × length` by default (`MarkupParser.StepBudget` overrides it). Past it the message renders as plain text, identically on every client and server since the budget depends only on the text. Calibrated over the benchmark corpus: prose spends < 1 step/char, tables and lists ~2, block quotes ~27, the formerly exponential inputs ~50. A guard test keeps the margin.
- **`StringExt.ParseLines`** fix (separate commit): `RegexOptions.ExplicitCapture` with an unnamed group made every line except the last come back empty. The plain-text fallback exposed it.

A depth cap on stylized nesting was tried first and rejected: backtracking explores deeper than the real nesting, so a cap changed results for shallow inputs (`MultiLineParagraphWithFormatting` broke).

## Verification

- New tests: the prod input (106-asterisk line) and 6 unbalanced-token shapes parse under a 5 s watchdog and round-trip; budget exhaustion falls back to plain text; 3-level nesting still works; regular messages stay ≥4× below the budget; `ParseLines` keeps every line.
- Chat.UnitTests 606/606, Core.UnitTests 705/705, Chat.UI.Blazor.UnitTests 789/789, MLSearch and Media unit tests green.
- `MarkupParserBenchmarks` on `dev` vs this branch, back to back: within noise on every sample (Long 746 → 739 µs, Table 83 → 81 µs, ConsoleLogFenced 161 → 155 µs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CykU6rJi5zFiAcDtkMRwM
