### PR TITLE
feat(chat): prefetch what a cold chat needs to open offline

### DIFF
--- a/docs/architecture/offline-render-path.md
+++ b/docs/architecture/offline-render-path.md
@@ -83,8 +83,8 @@ tables below refers to them by letter.
 | Code | Mechanism | What it warms |
 |---|---|---|
 | **S** | Startup render. The shell, navbar badges, and chat list render on every launch and pull their own data; on MAUI [AppNonScopedServiceStarter.PreloadContacts](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/UI.Blazor.App/Services/AppNonScopedServiceStarter.cs) additionally preloads every contact of the selected place. The per-place unread badges call `ChatListUI.ListUnordered(placeId)` for every place, which runs `ChatUI.Get` for every chat the user has - so the whole chat-list model is warm a few seconds after launch. | `IAccounts.GetOwn`, `INotifications.ListActive`, `IContacts.ListPlaceIds/ListIds/GetForChat`, `IPlaces.Get`, `IChats.Get/GetNews`, `IMentions.GetLastOwn`, `IChatPositions.GetOwn`, `IUserSettings.Get(*)` |
-| **T** | [ChatUI.PrefetchChatTails](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs). Starts 20 s after launch, rescans every minute, walks chats touched in the last 365 days newest-first in batches of 10 with a 10 s pause, and for each pulls the last 100 entries via `PrefetchLoadZone` + `PrefetchChatInfo`. Progress is stored in `ChatTailPrefetchState` so a chat is refetched only when it moves. | `IChats.GetTile` (per 5-entry tile, plus one preceding tile), `IConversations.GetTile`, `IChats.Get/GetIdRange/GetRules`, `IAuthors.ListAuthorIds` |
-| **D** | Pointer-down [ChatUI.Prefetch](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs) (`data-prefetch` on every chat link). Mirrors exactly what the first `GetChatItems` build will ask for. Only helps when online - it is a latency trick, not an offline one - but it is the only place `IChats.GetChatRangeMeta` is ever warmed ahead of time. | everything in the first build of a chat view |
+| **T** | [ChatUI.PrefetchChatTails](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs). Starts 20 s after launch, rescans every minute, walks chats touched in the last 365 days newest-first in batches of 10 with a 10 s pause, and for each pulls the last 100 entries via `PrefetchLoadZone` + `PrefetchChatInfo`. Progress is stored in `ChatTailPrefetchState`, versioned so that a change to this list walks every chat again, and a chat is otherwise refetched only when it moves. | `IChats.GetTile` (per 5-entry tile, plus one preceding tile), `IChats.GetChatRangeMeta` for the meta tiles around the tail, `IConversations.GetTile`, `IChats.Get/GetIdRange/GetRules`, `IAuthors.ListAuthorIds/GetOwn`, `IAuthors.Get` for every author in the tail, `IReactions.ListSummaries/Get` for the tail's reacted entries, `IChats.ListPinnedEntries` and the pinned entries' tiles |
+| **D** | Pointer-down [ChatUI.Prefetch](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs) (`data-prefetch` on every chat link). Mirrors exactly what the first `GetChatItems` build will ask for. Only helps when online - it is a latency trick, not an offline one. | everything in the first build of a chat view |
 | **V** | Viewed. Warm only because the user had the thing on screen at some point in this install. | per-message, per-author, per-notification data |
 | **—** | Not prefetched by anything. | |
 
@@ -175,9 +175,9 @@ The tab and sort settings (`ChatListSettings`) are local. The "Threads" tab adds
 | `IChatPositions.GetOwn(session, chatId, Read)` | cached | `ChatUI.LeaseReadPositionState` - awaited before first render | S |
 | `IChats.GetIdRange(session, chatId)` | cached | `ChatView.GetData`, `UpdateReadState`, `ChatUI.IsEmpty` | T |
 | `IChats.GetNews(session, chatId)` | cached | `UpdateReadState`, `NavigateToUnreadOrEnd` | S |
-| `IAuthors.GetOwn(session, chatId)` | cached | `UpdateReadState`, author badges, `LiveBlockUI` | — |
+| `IAuthors.GetOwn(session, chatId)` | cached | `UpdateReadState`, author badges, `LiveBlockUI` | T |
 | `IChats.GetRules(session, chatId)` | cached | Pinned bar, hover and context menus | T |
-| `IChats.ListPinnedEntries` + `IChats.GetEntry` per pin | cached | `ChatPinnedBar` | — |
+| `IChats.ListPinnedEntries` + `IChats.GetEntry` per pin | cached | `ChatPinnedBar` | T |
 | `IUserSettings.Get(UserAppSettings)`, `IUserSettings.Get(ChatUserSettings:{chatId})` | cached | Author colours and translation state, read per message | S |
 | `INotifications.ListActive` | cached | `NavigateToUnreadOrEnd` unread count | S |
 | `IPlaces.Get`, `IPlaces.GetWelcomeChatId`, `IAliases.*` | cached | Place chats, place-root and alias routes | S / V |
@@ -192,7 +192,7 @@ whole build, and with it every scroll request until the peer reconnects.
 | Remote call | Kind | Needed by | Coverage |
 |---|---|---|---|
 | `IChats.Get`, `IChats.GetIdRange` | cached | Every build | S, T |
-| `IChats.GetChatRangeMeta(session, chatId, metaTileStart)` × meta tiles covering the load zone ± `LoadLimit` | cached | Every build. `UseRangeMetaOrLastKnown` stands in only after a first successful read. | **D only** |
+| `IChats.GetChatRangeMeta(session, chatId, metaTileStart)` × meta tiles covering the load zone ± `LoadLimit` | cached | Every build. `UseRangeMetaOrLastKnown` stands in only after a first successful read. | T (around the tail), D |
 | `IConversations.GetTile(session, chatId, metaTileRange)` × meta tiles | cached | Every build, unconditionally | T |
 | `IChats.GetTile(session, chatId, idTileRange)` × id tiles (+1 preceding) | cached | Every tile in the zone, plus a speculative second copy for the adjacent zone | T (last 100 entries only) |
 | `ILiveSessions.GetState(session, chatId)` via `LiveSessionUI.GetConversation`, `LiveSessionUI.GetBlockSnapshot` and `LiveBlockUI.GetBlockState` | **no-cache** | Every build. `UseConversationOrLastKnown` / `UseSnapshotOrLastKnown` **await the first read** - a chat opened for the first time in this process never renders offline. | n/a |
@@ -203,12 +203,12 @@ whole build, and with it every scroll request until the peer reconnects.
 | Remote call | Kind | Needed by | Coverage |
 |---|---|---|---|
 | `IChats.GetEntry(session, entryId)` → the entry's `GetTile` | cached | `ChatEntryMessageInternalView` for every message, `TranscriptUI`, `DateVisor` on every scroll | T (same tiles) |
-| `IAuthors.Get(session, chatId, authorId)` | cached | Every author badge: name and avatar per message group, per reaction avatar, per thread and conversation card | **—** |
-| `IAuthors.GetOwn(session, chatId)` | cached | Every author badge | — |
+| `IAuthors.Get(session, chatId, authorId)` | cached | Every author badge: name and avatar per message group, per reaction avatar, per thread and conversation card | T (authors of the tail) |
+| `IAuthors.GetOwn(session, chatId)` | cached | Every author badge | T |
 | `IAuthors.GetPresence(session, chatId, authorId)` | cached | Presence dot on every message-group avatar | — |
 | `ILiveSessions.GetAudioStreamingAuthorIds` | **no-cache**, not gated | `AuthorPresenceIndicator` with `ShowRecording` on every message-group avatar; the indicator keeps its initial state while it pends | n/a |
 | `IChats.GetEntry(repliedEntryId)` | cached | Reply quotes | T if the quoted entry is in the tail, — otherwise |
-| `IReactions.ListSummaries`, `IReactions.Get` | cached | Entries with reactions | — |
+| `IReactions.ListSummaries`, `IReactions.Get` | cached | Entries with reactions | T (reacted entries of the tail) |
 | `IChats.IsEntryReadByMentionedUser` per mention; `IAuthors.GetByUserId`, `IAccounts.GetOwn`, `IContacts.Get` for `@u:` mentions | cached | Mention chips | — |
 | `IChats.GetReadPositionsStat`, `IAuthors.ListAuthorIds` | cached | Read ticks on own messages | — / T |
 | `INotifications.HasNotifiedMentionedMembers` | cached | Own messages with mentions | — |
@@ -244,21 +244,18 @@ question is what they do while offline.
 ## What the routine prefetch leaves cold
 
 Reading the coverage columns together, this is what a chat that the tail prefetcher has fully
-processed still lacks when opened cold, ordered by how visibly it breaks the screen:
+processed still lacks when opened cold, ordered by how visibly it breaks the screen. The range
+meta, the tail's authors, its reactions and its pins used to head this list; the tail prefetcher
+warms them now.
 
 | Gap | Effect offline | Cost to close |
 |---|---|---|
-| `IChats.GetChatRangeMeta` for the meta tiles around the tail | **The chat view never renders** - every build awaits it | One extra call per meta tile in `PrefetchLoadZone`, using the same tile arithmetic as `GetChatItemsInternal` |
 | `ILiveSessions.GetState` first read in `LiveSessionUI` | **The chat view never renders** - not a prefetch gap, a `no-cache` await | Stand in `null` when nothing is known yet (see the plan) |
-| `IAuthors.Get` for the tail's authors | Every message group shows an empty name and avatar | One call per distinct author in the fetched tiles |
-| `IAuthors.GetOwn` | Own-message detection in badges and `UpdateReadState` | One call per chat |
-| `IReactions.ListSummaries` for entries that have reactions | Reactions render blank | One call per reacted entry in the tail |
 | Thread cards: `IChats.Get(thread)`, `GetThreadCreator`, `GetThreadStat`, the thread's own tail | Thread cards render empty | Three calls plus a tile per thread start in the tail |
-| `IChats.ListPinnedEntries` + the pinned entries' tiles | Pinned bar empty | One call plus a tile per pin |
 | `IAuthors.Get` / `IAccounts.Get` / `IUserPresences.Get` for list rows never scrolled into view | Row name or avatar missing | Already partly covered by `PreloadContacts`; cheap to extend |
 | `IChats.Get` + `IAuthors.Get` per reaction notification | Notification rows empty | Walk `INotifications.ListActive` once |
 | Reply quotes, mention chips, link previews, forwards, locations, translations older than the tail | The affected fragment stays blank | Out of proportion to their frequency; accept as component-local pending state |
 
 Everything in the "chat list" and "shell" tables is already warm after a normal launch, because
-the badges and the list render it. The gaps are concentrated in the chat view, and two of them are
-blockers rather than blemishes.
+the badges and the list render it. What remains is concentrated in the chat view, and the one
+blocker left is an await, not a cache gap.

--- a/docs/plans/offline-mode.md
+++ b/docs/plans/offline-mode.md
@@ -56,7 +56,7 @@ What breaks, with the root cause behind each symptom:
 |---|---|---|
 | R1 | A compute call whose result was **never cached** waits for the connection with no timeout (`RpcCallTimeouts.Default.Query` is `(∞, ∞)`), and so does a never-cached call that was in flight when the link dropped. | A component - or an aggregate like `ChatUI.GetChatItems` that awaits many tiles - stays *Computing* until reconnect. Skeletons forever; scroll requests that never return. |
 | R2 | `no-cache` methods on the render path are awaited. `LiveSessionUI.GetConversation` / `GetBlockSnapshot` and `LiveBlockUI.GetBlockState` all await `ILiveSessions.GetState` on the first read; `AuthorPresenceIndicator` awaits `ILiveSessions.GetAudioStreamingAuthorIds`; `ChatVideoUI.GetActiveVideoStreams` awaits `ILiveVideoStreams.List`. | **A chat opened for the first time in the process never renders offline**, however well cached its data is. Presence dots and PTT-armed rows pend. |
-| R3 | The tail prefetcher doesn't warm everything the chat view needs: not `IChats.GetChatRangeMeta` (every build awaits it), not `IAuthors.Get` / `GetOwn`, not reactions, threads, or pins. | A fully prefetched chat still can't render cold, and when it can, authors and reactions are blank. |
+| R3 | The tail prefetcher didn't warm everything the chat view needs: not `IChats.GetChatRangeMeta` (every build awaits it), not `IAuthors.Get` / `GetOwn`, not reactions, threads, or pins. *Closed by T1.4-T1.6, except threads.* | A fully prefetched chat still couldn't render cold, and when it could, authors and reactions were blank. |
 | R4 | The peer learns about a dead link late. Nothing disconnects the RPC peer when the OS says offline (the app only parks reconnects), so the serve-stale paths engage only after the ~25-35 s keep-alive timeout. | Half a minute of hangs after pulling the plug, and again after every app resume on a dead network. |
 | R5 | Failures surface as errors. `ChatUI.Get` bounds `GetNews` with a 20 s `WaitAsync` and rethrows; a component whose state holds an error re-renders, `State.Value` throws, and the nearest `ErrorBarrier` takes over. `ChatPage` maps any non-timeout exception to "chat unavailable". | Once R1 is fixed by making misses fail, every fresh-mounted component with a miss would trip a barrier unless the failure is treated as "offline, keep what you have". |
 
@@ -101,17 +101,19 @@ already does: `LiveStreamUI.GetAudioStreamingAuthorIds` (returns empty), and
 `ChatVideoUI.GetActiveVideoStreams` (returns empty) so `HasOngoingCall` really does "degrade to
 false while offline" as its comment claims. Three small edits.
 
-**T1.4 Warm what every build awaits.** In `PrefetchLoadZone` add `IChats.GetChatRangeMeta` for the
-meta tiles covering `zone.Expand(LoadLimit)`, and `IAuthors.GetOwn`. Extract the meta-tile
-computation from `GetChatItemsInternal` into one helper both call, so they cannot drift.
+**T1.4 Warm what every build awaits.** *Done.* The tail prefetcher fetches `IChats.GetChatRangeMeta`
+for the meta tiles covering `tail.Expand(LoadLimit)`, and `PrefetchChatInfo` adds `IAuthors.GetOwn`.
+The meta-tile computation is one helper, `ChatUI.GetMetaIdTiles`, shared by the build, the
+pointer-down prefetch and the tail prefetch, so they cannot drift.
 
-**T1.5 Warm the tail's authors.** After the tiles land, collect the distinct `AuthorId`s and call
-`IAuthors.Get` for each (concurrency-capped as the tiles are). This is the bulk of what a cold
-chat shows besides text.
+**T1.5 Warm the tail's authors.** *Done.* After the tiles land, `PrefetchEntryDependencies` calls
+`IAuthors.Get` for every distinct author in them, and `IReactions.ListSummaries` / `Get` for the
+entries that carry reactions; `PrefetchPinnedEntries` warms the pinned bar. All tail-only, so the
+build's own load-zone prefetch stays as lean as it was.
 
-**T1.6 Version the prefetch state.** `ChatTailPrefetchState` records which chats are done; adding
-calls to the prefetch must re-run it. Add a `Version` field (or fold a version into the KVAS key)
-so a changed prefetch set starts from a clean state.
+**T1.6 Version the prefetch state.** *Done.* `ChatTailPrefetchState.Version` is compared against
+`ChatUI.PrefetchVersion`; a mismatch discards the stored progress, so every chat is walked again
+with the new set of calls.
 
 With Tier 1, a prefetched chat opens cold and shows text and authors; a cache miss still parks
 until reconnect, which is the R1 behaviour the next tier bounds.
@@ -174,11 +176,10 @@ land together.
 
 ### Tier 3 - coverage and polish
 
-**T3.1 Prefetch the rest of what the tail shows**, in decreasing order of visibility:
-`IReactions.ListSummaries` for entries with `HasReactions`; for thread-start entries `IChats.Get`,
-`IChatThreads.GetThreadCreator`, `GetThreadStat` and the thread's last tile; `IChats.ListPinnedEntries`
-and the pinned entries' tiles in `PrefetchChatInfo`. Reply quotes, mention chips, link previews,
-forwards and translations older than the tail stay component-local pending state.
+**T3.1 Prefetch the rest of what the tail shows.** Reactions and pins landed with T1.5; what is
+left is thread cards: for thread-start entries `IChats.Get`, `IChatThreads.GetThreadCreator`,
+`GetThreadStat` and the thread's last tile. Reply quotes, mention chips, link previews, forwards
+and translations older than the tail stay component-local pending state.
 
 **T3.2 Prefetch the left panel's leaves:** `IAuthors.Get` / `IAccounts.Get` / `IUserPresences.Get`
 for every row's last-entry author or peer (extend `PreloadContacts` and run it for every place, not

--- a/src/dotnet/UI.Blazor.App/Services/ChatTailPrefetchState.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatTailPrefetchState.cs
@@ -11,6 +11,7 @@ public sealed partial record ChatTailPrefetchState : IHasKvasKey<ChatTailPrefetc
 {
     [DataMember, Key(0)] public Moment Boundary { get; init; }
     [DataMember, Key(1)] public ApiArray<ChatTailPrefetch> Chats { get; init; } = [];
+    [DataMember, Key(2)] public int Version { get; init; }
 }
 
 [DataContract, MessagePackObject]

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.StateSync.cs
@@ -15,6 +15,8 @@ public partial class ChatUI
     private static readonly TimeSpan PrefetchMaxAge = TimeSpan.FromDays(365);
     private const int PrefetchBatchSize = 10;
     private const int PrefetchEntryLimit = 100;
+    // Bump whenever a prefetched chat gets a new set of calls: the chats already marked done lack them
+    private const int PrefetchVersion = 2;
 
     // All state sync logic should be here
 
@@ -249,6 +251,8 @@ public partial class ChatUI
 
         var accessor = LocalSettings.AccessorFor<ChatTailPrefetchState>();
         var stored = await accessor.Get(cancellationToken).ConfigureAwait(false);
+        if (stored.Version != PrefetchVersion)
+            stored = new ChatTailPrefetchState { Version = PrefetchVersion };
         var boundary = stored.Boundary;
         var prefetched = new Dictionary<ChatId, ChatTailPrefetch>();
         foreach (var item in stored.Chats)
@@ -318,6 +322,7 @@ public partial class ChatUI
 
             if (hasUnsavedChanges && savedAt.Elapsed >= PrefetchSavePeriod) {
                 var state = new ChatTailPrefetchState {
+                    Version = PrefetchVersion,
                     Boundary = boundary,
                     Chats = new ApiArray<ChatTailPrefetch>(prefetched.Values.ToArray()),
                 };
@@ -348,12 +353,23 @@ public partial class ChatUI
         if (start >= end)
             return end;
 
+        var chatId = chat.Id;
+        var tailRange = new Range<long>(start, end);
         var idTiles = EntryIdTiles
-            .GetCoveringTiles(new Range<long>(start, end))
+            .GetCoveringTiles(tailRange)
             .Select(t => t.Range)
             .ToList();
-        await PrefetchLoadZone(chat.Id, idTiles, chat.Chat.IsSummarized ?? false, cancellationToken)
-            .ConfigureAwait(false);
+        // Every build awaits the range meta before it can place a single tile, and nothing but the
+        // pointer-down prefetch ever warmed it - so a chat with its whole tail cached still couldn't
+        // open offline. Same for what the tail shows around its text: authors, reactions, pins.
+        var metaTask = GetMetaIdTiles(tailRange)
+            .Select(t => Chats.GetChatRangeMeta(Session, chatId, t.Start, cancellationToken))
+            .Collect(ApiConstants.Concurrency.High, cancellationToken);
+        var tilesTask = PrefetchLoadZone(chatId, idTiles, chat.Chat.IsSummarized ?? false, cancellationToken);
+        var pinnedTask = PrefetchPinnedEntries(chatId, cancellationToken);
+        await Task.WhenAll(metaTask, tilesTask, pinnedTask).ConfigureAwait(false);
+        var tiles = await tilesTask.ConfigureAwait(false);
+        await PrefetchEntryDependencies(chatId, tiles, cancellationToken).ConfigureAwait(false);
         return end;
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -249,10 +249,7 @@ public partial class ChatUI
                 .Select(t => t.Range)
                 .Where(r => r.Start >= 0)
                 .ToList();
-            var metaIdTiles = RangeMetaEntryIdTiles
-                .GetCoveringTiles(loadZone.Expand(LoadLimit))
-                .Where(t => t.Start >= 0)
-                .ToList();
+            var metaIdTiles = GetMetaIdTiles(loadZone);
             var metaTask = metaIdTiles
                 .Select(t => Chats.GetChatRangeMeta(Session, chatId, t.Range.Start, cancellationToken))
                 .Collect(ApiConstants.Concurrency.High, cancellationToken);
@@ -315,9 +312,7 @@ public partial class ChatUI
         var liveConversationTask = Hub.LiveSessionUI.GetConversation(chatId, cancellationToken);
         var rawLiveTask = Hub.LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken);
         var blockStateTask = Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken);
-        var metaIdTiles = RangeMetaEntryIdTiles.GetCoveringTiles(dataQuery.ExistingLidRange.Expand(LoadLimit))
-            .Where(t => t.Start >= 0)
-            .ToList();
+        var metaIdTiles = GetMetaIdTiles(dataQuery.ExistingLidRange);
         var chatRangeMetaListTask = metaIdTiles
             .Select(metaIdTile
                 => Chats.GetChatRangeMeta(Session, chatId, metaIdTile.Range.Start, cancellationToken))
@@ -1710,7 +1705,15 @@ public partial class ChatUI
         return (news.TextEntryLidRange, readEntryLid, chatInfo.Chat.IsSummarized ?? false);
     }
 
-    private Task PrefetchLoadZone(
+    private List<Tile<long>> GetMetaIdTiles(Range<long> lidRange)
+        // Shared by the build and both prefetches on purpose: Fusion dedupes on exact arguments, so a
+        // prefetch that derives its meta tiles even one boundary differently warms nothing - silently.
+        => RangeMetaEntryIdTiles
+            .GetCoveringTiles(lidRange.Expand(LoadLimit))
+            .Where(t => t.Start >= 0)
+            .ToList();
+
+    private Task<ChatTile[]> PrefetchLoadZone(
         ChatId chatId,
         List<Range<long>> idTiles,
         bool showConversations,
@@ -1736,6 +1739,7 @@ public partial class ChatUI
                 : Task.CompletedTask;
             var prefetchChatInfoTask = PrefetchChatInfo(chatId, cancellationToken);
             await Task.WhenAll(prefetchEntriesTask, prefetchConversationsTask, prefetchChatInfoTask).ConfigureAwait(false);
+            return await prefetchEntriesTask.ConfigureAwait(false);
         }, cancellationToken);
 
     // Serves the last fresh range-meta list while a refetch is in flight, so a rebuild triggered by a
@@ -1826,18 +1830,49 @@ public partial class ChatUI
                 var idRangeTask = Chats.GetIdRange(Session, chatId, cancellationToken);
                 var rulesTask = Chats.GetRules(Session, chatId, cancellationToken);
                 var authorsTask = Authors.ListAuthorIds(Session, chatId, cancellationToken);
+                var ownAuthorTask = Authors.GetOwn(Session, chatId, cancellationToken);
                 var isEmptyTask = IsEmpty(chatId, cancellationToken);
 
                 await Task.WhenAll(chatTask,
                         idRangeTask,
                         rulesTask,
                         authorsTask,
+                        ownAuthorTask,
                         isEmptyTask)
                     .ConfigureAwait(false);
             },
             Log,
             "Error prefetching chat tiles.",
             CancellationToken.None);
+
+    private Task PrefetchEntryDependencies(ChatId chatId, ChatTile[] tiles, CancellationToken cancellationToken)
+    {
+        // What the tail shows besides its text: the author of every message group and the reactions
+        // under the entries that carry them. Neither is a dependency of a tile, so nothing else warms them.
+        var entries = tiles.SelectMany(t => t.Entries).ToList();
+        var authorTasks = entries
+            .Select(e => e.AuthorId)
+            .Distinct()
+            .Select(authorId => Authors.Get(Session, chatId, authorId, cancellationToken))
+            .Collect(ApiConstants.Concurrency.High, cancellationToken);
+        var reactedEntries = entries.Where(e => e.HasReactions).ToList();
+        var reactionSummaryTasks = reactedEntries
+            .Select(e => Reactions.ListSummaries(Session, e.Id, cancellationToken))
+            .Collect(ApiConstants.Concurrency.High, cancellationToken);
+        var ownReactionTasks = reactedEntries
+            .Select(e => Reactions.Get(Session, e.Id, cancellationToken))
+            .Collect(ApiConstants.Concurrency.High, cancellationToken);
+        return Task.WhenAll(authorTasks, reactionSummaryTasks, ownReactionTasks);
+    }
+
+    private async Task PrefetchPinnedEntries(ChatId chatId, CancellationToken cancellationToken)
+    {
+        var pinnedIds = await Chats.ListPinnedEntries(Session, chatId, cancellationToken).ConfigureAwait(false);
+        await pinnedIds
+            .Select(entryId => Chats.GetEntry(Session, entryId, cancellationToken).AsTask())
+            .Collect(ApiConstants.Concurrency.High, cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     // What the author header signals as a kind: a streaming entry is audio that has not landed yet,
     // and the recording placeholder stands in for one while carrying neither Audio nor a

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -50,6 +50,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     private IPlaces Places => Hub.Places;
     private IChatPositions ChatPositions => Hub.ChatPositions;
     private IMentions Mentions => Hub.Mentions;
+    private IReactions Reactions => Hub.Reactions;
     private ActiveChatsUI ActiveChatsUI => Hub.ActiveChatsUI;
     private ChatAudioUI ChatAudioUI => Hub.ChatAudioUI;
     private ChatEditorUI ChatEditorUI => Hub.ChatEditorUI;


### PR DESCRIPTION
## Summary

First slice of the [offline mode plan](docs/plans/offline-mode.md) (T1.4 to T1.6): make the tail prefetcher warm everything a cold chat needs to open from the client cache.

- **Range meta.** Every chat-items build awaits `IChats.GetChatRangeMeta` before it can place a tile, and only the pointer-down prefetch ever warmed it, so a chat with its whole tail cached still couldn't open offline. The tail prefetch now fetches the meta tiles around the tail.
- **One tile helper.** `ChatUI.GetMetaIdTiles` is shared by the build, the pointer-down prefetch and the tail prefetch. Fusion dedupes on exact arguments; a prefetch that derives its tiles one boundary differently warms nothing.
- **What the tail shows around its text.** Authors of the fetched tiles, reaction summaries and own reactions of reacted entries, pinned entries, and the own author. Tail-only, so the build's own load-zone prefetch is unchanged.
- **Versioned prefetch state.** `ChatTailPrefetchState.Version` vs `ChatUI.PrefetchVersion`; a mismatch discards the stored progress so every chat is walked again with the new call set.

The render-path map and the plan are updated to match.

## Test plan

- [x] `UI.Blazor.App` builds clean (no new warnings).
- [x] `ChatUICacheTest` (3) plus `ConversationCollapseTest`, `LiveConversationDisplayTest` and `SendingMessagesDisplayTest` (49) pass locally - all of them drive `GetChatItems` through the shared meta-tile helper and the load-zone prefetch.
- [ ] On a device: launch online, wait for the tail prefetch to pass (~30 s for the top 10 chats), go to airplane mode, open a chat that was **not** opened in this process. With the Tier 1 live-session change still pending, the view will not render yet; verify instead via the Kvasar debug log that `GetChatRangeMeta`, `Authors.Get` and `Reactions.ListSummaries` lookups hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ng2LK65p44ysTh7xLZbfF
