### PR TITLE
fix(ptt): stop the double voice in armed chats - hand the headless wake scope off to the WebView scope

### DIFF
--- a/docs/architecture/server-clock-sync.md
+++ b/docs/architecture/server-clock-sync.md
@@ -458,6 +458,18 @@ Blazor circuit reconnection parks JS interop the same way RPC parks calls, so th
 server-mode branch needs its own generation guard rather than relying on
 `JSDisconnectedException` alone.
 
+**Client hosts seed a new scope from the previous one.** `ServerTimeSync` is
+scoped, and a MAUI process replaces its scope on a WebView reload and when a
+headless PTT wake is handed off to the WebView scope. Each new scope used to
+start from `SyncCount = 0`, so every listener start behind `EnsureSynced` waited
+~2 s for a fresh burst — right at the moment the user had just opened the app on
+a running conversation. The last accepted burst (offset, precision, min-RTT,
+drift rate, accept stamps) is therefore kept process-wide and applied by the next
+scope on start and on its first `EnsureSynced`, as a `Step` in a new epoch. The
+gates still judge the seed's age and any suspend since, so a stale seed only
+triggers the sync it would have triggered anyway. Server mode never seeds: the
+offset there is one browser's, and the process serves many.
+
 ## Contract changes
 
 [ISystemProperties.cs](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/Api.Contracts/Users/ISystemProperties.cs)

--- a/docs/live-audio/10-push-to-talk.md
+++ b/docs/live-audio/10-push-to-talk.md
@@ -294,6 +294,9 @@ and in the live WebView scope.
    live-edge trim. The anchor also lets the listening player skip the
    `ServerClock.WhenReady` wait entirely — a catch-up stream is clock-independent,
    and the anchor itself is server time, so it doubles as the player's `startAt`.
+   `ListeningStreamProcessor` sends it on the first connection only: the server
+   serves the target from t=0 to whoever asks, so a reconnect inside the stale
+   window that still carried it would replay what the listener already heard.
 6. Fires `platform.OnPlaybackStarted(hub, chatId)`.
 
 `Transmit(isHeadless, platform, cancellationToken)` refuses to open the mic when

--- a/docs/live-audio/10-push-to-talk.md
+++ b/docs/live-audio/10-push-to-talk.md
@@ -217,9 +217,25 @@ app-ready waits, and headless-session teardown.
   `ResolveScope` may have created a scope that nothing else would ever
   dispose.
 - **`ResolveScope()`** prefers the live WebView scope
-  (`AppServicesAccessor.TryGetScopedServices`), falls back to
-  `HeadlessBlazorScope.GetOrCreate()`, and re-checks the WebView scope once more
-  to cover losing the creation race to a just-published scope.
+  (`AppServicesAccessor.TryGetScopedServices`). When none is published but a
+  WebView is booting — an `Activity` exists on Android, a `MainPage` elsewhere, and
+  the current `MauiWebView` isn't dead — it waits up to
+  `PttWebViewScopeWaitTimeout` (8 s) for `WhenBlazorAppServicesReady` first: a
+  headless scope started in that window would only have to be handed off seconds
+  later. Otherwise it falls back to `HeadlessBlazorScope.GetOrCreate()`, and
+  re-checks the WebView scope once more to cover losing the creation race to a
+  just-published scope.
+- **`HandOffHeadless(webViewServices)`** runs from `MauiWebView.SetScopedServices`
+  the moment a WebView scope is published, on every platform. It detaches the
+  headless scope synchronously, then in the background snapshots its listening set
+  and incoming-voice stamps, stops and disposes it, waits for the WebView scope to
+  initialize, re-stamps the answer window there and re-listens the snapshot after
+  `ChatAudioUI.Enable()`. Both scopes are complete audio stacks — `ChatAudioUI`,
+  `ActiveChatsUI` and the playback engine factory are all scoped — and each one
+  re-listens every armed chat, so a headless scope left alive next to the WebView
+  scope plays the same chat twice with a constant offset. The catch-up anchor is
+  deliberately not carried over: the new player joins at the live edge, and a
+  copied anchor would replay the utterance from its start.
 - **`StopHeadless(platform)`** (user-initiated, e.g. the Android widget) detaches
   the current headless scope, stops replay, clears listening chats, then tears
   down and disposes.
@@ -233,7 +249,10 @@ app-ready waits, and headless-session teardown.
   has been idle for `TeardownIdleChecks` (2) consecutive checks — where "idle"
   means not recording, no listening chats and no `ReplayState`. Two checks are
   required because the replay-ended → listening-restored transition has a short
-  gap that must not read as "session over".
+  gap that must not read as "session over". A published WebView scope ends the
+  watch through `HandOffHeadless` instead — armed chats never leave the listening
+  set, so an idle check alone would keep a superseded scope alive for the whole
+  conversation.
 
 ### The core — `PttSessionCore` (UI.Blazor.App)
 
@@ -309,7 +328,10 @@ tolerates on the page-reload path, then runs
 `AppScopedServiceStarter.StartScopedServices`, whose failure is logged but never
 costs the wake. `TryDetachCurrent(reason)` clears `Current` synchronously so
 every reader sees the handoff immediately while the caller disposes on its own
-schedule.
+schedule. Its life ends at the first of: idle teardown, the user's stop, or a
+WebView scope being published (`PttSession.HandOffHeadless`). A hot reply
+survives that last one — the scope keeps recording until the reply closes and is
+disposed only then, while its listening moves over at once.
 
 ### Android — `PttWakeHandler`
 

--- a/docs/live-audio/10-push-to-talk.md
+++ b/docs/live-audio/10-push-to-talk.md
@@ -225,12 +225,16 @@ app-ready waits, and headless-session teardown.
   later. Otherwise it falls back to `HeadlessBlazorScope.GetOrCreate()`, and
   re-checks the WebView scope once more to cover losing the creation race to a
   just-published scope.
-- **`HandOffHeadless(webViewServices)`** runs from `MauiWebView.SetScopedServices`
+- **`HandOffHeadless()`** runs from `MauiWebView.SetScopedServices`
   the moment a WebView scope is published, on every platform. It detaches the
   headless scope synchronously, then in the background snapshots its listening set
   and incoming-voice stamps, stops and disposes it, waits for the WebView scope to
   initialize, re-stamps the answer window there and re-listens the snapshot after
-  `ChatAudioUI.Enable()`. Both scopes are complete audio stacks — `ChatAudioUI`,
+  `ChatAudioUI.Enable()`. The resume targets whichever scope is live when that wait
+  ends, not the one that triggered the handoff: a WebView reload in between replaces
+  it, and resuming into the replaced scope would leave the live one silent. The
+  headless scope is disposed even when the resume fails - keeping it alive would
+  restore the very second audio stack this handoff exists to remove. Both scopes are complete audio stacks — `ChatAudioUI`,
   `ActiveChatsUI` and the playback engine factory are all scoped — and each one
   re-listens every armed chat, so a headless scope left alive next to the WebView
   scope plays the same chat twice with a constant offset. The catch-up anchor is

--- a/src/dotnet/Api/Constants.Audio.cs
+++ b/src/dotnet/Api/Constants.Audio.cs
@@ -85,6 +85,9 @@ public static partial class Constants
         public static readonly TimeSpan GestureSensorStaleTimeout = TimeSpan.FromSeconds(3);
         // Matches the wake push's FCM TTL; older wakes skip catch-up-from-start and go live.
         public static readonly TimeSpan PttStaleWakeAge = TimeSpan.FromSeconds(60);
+        // How long a wake waits for a booting WebView's scope before it starts a headless one
+        // that would only have to be handed off to it; a WebView boot takes 2-6s on a phone.
+        public static readonly TimeSpan PttWebViewScopeWaitTimeout = TimeSpan.FromSeconds(8);
         // Clock-fuzz allowance between a wake's startedAt and the target stream's BeginsAt.
         public static readonly TimeSpan ListeningCatchUpTolerance = TimeSpan.FromSeconds(2);
         // Must outlast ServerTimeSync's first sync (3s startup delay + a few RPC round trips).

--- a/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/MainActivity.cs
@@ -55,6 +55,7 @@ public partial class MainActivity : MauiAppCompatActivity
 
     public static MainActivity Current => _current
         ?? throw StandardError.Internal($"{nameof(MainActivity)} isn't created yet.");
+    public static bool HasCurrent => _current is not null;
     // A recreated MainActivity can start before the one it replaces stops, so lifecycle callbacks
     // have to tell the live instance from the outgoing one rather than just matching the type.
     internal static bool IsCurrent(Android.App.Activity activity)

--- a/src/dotnet/App.Maui/Services/PttSession.cs
+++ b/src/dotnet/App.Maui/Services/PttSession.cs
@@ -13,6 +13,7 @@ public static class PttSession
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan TeardownCheckPeriod = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan StopHotReplyTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan HandOffHotReplyTimeout = TimeSpan.FromMinutes(2);
     private const int TeardownIdleChecks = 2;
     private static readonly Lock Lock = new();
     private static Task? _teardownWatcher;
@@ -26,7 +27,7 @@ public static class PttSession
             var sessionResolver = app.Services.GetRequiredService<TrueSessionResolver>();
             await sessionResolver.SessionTask.WaitAsync(StartupTimeout).ConfigureAwait(false);
 
-            var (scopedServices, isHeadless) = ResolveScope();
+            var (scopedServices, isHeadless) = await ResolveScope(true, CancellationToken.None).ConfigureAwait(false);
             var core = scopedServices.GetRequiredService<PttSessionCore>();
             var audioFocusDenialCount = core.AudioFocusDenialCount;
             var ignoreReason = await core.StartPlayback(chatId, startedAt, isForeground, isHeadless, platform)
@@ -64,8 +65,10 @@ public static class PttSession
             var sessionResolver = app.Services.GetRequiredService<TrueSessionResolver>();
             await sessionResolver.SessionTask.WaitAsync(cts.Token).ConfigureAwait(false);
 
+            // No wait for a booting WebView: the budget is short, and a reply opened headless
+            // survives the handoff anyway - see HandOff.
             IServiceProvider scopedServices;
-            (scopedServices, isHeadless) = ResolveScope();
+            (scopedServices, isHeadless) = await ResolveScope(false, cts.Token).ConfigureAwait(false);
             var core = scopedServices.GetRequiredService<PttSessionCore>();
             return await core.Transmit(isHeadless, platform, cts.Token).ConfigureAwait(false);
         }
@@ -85,6 +88,17 @@ public static class PttSession
             if (isHeadless)
                 EnsureTeardownWatcher(platform);
         }
+    }
+
+    public static void HandOffHeadless(IServiceProvider webViewServices)
+    {
+        // Synchronous detach: from here every reader routes to the WebView scope, while what the
+        // headless scope was doing moves over in the background.
+        if (HeadlessBlazorScope.TryDetachCurrent("WebView scope published") is not { } headless)
+            return;
+
+        _ = BackgroundTask.Run(
+            () => HandOff(headless, webViewServices), Log, "Headless scope handoff failed", CancellationToken.None);
     }
 
     public static void StopHeadless(PttPlatform platform)
@@ -131,10 +145,25 @@ public static class PttSession
 
     // Private methods
 
-    private static (IServiceProvider Services, bool IsHeadless) ResolveScope()
+    private static async Task<(IServiceProvider Services, bool IsHeadless)> ResolveScope(
+        bool mayWaitForWebViewScope, CancellationToken cancellationToken)
     {
         if (AppServicesAccessor.TryGetScopedServices(out var liveScope))
             return (liveScope, false);
+
+        if (mayWaitForWebViewScope && IsWebViewScopeExpected()) {
+            // A headless scope started now would only have to be handed off in a few seconds -
+            // see HandOffHeadless - and each handoff costs the listener a buffer of audio.
+            // WaitAsync rather than a token: the inner wait sits on a non-cancellable source.
+            await AppServicesAccessor.WhenBlazorAppServicesReady(cancellationToken)
+                .WaitAsync(Constants.Audio.PttWebViewScopeWaitTimeout, cancellationToken)
+                .SilentAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (AppServicesAccessor.TryGetScopedServices(out liveScope))
+                return (liveScope, false);
+
+            Log.LogWarning("The WebView scope didn't arrive in time, falling back to a headless scope");
+        }
         if (HeadlessBlazorScope.GetOrCreate() is { } headless)
             return (headless.Services, true);
         if (AppServicesAccessor.TryGetScopedServices(out liveScope!))
@@ -142,6 +171,77 @@ public static class PttSession
             return (liveScope, false);
 
         throw StandardError.Internal("No service scope is available.");
+    }
+
+    private static bool IsWebViewScopeExpected()
+    {
+        // A dead WebView is recreated only by the next navigation, which nothing headless drives.
+        if (MauiWebView.Current is { IsDead: true })
+            return false;
+
+#if ANDROID
+        // The Activity is what creates the WebView; MauiWebView.Current alone may be the
+        // disconnected one a destroyed Activity left behind, and MainPage outlives both.
+        return MainActivity.HasCurrent;
+#else
+        return MainPage.Current is not null;
+#endif
+    }
+
+    private static async Task HandOff(HeadlessBlazorScope headless, IServiceProvider webViewServices)
+    {
+        // Two things the WebView scope can't work out on its own: what was being listened to
+        // (its InitializeListening re-arms the armed set, but players start only after Enable,
+        // which a background WebView may never reach), and the answer window, which Android
+        // doesn't persist. The catch-up anchor deliberately stays behind: the new player joins
+        // at the live edge, a copied anchor would replay the utterance from its start.
+        var headlessHub = headless.Services.GetRequiredService<AppUIHub>();
+        var listeningChatIds = await headlessHub.ChatAudioUI.GetListeningChatIds().ConfigureAwait(false);
+        var lastIncomingVoiceAt = headlessHub.IncomingVoiceActivityUI.SnapshotLastIncomingVoiceAt();
+        // The headless players stop before the WebView ones start: a gap of one buffer beats two
+        // players. Listening only - a hot reply keeps recording, see below.
+        await headlessHub.ChatAudioUI.ClearListeningChats().ConfigureAwait(false);
+
+        var scopedServices = await AppServicesAccessor.WhenBlazorAppServicesReady()
+            .WaitAsync(StartupTimeout)
+            .ConfigureAwait(false);
+        if (ReferenceEquals(scopedServices, webViewServices))
+            await Resume(scopedServices, listeningChatIds, lastIncomingVoiceAt).ConfigureAwait(false);
+
+        if (headlessHub.ChatAudioUI.IsRecording()) {
+            // An Apple PTT Talk press on a killed app boots the WebView while the reply it
+            // opened is still recording, and closing the mic here would cut that very reply.
+            // The WebView scope can't compete for the mic: ActiveChatsUI.FixStoredActiveChats
+            // drops a stored recording on start.
+            Log.LogInformation("PTT: a hot reply keeps the headless scope alive until it closes");
+            using var cts = new CancellationTokenSource(HandOffHotReplyTimeout);
+            var cRecordingChatId = await Computed
+                .Capture(() => headlessHub.ChatAudioUI.GetRecordingChatId())
+                .ConfigureAwait(false);
+            await cRecordingChatId.When(x => x is null, cts.Token).SilentAwait(false);
+        }
+        await StopAndDispose(headless).ConfigureAwait(false);
+    }
+
+    private static async Task Resume(
+        IServiceProvider scopedServices,
+        ImmutableHashSet<ChatId> listeningChatIds,
+        IReadOnlyDictionary<ChatId, Moment> lastIncomingVoiceAt)
+    {
+        var hub = scopedServices.GetRequiredService<AppUIHub>();
+        foreach (var (chatId, at) in lastIncomingVoiceAt)
+            hub.IncomingVoiceActivityUI.NoteIncomingVoice(chatId, at);
+        if (listeningChatIds.IsEmpty)
+            return;
+
+        Log.LogInformation(
+            "PTT: handing {Count} listening chat(s) off to the WebView scope", listeningChatIds.Count);
+        // A SetListeningState landing before the stored active chats are read would make
+        // StoredState discard them.
+        await hub.ActiveChatsUI.WhenReady.ConfigureAwait(false);
+        hub.ChatAudioUI.Enable();
+        foreach (var chatId in listeningChatIds)
+            await hub.ChatAudioUI.SetListeningState(chatId, true).ConfigureAwait(false);
     }
 
     private static void EnsureTeardownWatcher(PttPlatform platform)
@@ -157,8 +257,13 @@ public static class PttSession
             var idleChecks = 0;
             while (true) {
                 await Task.Delay(TeardownCheckPeriod).ConfigureAwait(false);
+                if (AppServicesAccessor.TryGetScopedServices(out var liveScope)) {
+                    // Normally already done by MauiWebView.SetScopedServices; a no-op then
+                    HandOffHeadless(liveScope);
+                    return;
+                }
                 if (HeadlessBlazorScope.Current is not { } headless)
-                    return; // The WebView scope owns audio now
+                    return;
 
                 var chatAudioUI = headless.Services.GetRequiredService<AppUIHub>().ChatAudioUI;
                 // A transmit into a headless scope with nothing playing looks exactly like an idle

--- a/src/dotnet/App.Maui/Services/PttSession.cs
+++ b/src/dotnet/App.Maui/Services/PttSession.cs
@@ -90,7 +90,7 @@ public static class PttSession
         }
     }
 
-    public static void HandOffHeadless(IServiceProvider webViewServices)
+    public static void HandOffHeadless()
     {
         // Synchronous detach: from here every reader routes to the WebView scope, while what the
         // headless scope was doing moves over in the background.
@@ -98,7 +98,7 @@ public static class PttSession
             return;
 
         _ = BackgroundTask.Run(
-            () => HandOff(headless, webViewServices), Log, "Headless scope handoff failed", CancellationToken.None);
+            () => HandOff(headless), Log, "Headless scope handoff failed", CancellationToken.None);
     }
 
     public static void StopHeadless(PttPlatform platform)
@@ -188,7 +188,7 @@ public static class PttSession
 #endif
     }
 
-    private static async Task HandOff(HeadlessBlazorScope headless, IServiceProvider webViewServices)
+    private static async Task HandOff(HeadlessBlazorScope headless)
     {
         // Two things the WebView scope can't work out on its own: what was being listened to
         // (its InitializeListening re-arms the armed set, but players start only after Enable,
@@ -202,11 +202,19 @@ public static class PttSession
         // players. Listening only - a hot reply keeps recording, see below.
         await headlessHub.ChatAudioUI.ClearListeningChats().ConfigureAwait(false);
 
-        var scopedServices = await AppServicesAccessor.WhenBlazorAppServicesReady()
-            .WaitAsync(StartupTimeout)
-            .ConfigureAwait(false);
-        if (ReferenceEquals(scopedServices, webViewServices))
+        // Whichever scope is live when the wait ends is the one that must take over: a WebView
+        // reload between the publish that triggered this handoff and here replaces the scope, and
+        // resuming into the one that triggered us would leave the live scope silent.
+        try {
+            var scopedServices = await AppServicesAccessor.WhenBlazorAppServicesReady()
+                .WaitAsync(StartupTimeout)
+                .ConfigureAwait(false);
             await Resume(scopedServices, listeningChatIds, lastIncomingVoiceAt).ConfigureAwait(false);
+        }
+        catch (Exception e) {
+            // Still dispose below: a kept headless scope would be the second audio stack again.
+            Log.LogError(e, "PTT: couldn't hand the listening state off to the WebView scope");
+        }
 
         if (headlessHub.ChatAudioUI.IsRecording()) {
             // An Apple PTT Talk press on a killed app boots the WebView while the reply it
@@ -257,9 +265,9 @@ public static class PttSession
             var idleChecks = 0;
             while (true) {
                 await Task.Delay(TeardownCheckPeriod).ConfigureAwait(false);
-                if (AppServicesAccessor.TryGetScopedServices(out var liveScope)) {
+                if (AppServicesAccessor.TryGetScopedServices(out _)) {
                     // Normally already done by MauiWebView.SetScopedServices; a no-op then
-                    HandOffHeadless(liveScope);
+                    HandOffHeadless();
                     return;
                 }
                 if (HeadlessBlazorScope.Current is not { } headless)

--- a/src/dotnet/App.Maui/WebView/MauiWebView.cs
+++ b/src/dotnet/App.Maui/WebView/MauiWebView.cs
@@ -119,6 +119,7 @@ public sealed partial class MauiWebView
             Session = session;
             BlazorAppServices = scopedServices;
         }
+        PttSession.HandOffHeadless(scopedServices);
         return isSessionChanged
             ? SetupCookies(session)
             : Task.CompletedTask;

--- a/src/dotnet/App.Maui/WebView/MauiWebView.cs
+++ b/src/dotnet/App.Maui/WebView/MauiWebView.cs
@@ -119,7 +119,7 @@ public sealed partial class MauiWebView
             Session = session;
             BlazorAppServices = scopedServices;
         }
-        PttSession.HandOffHeadless(scopedServices);
+        PttSession.HandOffHeadless();
         return isSessionChanged
             ? SetupCookies(session)
             : Task.CompletedTask;

--- a/src/dotnet/UI.Blazor.App/Services/Audio/ListeningStreamProcessor.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Audio/ListeningStreamProcessor.cs
@@ -13,6 +13,7 @@ public sealed class ListeningStreamProcessor : WorkerBase
     private static bool DebugMode => Constants.DebugMode.LiveStreaming;
 
     private ResilientStream<MuxedAudioStreamItem>? _itemStream;
+    private bool _isCatchUpConsumed;
 
     private ILogger Log { get; }
     private ILogger? DebugLog { get; }
@@ -52,15 +53,17 @@ public sealed class ListeningStreamProcessor : WorkerBase
 
         var itemStream = new ResilientStream<MuxedAudioStreamItem> {
             Provider = async ct => {
-                // Re-evaluated per (re)connect: a reconnect after the wake window must not
-                // re-play the trigger utterance from its start.
-                var catchUpFrom = Ptt.IsStaleWake(CatchUpFrom, clocks.ServerClock.Now)
+                // The anchor is for the first connection only: the server serves the trigger
+                // utterance from t=0 to whoever asks, so a reconnect that still carried it would
+                // re-play what the listener already heard.
+                var catchUpFrom = _isCatchUpConsumed || Ptt.IsStaleWake(CatchUpFrom, clocks.ServerClock.Now)
                     ? default
                     : CatchUpFrom;
                 Log.LogInformation("-> LiveStreams.GetListeningStream({ChatId}), catchUpFrom={CatchUpFrom}",
                     ChatId, catchUpFrom);
                 var stream = await liveStreams.GetListeningStream(Session, ChatId, catchUpFrom, ct)
                     .ConfigureAwait(false);
+                _isCatchUpConsumed = true;
                 DebugLog?.LogInformation("<- LiveStreams.GetListeningStream({ChatId})", ChatId);
                 return stream;
             },

--- a/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatAudioUI.StateSync.cs
@@ -16,8 +16,12 @@ public partial class ChatAudioUI
 
     protected override async Task OnRun(CancellationToken cancellationToken)
     {
-        // All logic here can be delayed to let other code run
-        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(true); // Intended
+        // All logic here can be delayed to let other startup code run - unless someone already
+        // needs audio: a headless wake enables this service milliseconds after constructing it,
+        // and a full second of settling there is a second of the utterance the user doesn't hear.
+        await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(1), cancellationToken), WhenEnabled)
+            .ConfigureAwait(true); // Intended
+        cancellationToken.ThrowIfCancellationRequested();
         var baseChains = new[] {
             AsyncChain.From(InitializeListening),
             AsyncChain.From(StopListeningWhenPttDisarmed),

--- a/src/dotnet/UI.Blazor.App/Services/PttSessionCore.cs
+++ b/src/dotnet/UI.Blazor.App/Services/PttSessionCore.cs
@@ -43,6 +43,12 @@ public sealed class PttSessionCore(AppUIHub hub) : IDisposable
 
         if (isHeadless)
             chatAudioUI.IsPttHeadless = true;
+        // Before Enable: the audio workers start on it and re-listen the armed set at once, and
+        // a player started without the anchor waits for the server clock instead of joining the
+        // trigger utterance from its start. A fresh wake joins from the start; a stale one goes
+        // straight to live listening.
+        if (!isForeground && !Ptt.IsStaleWake(startedAt, Hub.Clocks.SystemClock.Now))
+            chatAudioUI.SetListeningCatchUp(chatId, startedAt);
         chatAudioUI.Enable();
         // Fire-and-forget: ServerTimeSync's own loop only starts syncing after a 3s settling delay,
         // and everything downstream that wants server time would sit behind it.
@@ -73,10 +79,6 @@ public sealed class PttSessionCore(AppUIHub hub) : IDisposable
         if (!armedChatIds.Contains(chatId))
             armedChatIds = [..armedChatIds, chatId];
 
-        // A fresh wake joins the trigger utterance from its start (it's still streaming or just
-        // ended); a stale one goes straight to live listening.
-        if (!Ptt.IsStaleWake(startedAt, Hub.Clocks.SystemClock.Now))
-            chatAudioUI.SetListeningCatchUp(chatId, startedAt);
         foreach (var armedChatId in armedChatIds)
             await chatAudioUI.SetListeningState(armedChatId, true).ConfigureAwait(false);
 

--- a/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
+++ b/src/dotnet/UI.Blazor/Services/ServerTimeSync.cs
@@ -57,8 +57,11 @@ public sealed class ServerTimeSync(IServiceProvider services) : WorkerBase
     // Probe RTT beyond this multiple of the measured min-RTT is a timeout, not a slow link.
     private const int ProbeTimeoutRttFactor = 3;
     private const int FailureLogPeriod = 5;
+    // Client-only, so one process is one device: the last accepted sync, for the next scope.
+    private static SeedState? _lastSeed;
 
     private readonly SemaphoreSlim _syncLock = new(1, 1);
+    private readonly Lock _seedLock = new();
     private readonly RunningEma _minRttEma = new(0f, 1, 0.3);
     private CancellationTokenSource? _slewTokenSource;
     private TimeSpan _appliedOffset;
@@ -89,6 +92,7 @@ public sealed class ServerTimeSync(IServiceProvider services) : WorkerBase
 
     public async Task EnsureSynced(CancellationToken cancellationToken)
     {
+        TryApplySeed();
         // Wall-vs-monotonic divergence is a reason to re-measure, never evidence that
         // a correction is legitimate - the two clocks disagree on sleep and on a wall
         // step alike, and which one lies is platform-dependent.
@@ -105,13 +109,16 @@ public sealed class ServerTimeSync(IServiceProvider services) : WorkerBase
     // Protected/internal methods
 
     protected override Task OnRun(CancellationToken cancellationToken)
-        => AsyncChain.From(Sync)
+    {
+        TryApplySeed();
+        return AsyncChain.From(Sync)
             .RetryForever(ConvergingDelays)
             .AppendDelay(GetNextSyncDelay)
             .CycleForever()
             .Log(LogLevel.Debug, Log)
             .PrependDelay(StartupDelay)
             .RunIsolated(cancellationToken);
+    }
 
     // Private methods
 
@@ -276,6 +283,42 @@ public sealed class ServerTimeSync(IServiceProvider services) : WorkerBase
             correction.ToShortString(), burst.MinRtt.ToShortString(), _driftRate * 1e6, _epoch);
         SetNextSyncAt();
         UpdateStats(outcome, burst, correction);
+        if (!IsServer)
+            Volatile.Write(ref _lastSeed, new SeedState(
+                burst.Offset, burst.Precision, burst.MinRtt, _driftRate, _lastAcceptedAt, _lastAcceptedWallAt));
+    }
+
+    private void TryApplySeed()
+    {
+        // A scope that replaces another - a WebView reload, a headless wake handed off to the
+        // WebView scope - would otherwise spend seconds re-measuring an offset the previous scope
+        // had to target precision moments ago, and every listener start waits on that. Client
+        // hosts only: in server mode the offset is one browser's, and the process serves many.
+        // EnsureSynced's gates still judge the seed's age and any suspend since, so a stale seed
+        // costs nothing but triggers the sync it would have triggered anyway.
+        if (IsServer)
+            return;
+
+        lock (_seedLock) {
+            if (SyncCount > 0 || Volatile.Read(ref _lastSeed) is not { } seed)
+                return;
+
+            SyncCount = 1;
+            _precision = seed.Precision;
+            _lastAcceptedAt = seed.AcceptedAt;
+            _lastAcceptedWallAt = seed.AcceptedWallAt;
+            _driftRate = seed.DriftRate;
+            _minRttEma.AppendSample((float)seed.MinRtt.TotalSeconds);
+            _mode = seed.Precision <= GetEffectiveTargetPrecision()
+                ? ServerClockSyncMode.Steady
+                : ServerClockSyncMode.Converging;
+            ApplyStep(seed.Offset);
+            SetNextSyncAt();
+            Log.LogInformation(
+                "Seeded from the previous scope: offset = {Offset} ± {Precision}, age = {Age}",
+                seed.Offset.ToShortString(), seed.Precision.ToShortString(),
+                (CpuClock.Now - seed.AcceptedAt).ToShortString());
+        }
     }
 
     private void OnAttemptFailed(ServerClockSyncOutcome outcome)
@@ -524,6 +567,14 @@ public sealed class ServerTimeSync(IServiceProvider services) : WorkerBase
     // Nested types
 
     private sealed record Sample(TimeSpan Rtt, double OffsetMs);
+
+    private sealed record SeedState(
+        TimeSpan Offset,
+        TimeSpan Precision,
+        TimeSpan MinRtt,
+        double DriftRate,
+        Moment AcceptedAt,
+        Moment AcceptedWallAt);
 
     private sealed record BurstResult(
         TimeSpan Offset,

--- a/tests/Chat.UI.Blazor.UnitTests/ListeningStreamProcessorTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ListeningStreamProcessorTest.cs
@@ -1,0 +1,82 @@
+using ActualChat.Live;
+using ActualChat.Streaming;
+using ActualChat.UI.Blazor.App.Services;
+using ActualLab.Rpc;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public sealed class ListeningStreamProcessorTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly TimeSpan ReconnectWaitTimeout = TimeSpan.FromSeconds(10);
+    private static readonly ChatId TestChatId = ChatId.Parse("aaaaaaaaaaaaaaaaaaaa");
+    private static readonly Session TestSession = Session.New();
+
+    [Fact]
+    public async Task CatchUpAnchorShouldReachTheFirstConnectionOnly()
+    {
+        // arrange
+        var anchor = Moment.Now - TimeSpan.FromSeconds(5);
+        var (services, catchUpFroms) = CreateServices();
+        var processor = new ListeningStreamProcessor(services, TestSession, TestChatId, anchor);
+
+        // act
+        _ = processor.Run();
+        await WaitForConnections(catchUpFroms, 2);
+        await processor.DisposeAsync();
+
+        // assert
+        catchUpFroms.Take(2).Should().Equal([anchor, default],
+            "the server serves the trigger utterance from t=0 to whoever asks, so a reconnect must not ask again");
+    }
+
+    [Fact]
+    public async Task StaleCatchUpAnchorShouldNeverReachTheServer()
+    {
+        // arrange
+        var anchor = Moment.Now - Constants.Audio.PttStaleWakeAge - TimeSpan.FromSeconds(1);
+        var (services, catchUpFroms) = CreateServices();
+        var processor = new ListeningStreamProcessor(services, TestSession, TestChatId, anchor);
+
+        // act
+        _ = processor.Run();
+        await WaitForConnections(catchUpFroms, 1);
+        await processor.DisposeAsync();
+
+        // assert
+        catchUpFroms[0].Should().Be(default(Moment));
+    }
+
+    // Private methods
+
+    private (IServiceProvider Services, List<Moment> CatchUpFroms) CreateServices()
+    {
+        var catchUpFroms = new List<Moment>();
+        var liveStreams = new Mock<ILiveAudioStreams>(MockBehavior.Strict);
+        liveStreams
+            .Setup(x => x.GetListeningStream(
+                It.IsAny<Session>(), It.IsAny<ChatId>(), It.IsAny<Moment>(), It.IsAny<CancellationToken>()))
+            .Returns((Session _, ChatId _, Moment catchUpFrom, CancellationToken _) => {
+                lock (catchUpFroms)
+                    catchUpFroms.Add(catchUpFrom);
+                // An ending stream is a transient drop to an infinite ResilientStream: it reconnects
+                return Task.FromResult(RpcStream.New(AsyncEnumerable.Empty<MuxedAudioStreamItem>()));
+            });
+        var services = new ServiceCollection()
+            .AddTestLogging(Out)
+            .AddSingleton(liveStreams.Object)
+            .BuildServiceProvider();
+        return (services, catchUpFroms);
+    }
+
+    private static async Task WaitForConnections(List<Moment> catchUpFroms, int count)
+    {
+        using var cts = new CancellationTokenSource(ReconnectWaitTimeout);
+        while (true) {
+            lock (catchUpFroms)
+                if (catchUpFroms.Count >= count)
+                    return;
+
+            await Task.Delay(50, cts.Token);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Users with an armed PTT chat heard the remote voice twice, with a constant offset, while a conversation was going on. Root cause: a wake-created `HeadlessBlazorScope` survived next to the WebView scope. Only Android's `MainActivity.OnCreate` ever retired it, so iOS never did, and on Android a wake landing in the WebView boot window after OnCreate was never retired either. Both scopes are complete audio stacks (`ChatAudioUI`, `ActiveChatsUI`, the playback engine factory are all scoped) and each one re-listens every armed chat, so the same chat played through two native engines.

- **fix(ptt): hand the headless wake scope off to the WebView scope on every platform.** `MauiWebView.SetScopedServices` calls `PttSession.HandOffHeadless`: detach synchronously, move the listening set and the answer-window stamps to the WebView scope, dispose the headless one. A hot reply keeps recording until it closes, so an Apple PTT Talk press that booted the app isn't cut short. `ResolveScope` waits up to 8 s for a booting WebView's scope before starting a headless one (wakes only), and `WatchTeardown` exits through the same handoff.
- **fix(ptt): send the wake catch-up anchor on the first listening connection only.** A reconnect inside the 60 s stale window replayed the trigger utterance from its start over the tail of the previous track.
- **perf(ptt): start a wake's listener without the settle delay.** `ChatAudioUI.OnRun` no longer sits a full second before starting its chains once `Enable()` is called; the catch-up anchor is stored before `Enable()` so the first player start doesn't take the no-anchor path.
- **perf(clock): seed a new scope's server clock from the previous scope's last sync.** A replacing scope (WebView reload, headless handoff) used to re-measure from `SyncCount = 0` and every listener start waited ~2 s behind `EnsureSynced`. Client hosts only.

Docs: `docs/live-audio/10-push-to-talk.md` and `docs/architecture/server-clock-sync.md`.

## Verification

Android, OnePlus test phone, wake with the app in background, then opening the app mid-conversation:

| Stage | Before | After |
|---|---|---|
| Wake → headless listener connect (with anchor) | 1060 ms | 36 ms |
| Wake → first sound | 1570 ms | 619 ms |
| Open app → WebView listener connect | 3.2 s | 245 ms |
| Open app → WebView first sound | 3.5 s | ~420 ms |

One player at a time through the handoff in every run (logcat: one `Play called` at a time, headless track aborted before the WebView one starts). Unit tests: `Chat.UI.Blazor.UnitTests` 799 passed, incl. the new `ListeningStreamProcessorTest`. iOS: C# compiled on the Mac (`-f net11.0-ios -t:Compile`, 0 errors); **iOS device test still owed** — that's the platform where the double voice was guaranteed before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N77mjKH3hdALyd9WaSVx6j
