### PR TITLE
fix(server): 5 s shutdown timeout, 1 s cap on backend reconnect delay

### DIFF
--- a/src/dotnet/App.Server/AppHost.Build.cs
+++ b/src/dotnet/App.Server/AppHost.Build.cs
@@ -210,7 +210,6 @@ public partial class AppHost
         builder.Host.ConfigureHostOptions(options => {
             options.ServicesStartConcurrently = true;
             options.ServicesStopConcurrently = true;
-            options.ShutdownTimeout = TimeSpan.FromSeconds(15);
         });
         builder.WebHost
             .UseDefaultServiceProvider((_, options) => {

--- a/src/dotnet/App.Server/GracefulShutdown.cs
+++ b/src/dotnet/App.Server/GracefulShutdown.cs
@@ -10,8 +10,8 @@ namespace ActualChat.App.Server;
 /// </summary>
 internal sealed class GracefulShutdown(IServiceProvider services) : IHostedLifecycleService
 {
-    private static readonly TimeSpan HandoverTimeout = TimeSpan.FromSeconds(5);
-    private static readonly TimeSpan DisconnectTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan HandoverTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan DisconnectTimeout = TimeSpan.FromSeconds(2.5);
 
     private IServiceProvider Services { get; } = services;
     private MeshWatcher MeshWatcher => field ??= Services.MeshWatcher();

--- a/src/dotnet/App.Server/Module/AppServerModule.cs
+++ b/src/dotnet/App.Server/Module/AppServerModule.cs
@@ -193,7 +193,7 @@ public sealed class AppServerModule(IServiceProvider moduleServices)
         services.Configure<HostOptions>(o => {
             o.ShutdownTimeout = Env.IsDevelopment()
                 ? TimeSpan.FromSeconds(1)
-                : TimeSpan.FromSeconds(30);
+                : TimeSpan.FromSeconds(5); // GracefulShutdown must fit in here
         });
 
         // AppHostLifecycleMonitor

--- a/src/dotnet/Core.Server/Rpc/RpcHostBuilder.cs
+++ b/src/dotnet/Core.Server/Rpc/RpcHostBuilder.cs
@@ -325,7 +325,7 @@ public readonly struct RpcHostBuilder
 
         // Replace RpcClientPeerReconnectDelayer: a backend peer typically fails to connect to a node
         // that's a second away from listening or from being rerouted away, so it must retry fast
-        Services.AddSingleton(c => new RpcClientPeerReconnectDelayer(c) { Delays = RetryDelaySeq.Exp(0.25, 3) });
+        Services.AddSingleton(c => new RpcClientPeerReconnectDelayer(c) { Delays = RetryDelaySeq.Exp(0.25, 1) });
     }
 
     private void AddRpcPeerFactory()


### PR DESCRIPTION
Follow-up to #4346, from the first graceful rollout on dev (23:05 UTC): the stop sequence finished in ~2 s per pod (lease handover 50 ms, closing 26 to 29 inbound RPC connections 2.1 s) but the process lingered until the 15 s host shutdown timeout.

- `HostOptions.ShutdownTimeout`: 15 s -> 5 s (1 s in Development stays). The duplicate setting in `AppHost.Build.cs`, which silently overrode the module's 30 s, is removed, so `AppServerModule` is the only place it's set.
- `GracefulShutdown` caps shrink to fit: handover 2 s, disconnect 2.5 s.
- Server-to-server reconnect delay: `Exp(0.25, 3)` -> `Exp(0.25, 1)`.

Not touched: the browser client's reconnect ladder (100 ms doubling to 10 s), which is what produced the 4 to 6 s worst-case landing time behind the load balancer's affinity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2JVHPjWiaoDDKedFJZg1o