### PR TITLE
fix(docker): cap container log size, stop logging every SQL statement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 name: actual-chat-infra
+
+# Without this, json-file logs grow unbounded: postgres once reached 34 GB.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 include:
   - ./services/aspire/docker-compose.yaml
   - ./services/embeddings/docker-compose.yaml
@@ -24,7 +32,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    entrypoint: ["docker-entrypoint.sh", "-c", "shared_buffers=256MB", "-c", "max_connections=1000", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "log_statement=all", "-c", "log_statement_sample_rate=0.1"]
+    # To log every SQL statement, append: "-c", "log_statement=all", "-c", "log_statement_sample_rate=0.1"
+    entrypoint: ["docker-entrypoint.sh", "-c", "shared_buffers=256MB", "-c", "max_connections=1000", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all"]
+    logging: *default-logging
   imageproxy:
     image: willnorris/imageproxy:latest
     platform: linux/amd64
@@ -57,6 +67,7 @@ services:
       - "local.voxt.ai:host-gateway"
       - "local.actual.chat:host-gateway"
       - "embedded.voxt.ai:host-gateway"
+    logging: *default-logging
   dns-forwarder:
     # Note: DNS_FORWARDER variable
     # In some cases this dns service is not required (macos).


### PR DESCRIPTION
## Problem

On my machine the Docker virtual disk had grown to 88 GB. A breakdown showed a single file responsible for almost half of it:

```
data/docker/containers  34.3 GB   <- one 34.1 GB postgres log
data/desktop-containerd 30.6 GB   images + build cache
data/docker/volumes      6.7 GB
data/docker/rootfs       4.7 GB
```

The 34.1 GB is `actual-chat-infra-postgres-1`'s `*-json.log`, growing continuously since the container was created (2025-10-08).

Two causes combine:

- the postgres entrypoint passes `-c log_statement=all`, so every SQL statement goes to stderr — the dev server's `_events` poll alone produces ~10 log lines several times per second;
- the `json-file` log driver has no `max-size`/`max-file` by default, so nothing ever rotates.

`log_statement_sample_rate=0.1` did not help: with `log_statement=all` it only samples statements that are already subject to duration logging.

## Fix

- an `x-logging` anchor (`max-size: 50m`, `max-file: 3`) applied to `postgres` and `nginx` — the two services whose logs actually grew (nginx was at 114 MB);
- `log_statement=all` and `log_statement_sample_rate=0.1` removed from the postgres entrypoint, with a comment showing how to re-enable statement logging when debugging.

## Applying it

The new settings take effect when the container is recreated:

```
docker compose up -d --force-recreate postgres
```

Do **not** pass `-V` / `--renew-anon-volumes` and do not use `down -v` — the postgres data lives in an anonymous volume, which a plain `--force-recreate` carries over but those flags would wipe.

Truncating the existing log in place (`truncate -s 0` on the container's `LogPath`) reclaims the 34 GB immediately without touching the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbLxC2EUpZGuFPivXbBWFV