### PR TITLE
fix(notifications): name the reactor in a group chat's reaction push

### DIFF
--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -34,6 +34,11 @@ public static class NotificationHelper
     public static string GetTitle(string senderName, string groupTitle)
         => groupTitle.IsNullOrEmpty() ? senderName : $"{senderName} @ {groupTitle}";
 
+    // The iOS extension headlines a group banner with the chat, so the text is the only place a
+    // sender gets named there; a peer chat's headline is the other party already.
+    public static bool MustNameAuthorInText(ChatId chatId)
+        => chatId.GetThreadOutermostParentOrSelf().Kind is ChatKind.Group or ChatKind.Place;
+
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
         // Unsized, the generator draws its 80px base, which an avatar slot on a 3x screen upscales.
         => urlMapper.IconUrl(chat.GetIconQuery(author, AvatarQuery.SupportedSizes[^1], renderAvatarTitle: true));
@@ -60,9 +65,7 @@ public static class NotificationHelper
         if (messages.IsEmpty)
             return notification.LeadText.IsNullOrEmpty() ? notification.Text : notification.LeadText;
 
-        // The banner headline is the chat, so these lines are the only place a sender is named.
-        var showAuthorNames = notification.ChatId.GetThreadOutermostParentOrSelf().Kind
-            is ChatKind.Group or ChatKind.Place;
+        var showAuthorNames = MustNameAuthorInText(notification.ChatId);
         var lines = new List<string>(messages.Count + 1);
         // Newest first: collapsed banners show only the first line(s), and that must be the
         // latest message, not the oldest unread one.

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -691,7 +691,10 @@ public class NotificationsBackend(IServiceProvider services)
             ? $"\"{authoredText}\""
             : entryContent.Render(l);
 
-        var content = new SharedNotificationContent(l.Notification_Reaction_Format(reaction.Emoji, text));
+        var reactionText = l.Notification_Reaction_Format(reaction.Emoji, text);
+        var content = new SharedNotificationContent(NotificationHelper.MustNameAuthorInText(entry.ChatId)
+            ? l.Notification_AuthorLine_Format(reactionAuthor.Avatar.Name, reactionText)
+            : reactionText);
         await EnqueueMessageRelatedNotifications(
             entry.ChatId, entry.Id, reactionAuthor, content,
             NotificationKind.Reaction, similarityKey, "", userIds, (reaction.Emoji, text), cancellationToken)

--- a/tests/Notifications.IntegrationTests/NotificationContentTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationContentTest.cs
@@ -33,7 +33,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be($"Alice @ {chat.Title}");
-        bobNotification.Text.Should().Be("❤️ to \"Ok!\"");
+        bobNotification.Text.Should().Be("Alice: ❤️ to \"Ok!\"");
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be("Alice @ Good chat");
-        bobNotification.Text.Should().Be("❤️ to your image");
+        bobNotification.Text.Should().Be("Alice: ❤️ to your image");
     }
 
     [Fact]

--- a/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
@@ -179,11 +179,15 @@ public class NotificationLocalizationTest(AppHostFixture fixture, ITestOutputHel
 
         // act
         await Tester.SignIn(reactor);
+        var reactorAuthor = await Tester.GetOwnAuthor(chatId).Require();
         await Tester.React(entry.Id, Emojis.Love);
 
         // assert
         var l = LanguageStringLocalizer.Get(Language.Parse(expected));
-        var expectedText = l.Notification_Reaction_Format(Emojis.Love, l.EmptyEntry_YourLocation);
+        // A group chat: the banner is headlined by the chat, so the text has to name the reactor.
+        var expectedText = l.Notification_AuthorLine_Format(
+            reactorAuthor.Avatar.Name,
+            l.Notification_Reaction_Format(Emojis.Love, l.EmptyEntry_YourLocation));
         await TestExt.When(async () => {
             var info = await Tester.NotificationsBackend.GetUserNotificationInfo(author.Id, CancellationToken.None);
             var reaction = info.Items.OfType<ReactionNotification>().Should().ContainSingle().Subject;


### PR DESCRIPTION
Closes #4374

## Problem

On iPhone, a reaction push in a group or place chat never said who reacted. The iOS notification service extension headlines a group banner with the chat name and relies on the body to name the sender. Message bodies do that through the aggregated author lines, but a reaction body was only `{emoji} to "{quote}"`, so the name was lost. Android was unaffected (the sender is the messaging-style person), and so were peer chats (the headline is the other party).

## Fix

The reaction text gets the same localized author line message bodies use, so a group-chat reaction now reads `Alice: 👍 to "your text"`. Peer-chat reactions are unchanged. The group/place check is extracted into `NotificationHelper.MustNameAuthorInText` and shared with `ComposeAggregatedText`.

No client change is needed; existing installs get the fix once the server is deployed.

## Testing

- `Notifications.IntegrationTests`: reaction, merge, dismiss-mode, localization and mode classes pass (50/50).
- `ReactionToLocationTextShouldUseTheRecipientsUILanguage` now expects the reactor's name in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
