### PR TITLE
feat(release): stage store builds in CI, publish them from promote-release.yml

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -29,6 +29,9 @@ RoboKitty post (steps 6–8). Those are the hard-to-revert, outward-facing parts
   — same path `/my-changes --post` and `/robokitty-post` use. No new HTTP code.
 - Release-notes **style** is defined below; match prior notes' tone, don't
   reinvent a format.
+- **Store notes** (`docs/releases/store-notes-vX.Y.txt`) feed
+  `promote-release.yml` — the same file is pushed to Google Play, the App Store
+  and the Microsoft Store, so it's a plain-text distillation of the notes.
 - The **`configs`** sibling repo needs a matching `release/vX.Y` branch — CI
   loads config from it. Locate the clone first (step 3); don't skip step 3b.
 
@@ -157,15 +160,30 @@ Read the full commit log and distill it into **end-user** notes. This is the
 core judgment step — see **Release-notes style** below. Draft the file at
 `docs/releases/release-notes-vX.Y.md`.
 
-**STOP and show the drafted notes to the user for review before committing.**
-Incorporate any edits they ask for.
+### 5b. Write the store notes
+
+Distill the notes once more into `docs/releases/store-notes-vX.Y.txt`. This
+file goes **verbatim** into Google Play's "What's new", the App Store's
+"What's New" and the Microsoft Store's release notes when the release is
+promoted (`/promote-release`), so:
+
+- **500 characters max** including newlines — Play's limit, and the promote
+  workflow refuses a longer file. Check with `wc -m`.
+- Plain text: no markdown, no bold, no headings. Emoji-free except `•` bullets.
+- First line: one sentence with the release theme. Then 4–6 `•` bullets, the
+  biggest user-visible wins first, one line each.
+- Same voice as the notes, no sign-off. See `store-notes-v2.17.txt` for the
+  shape.
+
+**STOP and show both drafts (notes + store notes) to the user for review
+before committing.** Incorporate any edits they ask for.
 
 ### 6. Commit the notes on the release branch
 
 ```bash
 git switch release/vX.Y
-# write docs/releases/release-notes-vX.Y.md (mkdir -p docs/releases if needed)
-git add docs/releases/release-notes-vX.Y.md
+# write docs/releases/release-notes-vX.Y.md and store-notes-vX.Y.txt
+git add docs/releases/release-notes-vX.Y.md docs/releases/store-notes-vX.Y.txt
 git commit -m "docs: add release notes vX.Y"
 git push origin release/vX.Y
 ```
@@ -192,9 +210,13 @@ git commit --no-edit
 git push origin dev
 ```
 
-If the only thing you actually need on `dev` is the notes file and the merge is
-noisy, the equivalent clean alternative is:
-`git switch dev && git checkout release/vX.Y -- docs/releases/release-notes-vX.Y.md && git commit -m "docs: add release notes vX.Y" && git push origin dev`.
+If the only thing you actually need on `dev` is the notes files and the merge
+is noisy, the equivalent clean alternative is:
+`git switch dev && git checkout release/vX.Y -- docs/releases/release-notes-vX.Y.md docs/releases/store-notes-vX.Y.txt && git commit -m "docs: add release notes vX.Y" && git push origin dev`.
+
+`/promote-release` dispatches `promote-release.yml` on `release/vX.Y` and
+reads `docs/releases/store-notes-vX.Y.txt` from there, so step 6 is what
+makes the promotion possible; this merge just keeps `dev` complete.
 
 ### 8. Announce in the Releases chat via RoboKitty
 
@@ -241,6 +263,16 @@ above; `ActualChat_RoboKitty_Dev_API_Key` + `https://dev.voxt.ai/api/mcp` target
 the dev instance.) Only if neither the tool nor the key is available, print the
 notes for the user to paste manually.
 
+### 9. Hand off to the promotion
+
+The `release/vX.Y` push triggers the release build. Its prod deploy jobs wait
+for a Maintainers approval in the `prod` environment, then only **stage** the
+apps: Play internal track, TestFlight (iOS + Mac), a pending Microsoft Store
+submission. Nothing reaches end users yet. Tell the user:
+
+> Release build: <run url>. Approve the prod deployment, test the staged
+> builds, then run `/promote-release` to publish them.
+
 ## Release-notes style
 
 The notes are for **end users**, not engineers. Translate commits into user
@@ -271,8 +303,10 @@ worth mentioning, ask: "would a user notice or care?" If no, fold it into the
 | Push app branches | `git push origin dev && git push origin release/vX.Y` (after config branch) |
 | Commit log | `git log --format='%s' origin/release/vX.(Y-1)..release/vX.Y` |
 | Notes file | `docs/releases/release-notes-vX.Y.md` |
+| Store notes | `docs/releases/store-notes-vX.Y.txt` — plain text, ≤ 500 chars, committed with the notes |
 | Merge to dev | `git merge --no-ff release/vX.Y`, keep dev's `version.json` |
 | Announce | `mcp__voxt-robokitty__post_message` → `s-pmMsV1UVKG-dCKQXnYpX9`, code-fenced |
+| Publish to stores | not here — `/promote-release` after the builds are tested |
 
 ## Common mistakes
 
@@ -287,3 +321,6 @@ worth mentioning, ask: "would a user notice or care?" If no, fold it into the
 - **Skipping the review pause.** The notes are public; show them first.
 - **Forgetting the `configs` release branch (step 3b).** The CI release build
   loads config from `configs`' `release/vX.Y`; without it the build fails.
+- **Skipping the store notes, or writing them in markdown.** They're pasted
+  verbatim into three store listings; a missing or 500+ character file makes
+  `/promote-release` fail at its first step.

--- a/.claude/skills/promote-release/SKILL.md
+++ b/.claude/skills/promote-release/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: promote-release
+description: |
+  Publish a tested Voxt release to the stores: Google Play production, App
+  Store review (iOS + Mac Catalyst), Microsoft Store certification. Use when
+  the user says "promote the release", "publish the apps", "release to the
+  stores", "/promote-release", or after /prepare-release once the staged
+  builds have been tested.
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+---
+
+# promote-release
+
+Second half of a release. `/prepare-release` cut `release/vX.Y`; its CI run
+(after the `prod` environment approval) **staged** the apps — Play internal
+track, TestFlight for iOS and Mac, a pending Microsoft Store submission — but
+published nothing. This skill confirms the builds were tested, then dispatches
+`promote-release.yml` **on the release branch**, which publishes them with the
+store notes from `docs/releases/store-notes-vX.Y.txt`.
+
+**This publishes to end users.** The one hard stop is step 3: never dispatch a
+platform the user hasn't confirmed as tested. The store jobs run in the
+`prod-store` GitHub environment, which admits `release/*` branches only; it
+has no reviewer gate, so the user's answer in step 3 is the only gate.
+
+## Reuse
+
+- **`promote-release.yml`** does all store work; the skill only gathers inputs
+  and dispatches it with `gh workflow run`. No store API calls from here.
+- **`gh run list` / `gh api .../artifacts`** identify the release run and the
+  build version — the same data the CI run already produced.
+- **Store notes** come from `/prepare-release` step 5b. Don't rewrite them
+  here; if the file is missing, follow that step's rules and commit it to
+  the release branch.
+
+## Steps
+
+### 1. Identify the release and its build version
+
+The release branch is `release/vX.Y` — the highest `origin/release/v*` unless
+the user names one. Find its latest CI run and read the build version from
+the artifact names (`chat.actual.app.<X.Y.Z>.ipa`):
+
+```bash
+git fetch origin
+branch=$(git branch -r --list 'origin/release/v*' | sed 's|.*origin/||' | sort -V | tail -1)
+run=$(gh run list --repo Actual-Chat/actual-chat --workflow build-test-deploy-dev.yml \
+        --branch "$branch" --json databaseId,conclusion,createdAt,url --limit 5)
+echo "$run" | jq -r '.[] | "\(.databaseId)\t\(.conclusion)\t\(.createdAt)\t\(.url)"'
+```
+
+Pick the newest run whose staging jobs succeeded and get the version:
+
+```bash
+gh run view <id> --repo Actual-Chat/actual-chat --json jobs \
+  -q '.jobs[] | select(.name | test("Deploy .* (play store|apple app store)|Upload win")) | "\(.conclusion)\t\(.name)"'
+gh api repos/Actual-Chat/actual-chat/actions/runs/<id>/artifacts -q '.artifacts[].name' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -u
+```
+
+The version is `X.Y.Z` (nbgv SimpleVersion, e.g. `2.17.246`). A staging job
+that failed or was skipped means that platform has nothing to promote — leave
+it out in step 3 and say why.
+
+**The Windows pending submission is whatever the latest release-branch run
+uploaded**: each upload replaces the previous draft. If a newer run than the
+one you picked has a green Windows upload job, that's the package Partner
+Center holds — promote Windows only if the versions match.
+
+### 2. Check the release branch carries the workflow and the store notes
+
+```bash
+git show origin/release/vX.Y:.github/workflows/promote-release.yml > /dev/null   # must exist
+git show origin/release/vX.Y:docs/releases/store-notes-vX.Y.txt | wc -m         # must exist, ≤ 500
+```
+
+The workflow runs on the release branch and reads both from there. If the
+store notes are missing, write them per `/prepare-release` step 5b (plain
+text, ≤ 500 chars), show them to the user, and commit to `release/vX.Y` with
+`docs: add store notes vX.Y`, then merge that into `dev` as in
+`/prepare-release` step 7. A release branch cut before the workflow existed
+needs the workflow cherry-picked onto it first — say so and stop.
+
+### 3. Confirm the builds were tested — HARD STOP
+
+Ask with `AskUserQuestion` (multiSelect), listing exactly what was staged, e.g.:
+
+> Which staged builds of X.Y.Z did you test? Only the selected platforms are
+> promoted.
+> - Android — Play internal track, version code N
+> - iOS — TestFlight X.Y.Z
+> - macOS — TestFlight X.Y.Z (Mac Catalyst)
+> - Windows — MSIX artifact / pending Store submission X.Y.Z.0
+
+Then ask, in the same call, the App Store version to publish under: the
+convention is `X.Y` for the first release from the branch and `X.Y.1`,
+`X.Y.2`, … for follow-ups. "Auto" (empty input) lets the workflow pick the
+next free one from App Store Connect — recommend it. Offer a Play rollout
+percentage only if the user brings it up; default is a full release.
+
+No platform selected → stop, nothing to do. Never infer "tested" from a green
+CI run, from the user having approved the `prod` environment, or from a prior
+conversation.
+
+### 4. Dispatch the promotion
+
+```bash
+gh workflow run promote-release.yml --repo Actual-Chat/actual-chat --ref release/vX.Y \
+  -f version=X.Y.Z \
+  -f android=<true|false> -f ios=<true|false> -f macos=<true|false> -f windows=<true|false> \
+  -f apple-version="" -f android-rollout=100
+sleep 5
+gh run list --repo Actual-Chat/actual-chat --workflow promote-release.yml --limit 1 --json databaseId,url
+```
+
+Tell the user the run URL, then watch:
+
+```bash
+gh run watch <id> --repo Actual-Chat/actual-chat --exit-status
+```
+
+Expect it to take a while: the iOS/macOS jobs wait for App Store Connect to
+finish processing if needed, and the Windows job polls Partner Center until
+pre-processing accepts the package (minutes). If `gh run watch` is
+interrupted, resume it; don't re-dispatch.
+
+### 5. Report
+
+Read the run's job summaries (`gh run view <id> --log` for failures) and
+report per platform:
+
+- Android: released to production (rollout %), version code.
+- iOS / macOS: App Store version string and build submitted for review.
+- Windows: submission id, in certification (hours; watch in Partner Center).
+
+For a failed job, quote the error and stop — don't retry blindly. The usual
+causes: build not on the internal track (wrong version), App Store version
+already waiting for review (cancel it in App Store Connect), no pending
+Microsoft Store submission (the release run's Windows upload didn't run).
+
+## Quick reference
+
+| Step | Command / action |
+|---|---|
+| Release run | `gh run list --workflow build-test-deploy-dev.yml --branch release/vX.Y` |
+| Build version | artifact names `chat.actual.app.<X.Y.Z>.ipa` → `X.Y.Z` |
+| Store notes | `docs/releases/store-notes-vX.Y.txt` on `release/vX.Y`, ≤ 500 chars |
+| Tested? | `AskUserQuestion`, multiSelect per platform — hard stop |
+| Dispatch | `gh workflow run promote-release.yml --ref release/vX.Y -f version=X.Y.Z -f android=… -f ios=… -f macos=… -f windows=…` |
+| Watch | `gh run watch <id> --exit-status` |
+
+## Common mistakes
+
+- **Passing `X.Y` as the version.** The workflow needs the three-part build
+  version from the artifacts; `2.17` fails validation.
+- **Dispatching on `dev`.** The `prod-store` environment rejects every ref
+  but `release/*`, so the store jobs fail before doing anything.
+- **Skipping the tested-build question**, or pre-selecting platforms for the
+  user. The only source of truth is the user's answer in this session.
+- **Promoting Windows from a stale run.** The pending submission is the last
+  uploaded package, not necessarily the one from the run you looked at.

--- a/.github/fastlane/Fastfile
+++ b/.github/fastlane/Fastfile
@@ -1,0 +1,124 @@
+# Promotes a processed TestFlight build to the App Store: picks (or creates) the
+# App Store version, attaches the build, sets What's New and submits for review.
+# Run from `.github`: fastlane promote platform:ios build_version:2.17.246 notes_path:<file> [version:2.17.1]
+#
+# `deliver` can't do this for us: it looks the build up by the App Store version
+# string, while our builds carry the full nbgv version (2.17.246) and the store
+# versions follow the 2.17 / 2.17.1 / 2.17.2 convention.
+
+APP_IDENTIFIER = "chat.actual.app"
+BUILD_WAIT = 45 * 60
+
+lane :promote do |options|
+  platform = Spaceship::ConnectAPI::Platform.map(options.fetch(:platform))
+  build_version = options.fetch(:build_version)
+  notes = File.read(options.fetch(:notes_path)).strip
+  requested_version = options[:version].to_s.strip
+  UI.user_error!("build_version must look like 2.17.246, got '#{build_version}'") unless build_version =~ /\A\d+\.\d+\.\d+\z/
+  UI.user_error!("Release notes are empty") if notes.empty?
+
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+    key_id: ENV.fetch("APPSTORE_API_KEY_ID"),
+    issuer_id: ENV.fetch("APPSTORE_API_ISSUER_ID"),
+    key: ENV.fetch("APPSTORE_API_KEY_BASE64"),
+    is_key_content_base64: true,
+  )
+
+  app = Spaceship::ConnectAPI::App.find(APP_IDENTIFIER)
+  UI.user_error!("App #{APP_IDENTIFIER} not found in App Store Connect") unless app
+
+  build = wait_for_build(app, platform, build_version)
+  version = ensure_app_store_version(app, platform, build_version, requested_version)
+  UI.message("Using App Store version #{version.version_string} (#{version.app_version_state})")
+
+  version.update(attributes: { releaseType: Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::AFTER_APPROVAL })
+  version.select_build(build_id: build.id)
+  UI.success("Attached build #{build.version} to #{version.version_string}")
+
+  version.get_app_store_version_localizations.each do |localization|
+    localization.update(attributes: { whats_new: notes })
+    UI.message("What's New set for #{localization.locale}")
+  end
+
+  build.update(attributes: { usesNonExemptEncryption: false }) if build.uses_non_exempt_encryption.nil?
+
+  submit_for_review(app, platform, version)
+  UI.success("#{platform} #{version.version_string} (build #{build.version}) submitted for review")
+
+  summary = ENV["GITHUB_STEP_SUMMARY"]
+  File.open(summary, "a") { |f| f.puts("- #{platform}: version **#{version.version_string}**, build #{build.version} submitted for review") } if summary
+end
+
+def wait_for_build(app, platform, build_version)
+  deadline = Time.now + BUILD_WAIT
+  loop do
+    build = Spaceship::ConnectAPI::Build.all(
+      app_id: app.id,
+      version: build_version,
+      build_number: build_version,
+      platform: platform,
+    ).first
+    state = build&.processing_state
+    return build if state == "VALID"
+    UI.user_error!("Build #{build_version} for #{platform} is #{state}") if build && state != "PROCESSING"
+    UI.user_error!("No processed build #{build_version} for #{platform} after #{BUILD_WAIT / 60} minutes") if Time.now > deadline
+    UI.message(build ? "Build #{build_version} is still processing, waiting..." : "Build #{build_version} not visible yet, waiting...")
+    sleep(30)
+  end
+end
+
+# The first release of a branch is published as X.Y, the next ones as X.Y.1, X.Y.2, ...
+# An editable version on the same train is reused; one from another train is renamed,
+# which is what `deliver` does too.
+def ensure_app_store_version(app, platform, build_version, requested_version)
+  train = build_version.split(".").first(2).join(".")
+  on_train = ->(v) { v == train || v.start_with?("#{train}.") }
+
+  edit = app.get_edit_app_store_version(platform: platform)
+  if edit && edit.app_version_state == Spaceship::ConnectAPI::AppStoreVersion::AppVersionState::WAITING_FOR_REVIEW
+    UI.user_error!("Version #{edit.version_string} is already waiting for review; cancel it in App Store Connect first")
+  end
+
+  version_string = requested_version
+  if version_string.empty?
+    if edit && on_train.call(edit.version_string)
+      version_string = edit.version_string
+    else
+      taken = app.get_app_store_versions(filter: { platform: platform })
+                 .map(&:version_string)
+                 .select(&on_train)
+      version_string = taken.empty? ? train : "#{train}.#{taken.map { |v| v.split(".")[2].to_i }.max + 1}"
+    end
+  end
+
+  if edit && edit.version_string != version_string
+    UI.important("Renaming editable version #{edit.version_string} to #{version_string}")
+  end
+  app.ensure_version!(version_string, platform: platform)
+  app.get_edit_app_store_version(platform: platform) || UI.user_error!("Version #{version_string} is not editable after creation")
+end
+
+def submit_for_review(app, platform, version)
+  if app.get_in_progress_review_submission(platform: platform)
+    UI.user_error!("A review submission is already in progress for #{platform}")
+  end
+
+  submission = app.get_ready_review_submission(platform: platform, includes: "items")
+  if submission.nil?
+    submission = app.create_review_submission(platform: platform)
+  elsif !submission.items.empty?
+    UI.user_error!("A review submission with items not created here already exists; cancel it in App Store Connect")
+  end
+
+  submission.add_app_store_version_to_review_items(app_store_version_id: version.id)
+
+  ready = Spaceship::ConnectAPI::AppStoreVersion::AppVersionState::READY_FOR_REVIEW
+  10.times do
+    state = Spaceship::ConnectAPI::AppStoreVersion.get(app_store_version_id: version.id).app_version_state
+    break if state == ready
+    UI.message("Waiting for the version to become #{ready} (now #{state})...")
+    sleep(15)
+  end
+
+  submission.submit_for_review
+end

--- a/.github/workflows/build-test-deploy-dev.yml
+++ b/.github/workflows/build-test-deploy-dev.yml
@@ -1257,7 +1257,7 @@ jobs:
           compression-level: 0
           retention-days: 2
   deploy-win-to-microsoft-store:
-    name: Deploy win app package for ${{ github.ref_name }} to microsoft store
+    name: Upload win app package for ${{ github.ref_name }} to microsoft store
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')
     runs-on: windows-latest
     needs:
@@ -1276,14 +1276,18 @@ jobs:
           name: ${{env.ARTIFACT_NAME}}
           path: ./packages
 
-      - name: Deploy to Store
+      # Stages the package in a pending Partner Center submission, like the
+      # Play internal track and TestFlight for the other platforms. It goes to
+      # certification only from promote-release.yml, once the build is tested.
+      - name: Upload to a pending Store submission
         uses: ActualLab/windows-store-action@main
         with:
+          mode: upload
           tenant-id: ${{ secrets.MSFT_TENANT_ID }}
           client-id: ${{ secrets.MSFT_CLIENT_ID }}
           client-secret: ${{ secrets.MSFT_CLIENT_SECRET }}
           app-id: ${{ secrets.MSFT_PRODUCT_ID }}
           package-path: ./packages
+          delete-pending: true
           delete-packages: true
           packages-keep: 10
-          skip-polling: false

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -236,7 +236,8 @@ jobs:
       # The release-branch run left the package in a pending submission
       # (mode: upload); this commits that submission with the release notes and
       # returns once pre-processing accepted it. Certification itself takes
-      # hours; watch it in Partner Center.
+      # hours; watch it in Partner Center. A later release upload replaces the
+      # pending submission, so the commit is refused unless it holds this build.
       - name: Commit the pending submission
         uses: ActualLab/windows-store-action@main
         with:
@@ -246,5 +247,6 @@ jobs:
           client-secret: ${{ secrets.MSFT_CLIENT_SECRET }}
           app-id: ${{ secrets.MSFT_PRODUCT_ID }}
           release-notes-path: ${{ needs.params.outputs.NOTES_PATH }}
+          expected-package: App.Maui_${{ inputs.version }}.0_x64.msix
           skip-polling: false
           poll-until: certification

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,250 @@
+name: Promote release
+run-name: Promote ${{ inputs.version }} to the stores
+
+# Second stage of a release. The release-branch run of build-test-deploy-dev.yml
+# only stages the prod builds (Play internal track, TestFlight, a pending
+# Microsoft Store submission). Once those builds are tested, this workflow
+# promotes them: Play production track, App Store review, Store certification.
+# Every store job runs under the prod-store environment, which only admits
+# release/* branches — dispatch this on the release branch being promoted.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Build version to promote, as in the release run's artifact names (e.g. 2.17.246)
+        required: true
+        type: string
+      android:
+        description: Google Play — promote the internal-track build to production
+        type: boolean
+        default: true
+      ios:
+        description: App Store — submit the iOS build for review
+        type: boolean
+        default: true
+      macos:
+        description: Mac App Store — submit the Mac Catalyst build for review
+        type: boolean
+        default: true
+      windows:
+        description: Microsoft Store — commit the pending submission to certification
+        type: boolean
+        default: true
+      apple-version:
+        description: App Store version string; empty = X.Y for the first release of the branch, then X.Y.1, X.Y.2, …
+        type: string
+        default: ""
+      android-rollout:
+        description: Google Play rollout percentage (100 = full release)
+        type: string
+        default: "100"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: promote-release
+  cancel-in-progress: false
+
+env:
+  APP_ID: chat.actual.app
+
+jobs:
+  params:
+    name: Resolve release parameters
+    runs-on: ubuntu-latest
+    outputs:
+      NOTES_PATH: ${{ steps.calc.outputs.NOTES_PATH }}
+      ANDROID_VERSION_CODE: ${{ steps.calc.outputs.ANDROID_VERSION_CODE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate version and locate store notes
+        id: calc
+        run: |
+          if [[ "${{ github.ref }}" != refs/heads/release/* ]]; then
+            echo "::error::dispatch this workflow on the release/vX.Y branch; the prod-store environment admits release/* only"
+            exit 1
+          fi
+
+          version="${{ inputs.version }}"
+          if [[ ! $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::version must be X.Y.Z (nbgv SimpleVersion), got '$version'"
+            exit 1
+          fi
+          major=${BASH_REMATCH[1]}; minor=${BASH_REMATCH[2]}; build=${BASH_REMATCH[3]}
+
+          notes="docs/releases/store-notes-v$major.$minor.txt"
+          if [[ ! -s $notes ]]; then
+            echo "::error::$notes is missing; /prepare-release writes it next to the release notes"
+            exit 1
+          fi
+          chars=$(wc -m < "$notes")
+          if (( chars > 500 )); then
+            echo "::error::$notes is $chars characters; Google Play allows 500"
+            exit 1
+          fi
+
+          # Mirrors nbgv's NBGV_SetVersionForMauiAndroid: major << 24 | minor << 16 | build
+          code=$(( major * 16777216 + minor * 65536 + build ))
+
+          echo "NOTES_PATH=$notes" | tee -a "$GITHUB_OUTPUT"
+          echo "ANDROID_VERSION_CODE=$code" | tee -a "$GITHUB_OUTPUT"
+
+          {
+            echo "## Promoting $version"
+            echo
+            echo "Android version code: \`$code\`"
+            echo
+            echo '```'
+            cat "$notes"
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  android:
+    name: Google Play — promote to production
+    if: ${{ inputs.android }}
+    needs: params
+    runs-on: ubuntu-latest
+    environment: prod-store
+    env:
+      VERSION: ${{ inputs.version }}
+      VERSION_CODE: ${{ needs.params.outputs.ANDROID_VERSION_CODE }}
+      NOTES_PATH: ${{ needs.params.outputs.NOTES_PATH }}
+      ROLLOUT: ${{ inputs.android-rollout }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
+          workload_identity_provider: projects/1074465586741/locations/global/workloadIdentityPools/actual-identity-pool/providers/github-actual-chat
+          service_account: sa-deploy-bot@actual-infrastructure.iam.gserviceaccount.com
+
+      # Play refuses a re-upload of an already-used version code, so promotion
+      # references the internal-track build by version code through the edits API.
+      - name: Promote the internal-track build to the production track
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: |
+          set -euo pipefail
+          api="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$APP_ID"
+          call() { curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "$@"; }
+
+          if [[ ! $ROLLOUT =~ ^[0-9]+$ ]] || (( ROLLOUT < 1 || ROLLOUT > 100 )); then
+            echo "::error::android-rollout must be 1..100, got '$ROLLOUT'"; exit 1
+          fi
+
+          edit=$(call -X POST "$api/edits" -d '{}' | jq -r .id)
+          echo "Edit $edit opened"
+
+          internal=$(call "$api/edits/$edit/tracks/internal")
+          echo "$internal" | jq .
+          if ! echo "$internal" | jq -e --arg vc "$VERSION_CODE" '[.releases[]?.versionCodes[]?] | index($vc)' > /dev/null; then
+            echo "::error::version code $VERSION_CODE ($VERSION) is not on the internal track"
+            exit 1
+          fi
+
+          body=$(jq -n --arg vc "$VERSION_CODE" --arg name "$VERSION" --arg rollout "$ROLLOUT" --rawfile notes "$NOTES_PATH" '
+            ($rollout | tonumber) as $pct
+            | {
+                track: "production",
+                releases: [
+                  {
+                    name: $name,
+                    versionCodes: [$vc],
+                    status: (if $pct >= 100 then "completed" else "inProgress" end),
+                    releaseNotes: [{ language: "en-US", text: ($notes | rtrimstr("\n")) }]
+                  }
+                  + (if $pct >= 100 then {} else { userFraction: ($pct / 100) } end)
+                ]
+              }')
+          echo "$body" | jq .
+          call -X PUT "$api/edits/$edit/tracks/production" -d "$body" | jq .
+          call -X POST "$api/edits/$edit:commit" -d '{}' | jq .
+
+          echo "- Android: version code $VERSION_CODE ($VERSION) released to production at ${ROLLOUT}%" >> "$GITHUB_STEP_SUMMARY"
+
+  ios:
+    name: App Store — submit iOS for review
+    if: ${{ inputs.ios }}
+    needs: params
+    runs-on: macos-26
+    environment: prod-store
+    env:
+      APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+      APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+      APPSTORE_API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_BASE64 }}
+      FASTLANE_SKIP_UPDATE_CHECK: 1
+      FASTLANE_HIDE_CHANGELOG: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Submit for review
+        working-directory: .github
+        run: |
+          command -v fastlane > /dev/null || sudo gem install fastlane -N
+          fastlane promote platform:ios \
+            build_version:"${{ inputs.version }}" \
+            version:"${{ inputs.apple-version }}" \
+            notes_path:"$GITHUB_WORKSPACE/${{ needs.params.outputs.NOTES_PATH }}"
+
+  macos:
+    name: Mac App Store — submit Mac Catalyst for review
+    if: ${{ inputs.macos }}
+    needs: params
+    runs-on: macos-26
+    environment: prod-store
+    env:
+      APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+      APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+      APPSTORE_API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_BASE64 }}
+      FASTLANE_SKIP_UPDATE_CHECK: 1
+      FASTLANE_HIDE_CHANGELOG: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Submit for review
+        working-directory: .github
+        run: |
+          command -v fastlane > /dev/null || sudo gem install fastlane -N
+          fastlane promote platform:osx \
+            build_version:"${{ inputs.version }}" \
+            version:"${{ inputs.apple-version }}" \
+            notes_path:"$GITHUB_WORKSPACE/${{ needs.params.outputs.NOTES_PATH }}"
+
+  windows:
+    name: Microsoft Store — commit to certification
+    if: ${{ inputs.windows }}
+    needs: params
+    runs-on: ubuntu-latest
+    environment: prod-store
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The release-branch run left the package in a pending submission
+      # (mode: upload); this commits that submission with the release notes and
+      # returns once pre-processing accepted it. Certification itself takes
+      # hours; watch it in Partner Center.
+      - name: Commit the pending submission
+        uses: ActualLab/windows-store-action@main
+        with:
+          mode: commit
+          tenant-id: ${{ secrets.MSFT_TENANT_ID }}
+          client-id: ${{ secrets.MSFT_CLIENT_ID }}
+          client-secret: ${{ secrets.MSFT_CLIENT_SECRET }}
+          app-id: ${{ secrets.MSFT_PRODUCT_ID }}
+          release-notes-path: ${{ needs.params.outputs.NOTES_PATH }}
+          skip-polling: false
+          poll-until: certification

--- a/docs/releases/store-notes-v2.17.txt
+++ b/docs/releases/store-notes-v2.17.txt
@@ -1,0 +1,7 @@
+Voxt now speaks your language: the whole app is localized, with eight new languages including Polish, Czech, Bulgarian and Indonesian.
+• Redesigned live conversation view
+• Chat icons and avatars in push notifications, faster cold start on Android
+• Steadier video calls: better audio/video sync, cameras no longer sideways on iOS
+• Faster chat opening and lighter battery use in the background
+• Sign-in codes via Telegram when SMS can't reach you
+• Dozens of small fixes and polish


### PR DESCRIPTION
## Summary

Splits app publishing into two stages.

- The `release/vX.Y` CI run now only **stages** the prod builds: Play internal track, TestFlight (iOS + Mac Catalyst), and a **pending** Microsoft Store submission (`ActualLab/windows-store-action` `mode: upload` instead of a straight publish).
- New `promote-release.yml` (manual dispatch on the release branch, `prod-store` environment) **publishes** a tested build:
  - Google Play: promotes the internal-track build to production by version code via the edits API (Play rejects a re-upload of a used version code); optional staged rollout.
  - App Store / Mac App Store: `.github/fastlane/Fastfile` lane `promote` (Spaceship) finds the TestFlight build by its full nbgv version (e.g. 2.17.246), picks the store version per the `X.Y` → `X.Y.1` → `X.Y.2` convention (or takes an explicit one), sets What's New, attaches the build and submits for review.
  - Microsoft Store: commits the pending submission with release notes, polls until pre-processing accepts it.
- Store notes live in `docs/releases/store-notes-vX.Y.txt` (plain text, ≤ 500 chars — Play's limit) and are written by `/prepare-release` step 5b; `store-notes-v2.17.txt` is included as the shape example.
- New `/promote-release` skill: finds the release run and build version, checks the release branch carries the workflow + notes, **asks which staged builds were tested** (hard stop; only confirmed platforms are dispatched), dispatches and watches the run.

Depends on ActualLab/windows-store-action#1 (`mode`, `release-notes-path`, `poll-until`, node20).

## Not verified live

No store API was called for real: the Play edits script, the Spaceship lane and the Store upload/commit modes are validated by syntax checks and a local smoke test of the action bundle only. First real promotion should go one platform at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n5K2aupRkbwZsVMZMRqNv