### PR TITLE
fix(ui): safe-area bands and mirrored header rounding across panels

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatSettings/chat-settings-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatSettings/chat-settings-modal.css
@@ -199,10 +199,22 @@ body.hoverable .chat-settings-container .tile-item:hover {
     @apply relative;
     @apply flex-none;
     @apply w-full;
-    @apply rounded-b-xl;
+    /* Rounded top-right + bottom-left only (mirror of the left panel): top-left and bottom-right stay square. */
+    @apply rounded-tr-2xl rounded-bl-2xl;
     @apply overflow-hidden;
-    height: calc(6.5rem + var(--safe-area-top-narrow));
-    padding-top: var(--safe-area-top-narrow);
+    height: 6.5rem;
+    /* Start below the top inset (which the bg-03 band paints) rather than reserving it inside, so the
+       header image sits under the notch strip - the right-panel look. */
+    margin-top: var(--safe-area-top-narrow);
+}
+/* Keep the top inset bg-03 (the panel colour) instead of the header image bleeding into the notch. */
+body.narrow .own-avatar-edit-header::before,
+body.narrow .chat-settings-header::before {
+    @apply content-empty;
+    @apply absolute left-0 right-0 top-0 z-30;
+    @apply pointer-events-none;
+    @apply bg-03;
+    height: var(--safe-area-top-narrow);
 }
 body.narrow .own-avatar-edit-header > .c-top::after,
 body.narrow .chat-settings-header > .c-top::after {

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/left-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/left-panel.css
@@ -69,25 +69,24 @@
 .left-panel-content.search-open {
     @apply bg-04;
 }
-/* Wide only: there the whole top is one flat strip painted by .base-layout::before, and this just
-   reserves the room under it. In narrow the panel's own background has to reach the top of the
-   screen instead, so the spacer collapses and the header below grows by the inset. */
+/* The panel reserves and paints its top inset as a bg-04 band. In narrow it is the visible safe-area
+   strip the header's rounded corner blends into; in wide .base-layout::before paints a flat strip over it. */
 .left-panel-content > .safe-area-top {
-    height: var(--safe-area-top-wide);
+    height: var(--safe-area-top);
     @apply bg-04;
 }
-/* bg-03 comes from .left-panel-content, so padding is all it takes to carry it into the inset. */
-body.narrow .left-panel-content-header:not(.place) {
-    padding-top: var(--safe-area-top-narrow);
+/* Round the wallpaper's top-left only in narrow mode, where the bg-04 safe-area strip exists to blend into. */
+body.narrow .left-panel-content-header > .c-content {
+    @apply rounded-tl-2xl;
 }
-/* The place wallpaper IS this panel's background, so it grows into the inset rather than starting
-   below it. .c-icon is centred in .c-content, so both take the same height. */
-body.narrow .left-panel-content-header.place > .c-content {
-    min-height: calc(6.5rem + var(--safe-area-top-narrow));
-    max-height: calc(6.5rem + var(--safe-area-top-narrow));
-}
-body.narrow .left-panel-content-header.place .c-icon {
-    height: calc(6.5rem + var(--safe-area-top-narrow));
+/* Fill the concave corner sliver with bg-04 on top of the header (painting over, not behind, so a
+   transparent wallpaper doesn't reveal a box). */
+body.narrow .left-panel-content-header::before {
+    @apply content-empty;
+    @apply absolute left-0 top-0 z-10;
+    @apply w-4 h-4;
+    @apply pointer-events-none;
+    background: radial-gradient(circle at bottom right, transparent 1rem, var(--background-04) calc(1rem + 0.5px));
 }
 .left-panel-content .left-panel-content-main-wrapper {
     @apply relative;
@@ -127,7 +126,7 @@ body.narrow .left-panel-content-header.place .c-icon {
         color-mix(in srgb, var(--blue-50-50) 80%, var(--violet-50-50)),
         var(--background-03));
     @apply flex-1 flex-y;
-    @apply rounded-tl-xl;
+    @apply rounded-tl-2xl;
     @apply overflow-hidden;
     @apply bg-03;
     background-image: var(--c-search-tint);
@@ -193,7 +192,7 @@ body.narrow .left-panel-content-header.place .c-icon {
 .left-panel-content-header.place > .c-content {
     @apply flex-y;
     @apply min-h-26 max-h-26;
-    @apply rounded-br-xl md:rounded-bl-xl;
+    @apply rounded-br-2xl md:rounded-bl-2xl;
     @apply overflow-hidden;
 }
 /* The search box keeps the panel's right edge, and the title truncates against it;
@@ -318,7 +317,7 @@ body.hoverable .add-members-btn:hover {
 .left-search-panel:before {
     @apply content-empty;
     @apply absolute inset-0 z-minus;
-    @apply rounded-tl-xl;
+    @apply rounded-tl-2xl;
     @apply bg-03;
     @apply opacity-0;
     /* Fixed blue header height so it stays constant when the keyboard opens (viewport units shrink with the keyboard) */

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
@@ -77,7 +77,7 @@ body.narrow .chat-side-panel.has-expanded-header > .c-top-region > .c-header.exp
    .c-top reserves the avatar's height in flow so the title/badge/description drop UNDER the avatar
    instead of behind it. Bell/share stay hidden; the square, the close (X) and the info below show. */
 body.narrow .chat-side-panel.has-expanded-header > .c-top-region > .c-header.expanded-header > .c-top {
-    height: calc(var(--safe-area-top) + var(--expanded-header-height));
+    height: var(--expanded-header-height);
 }
 body.narrow .chat-side-panel > .c-top-region > .c-header.expanded-header > .c-center {
     top: var(--safe-area-top);
@@ -149,10 +149,22 @@ body.narrow .chat-side-panel.has-expanded-header > .c-panel-content {
     @apply relative;
     @apply flex-none;
     @apply w-full;
-    @apply rounded-b-xl;
+    /* Rounded top-right + bottom-left only (mirror of the left panel): top-left and bottom-right stay square. */
+    @apply rounded-tr-2xl rounded-bl-2xl;
     @apply overflow-hidden;
-    height: calc((6.5rem - 3rem * var(--rp-collapse)) + var(--safe-area-top-narrow));
-    padding-top: var(--safe-area-top-narrow);
+    height: calc(6.5rem - 3rem * var(--rp-collapse));
+    /* Start below the top inset (which the bg-03 band paints) rather than reserving it inside, so the
+       header image sits under the notch strip - the left-panel look. */
+    margin-top: var(--safe-area-top-narrow);
+}
+/* Keep the top inset bg-03 in every state (the panel colour): the notch never shows the header image
+   nor the content behind the narrow overlay. */
+body.narrow .chat-side-panel::before {
+    content: '';
+    @apply absolute left-0 right-0 top-0 z-30;
+    @apply pointer-events-none;
+    @apply bg-03;
+    height: var(--safe-area-top);
 }
 .chat-side-panel > .c-top-region > .c-header > .c-bottom {
     @apply flex-y items-start justify-end gap-y-1;

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel-collapse.ts
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/right-panel-collapse.ts
@@ -61,6 +61,7 @@ export class RightPanelCollapse {
     private lingerTimer = 0;
     private headerClassObserver: MutationObserver | null = null;
     private chatInfoObserver: MutationObserver | null = null;
+    private chatInfoResizeObserver: ResizeObserver | null = null;
     private wasAvatarExpanded = false;
 
     // The collapse range = the header shrink (base - bar, a constant) plus the chat-info that also
@@ -121,6 +122,15 @@ export class RightPanelCollapse {
         if (topRegion) {
             this.chatInfoObserver = new MutationObserver(() => this.measureGeometry());
             this.chatInfoObserver.observe(topRegion, { childList: true, subtree: true });
+        }
+        // The card renders lazily and settles its height a frame or two after insertion (toggles, captions),
+        // which the childList observer above misses — so the range stayed short and the tabs overlapped the
+        // card until the first collapse re-measured it. A ResizeObserver catches the final height; the card
+        // has no collapse-dependent styles, so measuring it never feeds back on the var.
+        const chatInfo = rightPanel.querySelector('.c-chat-info');
+        if (chatInfo) {
+            this.chatInfoResizeObserver = new ResizeObserver(() => this.measureChatInfo());
+            this.chatInfoResizeObserver.observe(chatInfo);
         }
         this.measureGeometry();
         this.rightPanel.classList.toggle('rp-expanded', this.progress === 0);
@@ -209,6 +219,7 @@ export class RightPanelCollapse {
         clearTimeout(this.lingerTimer);
         this.headerClassObserver?.disconnect();
         this.chatInfoObserver?.disconnect();
+        this.chatInfoResizeObserver?.disconnect();
         this.rightPanel.classList.remove('snapping', 'dragging', 'collapsing', 'collapsed', 'rp-expanded');
         this.rightPanel.style.removeProperty('--rp-collapse');
         this.rightPanel.style.removeProperty('--rp-chatinfo-h');

--- a/src/dotnet/UI.Blazor.App/Components/Settings/LanguageShortcut.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/LanguageShortcut.razor
@@ -1,11 +1,12 @@
 @inherits ComputedStateComponent<AppUIHub, UserLanguageSettings>
 @{
-    var m = State.Value;
-    var text = m.ListSpoken().Select(x => x.ShortTitle.ToSentenceCase()).ToDelimitedString(", ");
+    var spoken = State.Value.ListSpoken();
+    var primary = spoken[0].ShortTitle.ToSentenceCase();
+    var extra = spoken.Count - 1;
 }
 
-<div class="text-primary text-sm whitespace-nowrap">
-    @text
+<div class="language-shortcut">
+    @primary@if (extra > 0) {<sup class="c-more">+@extra</sup>}
 </div>
 
 @code{

--- a/src/dotnet/UI.Blazor.App/Components/Settings/settings-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/Settings/settings-modal.css
@@ -56,6 +56,16 @@ body.narrow .close-settings-btn {
     @apply text-caption-6 text-03;
 }
 
+/* ── Voice & Transcription tab (language shortcut in the tab title) ── */
+
+.language-shortcut {
+    @apply text-primary text-sm whitespace-nowrap;
+}
+.language-shortcut .c-more {
+    @apply text-xxs;
+    line-height: 0;
+}
+
 /* ── Push to Talk tab ── */
 
 /* The tab content's flex gap reaches its direct children only, so this wrapper has to


### PR DESCRIPTION
- Left panel: keep the bg-04 safe-area band in narrow, round the wallpaper's outer corners (top-left + bottom-right), radial corner filler at 1rem
- Right panel: paint the top inset bg-03 in every state, seat the header image below it, round top-right + bottom-left (1rem), square the other two
- Chat settings / avatar-edit modal: same bg-03 safe-area band and mirrored header rounding as the right panel
- Right panel: measure chat-info with a ResizeObserver so --rp-chatinfo-h is correct on first render and the tabs no longer overlap the card
- Settings: show the spoken-language shortcut as primary + "+N" superscript