### PR TITLE
Localize system chat titles for Notes, Announcements and onboarding groups

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -327,6 +327,40 @@ English exists twice on purpose, and `EmptyEntryLocalizationTest` and
 `SystemEntryLocalizationTest` pin the English catalog to each `Default`, so the two
 renderings can't word the same event differently.
 
+### System chat titles
+
+The chats the app creates by itself - the personal Notes chat, the announcements chat,
+a place's Welcome chat, the onboarding groups (Family, Friends, Classmates / Alumni,
+Coworkers) - are stored under the English titles in
+`Constants.Chat.System` (a `SystemChat` is a tag plus its default title) and
+`Constants.Chat.AnnouncementsChatTitle`,
+and named in the reader's language on the way out: the frontend `Chats.Get` rewrites
+`Title` through `ChatTitleLocalizerExt` the same way it rewrites a peer chat's title to
+the peer's name, so the list, the header, pickers and share links all see one name.
+Code with no session localizes per reader - `NotificationsBackend` composes the push
+title per recipient alongside the text, and the email digest uses the recipient's
+language. `SystemChatTitleLocalizationTest` pins the English catalog to the Api
+constants, for the reason above.
+
+**The localized name applies only while the stored title is still the default one.**
+`ChatExt.GetSystemDefaultTitle` is the gate: an owner who renames Coworkers to "Acme
+team" sees "Acme team" everywhere, and so does everyone else. That is also why the
+onboarding step stores the English title rather than `L.Onboarding_ChatCoworkers` -
+a title stored in Russian would read as a rename to every other reader. Editing a
+system chat in settings does not pin its title by accident: the settings form diffs
+against the chat `Chats.Get` returned, so an unchanged (localized) title produces no
+`Title` in the diff.
+
+The keys are `SystemChat_Notes`, `SystemChat_Announcements_Format` (`{0}` is the
+product name) and `SystemChat_Welcome`; the onboarding groups reuse their
+`Onboarding_Chat*` labels, since the label offers exactly the chat that gets created.
+The search index still holds the stored English title, so searching for a system chat
+by its localized name is not yet supported (#4362). A forwarded message's "Forwarded
+from" header shows the `ChatEntryForwarded.ChatTitle` snapshot, taken from the
+forwarder's `Chats.Get` - so it reads in the forwarder's language, not the reader's.
+That is deliberate: the header names someone else's chat, and localizing it would need
+the system tag on the wire and in the entry row for a small surface.
+
 ### Enums are never rendered raw
 
 `@Scope.ToString()` in markup ships an English enum name in every language. Map

--- a/docs/plans/localization-remaining.md
+++ b/docs/plans/localization-remaining.md
@@ -89,8 +89,10 @@ tutorial-slide `alt`s (`Web/Chrome/01`, `Tutorial slide #1` — asset
 identifiers), diagnostics entries, `CaptchaView`'s fake-reCAPTCHA branch,
 `DeveloperTools`, `PlaceInfo`'s `EnableIncompleteUI` mockup text, the three
 `ChatPropertiesMenu` entries that sit inside a `@* … *@` comment block, and chat
-titles that become persisted data (`Notes`, a Place's `Welcome` chat,
-`Anonymous chat (<date>)`).
+titles that become persisted data (`Anonymous chat (<date>)`). System chat titles
+(`Notes`, `Welcome`, the announcements chat, the onboarding groups) are persisted
+in English too, but named per reader on the way out since #4328 — see
+[i18n.md → System chat titles](../i18n.md#system-chat-titles).
 
 ### The runtime check — `ui-localization-smoke.test.ts`
 
@@ -144,9 +146,11 @@ The `right-panel` step had been failing silently against a stale `.right-panel`
 selector — the component is `.chat-side-panel` — so nothing it covered was
 actually being checked. Fixed in the same pass.
 
-The Notes chat title is the one deliberate exception (`KnownEnglish` in the spec):
+The Notes chat title was the one deliberate exception (`KnownEnglish` in the spec):
 `ChatsBackend` creates that chat with the literal title "Notes" and the user can rename
-it, so it is data, not a string.
+it, so it is data, not a string. Since #4328 the stored title stays English but
+`Chats.Get` shows it under `SystemChat_Notes` until the user renames it, so the smoke
+test no longer sees "Notes" on a non-English page.
 
 ### System entries — localized at the render site
 

--- a/src/dotnet/Api/Chat/Chat.cs
+++ b/src/dotnet/Api/Chat/Chat.cs
@@ -50,7 +50,7 @@ public sealed partial record Chat(
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
     public ChatKind Kind => Id.Kind;
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
-    public bool HasSingleAuthor => SystemTag == Constants.Chat.SystemTags.Notes;
+    public bool HasSingleAuthor => this.IsNotes;
 
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
     public AliasInfo<ChatId> AliasInfo => field ??= new(Id, AliasId);

--- a/src/dotnet/Api/Chat/ChatExt.cs
+++ b/src/dotnet/Api/Chat/ChatExt.cs
@@ -8,6 +8,27 @@ public static class ChatExt
     public static bool IsMember(this AuthorRules authorRules)
         => authorRules.Author is { HasLeft: false };
 
+    extension(Chat chat)
+    {
+        // Null for a chat the app didn't name itself - and for a system chat its owner renamed:
+        // the localized name applies only while the stored title is still the default one.
+
+        public string? SystemDefaultTitle
+        {
+            get
+            {
+                var defaultTitle = chat.Id == Constants.Chat.AnnouncementsChatId
+                    ? Constants.Chat.AnnouncementsChatTitle
+                    : Constants.Chat.System.Get(chat.SystemTag)?.DefaultTitle;
+                return defaultTitle == chat.Title ? defaultTitle : null;
+            }
+        }
+
+        public bool IsNotes => chat.SystemTag == Constants.Chat.System.Notes.Tag;
+
+        public bool IsWelcome => chat.SystemTag == Constants.Chat.System.Welcome.Tag;
+    }
+
     public static bool RequiresOwner(this ChatDiff diff)
         => diff.Kind.HasValue
             || diff.IsPublic.HasValue

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -62,6 +62,7 @@ public static partial class Constants
     {
         public static readonly GroupChatId DefaultChatId = GroupChatId.Parse("the-actual-one");
         public static readonly GroupChatId AnnouncementsChatId = GroupChatId.Parse("announcements");
+        public static readonly string AnnouncementsChatTitle = $"{CoreConstants.AppName} Announcements";
         public static readonly GroupChatId FeedbackTemplateChatId = GroupChatId.Parse("feedback-template");
         public static readonly HashSet<ChatId> SystemChatIds = [DefaultChatId, AnnouncementsChatId, FeedbackTemplateChatId];
         public static readonly HashSet<string> SystemChatIdValues = SystemChatIds.Select(x => x.Value).ToHashSet();
@@ -85,24 +86,35 @@ public static partial class Constants
         public const int MaxSearchFilterLength = 100;
         public const int MinChatPageMapSize = 100;
 
-        public static class SystemTags
+        // The English titles here are a deliberate second copy of the SystemChat_* and Onboarding_Chat*
+        // keys in Strings.en.json: a chat is stored with this title and shown under the catalog's while it
+        // keeps it. SystemChatTitleLocalizationTest keeps the two copies equal.
+        public static class System
         {
-            public static readonly Symbol Notes = "notes";
-            // Not used!
-            public static readonly Symbol Family = "family";
-            // Not used!
-            public static readonly Symbol Friends = "friends";
-            // Not used!
-            public static readonly Symbol ClassmatesAlumni = "classmates-alumni";
-            // Not used!
-            public static readonly Symbol Coworkers = "coworkers";
-            public static readonly Symbol Welcome = "welcome";
-            public static readonly Symbol Bot = "ml-bot";
+            public static readonly SystemChat Notes = new("notes", "Notes");
+            public static readonly SystemChat Family = new("family", "Family");
+            public static readonly SystemChat Friends = new("friends", "Friends");
+            public static readonly SystemChat ClassmatesAlumni = new("classmates-alumni", "Classmates / Alumni");
+            public static readonly SystemChat Coworkers = new("coworkers", "Coworkers");
+            public static readonly SystemChat Welcome = new("welcome", "Welcome");
+            public static readonly SystemChat[] All = [Notes, Family, Friends, ClassmatesAlumni, Coworkers, Welcome];
+
+            public static SystemChat? Get(Symbol tag)
+                => All.FirstOrDefault(systemChat => systemChat.Tag == tag);
+
             public static class Rules {
-                private static readonly Symbol[] AllowMultiplePerUser = [Bot, Welcome];
+                private static readonly Symbol[] AllowMultiplePerUser = [Welcome];
                 public static bool MustBeUniquePerUser(Symbol systemTag)
                     => AllowMultiplePerUser.All(e => e != systemTag);
             }
+        }
+
+        /// <summary>
+        /// A chat the app creates by itself: its SystemTag value and the title it is stored with.
+        /// </summary>
+        public sealed record SystemChat(Symbol Tag, string DefaultTitle)
+        {
+            public static implicit operator Symbol(SystemChat systemChat) => systemChat.Tag;
         }
     }
 

--- a/src/dotnet/Chat.Contracts/IChatsUpgradeBackend.cs
+++ b/src/dotnet/Chat.Contracts/IChatsUpgradeBackend.cs
@@ -15,8 +15,6 @@ public interface IChatsUpgradeBackend : ICommandService, IBackendService
     Task<Chat> OnCreateFeedbackTemplateChat(ChatsUpgradeBackend_CreateFeedbackTemplateChat command, CancellationToken cancellationToken);
     [CommandHandler]
     Task OnUpgradeChat(ChatsUpgradeBackend_UpgradeChat command, CancellationToken cancellationToken);
-    [CommandHandler]
-    Task OnFixCorruptedReadPositions(ChatsUpgradeBackend_FixCorruptedReadPositions command, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -53,18 +51,6 @@ public sealed partial record ChatsUpgradeBackend_CreateFeedbackTemplateChat(
 {
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
     public ChatId ShardKey => Constants.Chat.FeedbackTemplateChatId;
-}
-
-/// <summary>
-/// Command to fix corrupted read position records.
-/// </summary>
-[DataContract, MessagePackObject]
-// ReSharper disable once InconsistentNaming
-public sealed partial record ChatsUpgradeBackend_FixCorruptedReadPositions(
-) : ICommand<Unit>, IBackendCommand, IHasShardKey<ChatId?>
-{
-    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
-    public ChatId? ShardKey => null;
 }
 
 /// <summary>

--- a/src/dotnet/Chat.Service/AuthorsBackend.cs
+++ b/src/dotnet/Chat.Service/AuthorsBackend.cs
@@ -192,7 +192,7 @@ public class AuthorsBackend(IServiceProvider services) : DbServiceBase<ChatDbCon
                     .Select(c => new { c.Id, c.SystemTag })
                     .FirstOrDefaultAsync(cancellationToken)
                     .ConfigureAwait(false);
-                if (chat == null || chat.SystemTag == Constants.Chat.SystemTags.Notes) {
+                if (chat == null || chat.SystemTag == Constants.Chat.System.Notes.Tag) {
                     var alreadyHasAuthor = await dbContext.Authors
                         .AnyAsync(a => a.ChatId == chatId.Value && a.UserId != userId.Value, cancellationToken)
                         .ConfigureAwait(false);

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -1,7 +1,6 @@
 using ActualChat.Contacts;
-using ActualChat.Hosting;
 using ActualChat.Kvas;
-using ActualChat.Logging;
+using ActualChat.Localization;
 using ActualChat.Transcription;
 
 namespace ActualChat.Chat;
@@ -24,6 +23,7 @@ public partial class Chats(IServiceProvider services) : IChats
     private IChatsBackend Backend { get; } = services.GetRequiredService<IChatsBackend>();
     private ISharedLocationsBackend SharedLocationsBackend { get; } = services.GetRequiredService<ISharedLocationsBackend>();
     private IServerKvasBackend ServerKvasBackend { get; } = services.GetRequiredService<IServerKvasBackend>();
+    private UserLocalizers UserLocalizers { get; } = services.GetRequiredService<UserLocalizers>();
     private KeyedFactory<IBackendChatMarkupHub, ChatId> ChatMarkupHubFactory { get; }
         = services.KeyedFactory<IBackendChatMarkupHub, ChatId>();
 
@@ -61,6 +61,11 @@ public partial class Chats(IServiceProvider services) : IChats
                 var place = await Places.Get(session, placeChatId.PlaceId, cancellationToken).ConfigureAwait(false);
                 if (place == null)
                     return null;
+            }
+            if (chat.SystemDefaultTitle is not null) {
+                var account = await Accounts.GetOwn(session, cancellationToken).ConfigureAwait(false);
+                var l = await UserLocalizers.Get(account.Id, cancellationToken).ConfigureAwait(false);
+                chat = l.LocalizeTitle(chat);
             }
         }
 

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -939,8 +939,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                 if (chatId is null) {
                     if (placeId is null) // No place is created yet, so we're creating its root chat
                         chatId = PlaceId.New().RootChatId;
-                    else if (Constants.Chat.SystemTags.Welcome == update.SystemTag)
-                        chatId = PlaceChatId.Parse(PlaceChatId.Format(placeId, Constants.Chat.SystemTags.Welcome));
+                    else if (Constants.Chat.System.Welcome == update.SystemTag)
+                        chatId = PlaceChatId.Parse(PlaceChatId.Format(placeId, Constants.Chat.System.Welcome.Tag.Value));
                     else
                         chatId = PlaceChatId.New(placeId);
                 }
@@ -957,9 +957,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
 
             if (update.IsSummarized.IsNone || !update.IsSummarized.Value.HasValue) {
                 var unsupportedSystemChats = new HashSet<Symbol> {
-                    Constants.Chat.SystemTags.Welcome,
-                    Constants.Chat.SystemTags.Notes,
-                    Constants.Chat.SystemTags.Bot,
+                    Constants.Chat.System.Welcome,
+                    Constants.Chat.System.Notes,
                 };
                 if (!update.SystemTag.HasValue || !unsupportedSystemChats.Contains(update.SystemTag.Value))
                     update = update with { IsSummarized = true }; // Enable summarization by default for new chats
@@ -971,7 +970,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             chat = ApplyDiff(chat, update);
             dbChat = new DbChat(chat);
             if (!dbChat.SystemTag.IsNullOrEmpty()
-                && Constants.Chat.SystemTags.Rules.MustBeUniquePerUser(dbChat.SystemTag)) {
+                && Constants.Chat.System.Rules.MustBeUniquePerUser(dbChat.SystemTag)) {
                 // Only group chats can have system tags
                 ownerId.Require("Command.OwnerId");
                 // Chats with system tags should be unique per user except Welcome chat.
@@ -1040,7 +1039,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             dbChat.RequireVersion(expectedVersion);
             if (chatId.Kind is ChatKind.Place) {
                 update.ValidateForPlaceChat();
-                if (Constants.Chat.SystemTags.Welcome == dbChat.SystemTag
+                if (Constants.Chat.System.Welcome.Tag == dbChat.SystemTag
                     && update.IsPublic == false)
                     throw StandardError.Constraint("Can't change chat type to private for 'Welcome' chat.");
             }
@@ -1056,7 +1055,7 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             chatId.Require();
             dbChat.Require();
 
-            if (Constants.Chat.SystemTags.Welcome == dbChat.SystemTag)
+            if (Constants.Chat.System.Welcome.Tag == dbChat.SystemTag)
                 throw StandardError.Constraint("It's prohibited to remove 'Welcome' chat.");
 
             await RemoveMedia(dbChat.MediaId, cancellationToken).ConfigureAwait(false);
@@ -1765,19 +1764,19 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         await using var __ = dbContext.ConfigureAwait(false);
 
         await dbContext.Chats
-            .LockShared(userId, Constants.Chat.SystemTags.Notes, cancellationToken)
+            .LockShared(userId, Constants.Chat.System.Notes, cancellationToken)
             .ConfigureAwait(false);
 
         var hasNotesChat = await dbContext.Chats
             .Join(dbContext.Authors, c => c.Id, a => a.ChatId, (c, a) => new { c, a })
-            .AnyAsync(x => x.a.UserId == userId.Value && x.c.SystemTag == Constants.Chat.SystemTags.Notes.Value, cancellationToken)
+            .AnyAsync(x => x.a.UserId == userId.Value && x.c.SystemTag == Constants.Chat.System.Notes.Tag.Value, cancellationToken)
             .ConfigureAwait(false);
 
         if (hasNotesChat)
             return;
 
         await dbContext.Chats
-            .Lock(userId, Constants.Chat.SystemTags.Notes, cancellationToken)
+            .Lock(userId, Constants.Chat.System.Notes, cancellationToken)
             .ConfigureAwait(false);
 
         var createNotesCommand = new ChatsBackend_Change(
@@ -1785,14 +1784,14 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
             null,
             new Change<ChatDiff> {
                 Create = new ChatDiff {
-                    Title = "Notes",
+                    Title = Constants.Chat.System.Notes.DefaultTitle,
                     Kind = ChatKind.Group,
                     IsPublic = false,
                     MediaId = MediaId.Parse("system-icons:notes"),
                     IsTemplate = false,
                     AllowGuestAuthors = false,
                     AllowAnonymousAuthors = false,
-                    SystemTag = Constants.Chat.SystemTags.Notes,
+                    SystemTag = Constants.Chat.System.Notes,
                 },
             },
             userId);
@@ -2063,9 +2062,9 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         var chatIds = await ListPlaceChatIds(placeId, cancellationToken).ConfigureAwait(false);
         foreach (var chatId in chatIds) {
             var chat = await Get(chatId, cancellationToken).ConfigureAwait(false);
-            if (chat != null && Constants.Chat.SystemTags.Welcome == chat.SystemTag) {
+            if (chat is { IsWelcome: true }) {
                 var resetChatTagCommand = new ChatsBackend_Change(chatId, null, new Change<ChatDiff> {
-                    Update = new ChatDiff { SystemTag = Symbol.Empty }
+                    Update = new ChatDiff { SystemTag = Symbol.Empty },
                 });
                 await Commander.Call(resetChatTagCommand, false, cancellationToken).ConfigureAwait(false);
             }

--- a/src/dotnet/Chat.Service/ChatsUpgradeBackend.InitializeData.cs
+++ b/src/dotnet/Chat.Service/ChatsUpgradeBackend.InitializeData.cs
@@ -59,7 +59,7 @@ public partial class ChatsUpgradeBackend
             null,
             new () {
                 Create = new ChatDiff {
-                    Title = $"{CoreConstants.AppName} Announcements",
+                    Title = Constants.Chat.AnnouncementsChatTitle,
                     IsPublic = true,
                 },
             },

--- a/src/dotnet/Chat.Service/ChatsUpgradeBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsUpgradeBackend.cs
@@ -10,7 +10,6 @@ public partial class ChatsUpgradeBackend : DbServiceBase<ChatDbContext>, IChatsU
     private ChatsBackend ChatsBackend { get; }
     private IAccountsBackend AccountsBackend { get; }
     private IAuthorsBackend AuthorsBackend { get; }
-    private IAuthorsUpgradeBackend AuthorsUpgradeBackend { get; }
     private IRolesBackend RolesBackend { get; }
     private IContactsBackend ContactsBackend { get; }
     private IBlobStorages Blobs { get; }
@@ -21,7 +20,6 @@ public partial class ChatsUpgradeBackend : DbServiceBase<ChatDbContext>, IChatsU
         ChatsBackend = (ChatsBackend)services.GetRequiredService<IChatsBackend>();
         AccountsBackend = services.GetRequiredService<IAccountsBackend>();
         AuthorsBackend = services.GetRequiredService<IAuthorsBackend>();
-        AuthorsUpgradeBackend = services.GetRequiredService<IAuthorsUpgradeBackend>();
         RolesBackend = services.GetRequiredService<IRolesBackend>();
         ContactsBackend = services.GetRequiredService<IContactsBackend>();
         Blobs = Services.GetRequiredService<IBlobStorages>();
@@ -114,46 +112,6 @@ public partial class ChatsUpgradeBackend : DbServiceBase<ChatDbContext>, IChatsU
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         chat = dbChat.ToModel();
         context.Operation.Items.KeylessSet(chat);
-    }
-
-    // [CommandHandler]
-    public virtual async Task OnFixCorruptedReadPositions(
-        ChatsUpgradeBackend_FixCorruptedReadPositions command,
-        CancellationToken cancellationToken)
-    {
-        if (Invalidation.IsActive)
-            return; // It just spawns other commands, so nothing to do here
-
-        var chatPositionsBackend = Services.GetRequiredService<IChatPositionsBackend>();
-
-        var userIds = await ListAllAccountIds(cancellationToken).ConfigureAwait(false);
-        foreach (var userId in userIds) {
-            var chatIds = await AuthorsUpgradeBackend.ListChatIds(userId, cancellationToken).ConfigureAwait(false);
-            foreach (var chatId in chatIds) {
-                var position = await chatPositionsBackend
-                    .Get(userId, chatId, ChatPositionKind.Read, cancellationToken)
-                    .ConfigureAwait(false);
-                if (position.EntryLid <= 0)
-                    continue;
-
-                var idRange = await ChatsBackend.GetLidRange(chatId, false, cancellationToken).ConfigureAwait(false);
-                var lastEntryLid = idRange.End - 1;
-                if (lastEntryLid >= position.EntryLid)
-                    continue;
-
-                // since it was corrupted for some time and user might not know that there are some new message
-                // let's show at least 1 unread message, so user could pay attention to this chat
-                var fixedPosition = new ChatPosition(lastEntryLid - 1);
-                Log.LogInformation(
-                    "Fixing corrupted last read position for user #{UserId} at chat #{ChatId}: {CurrentPosition} -> {FixedPosition}",
-                    userId,
-                    chatId,
-                    position,
-                    fixedPosition);
-                var setCmd = new ChatPositionsBackend_Set(userId, chatId, ChatPositionKind.Read, fixedPosition, true);
-                await Commander.Call(setCmd, true, cancellationToken).ConfigureAwait(false);
-            }
-        }
     }
 
     private async Task<UserId[]> ListAllAccountIds(CancellationToken cancellationToken)

--- a/src/dotnet/Chat.Service/Module/ChatDbInitializer.cs
+++ b/src/dotnet/Chat.Service/Module/ChatDbInitializer.cs
@@ -136,7 +136,7 @@ public class ChatDbInitializer(IServiceProvider services) : DbInitializer<ChatDb
             .Distinct()
             .Where(uid => !dbContext.Chats
                 .Join(dbContext.Authors, c => c.Id, a => a.ChatId, (c, a) => new { c, a })
-                .Any(x => x.a.UserId == uid && x.c.SystemTag == Constants.Chat.SystemTags.Notes.Value))
+                .Any(x => x.a.UserId == uid && x.c.SystemTag == Constants.Chat.System.Notes.Tag.Value))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -146,9 +146,6 @@ public class ChatDbInitializer(IServiceProvider services) : DbInitializer<ChatDb
         Log.LogInformation("There is no 'Notes' chat for some users, creating chats for them");
 
         foreach (var userId in userIds) {
-            if (userId is null)
-                continue;
-
             var createNotesChatCommand = new ChatsBackend_CreateNotesChat(UserId.Parse(userId));
             await Commander.Run(createNotesChatCommand, true, cancellationToken).ConfigureAwait(false);
         }

--- a/src/dotnet/Chat.Service/Module/ChatDbInitializer.cs
+++ b/src/dotnet/Chat.Service/Module/ChatDbInitializer.cs
@@ -46,8 +46,6 @@ public class ChatDbInitializer(IServiceProvider services) : DbInitializer<ChatDb
         // This initializer runs after everything else
         var chatDbInitializer = DbInitializer.GetCurrent<ChatDbInitializer>();
         await chatDbInitializer.WaitForOtherInitializers(_ => true).ConfigureAwait(false);
-
-        // await FixCorruptedReadPositions(cancellationToken).ConfigureAwait(false);
     }
 
     public override Task VerifyData(CancellationToken cancellationToken)
@@ -151,19 +149,5 @@ public class ChatDbInitializer(IServiceProvider services) : DbInitializer<ChatDb
         }
 
         Log.LogInformation("{Count} 'Notes' chats has been created", userIds.Count);
-    }
-
-    private async Task FixCorruptedReadPositions(CancellationToken cancellationToken)
-    {
-        try {
-            Log.LogInformation("Fixing corrupted chat read positions");
-            var command = new ChatsUpgradeBackend_FixCorruptedReadPositions();
-            await Commander.Call(command, cancellationToken).ConfigureAwait(false);
-            Log.LogInformation("Done");
-        }
-        catch (Exception e) {
-            Log.LogCritical(e, "Failed to fix corrupted chat read positions");
-            throw;
-        }
     }
 }

--- a/src/dotnet/Chat.Service/Places.cs
+++ b/src/dotnet/Chat.Service/Places.cs
@@ -61,7 +61,7 @@ public class Places(IServiceProvider services) : IPlaces
             .ConfigureAwait(false);
 
         // TODO(DF): Make it possible to change Welcome Chat
-        var welcomeChat = chats.SkipNullItems().FirstOrDefault(c => Constants.Chat.SystemTags.Welcome == c.SystemTag)
+        var welcomeChat = chats.SkipNullItems().FirstOrDefault(c => c.IsWelcome)
             ?? chats.SkipNullItems().MinBy(c => c.CreatedAt);
         return welcomeChat?.Id as PlaceChatId;
     }

--- a/src/dotnet/Chat.Service/TestDataGenerator.cs
+++ b/src/dotnet/Chat.Service/TestDataGenerator.cs
@@ -123,7 +123,8 @@ public sealed class TestDataGenerator(IServiceProvider services)
         };
         var place = await Commander.Call(createPlaceCommand, true, cancellationToken).ConfigureAwait(false);
 
-        await CreatePlaceChat(session, place, "Welcome", Constants.Chat.SystemTags.Welcome, true, cancellationToken)
+        var welcome = Constants.Chat.System.Welcome;
+        await CreatePlaceChat(session, place, welcome.DefaultTitle, welcome, true, cancellationToken)
             .ConfigureAwait(false);
         var privateChat = await CreatePlaceChat(session, place, "Backstage", Symbol.Empty, false, cancellationToken)
             .ConfigureAwait(false);

--- a/src/dotnet/Localization/Resources/ChatTitleLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/ChatTitleLocalizerExt.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Localization;
+
+namespace ActualChat.Localization;
+
+/// <summary>
+/// Names a chat the app created by itself - Notes, the announcements chat, an onboarding group, a place's
+/// Welcome chat - in the reader's language, for as long as it still carries its default English title.
+/// </summary>
+public static class ChatTitleLocalizerExt
+{
+    extension(IStringLocalizer l)
+    {
+        public Chat.Chat LocalizeTitle(Chat.Chat chat)
+        {
+            var title = l.GetSystemChatTitle(chat);
+            return title is null ? chat : chat with { Title = title };
+        }
+
+        // Null for a chat the user named, including a system chat its owner renamed.
+        public string? GetSystemChatTitle(Chat.Chat chat)
+        {
+            if (chat.SystemDefaultTitle is null)
+                return null;
+            if (chat.Id == Constants.Chat.AnnouncementsChatId)
+                return l.SystemChat_Announcements_Format(CoreConstants.AppName);
+
+            if (chat.SystemTag == Constants.Chat.System.Notes)
+                return l.SystemChat_Notes;
+            if (chat.SystemTag == Constants.Chat.System.Family)
+                return l.Onboarding_ChatFamily;
+            if (chat.SystemTag == Constants.Chat.System.Friends)
+                return l.Onboarding_ChatFriends;
+            if (chat.SystemTag == Constants.Chat.System.ClassmatesAlumni)
+                return l.Onboarding_ChatClassmates;
+            if (chat.SystemTag == Constants.Chat.System.Coworkers)
+                return l.Onboarding_ChatCoworkers;
+            if (chat.SystemTag == Constants.Chat.System.Welcome)
+                return l.SystemChat_Welcome;
+
+            return null;
+        }
+    }
+}

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -404,6 +404,10 @@ public static class LocalizedStringsLocalizerExt
         public string Navbar_SignIn => l["Navbar_SignIn"].Value;
         public string Navbar_TestPages => l["Navbar_TestPages"].Value;
 
+        public string SystemChat_Notes => l["SystemChat_Notes"].Value;
+        public string SystemChat_Announcements_Format(object arg0) => l["SystemChat_Announcements_Format", arg0].Value;
+        public string SystemChat_Welcome => l["SystemChat_Welcome"].Value;
+
         public string LeftPanel_AddNewMembers => l["LeftPanel_AddNewMembers"].Value;
         public string LeftPanel_JoinPlace => l["LeftPanel_JoinPlace"].Value;
         public string LeftPanel_PublicChatsAndPlaces => l["LeftPanel_PublicChatsAndPlaces"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Вход",
   "Navbar_TestPages": "Тестови страници",
 
+  "SystemChat_Notes": "Бележки",
+  "SystemChat_Announcements_Format": "Съобщения от {0}",
+  "SystemChat_Welcome": "Добре дошли",
+
   "LeftPanel_AddNewMembers": "Добавете нови участници",
   "LeftPanel_JoinPlace": "Присъединете се",
   "LeftPanel_PublicChatsAndPlaces": "Отворени чатове и Места",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Prijavite se",
   "Navbar_TestPages": "Test stranice",
 
+  "SystemChat_Notes": "Bilješke",
+  "SystemChat_Announcements_Format": "Obavještenja {0}",
+  "SystemChat_Welcome": "Dobro došli",
+
   "LeftPanel_AddNewMembers": "Dodajte nove članove",
   "LeftPanel_JoinPlace": "Pridružite se",
   "LeftPanel_PublicChatsAndPlaces": "Otvoreni chatovi i Mjesta",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Prijavite se",
   "Navbar_TestPages": "Test stranice",
 
+  "SystemChat_Notes": "Bilješke",
+  "SystemChat_Announcements_Format": "Obavještenja {0}",
+  "SystemChat_Welcome": "Dobro došli",
+
   "LeftPanel_AddNewMembers": "Dodajte nove članove",
   "LeftPanel_JoinPlace": "Pridružite se",
   "LeftPanel_PublicChatsAndPlaces": "Otvoreni chatovi i Mjesta",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Přihlásit se",
   "Navbar_TestPages": "Testovací stránky",
 
+  "SystemChat_Notes": "Poznámky",
+  "SystemChat_Announcements_Format": "Oznámení {0}",
+  "SystemChat_Welcome": "Vítejte",
+
   "LeftPanel_AddNewMembers": "Přidat nové členy",
   "LeftPanel_JoinPlace": "Připojit se",
   "LeftPanel_PublicChatsAndPlaces": "Otevřené chaty a Místa",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Anmelden",
   "Navbar_TestPages": "Testseiten",
 
+  "SystemChat_Notes": "Notizen",
+  "SystemChat_Announcements_Format": "{0}-Ankündigungen",
+  "SystemChat_Welcome": "Willkommen",
+
   "LeftPanel_AddNewMembers": "Neue Mitglieder hinzufügen",
   "LeftPanel_JoinPlace": "Beitreten",
   "LeftPanel_PublicChatsAndPlaces": "Öffentliche Chats und Places",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -469,6 +469,13 @@
   "Navbar_SignIn": "Sign in",
   "Navbar_TestPages": "Test Pages",
 
+  // Names of the chats the app creates by itself - the personal Notes chat, the product
+  // announcements chat, a place's Welcome chat - shown wherever a chat is titled: the list, the
+  // header, notifications. {0} is the product name. The onboarding groups reuse Onboarding_Chat*.
+  "SystemChat_Notes": "Notes",
+  "SystemChat_Announcements_Format": "{0} Announcements",
+  "SystemChat_Welcome": "Welcome",
+
   // Headers and buttons in the left panel, outside the chat list itself.
   "LeftPanel_AddNewMembers": "Add new members",
   "LeftPanel_JoinPlace": "Join",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Iniciar sesión",
   "Navbar_TestPages": "Páginas de prueba",
 
+  "SystemChat_Notes": "Notas",
+  "SystemChat_Announcements_Format": "Anuncios de {0}",
+  "SystemChat_Welcome": "Bienvenida",
+
   "LeftPanel_AddNewMembers": "Añadir miembros",
   "LeftPanel_JoinPlace": "Unirse",
   "LeftPanel_PublicChatsAndPlaces": "Chats y Lugares públicos",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Se connecter",
   "Navbar_TestPages": "Pages de test",
 
+  "SystemChat_Notes": "Notes",
+  "SystemChat_Announcements_Format": "Annonces {0}",
+  "SystemChat_Welcome": "Bienvenue",
+
   "LeftPanel_AddNewMembers": "Ajouter des membres",
   "LeftPanel_JoinPlace": "Rejoindre",
   "LeftPanel_PublicChatsAndPlaces": "Discussions et Lieux publics",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "साइन इन करें",
   "Navbar_TestPages": "टेस्ट पेज",
 
+  "SystemChat_Notes": "नोट्स",
+  "SystemChat_Announcements_Format": "{0} घोषणाएँ",
+  "SystemChat_Welcome": "स्वागत",
+
   "LeftPanel_AddNewMembers": "नए सदस्य जोड़ें",
   "LeftPanel_JoinPlace": "शामिल हों",
   "LeftPanel_PublicChatsAndPlaces": "सार्वजनिक चैट और प्लेस",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Prijavite se",
   "Navbar_TestPages": "Test stranice",
 
+  "SystemChat_Notes": "Bilješke",
+  "SystemChat_Announcements_Format": "Obavijesti {0}",
+  "SystemChat_Welcome": "Dobro došli",
+
   "LeftPanel_AddNewMembers": "Dodajte nove članove",
   "LeftPanel_JoinPlace": "Pridružite se",
   "LeftPanel_PublicChatsAndPlaces": "Otvoreni chatovi i Mjesta",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Masuk",
   "Navbar_TestPages": "Halaman uji",
 
+  "SystemChat_Notes": "Catatan",
+  "SystemChat_Announcements_Format": "Pengumuman {0}",
+  "SystemChat_Welcome": "Selamat datang",
+
   "LeftPanel_AddNewMembers": "Tambah anggota baru",
   "LeftPanel_JoinPlace": "Gabung",
   "LeftPanel_PublicChatsAndPlaces": "Obrolan & Tempat terbuka",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Accedi",
   "Navbar_TestPages": "Pagine di test",
 
+  "SystemChat_Notes": "Note",
+  "SystemChat_Announcements_Format": "Annunci di {0}",
+  "SystemChat_Welcome": "Benvenuto",
+
   "LeftPanel_AddNewMembers": "Aggiungi membri",
   "LeftPanel_JoinPlace": "Entra",
   "LeftPanel_PublicChatsAndPlaces": "Chat e Luoghi pubblici",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "ログイン",
   "Navbar_TestPages": "テストページ",
 
+  "SystemChat_Notes": "メモ",
+  "SystemChat_Announcements_Format": "{0} のお知らせ",
+  "SystemChat_Welcome": "ようこそ",
+
   "LeftPanel_AddNewMembers": "メンバーを追加",
   "LeftPanel_JoinPlace": "参加",
   "LeftPanel_PublicChatsAndPlaces": "公開チャットとプレイス",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "로그인",
   "Navbar_TestPages": "테스트 페이지",
 
+  "SystemChat_Notes": "메모",
+  "SystemChat_Announcements_Format": "{0} 공지사항",
+  "SystemChat_Welcome": "환영합니다",
+
   "LeftPanel_AddNewMembers": "새 멤버 추가",
   "LeftPanel_JoinPlace": "참여",
   "LeftPanel_PublicChatsAndPlaces": "공개 채팅 및 플레이스",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -469,6 +469,13 @@
   "Navbar_SignIn": "Пријавите се",
   "Navbar_TestPages": "Тестовые страницы",
 
+  // Names of the chats the app creates by itself - the personal Notes chat, the product
+  // announcements chat, a place's Welcome chat - shown wherever a chat is titled: the list, the
+  // header, notifications. {0} is the product name. The onboarding groups reuse Onboarding_Chat*.
+  "SystemChat_Notes": "Anotações",
+  "SystemChat_Announcements_Format": "{0} Announcements",
+  "SystemChat_Welcome": "Добро пожаловать",
+
   // Headers and buttons in the left panel, outside the chat list itself.
   "LeftPanel_AddNewMembers": "Neue Mitglieder hinzufügen",
   "LeftPanel_JoinPlace": "Присъединете се",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Zaloguj się",
   "Navbar_TestPages": "Strony testowe",
 
+  "SystemChat_Notes": "Notatki",
+  "SystemChat_Announcements_Format": "Ogłoszenia {0}",
+  "SystemChat_Welcome": "Witamy",
+
   "LeftPanel_AddNewMembers": "Dodaj nowych uczestników",
   "LeftPanel_JoinPlace": "Dołącz",
   "LeftPanel_PublicChatsAndPlaces": "Otwarte czaty i Miejsca",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Entrar",
   "Navbar_TestPages": "Páginas de teste",
 
+  "SystemChat_Notes": "Anotações",
+  "SystemChat_Announcements_Format": "Anúncios do {0}",
+  "SystemChat_Welcome": "Boas-vindas",
+
   "LeftPanel_AddNewMembers": "Adicionar membros",
   "LeftPanel_JoinPlace": "Entrar",
   "LeftPanel_PublicChatsAndPlaces": "Chats e Lugares públicos",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Войти",
   "Navbar_TestPages": "Тестовые страницы",
 
+  "SystemChat_Notes": "Заметки",
+  "SystemChat_Announcements_Format": "Анонсы {0}",
+  "SystemChat_Welcome": "Добро пожаловать",
+
   "LeftPanel_AddNewMembers": "Добавить участников",
   "LeftPanel_JoinPlace": "Вступить",
   "LeftPanel_PublicChatsAndPlaces": "Открытые чаты и Места",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Пријавите се",
   "Navbar_TestPages": "Тест странице",
 
+  "SystemChat_Notes": "Белешке",
+  "SystemChat_Announcements_Format": "Обавештења {0}",
+  "SystemChat_Welcome": "Добро дошли",
+
   "LeftPanel_AddNewMembers": "Додајте нове чланове",
   "LeftPanel_JoinPlace": "Придружите се",
   "LeftPanel_PublicChatsAndPlaces": "Отворени четови и Места",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Giriş yapın",
   "Navbar_TestPages": "Test sayfaları",
 
+  "SystemChat_Notes": "Notlar",
+  "SystemChat_Announcements_Format": "{0} Duyuruları",
+  "SystemChat_Welcome": "Hoş geldiniz",
+
   "LeftPanel_AddNewMembers": "Yeni üye ekleyin",
   "LeftPanel_JoinPlace": "Katılın",
   "LeftPanel_PublicChatsAndPlaces": "Herkese açık sohbetler ve Mekânlar",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Увійти",
   "Navbar_TestPages": "Тестові сторінки",
 
+  "SystemChat_Notes": "Нотатки",
+  "SystemChat_Announcements_Format": "Анонси {0}",
+  "SystemChat_Welcome": "Ласкаво просимо",
+
   "LeftPanel_AddNewMembers": "Додати учасників",
   "LeftPanel_JoinPlace": "Приєднатися",
   "LeftPanel_PublicChatsAndPlaces": "Відкриті чати та Місця",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "Đăng nhập",
   "Navbar_TestPages": "Trang thử nghiệm",
 
+  "SystemChat_Notes": "Ghi chú",
+  "SystemChat_Announcements_Format": "Thông báo {0}",
+  "SystemChat_Welcome": "Chào mừng",
+
   "LeftPanel_AddNewMembers": "Thêm thành viên mới",
   "LeftPanel_JoinPlace": "Tham gia",
   "LeftPanel_PublicChatsAndPlaces": "Cuộc trò chuyện và Địa điểm công khai",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -378,6 +378,10 @@
   "Navbar_SignIn": "登录",
   "Navbar_TestPages": "测试页面",
 
+  "SystemChat_Notes": "笔记",
+  "SystemChat_Announcements_Format": "{0} 公告",
+  "SystemChat_Welcome": "欢迎",
+
   "LeftPanel_AddNewMembers": "添加新成员",
   "LeftPanel_JoinPlace": "加入",
   "LeftPanel_PublicChatsAndPlaces": "公开聊天与地点",

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -508,17 +508,21 @@ public class NotificationsBackend(IServiceProvider services)
             .ToList();
         // The Started banner names who opened the voice chat instead of the generic phrase, so it
         // words itself per reader; every other phase carries the text the command already chose.
+        var mustLocalizeTitle = chat.SystemDefaultTitle is not null;
+        var localizers = isStartedBanner || mustLocalizeTitle
+            ? await GetLocalizers(recipientIds, cancellationToken).ConfigureAwait(false)
+            : [];
         var textByUserId = isStartedBanner
-            ? await ComposeContentByUserId(
-                    recipientIds, new VoiceChatStartedNotificationContent(authorNames), cancellationToken)
-                .ConfigureAwait(false)
+            ? ComposeContentByUserId(localizers, new VoiceChatStartedNotificationContent(authorNames))
             : new Dictionary<UserId, string>();
+        var titleByUserId = ComposeTitleByUserId(localizers, chat);
 
         foreach (var userId in recipientIds) {
             var userText = isStartedBanner ? textByUserId[userId] : text;
+            var userTitle = titleByUserId?[userId] ?? chat.Title;
             var notification = ConversationNotification.New(userId, conversationId, endEntryLid) with {
-                Title = chat.Title,
-                SenderName = chat.Title,
+                Title = userTitle,
+                SenderName = userTitle,
                 Text = userText,
                 IconUrl = iconUrl,
                 SentAt = now,
@@ -565,14 +569,15 @@ public class NotificationsBackend(IServiceProvider services)
             .ListUserIds(chatId, invitees, RequestedAuthorKind.Default, cancellationToken)
             .ConfigureAwait(false);
 
-        var textByUserId = await ComposeContentByUserId(
-                inviteeUserIds, new IncomingCallNotificationContent(hasVideo), cancellationToken)
-            .ConfigureAwait(false);
+        var localizers = await GetLocalizers(inviteeUserIds, cancellationToken).ConfigureAwait(false);
+        var textByUserId = ComposeContentByUserId(localizers, new IncomingCallNotificationContent(hasVideo));
+        var titleByUserId = ComposeTitleByUserId(localizers, chat);
 
         foreach (var inviteeUserId in inviteeUserIds) {
+            var title = titleByUserId?[inviteeUserId] ?? chat.Title;
             var notification = CallNotification.New(inviteeUserId, conversationId, caller, hasVideo) with {
-                Title = chat.Title,
-                SenderName = chat.Title,
+                Title = title,
+                SenderName = title,
                 Text = textByUserId[inviteeUserId],
                 IconUrl = iconUrl,
                 SentAt = now,
@@ -1358,15 +1363,24 @@ public class NotificationsBackend(IServiceProvider services)
         var emojis = reaction is { } r ? ApiArray.New(r.Emoji) : default;
         var otherUserIds = userIds.Where(userId => userId != changeAuthor.UserId).ToList();
         // Composed before the loop: each localizer costs a per-user Kvas read, and awaiting them
-        // one recipient at a time made the fan-out as slow as the chat is large. Left empty when
-        // the text can't vary by reader, which never looks anything up.
+        // one recipient at a time made the fan-out as slow as the chat is large. Nothing is looked
+        // up when neither the text nor the title can vary by reader.
         var sharedText = content.SharedText;
-        var contentByUserId = sharedText is not null
-            ? new Dictionary<UserId, string>()
-            : await ComposeContentByUserId(otherUserIds, content, cancellationToken).ConfigureAwait(false);
+        var mustLocalizeTitle = chat.SystemDefaultTitle is not null;
+        var localizers = sharedText is null || mustLocalizeTitle
+            ? await GetLocalizers(otherUserIds, cancellationToken).ConfigureAwait(false)
+            : [];
+        var contentByUserId = sharedText is null
+            ? ComposeContentByUserId(localizers, content)
+            : new Dictionary<UserId, string>();
+        var groupTitleByUserId = ComposeTitleByUserId(localizers, chat);
 
         foreach (var otherUserId in otherUserIds) {
             var text = sharedText ?? contentByUserId[otherUserId];
+            var userGroupTitle = groupTitleByUserId?[otherUserId] ?? groupTitle;
+            var userTitle = groupTitleByUserId is null
+                ? title
+                : NotificationHelper.GetTitle(senderName, userGroupTitle);
 
             ChatNotification notification = kind switch {
                 NotificationKind.Message => MessageNotification.New(otherUserId, chatId, entryLid, changeAuthor.Id),
@@ -1384,9 +1398,9 @@ public class NotificationsBackend(IServiceProvider services)
                 _ => throw StandardError.NotSupported<NotificationsBackend>($"Unsupported notification kind: {kind}."),
             };
             notification = notification with {
-                Title = title,
+                Title = userTitle,
                 SenderName = senderName,
-                GroupTitle = groupTitle,
+                GroupTitle = userGroupTitle,
                 Text = text,
                 IconUrl = iconUrl,
                 SentAt = now,
@@ -1409,31 +1423,46 @@ public class NotificationsBackend(IServiceProvider services)
     }
 
     // Every recipient's language in one round of reads rather than one per loop iteration - the
-    // way FilterByNotificationMode reads their notification modes. The text varies by language and
-    // not by reader, so it composes once per distinct language however many recipients share it.
-    private async Task<Dictionary<UserId, string>> ComposeContentByUserId(
-        IReadOnlyList<UserId> userIds,
-        NotificationContent content,
-        CancellationToken cancellationToken)
-    {
-        var localizers = await userIds
+    // way FilterByNotificationMode reads their notification modes.
+    private async Task<(UserId UserId, IStringLocalizer Localizer)[]> GetLocalizers(
+        IReadOnlyList<UserId> userIds, CancellationToken cancellationToken)
+        => await userIds
             .Select(async userId => (
                 UserId: userId,
                 Localizer: await UserLocalizers.Get(userId, cancellationToken).ConfigureAwait(false)))
             .Collect(cancellationToken)
             .ConfigureAwait(false);
 
-        var contentByLanguage = new Dictionary<Language, string>();
-        var contentByUserId = new Dictionary<UserId, string>(localizers.Length);
+    private static Dictionary<UserId, string> ComposeContentByUserId(
+        (UserId UserId, IStringLocalizer Localizer)[] localizers, NotificationContent content)
+        => ComposeByUserId(localizers, content, static (l, x) => x.Render(l));
+
+    // A system chat - Notes, the announcements chat - is named per reader the way the text is;
+    // null for any other chat, whose title reads the same to everyone.
+    private static Dictionary<UserId, string>? ComposeTitleByUserId(
+        (UserId UserId, IStringLocalizer Localizer)[] localizers, Chat.Chat chat)
+        => chat.SystemDefaultTitle is null
+            ? null
+            : ComposeByUserId(localizers, chat, static (l, x) => l.LocalizeTitle(x).Title);
+
+    // The text varies by language and not by reader, so it composes once per distinct language
+    // however many recipients share it.
+    private static Dictionary<UserId, string> ComposeByUserId<T>(
+        (UserId UserId, IStringLocalizer Localizer)[] localizers,
+        T state,
+        Func<IStringLocalizer, T, string> compose)
+    {
+        var textByLanguage = new Dictionary<Language, string>();
+        var textByUserId = new Dictionary<UserId, string>(localizers.Length);
         // static + a tuple argument rather than a capturing lambda: l changes every iteration, so a
         // closure here would be the per-recipient allocation this method exists to avoid.
         foreach (var (userId, l) in localizers)
-            contentByUserId[userId] = contentByLanguage.GetOrAdd(
+            textByUserId[userId] = textByLanguage.GetOrAdd(
                 ((IHasUILanguage)l).UILanguage,
-                static (_, x) => x.Content.Render(x.Localizer),
-                (Content: content, Localizer: l));
+                static (_, x) => x.Compose(x.Localizer, x.State),
+                (State: state, Localizer: l, Compose: compose));
 
-        return contentByUserId;
+        return textByUserId;
     }
 
     private async Task<IReadOnlyList<Device>> ListDevices(

--- a/src/dotnet/UI.Blazor.App/Components/ChatSettings/ChatSettingsStartModalPage.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatSettings/ChatSettingsStartModalPage.razor
@@ -182,7 +182,7 @@
         };
         _placeId = (chat.Id as PlaceChatId)?.PlaceId;
         if (_placeId is not null)
-            _isPlaceWelcomeChat = Constants.Chat.SystemTags.Welcome == chat.SystemTag;
+            _isPlaceWelcomeChat = chat.IsWelcome;
         Context.Items.KeylessSet(_form);
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatSettings/EditChatTypeModalPage.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatSettings/EditChatTypeModalPage.razor.cs
@@ -53,7 +53,7 @@ public partial class EditChatTypeModalPage
         var chat = await Chats.Get(Session, ChatId, CancellationToken.None).Require();
         _placeId = (chat.Id as PlaceChatId)?.PlaceId;
         if (_placeId is not null) {
-            _isPlaceWelcomeChat = Constants.Chat.SystemTags.Welcome == chat.SystemTag;
+            _isPlaceWelcomeChat = chat.IsWelcome;
             _place = await Places.Get(Session, _placeId, CancellationToken.None).Require().ConfigureAwait(false);
             if (_place.IsPublic && _place.AliasId is not null)
                 _aliasLocalPrefix = $"{Links.ChatAliasPrefix}{_place.AliasId.Value}{Links.Separator}{Links.AliasPrefix}";

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatWelcomeBlock.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatWelcomeBlock.razor
@@ -86,7 +86,7 @@
         var chatId = Chat.Id;
 
         var messageType = MessageType.Default;
-        if (Chat.HasSingleAuthor && Chat.SystemTag == Constants.Chat.SystemTags.Notes)
+        if (Chat.IsNotes)
             messageType = MessageType.Notes;
         var shareModel = await ShareUI.GetModel(chatId, cancellationToken).ConfigureAwait(false);
         if (shareModel is { Kind: ShareKind.Contact })

--- a/src/dotnet/UI.Blazor.App/Components/NewPlace/NewPlaceModalProps.razor
+++ b/src/dotnet/UI.Blazor.App/Components/NewPlace/NewPlaceModalProps.razor
@@ -158,12 +158,12 @@
                 ExpectedVersion = null,
                 Change = new() {
                     Create = new ChatDiff {
-                        Title = "Welcome",
+                        Title = Constants.Chat.System.Welcome.DefaultTitle,
                         Description = description,
                         Kind = null,
                         IsPublic = true,
                         MediaId = _form.Picture?.MediaRef?.MediaId,
-                        SystemTag = Constants.Chat.SystemTags.Welcome,
+                        SystemTag = Constants.Chat.System.Welcome,
                         PlaceId = place.Id
                     },
                 },

--- a/src/dotnet/UI.Blazor.App/Components/Onboarding/CreateChatsStep.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Onboarding/CreateChatsStep.razor
@@ -107,32 +107,30 @@
 
     protected override async Task<bool> Save() {
         if (_model.CreateFamilyChat)
-            await CreateChat(L.Onboarding_ChatFamily, Constants.Chat.SystemTags.Family);
+            await CreateChat(Constants.Chat.System.Family);
         if (_model.CreateFriendsChat)
-            await CreateChat(L.Onboarding_ChatFriends, Constants.Chat.SystemTags.Friends);
+            await CreateChat(Constants.Chat.System.Friends);
         if (_model.CreateClassmatesAlumniChat)
-            await CreateChat(
-                L.Onboarding_ChatClassmates,
-                Constants.Chat.SystemTags.ClassmatesAlumni,
-                "system-icons:alumni");
+            await CreateChat(Constants.Chat.System.ClassmatesAlumni, "system-icons:alumni");
         if (_model.CreateCoworkersChat)
-            await CreateChat(L.Onboarding_ChatCoworkers, Constants.Chat.SystemTags.Coworkers);
+            await CreateChat(Constants.Chat.System.Coworkers);
 
         return true;
     }
 
-    private async Task CreateChat(string title, Symbol systemTag, string? mediaId = null) {
+    private async Task CreateChat(Constants.Chat.SystemChat systemChat, string? mediaId = null) {
+        // Stored in English: the server names the chat in each reader's language while it keeps this title.
         var command = new Chats_Change {
             Session = Session,
             ChatId = default,
             ExpectedVersion = null,
             Change = new() {
                 Create = new ChatDiff {
-                    Title = title,
+                    Title = systemChat.DefaultTitle,
                     Kind = ChatKind.Group,
-                    MediaId = MediaId.Parse(mediaId ?? $"system-icons:{systemTag.Value}"),
+                    MediaId = MediaId.Parse(mediaId ?? $"system-icons:{systemChat.Tag.Value}"),
                     IsPublic = false,
-                    SystemTag = systemTag,
+                    SystemTag = systemChat.Tag,
                 },
             },
         };

--- a/src/dotnet/UI.Blazor.App/Services/ChatListExt.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListExt.cs
@@ -51,7 +51,7 @@ public static class ChatListExt
             ChatListPreOrder.ChatList => PreOrderChatListFor(chats, order, liftedAt),
             ChatListPreOrder.None => chats.ToFakeOrderedEnumerable(),
             ChatListPreOrder.NotesFirst => chats
-                .OrderByDescending(c => c.Chat.SystemTag == Constants.Chat.SystemTags.Notes),
+                .OrderByDescending(c => c.Chat.IsNotes),
             ChatListPreOrder.ReactionsFirst => LiftBy(chats, liftedAt),
             _ => throw new ArgumentOutOfRangeException(nameof(preOrder)),
         };
@@ -80,7 +80,7 @@ public static class ChatListExt
             ChatListPreOrder.ChatList => contacts.OrderByDescending(c => c.Contact.IsPinned),
             ChatListPreOrder.None => contacts.ToFakeOrderedEnumerable(),
             ChatListPreOrder.NotesFirst => contacts.OrderByDescending(
-                c => c.Chat.SystemTag == Constants.Chat.SystemTags.Notes),
+                c => c.Chat.IsNotes),
             _ => throw new ArgumentOutOfRangeException(nameof(preOrder)),
         };
         return order switch {

--- a/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
@@ -477,7 +477,7 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     private async Task<ChatInfo?> GetNotes(CancellationToken cancellationToken = default)
     {
         var chatById = await ListUnorderedRaw(null, cancellationToken).ConfigureAwait(false);
-        return chatById.Values.FirstOrDefault(c => c.Chat.SystemTag == Constants.Chat.SystemTags.Notes);
+        return chatById.Values.FirstOrDefault(c => c.Chat.IsNotes);
     }
 
     private async Task<IReadOnlyDictionary<ChatId, ChatInfo>> AddUnlistedSelectedChat(

--- a/src/dotnet/Users.Service/EmailsBackend.cs
+++ b/src/dotnet/Users.Service/EmailsBackend.cs
@@ -1,5 +1,6 @@
 using ActualChat.Chat.ML;
 using ActualChat.Contacts;
+using ActualChat.Localization;
 using ActualChat.Users.Email;
 using ActualChat.Users.Templates;
 using Mjml.Net;
@@ -231,7 +232,7 @@ public class EmailsBackend(IServiceProvider services) : IEmailsBackend
             return default;
 
         return new DigestParameters.DigestChat {
-            Name = chat.Title,
+            Name = LanguageStringLocalizer.Get(userLanguage).LocalizeTitle(chat).Title,
             Link = UrlMapper.ToAbsolute(Links.Chat(chat.Id)),
             UnreadCount = unreadCount,
             BulletPoints = bulletPoints,

--- a/tests/Chat.IntegrationTests/ChatOperationsTest.cs
+++ b/tests/Chat.IntegrationTests/ChatOperationsTest.cs
@@ -240,7 +240,7 @@ public class ChatOperationsTest(ChatCollection.AppHostFixture fixture, ITestOutp
                 .Collect(ct))
                 .SkipNullItems()
                 .ToList();
-            chats.Any(c => c.SystemTag == Constants.Chat.SystemTags.Notes).Should().BeTrue();
+            chats.Any(c => c.IsNotes).Should().BeTrue();
         });
 
         // assert
@@ -249,7 +249,7 @@ public class ChatOperationsTest(ChatCollection.AppHostFixture fixture, ITestOutp
             await using var dbContext = await dbHub.CreateDbContext();
             var dbChat = await dbContext.Chats
                 .Join(dbContext.Authors, c => c.Id, a => a.ChatId, (c, a) => new { c, a })
-                .Where(x => x.a.UserId == account.Id.Value && x.c.SystemTag == Constants.Chat.SystemTags.Notes.Value)
+                .Where(x => x.a.UserId == account.Id.Value && x.c.SystemTag == Constants.Chat.System.Notes.Tag.Value)
                 .Select(x => x.c)
                 .FirstOrDefaultAsync();
             dbChat.Should().NotBeNull();

--- a/tests/Chat.UI.Blazor.IntegrationTests/ChatVideoUIStateTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/ChatVideoUIStateTest.cs
@@ -127,7 +127,7 @@ public class ChatVideoUIStateTest(ChatAppHostFixture fixture, ITestOutputHelper 
                 .ConfigureAwait(false);
             notesChat = chats
                 .SkipNullItems()
-                .FirstOrDefault(c => c.SystemTag == Constants.Chat.SystemTags.Notes);
+                .FirstOrDefault(c => c.IsNotes);
             notesChat.Should().NotBeNull();
         });
 

--- a/tests/Chat.UI.Blazor.UnitTests/SystemChatTitleLocalizationTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/SystemChatTitleLocalizationTest.cs
@@ -1,0 +1,101 @@
+using ActualChat.Localization;
+using Microsoft.Extensions.Localization;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public sealed class SystemChatTitleLocalizationTest
+{
+    [Fact]
+    public void EnglishCatalogShouldMatchTheDefaultTitles()
+    {
+        // A chat is stored with the Api's English title and shown under the catalog's, so the two
+        // must agree - or an English reader would see one name in the list and another after a reload.
+
+        // arrange
+        var l = NewLocalizer(Languages.English);
+
+        // act
+        var mismatches = SystemChats()
+            .Select(chat => (Localized: l.GetSystemChatTitle(chat), chat.Title))
+            .Where(x => x.Localized != x.Title)
+            .Select(x => $"'{x.Localized}' != '{x.Title}'")
+            .ToList();
+
+        // assert
+        mismatches.Should().BeEmpty(
+            "the English catalog must name every system chat exactly as the Api does:\n{0}",
+            string.Join("\n", mismatches));
+    }
+
+    [Fact]
+    public void EveryShippedLanguageShouldNameEverySystemChat()
+    {
+        // arrange
+        var errors = new List<string>();
+
+        // act
+        foreach (var language in ShippedLanguages()) {
+            var l = NewLocalizer(language);
+            foreach (var chat in SystemChats()) {
+                var title = l.GetSystemChatTitle(chat);
+                if (title.IsNullOrEmpty())
+                    errors.Add($"'{language.IsoCode}' names nothing for '{chat.Title}'");
+                else if (title.Contains("SystemChat_") || title.Contains("Onboarding_"))
+                    errors.Add($"'{language.IsoCode}' leaves a key unresolved: '{title}'");
+            }
+        }
+
+        // assert
+        errors.Should().BeEmpty(
+            "every system chat must have a name in every shipped language:\n{0}", string.Join("\n", errors));
+    }
+
+    [Fact]
+    public void RenamedSystemChatShouldKeepItsName()
+    {
+        // arrange
+        var l = NewLocalizer(Languages.Russian);
+        var renamed = SystemChats().Select(chat => chat with { Title = "My " + chat.Title }).ToList();
+
+        // act
+        var titles = renamed.Select(chat => l.LocalizeTitle(chat).Title);
+
+        // assert
+        titles.Should().Equal(renamed.Select(chat => chat.Title), "a title the owner chose is not translated");
+    }
+
+    [Fact]
+    public void OrdinaryChatShouldKeepItsName()
+    {
+        // arrange
+        var l = NewLocalizer(Languages.Russian);
+        var chat = new Chat(GroupChatId.New()) { Title = Constants.Chat.System.Notes.DefaultTitle };
+
+        // act
+        var localized = l.LocalizeTitle(chat);
+
+        // assert
+        localized.Should().BeSameAs(chat, "a chat merely called 'Notes' is not the Notes chat");
+    }
+
+    // Private methods
+
+    private static IEnumerable<Chat> SystemChats()
+    {
+        yield return new Chat(Constants.Chat.AnnouncementsChatId) { Title = Constants.Chat.AnnouncementsChatTitle };
+        foreach (var systemChat in Constants.Chat.System.All) {
+            var chatId = systemChat == Constants.Chat.System.Welcome
+                ? PlaceChatId.New(PlaceId.New())
+                : (ChatId)GroupChatId.New();
+            yield return new Chat(chatId) { Title = systemChat.DefaultTitle, SystemTag = systemChat.Tag };
+        }
+    }
+
+    private static IStringLocalizer NewLocalizer(Language language)
+        => new TestStringLocalizer(StringCatalogs.LoadStrings(language)!, language);
+
+    private static IEnumerable<Language> ShippedLanguages()
+        => StringCatalogs.ShippedSubtags(StringCatalogs.Kind.Strings)
+            .Select(s => Languages.AllUIAndTestOnly.SingleOrDefault(l => l.IsoCode == s))
+            .OfType<Language>();
+}

--- a/tests/ts/e2e/ui-localization-smoke.test.ts
+++ b/tests/ts/e2e/ui-localization-smoke.test.ts
@@ -38,9 +38,7 @@ const IgnoredContainers = ['.docs-content'];
 
 // Keys whose English text legitimately shows up in a localized UI, and why. A text is excused
 // only when every key that produces it is listed here.
-const KnownEnglish: Record<string, string> = {
-    Navbar_Notes: 'the built-in Notes chat is created server-side with an English title the user can rename',
-};
+const KnownEnglish: Record<string, string> = {};
 
 interface TourStep {
     name: string;


### PR DESCRIPTION
Closes #4328.

## What

System chats are now named in the reader's UI language wherever a chat is titled: the chat list, the header, pickers, share links, push notifications and the email digest.

- **Notes**, the **announcements** chat, a place's **Welcome** chat, and the onboarding groups (**Family, Friends, Classmates / Alumni, Coworkers**).
- Titles stay English in the DB. The frontend `Chats.Get` rewrites `Title` through `ChatTitleLocalizerExt`, the same way it already rewrites a peer chat's title to the peer's name, so every UI surface sees one name. `NotificationsBackend` composes the push title per recipient next to the text, with one lookup per distinct language and no extra reads for ordinary chats.
- **A renamed system chat keeps its name.** `ChatExt.GetSystemDefaultTitle` substitutes only while the stored title is still the default, so an owner who renames Coworkers to "Acme team" sees "Acme team" everywhere, and so does everyone else. Saving the settings form without editing the title does not pin it, because the form diffs against the already-localized chat.
- Onboarding now stores the English default title instead of the current language's label, so the name follows later language changes.
- Each system chat is modelled as `Constants.Chat.SystemChat(Tag, DefaultTitle)` under `Constants.Chat.SystemChats` (formerly `SystemTags`), with an implicit conversion to `Symbol` so tag comparisons read as before.

Catalog: `SystemChat_Notes`, `SystemChat_Announcements_Format` (`{0}` is the product name) and `SystemChat_Welcome` in all 19 hand-written catalogs, bcms and Max regenerated. The onboarding groups reuse their `Onboarding_Chat*` labels.

## Not covered

- Onboarding chats created before this change in a non-English UI hold a localized title in the DB, so they look renamed and stay as they are. A one-off upgrade step could reset those to the English default.
- The search index still holds the stored English title, so searching for a system chat by its localized name does not work yet.

## Tests

- New `SystemChatTitleLocalizationTest` pins the English catalog to the Api defaults, checks every shipped language, a renamed chat and an ordinary chat that merely happens to be called "Notes".
- Localization unit tests (73) and `ChatOperationsTest` integration tests (31) pass. The Notes allowlist entry in `ui-localization-smoke.test.ts` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
