### PR TITLE
fix(notifications): deliver attention pings to caught-up recipients; show them red on the Mentions tab

### DIFF
--- a/docs/plans/notification-lifecycle.md
+++ b/docs/plans/notification-lifecycle.md
@@ -106,7 +106,7 @@ public virtual Moment? ExpiresAt => null;
 | Message, Reply, Thread, Mention, Conversation | `OnRead` | none |
 | Reaction | `OnView` | `SentAt + 1 day` |
 | IncomingCall | `Explicit` | `SentAt + RingTimeout + 5s` |
-| Attention | `OnRead` | none |
+| Attention | `OnView` | `SentAt + 1 day` |
 
 `IsRead` is gated on `DismissMode == OnRead`. That single gate is what unbreaks
 reactions: a `ReactionNotification` anchors at the reacted-to entry — the
@@ -122,7 +122,8 @@ explicitly and fails without the gate.
 
 `OnRead` is **opt-in**, declared on exactly the three types `GetReadAnchor` can
 resolve — `ChatEntryRelatedNotification`, `ChatEntryNotification` and
-`ConversationNotification` — with `ReactionNotification` overriding to `OnView`.
+`ConversationNotification` — with `ReactionNotification` and `AttentionNotification`
+overriding to `OnView`.
 Anchorless kinds fall through to `Explicit`. That way a kind that declares
 nothing can't be filtered by a read position that doesn't apply to it: the
 failure mode is a notification that lingers (visible, and expiry-governed) rather

--- a/src/dotnet/Api/Constants.cs
+++ b/src/dotnet/Api/Constants.cs
@@ -439,6 +439,10 @@ public static partial class Constants
         // A reaction clears when its entry is seen (NotificationDismissMode.OnView); this is the
         // backstop for a chat the user never reopens. Smiles aren't worth keeping around longer.
         public static readonly TimeSpan ReactionLifespan = TimeSpan.FromDays(1);
+        // An attention ping anchors at an entry the recipient has often read already (the mentioned
+        // message, or the one before "alert everyone"), so it clears on view too; this is the
+        // backstop for a chat the user never reopens.
+        public static readonly TimeSpan AttentionLifespan = TimeSpan.FromDays(1);
         // A dismissal older than the push's own TimeToLive can't be delivered any more, so
         // retrying it forever only grows the blob.
         public static readonly TimeSpan PendingDismissalTtl = TimeSpan.FromDays(1);

--- a/src/dotnet/Api/Notifications/AttentionNotification.cs
+++ b/src/dotnet/Api/Notifications/AttentionNotification.cs
@@ -5,6 +5,15 @@ namespace ActualChat.Notifications;
 public sealed partial record AttentionNotification(NotificationId Id, long Version = 0)
     : ChatEntryNotification(Id, Version)
 {
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
+    public override NotificationDismissMode DismissMode
+        // The anchor entry is one the recipient has typically read already - the mentioned message,
+        // or the one before an "alert everyone" - so OnRead dropped the ping before it reached a
+        // device. The chat view clears it instead, once the entry is actually on screen.
+        => NotificationDismissMode.OnView;
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
+    public override Moment? ExpiresAt => SentAt + Constants.Notification.AttentionLifespan;
+
     public static AttentionNotification New(UserId userId, ChatEntryId entryId, AuthorId? authorId = null)
         => new(NotificationId.New(userId, NotificationKind.Attention, entryId.Value)) {
             AuthorId = authorId,

--- a/src/dotnet/Api/Notifications/NotificationExt.cs
+++ b/src/dotnet/Api/Notifications/NotificationExt.cs
@@ -20,9 +20,8 @@ public static class NotificationExt
         // a client. NotificationDismissModeTest asserts the two agree for every kind.
         => kind switch {
             NotificationKind.Message or NotificationKind.Reply or NotificationKind.Thread
-                or NotificationKind.Mention or NotificationKind.Attention
-                or NotificationKind.Conversation => NotificationDismissMode.OnRead,
-            NotificationKind.Reaction => NotificationDismissMode.OnView,
+                or NotificationKind.Mention or NotificationKind.Conversation => NotificationDismissMode.OnRead,
+            NotificationKind.Reaction or NotificationKind.Attention => NotificationDismissMode.OnView,
             _ => NotificationDismissMode.Explicit,
         };
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
@@ -83,6 +83,7 @@
                                 Value="@m.UnreadCount"
                                 NotificationMode="@m.NotificationMode"
                                 HasMentions="@m.HasUnreadOwnMention"
+                                HasAttention="@m.HasAttention"
                                 ReactionEmoji="@m.ReactionEmoji"/>
                         }
                         @if (m.IsUnreadByOthers && !showEnding) {
@@ -115,6 +116,7 @@
                         Value="@m.UnreadCount"
                         NotificationMode="@m.NotificationMode"
                         HasMentions="@m.HasUnreadOwnMention"
+                        HasAttention="@m.HasAttention"
                         ReactionEmoji="@m.ReactionEmoji"/>
                 }
                 @if (showAudioControls) {
@@ -128,6 +130,7 @@
                     Value="@m.UnreadCount"
                     NotificationMode="@m.NotificationMode"
                     HasMentions="@m.HasUnreadOwnMention"
+                    HasAttention="@m.HasAttention"
                     ReactionEmoji="@m.ReactionEmoji"/>
                 @if (showAudioControls) {
                     <ChatAudioControls Chat="@chat" AudioState="@audioState" Class="ending-btn"/>
@@ -260,6 +263,7 @@
             IsSelected = chatState.IsSelected,
             UnreadCount = unreadState.Count,
             HasUnreadOwnMention = unreadState.HasOwnMention,
+            HasAttention = unreadState.HasAttention,
             ReactionEmoji = unreadState.ReactionEmoji,
             LastTextEntry = lastEntry,
             LastTextEntryText = preview.Text,
@@ -363,6 +367,7 @@
         public ChatNotificationMode NotificationMode { get; init; }
         public Trimmed<int> UnreadCount { get; init; }
         public bool HasUnreadOwnMention { get; init; }
+        public bool HasAttention { get; init; }
         public Emoji? ReactionEmoji { get; init; }
         public bool IsSelected { get; init; }
         public bool IsLastItemInBlock { get; init; }

--- a/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarChatButtons.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarChatButtons.razor
@@ -34,6 +34,7 @@
                 <UnreadCount
                     Value="@unreadState.Count"
                     HasMentions="@unreadState.HasOwnMention"
+                    HasAttention="@unreadState.HasAttention"
                     NotificationMode="@chatInfo.ChatUserSettings.NotificationMode"/>
             </BadgeContent>
         </NavbarGroupSelectionButton>
@@ -57,7 +58,8 @@
     protected override async Task OnAfterRenderAsync(bool firstRender) {
         if (firstRender) {
             BlazorRef = DotNetObjectReference.Create(this);
-            JSRef = await JS.InvokeAsync<IJSObjectReference>(ISortableListBackend.JSCreateMethod, Ref, BlazorRef, "data-chat-id");
+            JSRef = await JS.InvokeAsync<IJSObjectReference>(
+                ISortableListBackend.JSCreateMethod, Ref, BlazorRef, "data-chat-id");
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/UnreadCount.razor
+++ b/src/dotnet/UI.Blazor.App/Components/UnreadCount.razor
@@ -3,19 +3,21 @@
 @implements IDisposable
 @{
     _lastRenderTime = Clock.Now;
-    if (Value == 0 && !HasMentions && ReactionEmoji is null)
+    var hasMentionMark = HasMentions || HasAttention;
+    if (Value == 0 && !hasMentionMark && ReactionEmoji is null)
         return;
 
-    var text = HasMentions ? "@" : Value == 0 ? "" : Value.FormatK();
-    var emoji = HasMentions || Value != 0 ? null : ReactionEmoji;
+    var text = hasMentionMark ? "@" : Value == 0 ? "" : Value.FormatK();
+    var emoji = hasMentionMark || Value != 0 ? null : ReactionEmoji;
     var isMuted = NotificationMode switch {
-        ChatNotificationMode.ImportantOnly => !HasMentions,
-        ChatNotificationMode.Muted => !HasMentions,
+        ChatNotificationMode.ImportantOnly => !hasMentionMark,
+        ChatNotificationMode.Muted => !hasMentionMark,
         _ => false,
     };
-    var bgColor = isMuted ? "bg-counter" : "bg-primary";
+    // An attention ping is a ringer, so its "@" is red - even where the chat is muted.
+    var bgColor = HasAttention ? "bg-danger" : isMuted ? "bg-counter" : "bg-primary";
     var cursorClass = Click.HasDelegate ? "cursor-pointer" : "";
-    var mentionClass = HasMentions ? "unread-mention" : "";
+    var mentionClass = hasMentionMark ? "unread-mention" : "";
     var reactionClass = emoji is not null ? "unread-reaction" : "";
     var cssClass = $"message-counter-badge {cursorClass} {mentionClass} {reactionClass}";
 }
@@ -35,6 +37,7 @@
 
     [Parameter, EditorRequired] public Trimmed<int> Value { get; set; }
     [Parameter] public bool HasMentions { get; set; }
+    [Parameter] public bool HasAttention { get; set; }
     [Parameter] public Emoji? ReactionEmoji { get; set; }
     [Parameter] public ChatNotificationMode NotificationMode { get; set; }
     [Parameter] public TimeSpan UpdateDelay { get; set; } = TimeSpan.FromSeconds(0.5);

--- a/src/dotnet/UI.Blazor.App/Services/ChatInfo.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatInfo.cs
@@ -42,4 +42,5 @@ public readonly record struct ChatUnreadState(
     Trimmed<int> Count,
     bool HasOwnMention,
     bool HasUnmutedUnread,
-    Emoji? ReactionEmoji = null);
+    Emoji? ReactionEmoji = null,
+    bool HasAttention = false);

--- a/src/dotnet/UI.Blazor.App/Services/ChatListExt.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListExt.cs
@@ -42,18 +42,17 @@ public static class ChatListExt
         this IEnumerable<ChatInfo> chats,
         ChatListOrder order,
         ChatListPreOrder preOrder,
-        IReadOnlyDictionary<ChatId, Moment>? reactedAt = null)
+        IReadOnlyDictionary<ChatId, Moment>? liftedAt = null)
     {
+        // liftedAt holds the chats lifted above the rest, newest first: reacted chats in the
+        // notifications panel, pinged ones on its Mentions tab. ByLastEventTime sorts on a version,
+        // not a Moment, so the lifting time can't be folded into it.
         var preOrderedChats = preOrder switch {
-            ChatListPreOrder.ChatList => PreOrderChatListFor(chats, order),
+            ChatListPreOrder.ChatList => PreOrderChatListFor(chats, order, liftedAt),
             ChatListPreOrder.None => chats.ToFakeOrderedEnumerable(),
             ChatListPreOrder.NotesFirst => chats
                 .OrderByDescending(c => c.Chat.SystemTag == Constants.Chat.SystemTags.Notes),
-            // ByLastEventTime sorts on a version, not a Moment, so a reaction time can't be folded
-            // into it - a reacted chat is lifted above the rest instead.
-            ChatListPreOrder.ReactionsFirst => chats
-                .OrderByDescending(c => GetReactedAt(reactedAt, c.Id) is not null)
-                .ThenByDescending(c => GetReactedAt(reactedAt, c.Id) ?? Moment.EpochStart),
+            ChatListPreOrder.ReactionsFirst => LiftBy(chats, liftedAt),
             _ => throw new ArgumentOutOfRangeException(nameof(preOrder)),
         };
         return order switch {
@@ -93,23 +92,34 @@ public static class ChatListExt
         };
     }
 
+    // Private methods
+
     private static IOrderedEnumerable<ChatInfo> PreOrderChatListFor(
         this IEnumerable<ChatInfo> chats,
-        ChatListOrder order)
+        ChatListOrder order,
+        IReadOnlyDictionary<ChatId, Moment>? liftedAt)
         => order switch {
-            ChatListOrder.ByLastEventTime => PreOrderChats(chats),
-            ChatListOrder.ByOwnUpdateTime => PreOrderChats(chats),
-            ChatListOrder.ByUnreadCount => PreOrderChats(chats),
+            ChatListOrder.ByLastEventTime => PreOrderChats(chats, liftedAt),
+            ChatListOrder.ByOwnUpdateTime => PreOrderChats(chats, liftedAt),
+            ChatListOrder.ByUnreadCount => PreOrderChats(chats, liftedAt),
             ChatListOrder.ByAlphabet => chats.OrderByDescending(c => c.Contact.IsPinned),
             _ => throw new ArgumentOutOfRangeException(nameof(order)),
         };
 
     private static IOrderedEnumerable<ChatInfo> PreOrderChats(
-        IEnumerable<ChatInfo> chats)
-        => chats
-            .OrderByDescending(c => c.Contact.IsPinned)
+        IEnumerable<ChatInfo> chats,
+        IReadOnlyDictionary<ChatId, Moment>? liftedAt)
+        => LiftBy(chats, liftedAt)
+            .ThenByDescending(c => c.Contact.IsPinned)
             .ThenByDescending(c => c.HasUnreadMentions);
 
-    private static Moment? GetReactedAt(IReadOnlyDictionary<ChatId, Moment>? reactedAt, ChatId chatId)
-        => reactedAt is not null && reactedAt.TryGetValue(chatId, out var moment) ? moment : null;
+    private static IOrderedEnumerable<ChatInfo> LiftBy(
+        IEnumerable<ChatInfo> chats,
+        IReadOnlyDictionary<ChatId, Moment>? liftedAt)
+        => chats
+            .OrderByDescending(c => GetLiftedAt(liftedAt, c.Id) is not null)
+            .ThenByDescending(c => GetLiftedAt(liftedAt, c.Id) ?? Moment.EpochStart);
+
+    private static Moment? GetLiftedAt(IReadOnlyDictionary<ChatId, Moment>? liftedAt, ChatId chatId)
+        => liftedAt is not null && liftedAt.TryGetValue(chatId, out var moment) ? moment : null;
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
@@ -109,7 +109,16 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
         PlaceId? placeId, ChatListFilter filter, CancellationToken cancellationToken = default)
     {
         var chatById = await ListUnordered(placeId, filter, cancellationToken).ConfigureAwait(false);
-        return await ComputeGatedUnreadChatCount(chatById, false, cancellationToken).ConfigureAwait(false);
+        var count = await ComputeGatedUnreadChatCount(chatById, false, cancellationToken).ConfigureAwait(false);
+        if (filter != ChatListFilter.UnreadMentions)
+            return count;
+
+        // A ping puts its chat on the Mentions tab whether or not the chat has anything unread.
+        var pingedChatIds = await NotificationsUI.ListAttentionChatIds(cancellationToken).ConfigureAwait(false);
+        var pingedCount = pingedChatIds.Count(chatId => !chatById.ContainsKey(chatId));
+        return pingedCount == 0
+            ? count
+            : new Trimmed<int>(count.Value + pingedCount, ChatInfoExt.MaxUnreadChatCount);
     }
 
     [ComputeMethod(InvalidationDelay = 0.6)]
@@ -152,17 +161,22 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
         DebugLog?.LogDebug("-> List({PlaceId}, {Settings})", placeId, settings);
         var chatById = await ListUnorderedForDisplay(placeId, settings, cancellationToken).ConfigureAwait(false);
         var filter = settings.GetFilter();
-        // AcrossPlace filters are exactly the notifications panel's, but the Mentions tab neither
-        // surfaces reactions nor sorts by them - see ListUnorderedForDisplay.
-        var isNotificationsPanel = filter.AcrossPlace && filter != ChatListFilter.UnreadMentions;
-        var reactedAt = isNotificationsPanel
-            ? await GetReactedAt(chatById.Keys, cancellationToken).ConfigureAwait(false)
-            : null;
+        // AcrossPlace filters are exactly the notifications panel's. Its Mentions tab lifts the chats
+        // with an attention ping and ignores reactions; the other tabs lift reacted chats - see
+        // ListUnorderedForDisplay.
+        var isMentionsTab = filter == ChatListFilter.UnreadMentions;
+        var isNotificationsPanel = filter.AcrossPlace && !isMentionsTab;
+        var liftedAt = isNotificationsPanel
+            ? await GetLiftedAt(chatById.Keys, GetReactedAt, cancellationToken).ConfigureAwait(false)
+            : isMentionsTab
+                ? await GetLiftedAt(chatById.Keys, NotificationsUI.GetAttentionAt, cancellationToken)
+                    .ConfigureAwait(false)
+                : null;
         var preOrder = isNotificationsPanel ? ChatListPreOrder.ReactionsFirst : ChatListPreOrder.ChatList;
         DebugLog?.LogDebug(
             "<- List({PlaceId}, {Settings}): {Count} items",
             placeId, settings, chatById.Count);
-        return chatById.Values.OrderBy(settings.Order, preOrder, reactedAt).ToList();
+        return chatById.Values.OrderBy(settings.Order, preOrder, liftedAt).ToList();
     }
 
     public virtual Task<IReadOnlyDictionary<ChatId, ChatInfo>> ListPeopleOnly(
@@ -248,23 +262,23 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
             return chatById;
 
         var expiring = await NotificationsPanelUI.GetExpiring(filter.Id, cancellationToken).ConfigureAwait(false);
-        // The Mentions tab means own-mentions and nothing else.
-        var reactedChatIds = filter == ChatListFilter.UnreadMentions
-            ? ApiArray<ChatId>.Empty
+        // The Mentions tab means own-mentions and attention pings; reactions land on the other tabs.
+        var liftedChatIds = filter == ChatListFilter.UnreadMentions
+            ? await NotificationsUI.ListAttentionChatIds(cancellationToken).ConfigureAwait(false)
             : await NotificationsUI.ListReactedChatIds(cancellationToken).ConfigureAwait(false);
-        if (expiring.Count == 0 && reactedChatIds.Count == 0)
+        if (expiring.Count == 0 && liftedChatIds.Count == 0)
             return chatById;
 
         // The ChatInfo each one had on its way out, so this needs no lookup over every chat.
         var result = new Dictionary<ChatId, ChatInfo>(chatById);
         foreach (var (chatId, chatInfo) in expiring)
             result.TryAdd(chatId, chatInfo);
-        foreach (var chatId in reactedChatIds) {
+        foreach (var chatId in liftedChatIds) {
             if (result.ContainsKey(chatId))
                 continue;
 
             // Only chats the filter rejected land here - the ones it accepts are already in chatById.
-            // A reaction relaxes just the ChatInfoFilter (unread) dimension: a chat the Filter (kind)
+            // A reaction or a ping relaxes just the ChatInfoFilter (unread) dimension: a chat the Filter (kind)
             // dimension rejects - e.g. a group chat on the People tab - must stay out.
             var chatInfo = await ChatUI.Get(chatId, cancellationToken).ConfigureAwait(false);
             if (chatInfo is not null && !filter.Invoke(chatInfo) && (filter.Filter?.Invoke(chatInfo.Chat) ?? true))
@@ -436,20 +450,28 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
 
     // Private methods
 
-    private async Task<IReadOnlyDictionary<ChatId, Moment>?> GetReactedAt(
-        IEnumerable<ChatId> chatIds, CancellationToken cancellationToken)
+    private static async Task<IReadOnlyDictionary<ChatId, Moment>?> GetLiftedAt(
+        IEnumerable<ChatId> chatIds,
+        Func<ChatId, CancellationToken, Task<Moment?>> getLiftedAt,
+        CancellationToken cancellationToken)
     {
         var result = (Dictionary<ChatId, Moment>?)null;
         foreach (var chatId in chatIds) {
-            var state = await NotificationsUI.GetReactionState(chatId, cancellationToken).ConfigureAwait(false);
-            if (state.Emoji is null)
+            var liftedAt = await getLiftedAt.Invoke(chatId, cancellationToken).ConfigureAwait(false);
+            if (liftedAt is null)
                 continue;
 
             result ??= new Dictionary<ChatId, Moment>();
-            result.Add(chatId, state.SentAt);
+            result.Add(chatId, liftedAt.Value);
         }
 
         return result;
+    }
+
+    private async Task<Moment?> GetReactedAt(ChatId chatId, CancellationToken cancellationToken)
+    {
+        var state = await NotificationsUI.GetReactionState(chatId, cancellationToken).ConfigureAwait(false);
+        return state.Emoji is null ? null : state.SentAt;
     }
 
     private async Task<ChatInfo?> GetNotes(CancellationToken cancellationToken = default)

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -313,11 +313,13 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
             return default;
 
         var reactionState = await NotificationsUI.GetReactionState(chatId, cancellationToken).ConfigureAwait(false);
+        var attentionAt = await NotificationsUI.GetAttentionAt(chatId, cancellationToken).ConfigureAwait(false);
         return new ChatUnreadState(
             chatInfo.UnreadCount,
             chatInfo.HasUnreadOwnMention,
             chatInfo.UnmutedUnreadCount > 0 && chatInfo.UnreadCount > 0,
-            reactionState.Emoji);
+            reactionState.Emoji,
+            attentionAt is not null);
     }
 
     // Consolidated so streaming-expansion flaps of the end anchor (pushed out, then restored by the

--- a/src/dotnet/UI.Blazor.App/Services/NotificationsUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationsUI.cs
@@ -39,6 +39,24 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
             .ToApiArray();
     }
 
+    [ComputeMethod]
+    public virtual async Task<Moment?> GetAttentionAt(ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
+        return SelectAttentionAt(active, chatId);
+    }
+
+    [ComputeMethod]
+    public virtual async Task<ApiArray<ChatId>> ListAttentionChatIds(CancellationToken cancellationToken = default)
+    {
+        var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
+        return active
+            .OfType<AttentionNotification>()
+            .Select(x => x.ChatId)
+            .Distinct()
+            .ToApiArray();
+    }
+
     // Protected/internal methods
 
     // Internal rather than private so the projections can be tested without a hub.
@@ -60,6 +78,13 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
         // LastEmoji is null on notifications persisted before it existed; the accumulated set is the fallback.
         return new ChatReactionState(newest.LastEmoji ?? newest.Emojis.LastOrDefault(), newest.SentAt);
     }
+
+    internal static Moment? SelectAttentionAt(ApiArray<Notification> active, ChatId chatId)
+        => active
+            .OfType<AttentionNotification>()
+            .Where(x => x.ChatId == chatId)
+            .Select(x => (Moment?)x.SentAt)
+            .Max();
 }
 
 public readonly record struct ChatReactionState(Emoji? Emoji, Moment SentAt);

--- a/src/dotnet/UI.Blazor.App/Services/SeenNotificationDismisser.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SeenNotificationDismisser.cs
@@ -4,10 +4,11 @@ using Notification = ActualChat.Notifications.Notification;
 
 namespace ActualChat.UI.Blazor.App.Services;
 
-// Clears NotificationDismissMode.OnView notifications - reactions - once the entry they point at
-// has actually been on screen. Their anchor entry is the recipient's own message, so the Read
-// position can't answer "have you seen this": it covers that entry from the moment it was sent.
-public class SeenNotificationDismisser(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
+// Clears NotificationDismissMode.OnView notifications - reactions and attention pings - once the
+// entry they point at has actually been on screen. Their anchor entry is one the Read position
+// may already cover (the recipient's own message, a mention they saw), so it can't answer "have
+// you seen this".
+public sealed class SeenNotificationDismisser(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
 {
     private readonly HashSet<NotificationId> _dismissed = [];
 
@@ -49,8 +50,8 @@ public class SeenNotificationDismisser(AppUIHub hub) : UIWorkerBase<AppUIHub>(hu
                 return;
         }
         try {
-            await Commander.Call(new Notifications_Dismiss { Session = Session, NotificationId = notification.Id }, cancellationToken)
-                .ConfigureAwait(false);
+            var command = new Notifications_Dismiss { Session = Session, NotificationId = notification.Id };
+            await Commander.Call(command, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
             lock (Lock)

--- a/tests/Chat.UI.Blazor.UnitTests/ChatListOrderTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatListOrderTest.cs
@@ -43,14 +43,51 @@ public sealed class ChatListOrderTest
         ordered.Select(x => x.Id).Should().Equal([newer.Id, older.Id]);
     }
 
+    [Fact]
+    public void ChatListWithLiftedChatsShouldPutThemAbovePinned()
+    {
+        // arrange
+        var pinnedChat = NewChatInfo(version: 100, isPinned: true);
+        var pingedChat = NewChatInfo(version: 1);
+        var liftedAt = new Dictionary<ChatId, Moment> {
+            [pingedChat.Id] = Moment.EpochStart + TimeSpan.FromMinutes(5),
+        };
+
+        // act
+        var ordered = new[] { pinnedChat, pingedChat }
+            .OrderBy(ChatListOrder.ByLastEventTime, ChatListPreOrder.ChatList, liftedAt)
+            .ToList();
+
+        // assert
+        ordered.Select(x => x.Id).Should().Equal([pingedChat.Id, pinnedChat.Id],
+            because: "an attention ping outranks pinning on the Mentions tab");
+    }
+
+    [Fact]
+    public void ChatListWithoutLiftedChatsShouldKeepPinnedFirst()
+    {
+        // arrange
+        var pinnedChat = NewChatInfo(version: 1, isPinned: true);
+        var busyChat = NewChatInfo(version: 100);
+
+        // act
+        var ordered = new[] { busyChat, pinnedChat }
+            .OrderBy(ChatListOrder.ByLastEventTime, ChatListPreOrder.ChatList)
+            .ToList();
+
+        // assert
+        ordered.Select(x => x.Id).Should().Equal([pinnedChat.Id, busyChat.Id]);
+    }
+
     // Private methods
 
-    private static ChatInfo NewChatInfo(long version)
+    private static ChatInfo NewChatInfo(long version, bool isPinned = false)
     {
         var chatId = ChatId.Parse(GroupChatId.New().Value);
         var contactId = ContactId.NewAny(OwnerId, chatId);
         return new ChatInfo(new Contact(contactId, version) {
             Chat = new Chat(chatId),
+            IsPinned = isPinned,
         });
     }
 }

--- a/tests/Chat.UI.Blazor.UnitTests/NotificationsUIProjectionTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/NotificationsUIProjectionTest.cs
@@ -8,6 +8,7 @@ public sealed class NotificationsUIProjectionTest
 {
     private static readonly UserId TestUserId = UserId.New();
     private static readonly ChatId ChatA = ChatId.Parse("the-actual-one");
+    private static readonly ChatId ChatB = ChatId.Parse(GroupChatId.New().Value);
 
     [Fact]
     public void ListByKindShouldFilterAndSortNewestFirst()
@@ -88,8 +89,40 @@ public sealed class NotificationsUIProjectionTest
         state.Should().Be(default(ChatReactionState));
     }
 
+    [Fact]
+    public void AttentionAtShouldTakeNewestPingForChat()
+    {
+        // arrange
+        var older = NewAttention(ChatA, 1, Moment.EpochStart + TimeSpan.FromSeconds(1));
+        var newer = NewAttention(ChatA, 2, Moment.EpochStart + TimeSpan.FromSeconds(2));
+        var otherChatPing = NewAttention(ChatB, 1, Moment.EpochStart + TimeSpan.FromSeconds(3));
+        var active = ApiArray.New<Notification>(older, otherChatPing, newer);
+
+        // act
+        var attentionAt = NotificationsUI.SelectAttentionAt(active, ChatA);
+
+        // assert
+        attentionAt.Should().Be(newer.SentAt);
+    }
+
+    [Fact]
+    public void AttentionAtShouldBeNullForChatWithoutPings()
+    {
+        // arrange
+        var active = ApiArray.New<Notification>(NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1)));
+
+        // act
+        var attentionAt = NotificationsUI.SelectAttentionAt(active, ChatA);
+
+        // assert
+        attentionAt.Should().BeNull();
+    }
+
     // Private methods
 
     private static ReactionNotification NewReaction(long entryLid, Moment sentAt)
         => ReactionNotification.New(TestUserId, ChatEntryId.New(ChatA, entryLid)) with { SentAt = sentAt };
+
+    private static AttentionNotification NewAttention(ChatId chatId, long entryLid, Moment sentAt)
+        => AttentionNotification.New(TestUserId, ChatEntryId.New(chatId, entryLid)) with { SentAt = sentAt };
 }

--- a/tests/Notifications.IntegrationTests/NotificationDismissModeTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationDismissModeTest.cs
@@ -59,6 +59,48 @@ public sealed class NotificationDismissModeTest(AppHostFixture fixture, ITestOut
     }
 
     [Fact]
+    public async Task AlertEveryoneShouldReachRecipientWhoHasReadTheChat()
+    {
+        // arrange
+        var alice = await Tester.SignInAsAlice();
+        await Tester.SignInAsBob();
+        var (chatId, _) = await Tester.CreateChat(false, "Alert dismiss-mode chat");
+        await Tester.InviteToChat(chatId, alice);
+        var entry = await Tester.CreateTextEntry(chatId, "Anyone around?");
+        await SetReadPosition(alice.Id, chatId, entry.LocalId);
+
+        // act
+        await Commander.Call(new Notifications_NotifyMembers { Session = Tester.Session, ChatId = chatId });
+
+        // assert
+        await TestExt.When(async () => {
+            var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+            info.Items.Should().ContainSingle(n => n is AttentionNotification,
+                "an explicit ping is a ringer, so having read the chat beforehand must not swallow it");
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task AlertEveryoneShouldReachRecipientWhoHasNotReadTheChat()
+    {
+        // arrange
+        var alice = await Tester.SignInAsAlice();
+        await Tester.SignInAsBob();
+        var (chatId, _) = await Tester.CreateChat(false, "Alert control chat");
+        await Tester.InviteToChat(chatId, alice);
+        await Tester.CreateTextEntry(chatId, "Anyone around?");
+
+        // act
+        await Commander.Call(new Notifications_NotifyMembers { Session = Tester.Session, ChatId = chatId });
+
+        // assert
+        await TestExt.When(async () => {
+            var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+            info.Items.Should().ContainSingle(n => n is AttentionNotification);
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
     public async Task ExpiredRingShouldNotBeCommitted()
     {
         // arrange
@@ -93,6 +135,7 @@ public sealed class NotificationDismissModeTest(AppHostFixture fixture, ITestOut
         Notification mention = MentionNotification.New(userId, entryId) with { SentAt = sentAt };
         Notification conversation = ConversationNotification.New(userId, conversationId, 2) with { SentAt = sentAt };
         Notification reaction = ReactionNotification.New(userId, entryId) with { SentAt = sentAt };
+        Notification attention = AttentionNotification.New(userId, entryId) with { SentAt = sentAt };
         Notification call = CallNotification.New(userId, conversationId, default, false) with { SentAt = sentAt };
         Notification invitation = InvitationNotification.New(userId, TestChatId) with { SentAt = sentAt };
 
@@ -106,6 +149,9 @@ public sealed class NotificationDismissModeTest(AppHostFixture fixture, ITestOut
         conversation.ExpiresAt.Should().BeNull();
         reaction.DismissMode.Should().Be(NotificationDismissMode.OnView);
         reaction.ExpiresAt.Should().Be(sentAt + Constants.Notification.ReactionLifespan);
+        attention.DismissMode.Should().Be(NotificationDismissMode.OnView,
+            "a ping anchors at an entry the recipient has typically read, so a read position must not drop it");
+        attention.ExpiresAt.Should().Be(sentAt + Constants.Notification.AttentionLifespan);
 
         // Anchorless kinds fall through to the Explicit default rather than declaring it.
         call.DismissMode.Should().Be(NotificationDismissMode.Explicit);


### PR DESCRIPTION
## Summary
- **Root cause of "alerts never arrive on Android"**: an `AttentionNotification` was `OnRead`, and `ApplyHardUpdate` drops an incoming `OnRead` notification whose anchor entry the recipient already read. A ping anchors at exactly such an entry (the mentioned message, or the entry before the "alert everyone" system entry), so anyone caught up in the chat got nothing - no push, no banner, no log line. Confirmed on the prod team chat (pings to a caught-up member vanished while a not-yet-caught-up member got his) and reproduced with a paired integration test.
- **Fix**: `AttentionNotification` is now `OnView` with a one-day expiry, like `ReactionNotification` and for the same reason. The chat view clears it via `SeenNotificationDismisser` once the entry is on screen; `GetDismissMode` maps the kind the same way. Lifecycle doc updated.
- **Mentions tab**: a chat with an active ping shows up on the Mentions tab (counted in its badge) even with nothing else unread, sorts above pinned chats there, and its row gets a red `@` (`bg-danger`) instead of the blue mention badge - red even when the chat is muted, since a ping is a ringer. The red `@` also shows in the main list and on navbar chat buttons.
- Plumbing: `NotificationsUI.GetAttentionAt` / `ListAttentionChatIds` over the active set; `ChatUnreadState.HasAttention`; `ChatListExt.OrderBy` takes a generic "lifted" dictionary shared by `ReactionsFirst` and the Mentions tab.

## Test plan
- [x] `NotificationDismissModeTest`: new `AlertEveryoneShouldReachRecipientWhoHasReadTheChat` (failed before, passes now) + `...WhoHasNotReadTheChat` control; per-kind policy test extended with Attention
- [x] Full `Notifications.IntegrationTests` suite: 198/198
- [x] `NotificationsUIProjectionTest` + `ChatListOrderTest` for the new projection and the lifting order: 11/11
- [x] Live on local.voxt.ai (server-loop): pinged a caught-up user from another account - notification created, Mentions tab appeared with the chat carrying a red `@`, and opening the chat dismissed it within a second
- [ ] Android: install and confirm the attention banner arrives for a caught-up recipient (channel sound itself is #4358)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXometGGBCHXTdAPYrgLBj
