### PR TITLE
fix(notifications): recreate the attention channel when its sound goes stale

### DIFF
--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/ChatAttentionService.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/ChatAttentionService.cs
@@ -217,8 +217,13 @@ public sealed class ChatAttentionService
             .OrderBy(c => c.CreatedOnUtc)
             .Take(MaxNotificationCount)
             .ToArray();
+        // Android 16 force-silences a notification posted while another one from the same group is
+        // already showing (https://issuetracker.google.com/issues/424448500). Children carry the
+        // alert to GROUP_ALERT_SUMMARY and the summary is posted first, so there's never a second
+        // notification competing with the one meant to make noise.
+        var hasSummary = requests.Length > 1;
         for (int i = 0; i < mostImportantRequests.Length; i++) {
-            var request = requests[i];
+            var request = mostImportantRequests[i];
             var title = request.Title;
             var content = request.Body;
 
@@ -240,11 +245,13 @@ public sealed class ChatAttentionService
                 builder.AddAction(0, L.ChatAttention_Snooze, snoozePendingIntent);
 
             builder.SetOnlyAlertOnce(true);
+            if (hasSummary)
+                builder.SetGroupAlertBehavior(NotificationCompat.GroupAlertSummary);
             var notification = builder.Build()!;
             notifications.Add((i + 1, notification));
         }
 
-        if (requests.Length > 1) {
+        if (hasSummary) {
             var minStartTime = requests.Min(c => c.CreatedOnUtc).ToLocalTime();
             var summaryBuilder = CreateNotification(
                 minStartTime,
@@ -254,7 +261,7 @@ public sealed class ChatAttentionService
             summaryBuilder.SetGroupSummary(true);
             summaryBuilder.SetOnlyAlertOnce(true);
             var summaryNotification = summaryBuilder.Build()!;
-            notifications.Add((0, summaryNotification));
+            notifications.Insert(0, (0, summaryNotification));
         }
 
         foreach (var (id, notification) in notifications)

--- a/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/Notifications/NotificationHelper.cs
@@ -152,9 +152,22 @@ public static class NotificationHelper
         notificationManager.CreateNotificationChannel(channel);
     }
 
+    // Bump whenever this method's channel config (sound, vibration, importance, ...) intentionally
+    // changes - see MauiPreferences.AttentionChannelConfigVersion.
+    private const int AttentionChannelConfigVersion = 1;
+
     public static void EnsureAttentionNotificationChannelExist(Context context, string channelId)
     {
         var notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService)!;
+        // A channel's sound is fixed at creation and never updated by a later CreateNotificationChannel
+        // call - e.g. a numeric-id resource URI baked in by an older build can dangle after a rebuild
+        // renumbers raw resource ids, and MediaPlayer then fails to prepare it while vibration, not
+        // resource-backed, still fires. Deleting an out-of-date channel makes Android recreate it
+        // fresh under the same id.
+        if (MauiPreferences.AttentionChannelConfigVersion != AttentionChannelConfigVersion) {
+            notificationManager.DeleteNotificationChannel(channelId);
+            MauiPreferences.AttentionChannelConfigVersion = AttentionChannelConfigVersion;
+        }
         var channel = new NotificationChannel(channelId,
             L.NotificationChannel_Attention,
             NotificationImportance.High);
@@ -163,9 +176,15 @@ public static class NotificationHelper
             .SetContentType(AudioContentType.Music)!
             .Build();
         //var ringtoneUri = RingtoneManager.GetDefaultUri(RingtoneType.Ringtone);
-        var ringtoneUri = Android.Net.Uri.Parse($"android.resource://{context.PackageName}/"
-            // ReSharper disable once AccessToStaticMemberViaDerivedType
-            + Microsoft.Maui.Resource.Raw.attention_ringtone);
+        // Name-based (not id-based) so it keeps resolving across builds that renumber raw resource ids.
+        // The name comes from the live id rather than a hardcoded string so it can't itself drift out
+        // of sync with the resource - a rename/removal breaks the id reference below at compile time.
+        var ringtoneId = Microsoft.Maui.Resource.Raw.attention_ringtone;
+        var resources = context.Resources!;
+        var ringtoneType = resources.GetResourceTypeName(ringtoneId);
+        var ringtoneName = resources.GetResourceEntryName(ringtoneId);
+        var ringtoneUri = Android.Net.Uri.Parse(
+            $"android.resource://{context.PackageName}/{ringtoneType}/{ringtoneName}");
         channel.SetSound(ringtoneUri, attrs);
         var vibratePattern = new long[] { 0, 700, 500, 700, 500, 500 };
         channel.SetVibrationPattern(vibratePattern);

--- a/src/dotnet/Maui/MauiPreferences.cs
+++ b/src/dotnet/Maui/MauiPreferences.cs
@@ -20,6 +20,7 @@ public static class MauiPreferences
     private const string UILanguageKey = "UILanguage";
     private const string MinReportableClientVersionKey = "min_reportable_client_version";
     private const string IsPttArmedKey = "is_ptt_armed";
+    private const string AttentionChannelConfigVersionKey = "attention_channel_config_version";
 
     private static readonly Lock Lock = new();
     private static readonly ConcurrentDictionary<string, object?> Cache = new();
@@ -88,6 +89,13 @@ public static class MauiPreferences
         // service while still in the foreground - the app's own state arrives far too late.
         get => Get<bool?>(IsPttArmedKey) ?? false;
         set => Set(IsPttArmedKey, value);
+    }
+
+    // An Android NotificationChannel's sound/vibration/importance are frozen at first creation, so a
+    // mismatch here tells NotificationHelper to delete and recreate the channel under the same id.
+    public static int AttentionChannelConfigVersion {
+        get => Get<int?>(AttentionChannelConfigVersionKey) ?? 0;
+        set => Set(AttentionChannelConfigVersionKey, value);
     }
 
     public static string? GetHostIp(string hostName)

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -600,7 +600,6 @@ body.hoverable .message-wrapper:has(.chat-welcome-block):hover {
     background-size: 300%;
     background-position-x: 100%;
     animation: shimmer 5s infinite steps(50);
-    transition: width 150ms;
 }
 .notify-mentioned-members .c-icon {
     @apply flex-none flex items-center justify-center;
@@ -608,26 +607,27 @@ body.hoverable .message-wrapper:has(.chat-welcome-block):hover {
     @apply -ml-1;
 }
 body.hoverable .notify-mentioned-members.not-notified {
-    @apply w-7;
+    @apply flex-nowrap;
+    @apply w-fit;
     @apply cursor-pointer;
-}
-body.hoverable .notify-mentioned-members.not-notified:hover {
-    @apply w-30;
-    transition: width 150ms;
 }
 .notify-mentioned-members.has-notified {
     @apply rounded-lg;
 }
+/* The pill sizes to its label rather than to a fixed expanded width: that width fit the English
+   label but not its translations, and the overflow wrapped the label under the icon. */
 body.hoverable .notify-mentioned-members .not-mentioned {
     @apply flex items-center;
-    @apply w-0 h-0;
+    @apply max-w-0;
+    @apply overflow-hidden;
+    @apply whitespace-nowrap;
     filter: opacity(0);
-    transition: filter 0ms linear 0ms, -webkit-filter 0ms linear 0ms, width 0ms linear 0ms;
+    transition: filter 0ms linear 0ms, -webkit-filter 0ms linear 0ms, max-width 0ms linear 0ms;
 }
 body.hoverable .notify-mentioned-members:hover .not-mentioned {
-    width: auto;
+    @apply max-w-60;
     filter: opacity(1);
-    transition: filter 150ms linear 150ms, -webkit-filter 150ms linear 150ms, width 150ms linear 150ms;
+    transition: filter 150ms linear 150ms, -webkit-filter 150ms linear 150ms, max-width 150ms linear 150ms;
 }
 @keyframes shimmer {
     0%, 90% {


### PR DESCRIPTION
## Summary
- The Android attention-notification channel's sound `Uri` was built from a numeric raw-resource id. AAPT2 doesn't guarantee that id stays stable across builds, and a `NotificationChannel`'s config is frozen forever after first creation - a device that created the channel under an older build is stuck with a dangling id, so `MediaPlayer` fails to prepare it while vibration (not resource-backed) keeps firing. Confirmed on a real Android 16 device via `adb logcat`/`dumpsys` (see PR discussion for the trace): `RingtonePlayer: error loading sound ... IOException: Prepare failed: status=0x1`, and via `aapt2 dump resources` that the same resource name maps to a different numeric id between builds.
- Fix: build the sound `Uri` by name (`android.resource://<pkg>/raw/attention_ringtone`), derived at runtime from the live resource id rather than hardcoded, so it can't itself drift. Added `MauiPreferences.AttentionChannelConfigVersion`, checked on every `EnsureAttentionNotificationChannelExist` call - a mismatch deletes and recreates the channel under the *same* id, so already-affected devices self-heal without losing the channel id or needing a new one per future config change.
- Also fixes an unrelated indexing bug in `ChatAttentionService.Notify` (iterated the sorted/capped request list but read from the unsorted one), and moves the multi-request summary notification to `GROUP_ALERT_SUMMARY`, posted before its children, so several pending chats alert once instead of once per chat.

## Test plan
- [x] `dotnet build App.Maui.csproj -f net11.0-android` - 0 errors
- [x] Statically verified the derived sound `Uri` against a freshly built APK with `aapt2 dump resources` (`raw/attention_ringtone` resolves to `res/raw/attention_ringtone.mp3`)
- [ ] Install on a device that already has the (broken) channel and confirm the attention notification now plays sound, not just vibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxBaviexugYdpbDYN4ukzJ