### PR TITLE
feat(ui): add "Share link" action to link previews

### DIFF
--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -307,6 +307,7 @@ public static class LocalizedStringsLocalizerExt
         public string MessageMenu_CancelSend => l["MessageMenu_CancelSend"].Value;
         public string MessageMenu_OpenLink => l["MessageMenu_OpenLink"].Value;
         public string MessageMenu_CopyLinkUrl => l["MessageMenu_CopyLinkUrl"].Value;
+        public string MessageMenu_ShareLink => l["MessageMenu_ShareLink"].Value;
         public string MessageMenu_ForwardMessage => l["MessageMenu_ForwardMessage"].Value;
         public string MessageMenu_Preview => l["MessageMenu_Preview"].Value;
         public string MessageMenu_ShareFile => l["MessageMenu_ShareFile"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Отворете линка",
   "MessageMenu_CopyLinkUrl": "Копирайте URL адреса",
   "MessageMenu_ForwardMessage": "Препратете съобщението",
+  "MessageMenu_ShareLink": "Споделяне на връзка",
   "MessageMenu_Preview": "Преглед",
   "MessageMenu_ShareFile": "Споделете файла",
   "MessageMenu_CopyDownloadLink": "Копирайте линка за изтегляне",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Otvorite link",
   "MessageMenu_CopyLinkUrl": "Kopirajte URL linka",
   "MessageMenu_ForwardMessage": "Proslijedite poruku",
+  "MessageMenu_ShareLink": "Podijeli link",
   "MessageMenu_Preview": "Pregled",
   "MessageMenu_ShareFile": "Podijelite fajl",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Otvorite link",
   "MessageMenu_CopyLinkUrl": "Kopirajte URL linka",
   "MessageMenu_ForwardMessage": "Proslijedite poruku",
+  "MessageMenu_ShareLink": "Podijeli link",
   "MessageMenu_Preview": "Pregled",
   "MessageMenu_ShareFile": "Podijelite fajl",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Otevřít odkaz",
   "MessageMenu_CopyLinkUrl": "Kopírovat URL odkazu",
   "MessageMenu_ForwardMessage": "Přeposlat zprávu",
+  "MessageMenu_ShareLink": "Sdílet odkaz",
   "MessageMenu_Preview": "Náhled",
   "MessageMenu_ShareFile": "Sdílet soubor",
   "MessageMenu_CopyDownloadLink": "Kopírovat odkaz ke stažení",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Link öffnen",
   "MessageMenu_CopyLinkUrl": "Link-URL kopieren",
   "MessageMenu_ForwardMessage": "Nachricht weiterleiten",
+  "MessageMenu_ShareLink": "Link teilen",
   "MessageMenu_Preview": "Vorschau",
   "MessageMenu_ShareFile": "Datei teilen",
   "MessageMenu_CopyDownloadLink": "Download-Link kopieren",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -365,6 +365,7 @@
   "MessageMenu_OpenLink": "Open link",
   "MessageMenu_CopyLinkUrl": "Copy link URL",
   "MessageMenu_ForwardMessage": "Forward message",
+  "MessageMenu_ShareLink": "Share link",
   "MessageMenu_Preview": "Preview",
   "MessageMenu_ShareFile": "Share file",
   "MessageMenu_CopyDownloadLink": "Copy download link",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Abrir enlace",
   "MessageMenu_CopyLinkUrl": "Copiar la URL del enlace",
   "MessageMenu_ForwardMessage": "Reenviar mensaje",
+  "MessageMenu_ShareLink": "Compartir enlace",
   "MessageMenu_Preview": "Vista previa",
   "MessageMenu_ShareFile": "Compartir archivo",
   "MessageMenu_CopyDownloadLink": "Copiar enlace de descarga",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Ouvrir le lien",
   "MessageMenu_CopyLinkUrl": "Copier l’URL du lien",
   "MessageMenu_ForwardMessage": "Transférer le message",
+  "MessageMenu_ShareLink": "Partager le lien",
   "MessageMenu_Preview": "Aperçu",
   "MessageMenu_ShareFile": "Partager le fichier",
   "MessageMenu_CopyDownloadLink": "Copier le lien de téléchargement",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "लिंक खोलें",
   "MessageMenu_CopyLinkUrl": "लिंक का URL कॉपी करें",
   "MessageMenu_ForwardMessage": "संदेश अग्रेषित करें",
+  "MessageMenu_ShareLink": "लिंक साझा करें",
   "MessageMenu_Preview": "पूर्वावलोकन",
   "MessageMenu_ShareFile": "फ़ाइल साझा करें",
   "MessageMenu_CopyDownloadLink": "डाउनलोड लिंक कॉपी करें",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Otvorite link",
   "MessageMenu_CopyLinkUrl": "Kopirajte URL linka",
   "MessageMenu_ForwardMessage": "Proslijedite poruku",
+  "MessageMenu_ShareLink": "Podijeli poveznicu",
   "MessageMenu_Preview": "Pregled",
   "MessageMenu_ShareFile": "Podijelite datoteka",
   "MessageMenu_CopyDownloadLink": "Kopirajte link za preuzimanje",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Buka tautan",
   "MessageMenu_CopyLinkUrl": "Salin URL tautan",
   "MessageMenu_ForwardMessage": "Teruskan pesan",
+  "MessageMenu_ShareLink": "Bagikan tautan",
   "MessageMenu_Preview": "Pratinjau",
   "MessageMenu_ShareFile": "Bagikan file",
   "MessageMenu_CopyDownloadLink": "Salin tautan unduhan",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Apri il link",
   "MessageMenu_CopyLinkUrl": "Copia l’URL del link",
   "MessageMenu_ForwardMessage": "Inoltra il messaggio",
+  "MessageMenu_ShareLink": "Condividi link",
   "MessageMenu_Preview": "Anteprima",
   "MessageMenu_ShareFile": "Condividi il file",
   "MessageMenu_CopyDownloadLink": "Copia il link di download",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "リンクを開く",
   "MessageMenu_CopyLinkUrl": "リンクのURLをコピー",
   "MessageMenu_ForwardMessage": "メッセージを転送",
+  "MessageMenu_ShareLink": "リンクを共有",
   "MessageMenu_Preview": "プレビュー",
   "MessageMenu_ShareFile": "ファイルを共有",
   "MessageMenu_CopyDownloadLink": "ダウンロードリンクをコピー",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "링크 열기",
   "MessageMenu_CopyLinkUrl": "링크 주소 복사",
   "MessageMenu_ForwardMessage": "메시지 전달",
+  "MessageMenu_ShareLink": "링크 공유",
   "MessageMenu_Preview": "미리보기",
   "MessageMenu_ShareFile": "파일 공유",
   "MessageMenu_CopyDownloadLink": "다운로드 링크 복사",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -365,6 +365,7 @@
   "MessageMenu_OpenLink": "Відкрити посилання",
   "MessageMenu_CopyLinkUrl": "Копіювати адресу посилання",
   "MessageMenu_ForwardMessage": "Препратете съобщението",
+  "MessageMenu_ShareLink": "Share link",
   "MessageMenu_Preview": "Pré-visualizar",
   "MessageMenu_ShareFile": "Поделиться файлом",
   "MessageMenu_CopyDownloadLink": "Копіювати посилання для завантаження",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Otwórz link",
   "MessageMenu_CopyLinkUrl": "Kopiuj adres URL linku",
   "MessageMenu_ForwardMessage": "Prześlij wiadomość dalej",
+  "MessageMenu_ShareLink": "Udostępnij link",
   "MessageMenu_Preview": "Podgląd",
   "MessageMenu_ShareFile": "Udostępnij plik",
   "MessageMenu_CopyDownloadLink": "Kopiuj link do pobrania",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Abrir link",
   "MessageMenu_CopyLinkUrl": "Copiar a URL do link",
   "MessageMenu_ForwardMessage": "Encaminhar mensagem",
+  "MessageMenu_ShareLink": "Compartilhar link",
   "MessageMenu_Preview": "Pré-visualizar",
   "MessageMenu_ShareFile": "Compartilhar arquivo",
   "MessageMenu_CopyDownloadLink": "Copiar link de download",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Открыть ссылку",
   "MessageMenu_CopyLinkUrl": "Копировать адрес ссылки",
   "MessageMenu_ForwardMessage": "Переслать сообщение",
+  "MessageMenu_ShareLink": "Поделиться ссылкой",
   "MessageMenu_Preview": "Просмотр",
   "MessageMenu_ShareFile": "Поделиться файлом",
   "MessageMenu_CopyDownloadLink": "Копировать ссылку для скачивания",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Отворите линк",
   "MessageMenu_CopyLinkUrl": "Копирајте URL линка",
   "MessageMenu_ForwardMessage": "Прослиједите поруку",
+  "MessageMenu_ShareLink": "Подели линк",
   "MessageMenu_Preview": "Преглед",
   "MessageMenu_ShareFile": "Поделите фајл",
   "MessageMenu_CopyDownloadLink": "Копирајте линк за преузимање",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Bağlantıyı açın",
   "MessageMenu_CopyLinkUrl": "Bağlantı adresini kopyalayın",
   "MessageMenu_ForwardMessage": "Mesajı iletin",
+  "MessageMenu_ShareLink": "Bağlantıyı paylaş",
   "MessageMenu_Preview": "Önizleyin",
   "MessageMenu_ShareFile": "Dosyayı paylaşın",
   "MessageMenu_CopyDownloadLink": "İndirme bağlantısını kopyalayın",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Відкрити посилання",
   "MessageMenu_CopyLinkUrl": "Копіювати адресу посилання",
   "MessageMenu_ForwardMessage": "Переслати повідомлення",
+  "MessageMenu_ShareLink": "Поділитися посиланням",
   "MessageMenu_Preview": "Перегляд",
   "MessageMenu_ShareFile": "Поділитися файлом",
   "MessageMenu_CopyDownloadLink": "Копіювати посилання для завантаження",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "Mở liên kết",
   "MessageMenu_CopyLinkUrl": "Sao chép địa chỉ liên kết",
   "MessageMenu_ForwardMessage": "Chuyển tiếp tin nhắn",
+  "MessageMenu_ShareLink": "Chia sẻ liên kết",
   "MessageMenu_Preview": "Xem trước",
   "MessageMenu_ShareFile": "Chia sẻ tệp",
   "MessageMenu_CopyDownloadLink": "Sao chép liên kết tải xuống",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -287,6 +287,7 @@
   "MessageMenu_OpenLink": "打开链接",
   "MessageMenu_CopyLinkUrl": "复制链接地址",
   "MessageMenu_ForwardMessage": "转发消息",
+  "MessageMenu_ShareLink": "分享链接",
   "MessageMenu_Preview": "预览",
   "MessageMenu_ShareFile": "分享文件",
   "MessageMenu_CopyDownloadLink": "复制下载链接",

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LinkPreviewMenu.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LinkPreviewMenu.razor
@@ -13,6 +13,11 @@
         Click="@OnCopy">
     </MenuEntry>
     <MenuEntry
+        Icon="icon-share-more"
+        Text="@L.MessageMenu_ShareLink"
+        Click="@OnShareLink">
+    </MenuEntry>
+    <MenuEntry
         Icon="icon-share"
         Text="@L.MessageMenu_ForwardMessage"
         Click="@OnForward">
@@ -26,6 +31,7 @@
 
     private SelectionUI SelectionUI => Hub.SelectionUI;
     private ClipboardUI ClipboardUI => Hub.ClipboardUI;
+    private ShareUI ShareUI => Hub.ShareUI;
 
     protected override void OnParametersSet() {
         switch (Arguments) {
@@ -60,6 +66,12 @@
     private async Task OnCopy() {
         await WhenClosed.ConfigureAwait(true);
         await ClipboardUI.WriteText(_url).ConfigureAwait(false);
+    }
+
+    private async Task OnShareLink() {
+        await WhenClosed.ConfigureAwait(true);
+        var localUrl = _localUrl.IsNullOrEmpty() ? (LocalUrl?)null : new LocalUrl(_localUrl);
+        await ShareUI.ShareLink(_url, localUrl, L.MessageMenu_ShareLink).ConfigureAwait(false);
     }
 
     private async Task OnForward() {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LinkPreviewView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LinkPreviewView.razor
@@ -49,9 +49,9 @@
     </CopyTrigger>
     @if (m.LocalLink is null) {
         <HeaderButton
-            Tooltip="@L.MessageMenu_Forward"
-            Click="@(() => SelectionUI.Forward(m.Entry.Id))">
-            <i class="icon-share"></i>
+            Tooltip="@L.MessageMenu_ShareLink"
+            Click="@(() => ShareUI.ShareLink(uri.ToString(), m.LocalLink?.LocalUrl, L.MessageMenu_ShareLink))">
+            <i class="icon-share-more"></i>
         </HeaderButton>
     }
 </div>
@@ -88,8 +88,8 @@
 }
 
 @code {
-    private SelectionUI SelectionUI => Hub.SelectionUI;
     private LinkPreviewUI LinkPreviewUI => Hub.LinkPreviewUI;
+    private ShareUI ShareUI => Hub.ShareUI;
 
     [Parameter, EditorRequired] public ChatEntry Entry { get; set; } = null!;
     [Parameter, EditorRequired] public LinkPreview LinkPreview { get; set; } = null!;

--- a/src/dotnet/UI.Blazor.App/Components/Share/ShareActions.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Share/ShareActions.razor
@@ -46,5 +46,7 @@
             Model.Title,
             Model.Request.Link.GetValueOrDefault(),
             Model.ImageUrl,
-            ScanHandler));
+            ScanHandler) {
+            AbsoluteUrl = Model.Request.HasExternalLink() ? Model.Request.GetShareLink(UrlMapper) : null,
+        });
 }

--- a/src/dotnet/UI.Blazor.App/Components/Share/ShareExternallyButton.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Share/ShareExternallyButton.razor
@@ -22,7 +22,7 @@
             <Title>@(Title ?? L.Share_ShareExternally)</Title>
         </Button>
     } else {
-        var text = Request.HasLink() ? L.MessageMenu_CopyLink : L.LogView_CopyToClipboard;
+        var text = Request.HasAnyLink() ? L.MessageMenu_CopyLink : L.LogView_CopyToClipboard;
         <CopyTrigger Class="w-full" Tooltip="@L.Common_Copy" CopyText="@Request.GetShareTextAndLink(UrlMapper)">
             <Button Class="btn-modal">
                 <Icon>

--- a/src/dotnet/UI.Blazor.App/Components/Share/ShareModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Share/ShareModal.razor
@@ -85,7 +85,7 @@
     protected override void OnInitialized() {
         _comment = ModalModel.Request.Text;
         // A private place's invite is for its members only, so it has no business outside the app
-        _mustShowActions = ModalModel.Request.HasLink()
+        _mustShowActions = ModalModel.Request.HasAnyLink()
             && ModalModel.SelectorPrefs is not ShareWithPlaceMembersOnly;
         if (ModalModel.SelectorPrefs is ShareWithPlaceMembersOnly selector) {
             _memberListSource = new PlaceMemberListSource(Hub, selector.PlaceId, [OwnAccount.Id]);

--- a/src/dotnet/UI.Blazor.App/Components/Share/ShareQrModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Share/ShareQrModal.razor
@@ -26,7 +26,7 @@
         } else {
             <div class="c-code">
                 <qr-code
-                    url="@UrlMapper.ToAbsolute(ModalModel.Link)"
+                    url="@(ModalModel.AbsoluteUrl ?? UrlMapper.ToAbsolute(ModalModel.Link))"
                     image="@ModalModel.ImageUrl"></qr-code>
             </div>
             <div class="c-hint">@L.ShareQr_Hint_Format(CoreConstants.AppName)</div>

--- a/src/dotnet/UI.Blazor.App/ShareUIExt.cs
+++ b/src/dotnet/UI.Blazor.App/ShareUIExt.cs
@@ -34,6 +34,16 @@ public static class ShareUIExt
             : await shareUI.Share(shareModel).ConfigureAwait(false);
     }
 
+    // Shares a link preview's target as a new message: a LocalUrl for an in-app link,
+    // else the raw off-origin URL that has no LocalUrl form
+    public static Task<ModalRef> ShareLink(this ShareUI shareUI, string url, LocalUrl? localUrl, string title)
+    {
+        var request = localUrl is { } local
+            ? new ShareRequest(local)
+            : new ShareRequest("") { ExternalLink = url };
+        return shareUI.Share(new ShareModalModel(ShareKind.Other, title, "", request, null));
+    }
+
     public static async Task<ModalRef?> ShareOwnAccount(
         this ShareUI shareUI, CancellationToken cancellationToken = default)
     {

--- a/src/dotnet/UI.Blazor/Components/Share/ShareQrModalModel.cs
+++ b/src/dotnet/UI.Blazor/Components/Share/ShareQrModalModel.cs
@@ -5,4 +5,8 @@ public sealed record ShareQrModalModel(
     string Title,
     LocalUrl Link,
     string? ImageUrl = null,
-    Func<LocalUrl, Task<bool>>? ScanHandler = null);
+    Func<LocalUrl, Task<bool>>? ScanHandler = null)
+{
+    // Overrides the encoded URL when set - lets an off-origin link with no LocalUrl form still yield a QR
+    public string? AbsoluteUrl { get; init; }
+}

--- a/src/dotnet/UI.Blazor/Components/Share/ShareRequest.cs
+++ b/src/dotnet/UI.Blazor/Components/Share/ShareRequest.cs
@@ -6,6 +6,9 @@ public sealed record ShareRequest(
 {
     public IReadOnlyList<MediaRef> Media { get; init; } = [];
 
+    // An absolute, off-origin URL with no LocalUrl form (e.g. a link preview's external target)
+    public string? ExternalLink { get; init; }
+
     public ShareRequest(LocalUrl link) : this("", link)
     { }
 
@@ -20,6 +23,11 @@ public sealed record ShareRequest(
         link = default;
         return false;
     }
+
+    public bool HasExternalLink()
+        => !ExternalLink.IsNullOrEmpty();
+    public bool HasAnyLink()
+        => HasLink() || HasExternalLink();
 
     public bool HasMedia()
         => Media.Count > 0;

--- a/src/dotnet/UI.Blazor/Components/Share/ShareRequestExt.cs
+++ b/src/dotnet/UI.Blazor/Components/Share/ShareRequestExt.cs
@@ -4,25 +4,25 @@ public static class ShareRequestExt
 {
     public static string GetDisplayTextAndLink(this ShareRequest request)
     {
-        if (request.Link is not { } link)
+        var displayLink = request.GetDisplayLink();
+        if (displayLink is null)
             return request.Text;
-        var displayLink = GetDisplayLink(link);
         return request.Text.IsNullOrEmpty() ? displayLink : $"{request.Text}: {displayLink}";
     }
 
     public static string? GetDisplayLink(this ShareRequest request)
-        => request.Link is { } link ? GetDisplayLink(link) : null;
+        => request.Link is { } link ? GetDisplayLink(link) : request.ExternalLink.NullIfEmpty();
 
     public static string GetShareTextAndLink(this ShareRequest request, UrlMapper urlMapper)
     {
-        if (request.Link is not { } link)
+        var fullLink = request.GetShareLink(urlMapper).NullIfEmpty();
+        if (fullLink is null)
             return request.Text;
-        var fullLink = urlMapper.ToAbsolute(link);
         return request.Text.IsNullOrEmpty() ? fullLink : $"{request.Text}: {fullLink}";
     }
 
     public static string GetShareLink(this ShareRequest request, UrlMapper urlMapper)
-        => request.Link is { } link ? urlMapper.ToAbsolute(link) : "";
+        => request.Link is { } link ? urlMapper.ToAbsolute(link) : request.ExternalLink ?? "";
 
     private static string GetDisplayLink(LocalUrl link)
         => link.IsHome() ? link.Value : link.Value[1..];


### PR DESCRIPTION
Share just the URL (not the whole message) via the existing ShareModal: a new "Share link" entry in the link preview's mobile menu, and on desktop the hover Forward button is replaced by Share link. ShareRequest gains an optional ExternalLink so off-origin URLs (which have no LocalUrl form) flow through the same share/QR path additively. Localized in 23 languages.