### PR TITLE
fix(markup): honor the language written on a code fence

### DIFF
--- a/src/dotnet/Api/Chat/Markup/MarkupParser.cs
+++ b/src/dotnet/Api/Chat/Markup/MarkupParser.cs
@@ -124,6 +124,7 @@ public sealed partial class MarkupParser : IMarkupParser
     private static readonly Func<char, bool> IsNotEndOfLineChar = c => c is not ('\r' or '\n' or '\u2028');
     private static readonly Func<char, bool> IsIdChar =
         c => char.IsLetterOrDigit(c) || c is '_' or '-' or ':' or '.' or '%' or '~';
+    private static readonly Func<char, bool> IsCodeBlockLanguageChar = c => c != '`' && !char.IsWhiteSpace(c);
     private static readonly Func<char, bool> IsSpecialChar = c => c is '*' or '`' or '@' or '|';
     private static readonly Func<char, bool> IsNotSpecialOrWhitespaceChar =
         c => !(char.IsWhiteSpace(c) || c is '*' or '`' or '@' or '|');
@@ -322,7 +323,10 @@ public sealed partial class MarkupParser : IMarkupParser
 
     // Code block
     private static readonly Parser<char, string> CodeBlockWithLanguageStart =
-        CodeBlockToken.Then(CharRun.String(IsIdChar).Before(EndOfLine)); // Language
+        CodeBlockToken
+            .Then(CharRun.String(IsCodeBlockLanguageChar))
+            .Before(CharRun.Skip(IsWhitespaceChar))
+            .Before(EndOfLine); // Language
     private static readonly Parser<char, string> CodeBlockWithoutLanguageStart =
         CodeBlockToken.ThenReturn(""); // Language
     private static readonly Parser<char, char> CodeBlockEnd =
@@ -372,7 +376,7 @@ public sealed partial class MarkupParser : IMarkupParser
         from language in TryOneOf(CodeBlockWithLanguageStart, CodeBlockWithoutLanguageStart)
         from code in Try(CodeBlockCode).Optional()
         from end in CodeBlockEndOrEof
-        select (Markup)new CodeBlockMarkup(code.GetValueOrDefault(""), language.TrimEnd())
+        select (Markup)new CodeBlockMarkup(code.GetValueOrDefault(""), language)
         ).Debug("<Code>");
 
     // Block-level pieces that don't depend on any grammar variant, so they're built once rather

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/code-block-markup-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/code-block-markup-view.ts
@@ -16,12 +16,29 @@ import kotlin from 'highlight.js/lib/languages/kotlin';
 import c from 'highlight.js/lib/languages/c';
 import cpp from 'highlight.js/lib/languages/cpp';
 import csharp from 'highlight.js/lib/languages/csharp';
+import sql from 'highlight.js/lib/languages/sql';
+import swift from 'highlight.js/lib/languages/swift';
+import dart from 'highlight.js/lib/languages/dart';
+import powershell from 'highlight.js/lib/languages/powershell';
+import shell from 'highlight.js/lib/languages/shell';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import ini from 'highlight.js/lib/languages/ini';
+import markdown from 'highlight.js/lib/languages/markdown';
+import diff from 'highlight.js/lib/languages/diff';
+import plaintext from 'highlight.js/lib/languages/plaintext';
 import { getLogs } from 'logging';
 import { Theme, ThemeInfo } from 'theme';
 
 const { errorLog } = getLogs('CodeBlockMarkupView');
 
-export function highlightCode(root: HTMLElement, languageName: string, code: string) {
+// Auto-detection scans only these: the rest are registered for explicit ```lang fences,
+// and letting them compete makes guesses on unlabeled snippets noticeably worse.
+const AutoDetectLanguages = [
+    'bash', 'javascript', 'typescript', 'json', 'xml', 'yaml', 'css',
+    'python', 'go', 'rust', 'java', 'kotlin', 'c', 'cpp', 'csharp',
+];
+
+export function highlightCode(root: HTMLElement, languageName: string | null, code: string) {
     const pre = root.querySelector('pre');
     if (!pre)
         return;
@@ -29,24 +46,30 @@ export function highlightCode(root: HTMLElement, languageName: string, code: str
     if (!codeElement)
         return;
 
-    let primaryLanguage = languageName;
+    const requestedLanguage = languageName ?? '';
+    let primaryLanguage = requestedLanguage;
+    let isKnownLanguage = false;
     try {
-        const language = hljs.getLanguage(languageName);
+        const language = hljs.getLanguage(requestedLanguage);
         if (language) {
-            codeElement.innerHTML = hljs.highlight(code, { language: languageName }).value;
+            codeElement.innerHTML = hljs.highlight(code, { language: requestedLanguage }).value;
+            isKnownLanguage = true;
         } else if (looksLikeTable(code)) {
             codeElement.innerHTML = highlightTableCells(code);
-            primaryLanguage = '';
         } else {
-            const result = hljs.highlightAuto(code);
+            const result = hljs.highlightAuto(code, AutoDetectLanguages);
             codeElement.innerHTML = result.value;
-            primaryLanguage = result.language ?? '';
+            if (!requestedLanguage)
+                primaryLanguage = result.language ?? '';
         }
     } catch (e) {
         errorLog?.log(`highlightCode: failed to highlight code`, e);
     }
 
-    updateLanguageLabel(root, codeElement, primaryLanguage);
+    if (requestedLanguage && !isKnownLanguage)
+        setLanguageLabel(root, requestedLanguage);
+    else
+        updateLanguageLabel(root, codeElement, primaryLanguage);
     setupWrapToggle(root);
 }
 
@@ -83,11 +106,14 @@ function highlightTableCells(code: string): string {
 }
 
 function updateLanguageLabel(root: HTMLElement, codeElement: HTMLElement, primaryLanguage: string) {
-    const label = root.querySelector('.code-block-language');
-    if (!label)
-        return;
     const langs = computeLanguageDistribution(codeElement, primaryLanguage);
-    label.textContent = formatLanguageLabel(langs);
+    setLanguageLabel(root, formatLanguageLabel(langs));
+}
+
+function setLanguageLabel(root: HTMLElement, text: string) {
+    const label = root.querySelector('.code-block-language');
+    if (label)
+        label.textContent = text;
 }
 
 function computeLanguageDistribution(codeElement: HTMLElement, primaryLanguage: string): { name: string, length: number }[] {
@@ -168,6 +194,16 @@ function init() {
     hljs.registerLanguage('c', c);
     hljs.registerLanguage('cpp', cpp);
     hljs.registerLanguage('csharp', csharp);
+    hljs.registerLanguage('sql', sql as unknown as LanguageFn);
+    hljs.registerLanguage('swift', swift);
+    hljs.registerLanguage('dart', dart as unknown as LanguageFn);
+    hljs.registerLanguage('powershell', powershell as unknown as LanguageFn);
+    hljs.registerLanguage('shell', shell);
+    hljs.registerLanguage('dockerfile', dockerfile);
+    hljs.registerLanguage('ini', ini);
+    hljs.registerLanguage('markdown', markdown);
+    hljs.registerLanguage('diff', diff);
+    hljs.registerLanguage('plaintext', plaintext as unknown as LanguageFn);
 
     if (Theme.info)
         applyTheme(Theme.info);

--- a/tests/Chat.UnitTests/MarkupParserTest.cs
+++ b/tests/Chat.UnitTests/MarkupParserTest.cs
@@ -362,6 +362,22 @@ code
         m.Language.Should().Be("");
         m.Code.Should().Be("code");
 
+        m = Parse<CodeBlockMarkup>("```c#\ncode\n```");
+        m.Language.Should().Be("c#");
+        m.Code.Should().Be("code");
+
+        m = Parse<CodeBlockMarkup>("```C++\ncode\n```");
+        m.Language.Should().Be("C++");
+        m.Code.Should().Be("code");
+
+        m = Parse<CodeBlockMarkup>("```cs \u00a0\ncode\n```", false);
+        m.Language.Should().Be("cs", "trailing whitespace after the language isn't part of it");
+        m.Code.Should().Be("code");
+
+        m = Parse<CodeBlockMarkup>("```cs extra\ncode\n```", false);
+        m.Language.Should().Be("", "the fence line must hold a single word to be a language");
+        m.Code.Should().Be("cs extra\r\ncode");
+
         m = Parse<CodeBlockMarkup>(@"```cs
 ```");
         m.Language.Should().Be("cs");


### PR DESCRIPTION
Closes #4275

## Problem

Writing a language after the opening fence looked like it was ignored:

- The parser accepted only identifier characters and required the line to end right after them. `c#`, `C++`, or a trailing space (the editor often leaves a non-breaking one) made the name the first line of code.
- The renderer bundled fifteen grammars; any other name (`sql`, `swift`, …) was replaced by highlight.js's own guess in the block header.

## Fix

- **Parser**: the language is any run of non-whitespace characters other than a backtick; trailing whitespace on the fence line is ignored. A bare fence and a multi-word fence line behave as before.
- **Renderer**: an unbundled language is shown in the header as typed instead of a guess. Auto-detection for unlabeled blocks stays pinned to the original fifteen grammars.
- **Grammars**: added sql, swift, dart, powershell, shell, dockerfile, ini, markdown, diff, plaintext.

## Verification

- `Chat.UnitTests`: 606 passed, 0 failed; new cases cover `c#`, `C++`, trailing whitespace, and the multi-word fence line.
- Posted ```` ```c# ````, ```` ```sql ````, ```` ```cs ```` with a trailing space, and an unknown ```` ```foo ```` through the real editor against a local server: headers read C#, SQL, C#, and `foo`, the first three syntax-colored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
