### PR TITLE
fix(car-audio): register UserCarAudioSettings in UserSettings.KeyToType

### DIFF
--- a/src/dotnet/Users.Service/UserSettings.cs
+++ b/src/dotnet/Users.Service/UserSettings.cs
@@ -9,7 +9,8 @@ namespace ActualChat.Users;
 /// </summary>
 public class UserSettings(IServiceProvider services) : IUserSettings
 {
-    private static readonly Dictionary<string, Type> KeyToType = new() {
+    // Internal so UserSettingsKeyToTypeTest can check it covers every UserSettingsUIExt accessor
+    internal static readonly IReadOnlyDictionary<string, Type> KeyToType = new Dictionary<string, Type> {
         [nameof(UserAppSettings)] = typeof(UserAppSettings),
         [nameof(UserEmailsSettings)] = typeof(UserEmailsSettings),
         [nameof(UserLanguageSettings)] = typeof(UserLanguageSettings),
@@ -25,6 +26,7 @@ public class UserSettings(IServiceProvider services) : IUserSettings
         [nameof(FakeDeviceContactOptions)] = typeof(FakeDeviceContactOptions),
         [nameof(UserReplaySettings)] = typeof(UserReplaySettings),
         [nameof(UserPttSettings)] = typeof(UserPttSettings),
+        [nameof(UserCarAudioSettings)] = typeof(UserCarAudioSettings),
         [nameof(RecentMentions)] = typeof(RecentMentions),
         [nameof(RecentGifs)] = typeof(RecentGifs),
     };

--- a/src/dotnet/Users.Service/Users.Service.csproj
+++ b/src/dotnet/Users.Service/Users.Service.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <InternalsVisibleTo Include="$(RootNamespace).Users.UnitTests$(AssemblyPublicKey)" />
     <InternalsVisibleTo Include="$(RootNamespace).Users.IntegrationTests$(AssemblyPublicKey)" />
   </ItemGroup>
 

--- a/tests/Users.UnitTests/UserSettingsKeyToTypeTest.cs
+++ b/tests/Users.UnitTests/UserSettingsKeyToTypeTest.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+namespace ActualChat.Users.UnitTests;
+
+/// <summary>
+/// Guards the registration a settings type needs on the server: without it
+/// <see cref="UserSettings"/> reads the stored value back as the abstract base and returns null,
+/// so the setting silently reverts to its defaults.
+/// </summary>
+public sealed class UserSettingsKeyToTypeTest
+{
+    [Fact]
+    public void EveryAccessorTypeShouldBeRegistered()
+    {
+        // arrange
+        // A single-parameter accessor keys its settings by the type name; the rest take
+        // an id and land on the parameterized "@" path, which UserSettings resolves separately.
+        var accessorTypes = typeof(UserSettingsUIExt)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(x => x.GetParameters().Length == 1
+                && x.ReturnType.IsGenericType
+                && x.ReturnType.GetGenericTypeDefinition() == typeof(UserSettingsAccessor<>))
+            .Select(x => x.ReturnType.GetGenericArguments()[0])
+            .ToList();
+
+        // act
+        var unregistered = accessorTypes
+            .Where(x => !UserSettings.KeyToType.ContainsKey(x.Name))
+            .Select(x => x.Name)
+            .ToList();
+
+        // assert
+        accessorTypes.Should().NotBeEmpty("the reflection query must keep matching UserSettingsUIExt");
+        unregistered.Should().BeEmpty("UserSettings.KeyToType must list every type UserSettingsUIExt exposes");
+    }
+}


### PR DESCRIPTION
Alexey reported that the Android Auto audio routing settings don't stick: the switch moves, then snaps back to Auto a few seconds later.

## Root cause

`UserCarAudioSettings` was never added to `UserSettings.KeyToType`, so on the read path `ResolveType` falls back to the abstract `StoredSettings`. The row is written under the concrete type, so reading it as the union base throws inside `KvasSerializer.Read`, which logs a warning and returns null — `UserSettingsAccessor.Get` then substitutes `new UserCarAudioSettings()`, i.e. Auto/Auto.

The write worked all along; only the read was broken. The 3-second `Temporals` override is what makes the UI look correct right after the tap and then revert.

No migration needed: already-stored values become readable as soon as the key resolves.

## The same gap, twice

`UserWalkieTalkieSettings` hit this in 723703ceff — "without it the server deserialized every stored walkie record as the abstract base and silently returned defaults, so no walkie setting ever round-tripped". Both times the type went into the `[Union]` list in one commit and the dictionary entry was forgotten.

So `KeyToType` is now `internal` and `UserSettingsKeyToTypeTest` derives the expected set from `UserSettingsUIExt`: every single-parameter accessor keys its settings by the type name and must be registered. Verified red without the fix, green with it; full `Users.UnitTests` run is 285 passed / 0 failed.

## Known limit

Settings reached only through `StateFactory.NewUserSettingsSynced(UserSettingsUI, SomeType.KvasKey, …)` — as `RecentMentionsUI` does — pass the key as a call argument, which reflection can't see. Both real incidents went through `UserSettingsUIExt`, so the test covers them, but a future type registered only that way would still slip. Closing that would mean deriving the dictionary from the `[Union]` list plus an exclusion list for the device-local and parameterized types, and that exclusion list is subject to the same drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCXs4Mm466ZWp43rskgjN4
