### PR TITLE
feat(search): add "My messages" filter scoped to current user's authorship

### DIFF
--- a/src/dotnet/Api/Search/EntrySearchQuery.cs
+++ b/src/dotnet/Api/Search/EntrySearchQuery.cs
@@ -11,4 +11,5 @@ public partial record EntrySearchQuery
     [DataMember, Key(2)] public ChatId? ChatId { get; init; }
     [DataMember, Key(3)] public int Skip { get; init; }
     [DataMember, Key(4)] public int Limit { get; init; } = Constants.Search.DefaultPageSize;
+    [DataMember, Key(5)] public bool OwnEntriesOnly { get; init; }
 }

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -452,6 +452,7 @@ public static class LocalizedStringsLocalizerExt
         public string Search_TypeGroups => l["Search_TypeGroups"].Value;
         public string Search_TypePlaces => l["Search_TypePlaces"].Value;
         public string Search_TypeMessages => l["Search_TypeMessages"].Value;
+        public string Search_TypeMyMessages => l["Search_TypeMyMessages"].Value;
         public string Search_TabTags => l["Search_TabTags"].Value;
         public string Search_RecentSearches => l["Search_RecentSearches"].Value;
         public string Search_RecentlyViewed => l["Search_RecentlyViewed"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Групи",
   "Search_TypePlaces": "Места",
   "Search_TypeMessages": "Съобщения",
+  "Search_TypeMyMessages": "Моите съобщения",
   "Search_TabTags": "Етикети",
   "Search_RecentSearches": "Скорошни търсения",
   "Search_RecentlyViewed": "Скоро разглеждани",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupe",
   "Search_TypePlaces": "Mjesta",
   "Search_TypeMessages": "Poruke",
+  "Search_TypeMyMessages": "Moje poruke",
   "Search_TabTags": "Oznake",
   "Search_RecentSearches": "Nedavne pretrage",
   "Search_RecentlyViewed": "Nedavno pregledano",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupe",
   "Search_TypePlaces": "Mjesta",
   "Search_TypeMessages": "Poruke",
+  "Search_TypeMyMessages": "Moje poruke",
   "Search_TabTags": "Oznake",
   "Search_RecentSearches": "Nedavne pretrage",
   "Search_RecentlyViewed": "Nedavno pregledano",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Skupiny",
   "Search_TypePlaces": "Místa",
   "Search_TypeMessages": "Zprávy",
+  "Search_TypeMyMessages": "Moje zprávy",
   "Search_TabTags": "Štítky",
   "Search_RecentSearches": "Nedávná hledání",
   "Search_RecentlyViewed": "Nedávno zobrazené",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Gruppen",
   "Search_TypePlaces": "Places",
   "Search_TypeMessages": "Nachrichten",
+  "Search_TypeMyMessages": "Meine Nachrichten",
   "Search_TabTags": "Tags",
   "Search_RecentSearches": "Letzte Suchen",
   "Search_RecentlyViewed": "Zuletzt angesehen",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -525,6 +525,7 @@
   "Search_TypeGroups": "Groups",
   "Search_TypePlaces": "Places",
   "Search_TypeMessages": "Messages",
+  "Search_TypeMyMessages": "My messages",
   "Search_TabTags": "Tags",
   "Search_RecentSearches": "Recent searches",
   "Search_RecentlyViewed": "Recently viewed",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupos",
   "Search_TypePlaces": "Lugares",
   "Search_TypeMessages": "Mensajes",
+  "Search_TypeMyMessages": "Mis mensajes",
   "Search_TabTags": "Etiquetas",
   "Search_RecentSearches": "Búsquedas recientes",
   "Search_RecentlyViewed": "Vistos recientemente",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Groupes",
   "Search_TypePlaces": "Lieux",
   "Search_TypeMessages": "Messages",
+  "Search_TypeMyMessages": "Mes messages",
   "Search_TabTags": "Tags",
   "Search_RecentSearches": "Recherches récentes",
   "Search_RecentlyViewed": "Consultés récemment",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "समूह",
   "Search_TypePlaces": "प्लेस",
   "Search_TypeMessages": "संदेश",
+  "Search_TypeMyMessages": "मेरे संदेश",
   "Search_TabTags": "टैग",
   "Search_RecentSearches": "हाल की खोजें",
   "Search_RecentlyViewed": "हाल ही में देखे गए",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupe",
   "Search_TypePlaces": "Mjesta",
   "Search_TypeMessages": "Poruke",
+  "Search_TypeMyMessages": "Moje poruke",
   "Search_TabTags": "Oznake",
   "Search_RecentSearches": "Nedavne pretrage",
   "Search_RecentlyViewed": "Nedavno pregledano",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grup",
   "Search_TypePlaces": "Tempat",
   "Search_TypeMessages": "Pesan",
+  "Search_TypeMyMessages": "Pesan saya",
   "Search_TabTags": "Tag",
   "Search_RecentSearches": "Pencarian terbaru",
   "Search_RecentlyViewed": "Baru dilihat",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Gruppi",
   "Search_TypePlaces": "Luoghi",
   "Search_TypeMessages": "Messaggi",
+  "Search_TypeMyMessages": "I miei messaggi",
   "Search_TabTags": "Tag",
   "Search_RecentSearches": "Ricerche recenti",
   "Search_RecentlyViewed": "Visti di recente",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "グループ",
   "Search_TypePlaces": "プレイス",
   "Search_TypeMessages": "メッセージ",
+  "Search_TypeMyMessages": "自分のメッセージ",
   "Search_TabTags": "タグ",
   "Search_RecentSearches": "最近の検索",
   "Search_RecentlyViewed": "最近見たもの",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "그룹",
   "Search_TypePlaces": "플레이스",
   "Search_TypeMessages": "메시지",
+  "Search_TypeMyMessages": "내 메시지",
   "Search_TabTags": "태그",
   "Search_RecentSearches": "최근 검색",
   "Search_RecentlyViewed": "최근 본 항목",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -525,6 +525,7 @@
   "Search_TypeGroups": "グループ",
   "Search_TypePlaces": "プレイス",
   "Search_TypeMessages": "Повідомлення",
+  "Search_TypeMyMessages": "Мої повідомлення",
   "Search_TabTags": "Etiquetas",
   "Search_RecentSearches": "Ostatnie wyszukiwania",
   "Search_RecentlyViewed": "Недавно просмотренные",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupy",
   "Search_TypePlaces": "Miejsca",
   "Search_TypeMessages": "Wiadomości",
+  "Search_TypeMyMessages": "Moje wiadomości",
   "Search_TabTags": "Tagi",
   "Search_RecentSearches": "Ostatnie wyszukiwania",
   "Search_RecentlyViewed": "Ostatnio oglądane",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Grupos",
   "Search_TypePlaces": "Lugares",
   "Search_TypeMessages": "Mensagens",
+  "Search_TypeMyMessages": "Minhas mensagens",
   "Search_TabTags": "Tags",
   "Search_RecentSearches": "Buscas recentes",
   "Search_RecentlyViewed": "Vistos recentemente",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Группы",
   "Search_TypePlaces": "Места",
   "Search_TypeMessages": "Сообщения",
+  "Search_TypeMyMessages": "Мои сообщения",
   "Search_TabTags": "Теги",
   "Search_RecentSearches": "Недавние запросы",
   "Search_RecentlyViewed": "Недавно просмотренные",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Групе",
   "Search_TypePlaces": "Места",
   "Search_TypeMessages": "Поруке",
+  "Search_TypeMyMessages": "Моје поруке",
   "Search_TabTags": "Ознаке",
   "Search_RecentSearches": "Недавне претраге",
   "Search_RecentlyViewed": "Недавно прегледано",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Gruplar",
   "Search_TypePlaces": "Mekânlar",
   "Search_TypeMessages": "Mesajlar",
+  "Search_TypeMyMessages": "Mesajlarım",
   "Search_TabTags": "Etiketler",
   "Search_RecentSearches": "Son aramalar",
   "Search_RecentlyViewed": "Son görüntülenenler",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Групи",
   "Search_TypePlaces": "Місця",
   "Search_TypeMessages": "Повідомлення",
+  "Search_TypeMyMessages": "Мої повідомлення",
   "Search_TabTags": "Теги",
   "Search_RecentSearches": "Нещодавні запити",
   "Search_RecentlyViewed": "Нещодавно переглянуті",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "Nhóm",
   "Search_TypePlaces": "Địa điểm",
   "Search_TypeMessages": "Tin nhắn",
+  "Search_TypeMyMessages": "Tin nhắn của tôi",
   "Search_TabTags": "Thẻ",
   "Search_RecentSearches": "Tìm kiếm gần đây",
   "Search_RecentlyViewed": "Đã xem gần đây",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -424,6 +424,7 @@
   "Search_TypeGroups": "群组",
   "Search_TypePlaces": "地点",
   "Search_TypeMessages": "消息",
+  "Search_TypeMyMessages": "我的消息",
   "Search_TabTags": "标签",
   "Search_RecentSearches": "最近搜索",
   "Search_RecentlyViewed": "最近查看",

--- a/src/dotnet/MLSearch.Service/ChatEntryExt.cs
+++ b/src/dotnet/MLSearch.Service/ChatEntryExt.cs
@@ -4,7 +4,7 @@ namespace ActualChat.MLSearch;
 
 public static class ChatEntryExt
 {
-    public static IndexedEntry ToIndexedEntry(this ChatEntry entry, IMarkupParser markupParser)
+    public static IndexedEntry ToIndexedEntry(this ChatEntry entry, IMarkupParser markupParser, UserId? authorUserId)
     {
         var markup = markupParser.Parse(entry.Content);
         return new IndexedEntry {
@@ -12,6 +12,7 @@ public static class ChatEntryExt
             Content = entry.Content,
             Hashtags = HashtagExtractor.Instance.GetTags(markup).ToArray(),
             At = entry.GetIndexedEntryDate(),
+            AuthorUserId = authorUserId,
         };
     }
 

--- a/src/dotnet/MLSearch.Service/Documents/IndexedEntry.cs
+++ b/src/dotnet/MLSearch.Service/Documents/IndexedEntry.cs
@@ -8,6 +8,7 @@ public sealed record IndexedEntry : IHasId<ChatEntryId>, IHasRoutingKey<ChatEntr
     public string Content { get; init; } = "";
     public string[] Hashtags { get; init; } = [];
     public Moment At { get; init; }
+    public UserId? AuthorUserId { get; init; }
     public JoinField EntryToChat => JoinField.Link<IndexedEntry, IndexedChat>(new (ChatId));
 
     // Computed

--- a/src/dotnet/MLSearch.Service/Engine/OpenSearchNames.cs
+++ b/src/dotnet/MLSearch.Service/Engine/OpenSearchNames.cs
@@ -2,7 +2,7 @@ namespace ActualChat.MLSearch.Engine;
 
 internal sealed class OpenSearchNames
 {
-    public const string EntryIndexVersion = "v5";
+    public const string EntryIndexVersion = "v4";
     public const string UserIndexVersion = "v6";
     public const string GroupIndexVersion = "v5";
     public const string PlaceIndexVersion = "v3";

--- a/src/dotnet/MLSearch.Service/Engine/OpenSearchNames.cs
+++ b/src/dotnet/MLSearch.Service/Engine/OpenSearchNames.cs
@@ -2,7 +2,7 @@ namespace ActualChat.MLSearch.Engine;
 
 internal sealed class OpenSearchNames
 {
-    public const string EntryIndexVersion = "v4";
+    public const string EntryIndexVersion = "v5";
     public const string UserIndexVersion = "v6";
     public const string GroupIndexVersion = "v5";
     public const string PlaceIndexVersion = "v3";

--- a/src/dotnet/MLSearch.Service/Flows/EntryIndexingFlow.cs
+++ b/src/dotnet/MLSearch.Service/Flows/EntryIndexingFlow.cs
@@ -12,6 +12,7 @@ public sealed partial class EntryIndexingFlow : BatchedIndexingFlow<ChatEntry, C
 {
     private MLSearchSettings Settings => field ??= Services.GetRequiredService<MLSearchSettings>();
     private IChatsBackend ChatsBackend => field ??= Services.GetRequiredService<IChatsBackend>();
+    private IAuthorsBackend AuthorsBackend => field ??= Services.GetRequiredService<IAuthorsBackend>();
     private IPlacesBackend PlacesBackend => field ??= Services.GetRequiredService<IPlacesBackend>();
     private IndexedDocuments IndexedDocuments => field ??= Services.GetRequiredService<IndexedDocuments>();
     private IMarkupParser MarkupParser => field ??= Services.GetRequiredService<IMarkupParser>();
@@ -70,9 +71,17 @@ public sealed partial class EntryIndexingFlow : BatchedIndexingFlow<ChatEntry, C
     {
         await WhenReady.ConfigureAwait(false);
 
-        var updated = batch
+        var live = batch
             .Where(x => x is { IsRemoved: false, IsSystemEntry: false })
-            .Select(x => x.ToIndexedEntry(MarkupParser))
+            .ToList();
+        var authorUserIds = new Dictionary<AuthorId, UserId?>();
+        foreach (var authorId in live.Select(x => x.AuthorId).Distinct()) {
+            var author = await AuthorsBackend.Get(ChatId, authorId, RequestedAuthorKind.Full, cancellationToken)
+                .ConfigureAwait(false);
+            authorUserIds[authorId] = author?.UserId;
+        }
+        var updated = live
+            .Select(x => x.ToIndexedEntry(MarkupParser, authorUserIds.GetValueOrDefault(x.AuthorId)))
             .ToList();
         var removed = batch
             .Where(x => x is { IsRemoved: true, IsSystemEntry: false })

--- a/src/dotnet/MLSearch.Service/Flows/EntryIndexingFlow.cs
+++ b/src/dotnet/MLSearch.Service/Flows/EntryIndexingFlow.cs
@@ -6,7 +6,7 @@ using ActualChat.Search;
 
 namespace ActualChat.MLSearch.Flows;
 
-[Flow(DelayQuanta = 30)]
+[Flow(DelayQuanta = 30, DataVersion = 2)]
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject(true)]
 public sealed partial class EntryIndexingFlow : BatchedIndexingFlow<ChatEntry, ChatEntryId>
 {

--- a/src/dotnet/MLSearch.Service/Flows/EntryIndexingMasterFlow.cs
+++ b/src/dotnet/MLSearch.Service/Flows/EntryIndexingMasterFlow.cs
@@ -2,6 +2,7 @@ using ActualChat.Flows;
 
 namespace ActualChat.MLSearch.Flows;
 
+[Flow(DataVersion = 2)]
 [DataContract, MemoryPackable(GenerateType.VersionTolerant), MessagePackObject(true)]
 public partial class EntryIndexingMasterFlow
     : IndexingMasterFlow<EntryIndexingFlow, Chat.Chat, ChatId>, IMasterFlow

--- a/src/dotnet/MLSearch.Service/OpenSearchConfigurator.cs
+++ b/src/dotnet/MLSearch.Service/OpenSearchConfigurator.cs
@@ -98,13 +98,16 @@ public sealed class OpenSearchConfigurator(IServiceProvider services) : WorkerBa
     private async Task EnsureEntryIndex(CancellationToken cancellationToken)
     {
         await EnsureIndex(OpenSearchNames.EntryIndexName, ConfigureEntryIndex, cancellationToken).ConfigureAwait(false);
-        // Hashtags were added after the index shipped, and EnsureIndex is create-only. Without this
-        // merge an already-created index would map them dynamically as text, and a tag containing
-        // '-' would be analyzed into several terms no exact-tag query can match.
+        // Hashtags and AuthorUserId were added after the index shipped, and EnsureIndex is create-only.
+        // Merging their mappings here keeps the live index searchable without a version bump / reindex:
+        // Hashtags must stay keyword (a tag with '-' would otherwise analyze into several terms), and
+        // AuthorUserId backs the "my messages" filter. Existing docs get the field only once reindexed.
         await OpenSearchClient.Indices
             .PutMappingAsync<IndexedEntry>(m => m
                     .Index(OpenSearchNames.EntryIndexName)
-                    .Properties(pp => pp.Keyword(p => p.Name(x => x.Hashtags))),
+                    .Properties(pp => pp
+                        .Keyword(p => p.Name(x => x.Hashtags))
+                        .Keyword(p => p.Name(x => x.AuthorUserId))),
                 cancellationToken)
             .Assert(Log)
             .ConfigureAwait(false);

--- a/src/dotnet/MLSearch.Service/OpenSearchConfigurator.cs
+++ b/src/dotnet/MLSearch.Service/OpenSearchConfigurator.cs
@@ -190,6 +190,7 @@ public sealed class OpenSearchConfigurator(IServiceProvider services) : WorkerBa
                         .Text(p => p.Name(e => e.Content))
                         .Keyword(p => p.Name(x => x.Hashtags))
                         .Date(p => p.Name(x => x.At))
+                        .Keyword(p => p.Name(x => x.AuthorUserId))
                         .Join(j => j.Name(x => x.EntryToChat).Relations(r => r.Join<IndexedChat, IndexedEntry>())))
                 )
             .Settings(s => s

--- a/src/dotnet/MLSearch.Service/SearchBackend.cs
+++ b/src/dotnet/MLSearch.Service/SearchBackend.cs
@@ -494,6 +494,8 @@ public class SearchBackend(IServiceProvider services) : DbServiceBase<MLSearchDb
                 clauses.Add(isPrefix
                     ? q => q.Prefix(p => p.Field(x => x.Hashtags).Value(tag))
                     : q => q.Term(t => t.Field(x => x.Hashtags).Value(tag)));
+            if (query.OwnEntriesOnly)
+                clauses.Add(q => q.Term(t => t.Field(x => x.AuthorUserId).Value(userId.Value)));
 
             return descriptor.Must(clauses.ToArray());
         }

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
@@ -177,6 +177,7 @@
         SearchTypeFilter.People => L.Search_TypePeople,
         SearchTypeFilter.Groups => L.Search_TypeGroups,
         SearchTypeFilter.Messages => L.Search_TypeMessages,
+        SearchTypeFilter.MyMessages => L.Search_TypeMyMessages,
         _ => "",
     };
 

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/SearchFilterMenu.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/SearchFilterMenu.razor
@@ -21,6 +21,7 @@
         @RenderType(SearchTypeFilter.People, L.Search_TypePeople)
         @RenderType(SearchTypeFilter.Groups, L.Search_TypeGroups)
         @RenderType(SearchTypeFilter.Messages, L.Search_TypeMessages)
+        @RenderType(SearchTypeFilter.MyMessages, L.Search_TypeMyMessages)
     </div>
 </div>
 

--- a/src/dotnet/UI.Blazor.App/Services/Search/SearchFilters.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Search/SearchFilters.cs
@@ -13,6 +13,7 @@ public enum SearchTypeFilter
     People,
     Groups,
     Messages,
+    MyMessages,
 }
 
 public sealed record SearchResultGroupKey(ActualChat.Search.SearchScope Scope, bool IsGlobalSearchResult);

--- a/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.StateSync.cs
@@ -183,7 +183,7 @@ public partial class SearchUI
         var filteredScopes = typeFilter switch {
             SearchTypeFilter.People => scopes.Where(x => x == SearchScope.People),
             SearchTypeFilter.Groups => scopes.Where(x => x is SearchScope.Groups or SearchScope.Places),
-            SearchTypeFilter.Messages => scopes.Where(x => x == SearchScope.Messages),
+            SearchTypeFilter.Messages or SearchTypeFilter.MyMessages => scopes.Where(x => x == SearchScope.Messages),
             _ => scopes,
         };
         var subgroups = includeGlobal

--- a/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.cs
@@ -277,6 +277,7 @@ public partial class SearchUI : UIWorkerBase<AppUIHub>, IComputeService, INotify
                 PlaceId = PlaceId,
                 ChatId = LocationFilter == SearchLocationFilter.Chat ? ChatId : null,
                 Limit = DisplayLimit(key.Scope) + 1,
+                OwnEntriesOnly = TypeFilter == SearchTypeFilter.MyMessages,
             };
     }
 


### PR DESCRIPTION


Adds a fifth Result Type option in the left-panel search that restricts message search to entries authored by the current user, composable with the Anywhere/Chat/Place location filter.

- Index the author's UserId on chat entries (IndexedEntry.AuthorUserId), resolved AuthorId->UserId during indexing; bump entry index v4->v5 for a full reindex/backfill.
- EntrySearchQuery.OwnEntriesOnly -> backend adds a term filter on AuthorUserId == current user.
- Client SearchTypeFilter.MyMessages wires through ToSubgroups/ToEntryQuery.
- Menu option, badge, and Search_TypeMyMessages localization across 23 locales.