### PR TITLE
feat(serialization): tolerate unknown [Union] members on read

### DIFF
--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -860,6 +860,17 @@ The key rules:
   properties like `ShardKey`, whose getter can throw on a deserialized instance.
 - **`[Key]` and `[Union]` ordinals are wire format.** Append; never renumber or reuse one on a
   type that has shipped.
+- **Don't reach for `[Union]` for a set that will keep growing.** An unknown enum value costs a
+  reader nothing; an unknown union tag used to be fatal, because the reader can't know the
+  payload's shape and so can't even skip it. `ForwardCompatibleUnionFormatter` makes an unknown
+  tag survivable on the roots that register for it (`UnionToleranceCoverageTest` fails a new root
+  that neither registers nor is exempt with a reason) — but survivable is not *meaningful*: a
+  placeholder is all the reader gets. Where the members are shaped alike, one type with an enum
+  discriminator and a payload keeps the surrounding fields readable, which is strictly better.
+  Reserve `[Union]` for sets whose members genuinely differ in shape.
+- **A `[Union]` member must not reuse a `[Key]` or member name the base declares.** Placeholder
+  recovery reads the base's fields out of a payload it otherwise can't parse; a collision doesn't
+  throw, it silently reads a member's value as an id.
 - **Never add MemoryPack attributes.** MemoryPack no longer writes anything — it only reads
   legacy **stored settings (KVAS)** and **flow state** blobs. A type carrying `[MemoryPackable]`
   either is one of those or is reachable from one; there is no third reason. Anything introduced

--- a/src/dotnet/Api.Contracts/ApiConstants.cs
+++ b/src/dotnet/Api.Contracts/ApiConstants.cs
@@ -8,6 +8,10 @@ public static class ApiConstants
     public static readonly string FullVersionString = typeof(ApiConstants).Assembly.GetInformationalVersion() ?? "0.0+unknown"; // X.Y.Z+123abc
     public static readonly string DisplayVersionString = "v" + FullVersionString.Replace('+', ' ');
     public static readonly Version Version = Version.Parse(VersionString);
+
+    // The last release without ForwardCompatibleUnionFormatter. A peer at or below it treats an
+    // entry kind added later as fatal, so IChats routes it to the filtering tile methods.
+    public const string LastVersionWithoutUnionTolerance = "2.18.9999";
     // X.Y.Z, i.e. the version the stores publish - unlike Version, which is always X.Y.0
     public static readonly Version BuildVersion = VersionExt.ParseBuildVersion(FullVersionString);
 

--- a/src/dotnet/Api.Contracts/Chat/IChats.cs
+++ b/src/dotnet/Api.Contracts/Chat/IChats.cs
@@ -41,9 +41,22 @@ public interface IChats : IComputeService
         ChatId chatId,
         CancellationToken cancellationToken);
 
-    // Client-side methods always skips entries with IsRemoved flag
+    // Client-side methods always skips entries with IsRemoved flag.
+    // The LegacyName aliases here and on GetLegacyTile route v2.18- clients - the ones without
+    // ForwardCompatibleUnionFormatter, to which an unknown entry kind is fatal - to the filtering
+    // variant. See ChatEntry.IsKnownTo.
     [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]
+    [LegacyName("GetTile_NewUnused", ApiConstants.LastVersionWithoutUnionTolerance)]
     Task<ChatTile> GetTile(
+        Session session,
+        ChatId chatId,
+        Range<long> lidTileRange,
+        CancellationToken cancellationToken);
+
+    [ComputeMethod(MinCacheDuration = 10), RemoteComputeMethod(MinCacheDuration = 300)]
+    [LegacyName(nameof(GetTile), ApiConstants.LastVersionWithoutUnionTolerance)]
+    [Obsolete("2026.09: Use GetTile - this one only drops entry kinds a pre-2.19 client can't read.")]
+    Task<ChatTile> GetLegacyTile(
         Session session,
         ChatId chatId,
         Range<long> lidTileRange,
@@ -53,6 +66,8 @@ public interface IChats : IComputeService
     // per 5 entries, and as a compute method each of those becomes a cached, invalidation-tracked
     // slot - here and on the wire. This is a plain RPC call instead; the server still serves it
     // from the GetTile cache.
+    // No LegacyName pair here: no client calls this one - the scans that do run server-side,
+    // against IChatsBackend.GetTileNonComputed.
     Task<ChatTile> GetTileNonComputed(
         Session session,
         ChatId chatId,

--- a/src/dotnet/Api/Chat/ChatEntry.Unsupported.cs
+++ b/src/dotnet/Api/Chat/ChatEntry.Unsupported.cs
@@ -1,0 +1,93 @@
+using System.Collections.Frozen;
+
+namespace ActualChat.Chat;
+
+public abstract partial record ChatEntry : IForwardCompatibleUnion<ChatEntry>
+{
+    public const int FirstSystemUnionTag = 100;
+    public const int LastSystemUnionTag = 199;
+
+    // Tags 0..2 predate the ranges below, so they're classified by name rather than by value.
+    // They stay here even if their members are ever removed: a removed member's tag becomes
+    // unknown to later builds while old data still carries it, and a pure range check would
+    // then put a system entry on the message side.
+    private static readonly FrozenSet<int> LegacySystemUnionTags = new[] { 1, 2 }.ToFrozenSet();
+
+    public static bool IsSystemUnionTag(int tag)
+        => LegacySystemUnionTags.Contains(tag)
+            || tag is >= FirstSystemUnionTag and <= LastSystemUnionTag;
+
+    static ChatEntry? IForwardCompatibleUnion<ChatEntry>.NewUnsupported(
+        int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)
+        => NewUnsupported(IsSystemUnionTag(tag), ref payload, options);
+
+    // Protected/internal methods
+
+    internal static ChatEntry NewUnsupported(
+        bool isSystemEntry, ref MessagePackReader payload, MessagePackSerializerOptions options)
+    {
+        var (id, version, flags, authorId) = ReadPrefix(ref payload, options);
+        ChatEntry entry = isSystemEntry
+            ? new UnsupportedSystemEntry(id, version)
+            : new TextEntry(id, version);
+        return entry with {
+            Flags = flags | ChatEntryFlags.IsUnsupported,
+            AuthorId = authorId,
+        };
+    }
+
+    // Private methods
+
+    private static (ChatEntryId Id, long Version, ChatEntryFlags Flags, AuthorId AuthorId) ReadPrefix(
+        ref MessagePackReader payload, MessagePackSerializerOptions options)
+    {
+        var id = default(ChatEntryId)!;
+        var version = 0L;
+        var flags = ChatEntryFlags.None;
+        var authorId = default(AuthorId)!;
+        switch (payload.NextMessagePackType) {
+        case MessagePackType.Array:
+            // Keyed layout: every member's payload starts with the base record's keys, in order.
+            var itemCount = payload.ReadArrayHeader();
+            for (var i = 0; i < itemCount && i <= 3; i++)
+                switch (i) {
+                case 0:
+                    id = MessagePackSerializer.Deserialize<ChatEntryId>(ref payload, options);
+                    break;
+                case 1:
+                    version = payload.ReadInt64();
+                    break;
+                case 2:
+                    flags = MessagePackSerializer.Deserialize<ChatEntryFlags>(ref payload, options);
+                    break;
+                case 3:
+                    authorId = MessagePackSerializer.Deserialize<AuthorId>(ref payload, options);
+                    break;
+                }
+            break;
+        case MessagePackType.Map:
+            // Keyless layout: derived members are written first, so there is no prefix to walk.
+            var pairCount = payload.ReadMapHeader();
+            for (var i = 0; i < pairCount; i++)
+                switch (payload.ReadString()) {
+                case nameof(Id):
+                    id = MessagePackSerializer.Deserialize<ChatEntryId>(ref payload, options);
+                    break;
+                case nameof(Version):
+                    version = payload.ReadInt64();
+                    break;
+                case nameof(Flags):
+                    flags = MessagePackSerializer.Deserialize<ChatEntryFlags>(ref payload, options);
+                    break;
+                case nameof(AuthorId):
+                    authorId = MessagePackSerializer.Deserialize<AuthorId>(ref payload, options);
+                    break;
+                default:
+                    payload.Skip();
+                    break;
+                }
+            break;
+        }
+        return (id, version, flags, authorId);
+    }
+}

--- a/src/dotnet/Api/Chat/ChatEntry.Unsupported.cs
+++ b/src/dotnet/Api/Chat/ChatEntry.Unsupported.cs
@@ -13,9 +13,34 @@ public abstract partial record ChatEntry : IForwardCompatibleUnion<ChatEntry>
     // then put a system entry on the message side.
     private static readonly FrozenSet<int> LegacySystemUnionTags = new[] { 1, 2 }.ToFrozenSet();
 
+    // The release each union tag first shipped in; absent = known to every peer we still talk to.
+    // A peer older than that can't read the tag, so IChats.GetLegacyTile filters such entries out.
+    private static readonly FrozenDictionary<int, Version> UnionTagSinceVersions =
+        new Dictionary<int, Version> {
+            [100] = new (2, 19), // UnsupportedSystemEntry
+        }.ToFrozenDictionary();
+
     public static bool IsSystemUnionTag(int tag)
         => LegacySystemUnionTags.Contains(tag)
             || tag is >= FirstSystemUnionTag and <= LastSystemUnionTag;
+
+    public static bool IsKnownTo(ChatEntry entry, Version apiVersion)
+        => GetUnionTag(entry) is not { } tag
+            || GetUnionTagSince(tag) is not { } since
+            || since <= apiVersion;
+
+    public static Version? GetUnionTagSince(int tag)
+        => UnionTagSinceVersions.GetValueOrDefault(tag);
+
+    public static int? GetUnionTag(ChatEntry entry)
+    {
+        var entryType = entry.GetType();
+        foreach (var union in typeof(ChatEntry).GetCustomAttributes<UnionAttribute>())
+            if (union.SubType == entryType)
+                return union.Key;
+
+        return null;
+    }
 
     static ChatEntry? IForwardCompatibleUnion<ChatEntry>.NewUnsupported(
         int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)

--- a/src/dotnet/Api/Chat/ChatEntry.cs
+++ b/src/dotnet/Api/Chat/ChatEntry.cs
@@ -16,6 +16,8 @@ namespace ActualChat.Chat;
 [Union(0, typeof(TextEntry))]
 [Union(1, typeof(MembersChangedEntry))]
 [Union(2, typeof(NotifyMembersEntry))]
+// 100..199 is the SystemEntry range - see ChatEntry.IsSystemUnionTag
+[Union(100, typeof(UnsupportedSystemEntry))]
 public abstract partial record ChatEntry(
     [property: DataMember(Order = 0), Key(0)] ChatEntryId Id,
     [property: DataMember(Order = 1), Key(1)] long Version = 0
@@ -101,6 +103,11 @@ public abstract partial record ChatEntry(
     public bool IsThread {
         get => Flags.HasFlag(ChatEntryFlags.IsThread);
         init => Flags = value ? Flags | ChatEntryFlags.IsThread : Flags & ~ChatEntryFlags.IsThread;
+    }
+    [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
+    public bool IsUnsupported {
+        get => Flags.HasFlag(ChatEntryFlags.IsUnsupported);
+        init => Flags = value ? Flags | ChatEntryFlags.IsUnsupported : Flags & ~ChatEntryFlags.IsUnsupported;
     }
     [JsonIgnore, Newtonsoft.Json.JsonIgnore, IgnoreDataMember, IgnoreMember]
     public bool HasUploadingAttachments {

--- a/src/dotnet/Api/Chat/ChatEntryFlags.cs
+++ b/src/dotnet/Api/Chat/ChatEntryFlags.cs
@@ -9,4 +9,5 @@ public enum ChatEntryFlags
     IsThreadStart = 1 << 2,
     IsThread = 1 << 3,
     HasUploadingAttachments = 1 << 4,
+    IsUnsupported = 1 << 5,
 }

--- a/src/dotnet/Api/Chat/ChatTile.cs
+++ b/src/dotnet/Api/Chat/ChatTile.cs
@@ -15,6 +15,16 @@ public sealed partial class ChatTile
     [JsonConstructor, Newtonsoft.Json.JsonConstructor, SerializationConstructor]
     public ChatTile() { }
 
+    public ChatTile WithoutEntriesUnknownTo(Version apiVersion)
+    {
+        // The lid range is left as it was: a dropped entry leaves a gap, which is exactly what a
+        // peer that can't read it should see - the shape a removed entry already produces.
+        var known = Entries.Where(x => ChatEntry.IsKnownTo(x, apiVersion)).ToArray();
+        return known.Length == Entries.Length
+            ? this
+            : new ChatTile(LidTileRange, IncludesRemoved, known);
+    }
+
     public ChatTile(Range<long> lidTileRange, bool includesRemoved, ChatEntry[] entries)
     {
         var beginsAtRange = new Range<Moment>(Moment.MaxValue, Moment.MinValue);

--- a/src/dotnet/Api/Chat/Markup/EmptyEntryMarkupBuilder.cs
+++ b/src/dotnet/Api/Chat/Markup/EmptyEntryMarkupBuilder.cs
@@ -17,6 +17,10 @@ public class EmptyEntryMarkupBuilder
     // only a caller that resolved one can tell a live share from a one-shot pin.
     public Markup Build(ChatEntry entry, MarkupConsumer consumer, bool isLiveLocation = false)
     {
+        // Ahead of the MessageView shortcut: an entry of a kind this build has no member for is
+        // the one case where the message view has something to say instead of nothing.
+        if (entry.IsUnsupported)
+            return new PlainTextMarkup(Unsupported);
         if (consumer is MarkupConsumer.MessageView)
             return Markup.EmptyText;
 
@@ -71,6 +75,7 @@ public class EmptyEntryMarkupBuilder
     protected virtual string SentLiveLocation => "Shared live location";
     protected virtual string YourLocation => "your location";
     protected virtual string QuoteAttachment => "Click to see the attachment";
+    protected virtual string Unsupported => "Update the app to see this message";
     protected virtual string SentImages(int count) => $"Sent {count.Format()} image{Plural(count)}";
     protected virtual string YourImages(int count) => $"your image{Plural(count)}";
     protected virtual string SentVideos(int count) => $"Sent {count.Format()} video{Plural(count)}";

--- a/src/dotnet/Api/Chat/Markup/Markup.cs
+++ b/src/dotnet/Api/Chat/Markup/Markup.cs
@@ -30,7 +30,7 @@ namespace ActualChat.Chat;
 [Union(20, typeof(TableMarkup))]
 [Union(21, typeof(TableRowMarkup))]
 [Union(22, typeof(TableCellMarkup))]
-public abstract class Markup : ISanitized
+public abstract class Markup : ISanitized, IForwardCompatibleUnion<Markup>
 {
     protected static ArrayPool<Markup> MarkupArrayPool = ArrayPool<Markup>.Shared;
 
@@ -44,6 +44,12 @@ public abstract class Markup : ISanitized
     [JsonIgnore, Newtonsoft.Json.JsonIgnore]
     [IgnoreDataMember, IgnoreMember]
     public bool IsIncomplete { get; init; }
+
+    static Markup? IForwardCompatibleUnion<Markup>.NewUnsupported(
+        int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)
+        // A node that can't be understood contributes nothing, rather than breaking the message
+        // it sits in - the surrounding markup is still perfectly readable without it.
+        => PlainTextMarkup.Empty;
 
     public static Markup Join(Markup first, Markup second)
     {

--- a/src/dotnet/Api/Chat/Markup/SystemEntryMarkupBuilder.cs
+++ b/src/dotnet/Api/Chat/Markup/SystemEntryMarkupBuilder.cs
@@ -18,6 +18,9 @@ public class SystemEntryMarkupBuilder
         => entry switch {
             MembersChangedEntry e => BuildMembersChanged(e),
             NotifyMembersEntry e => BuildNotifyMembers(e),
+            // A system event of a kind this build has no member for renders as nothing: a system
+            // event is low-value by construction, so "update your app" in its place is just a nag.
+            UnsupportedSystemEntry => Markup.EmptyText,
             // SystemEntryLocalizationTest fails on any [Union] kind that lands here
             _ => Markup.EmptyText,
         };

--- a/src/dotnet/Api/Chat/SystemEntry.cs
+++ b/src/dotnet/Api/Chat/SystemEntry.cs
@@ -11,4 +11,12 @@ namespace ActualChat.Chat;
 [DataContract, MessagePackObject]
 [Union(0, typeof(MembersChangedEntry))]
 [Union(1, typeof(NotifyMembersEntry))]
-public abstract partial record SystemEntry(ChatEntryId Id, long Version = 0) : ChatEntry(Id, Version);
+[Union(2, typeof(UnsupportedSystemEntry))]
+public abstract partial record SystemEntry(ChatEntryId Id, long Version = 0)
+    : ChatEntry(Id, Version), IForwardCompatibleUnion<SystemEntry>
+{
+    static SystemEntry? IForwardCompatibleUnion<SystemEntry>.NewUnsupported(
+        int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)
+        // Under this root every tag is a system entry, so ChatEntry's classification doesn't apply.
+        => (SystemEntry)NewUnsupported(true, ref payload, options);
+}

--- a/src/dotnet/Api/Chat/UnsupportedSystemEntry.cs
+++ b/src/dotnet/Api/Chat/UnsupportedSystemEntry.cs
@@ -1,0 +1,21 @@
+namespace ActualChat.Chat;
+
+/// <summary>
+/// Stands in for a system entry this build has no member for — an unknown <c>[Union]</c> tag on
+/// the wire, or a row whose option the database reader doesn't recognize. It carries the base
+/// prefix and nothing else, and renders as nothing at all.
+/// </summary>
+/// <remarks>
+/// A registered member rather than a read-only placeholder, because a server that rolled back
+/// past the release which wrote the row still has to serve it: it reads one of these out of the
+/// database and fans it out. A peer that doesn't know tag 100 classifies it as a system entry and
+/// builds its own placeholder, which is the same value.
+/// </remarks>
+[DataContract, MessagePackObject]
+public sealed partial record UnsupportedSystemEntry : SystemEntry
+{
+    public UnsupportedSystemEntry() : base((ChatEntryId)null!) { }
+
+    [SerializationConstructor]
+    public UnsupportedSystemEntry(ChatEntryId id, long version = 0) : base(id, version) { }
+}

--- a/src/dotnet/Api/Invite/Invite.cs
+++ b/src/dotnet/Api/Invite/Invite.cs
@@ -17,8 +17,13 @@ namespace ActualChat.Invite;
 public abstract partial record Invite(
     [property: DataMember, Key(0)] Symbol Id,
     [property: DataMember, Key(1)] long Version = 0
-    ) : IHasId<Symbol>, IHasVersion<long>, IRequirementTarget
+    ) : IHasId<Symbol>, IHasVersion<long>, IRequirementTarget, IForwardCompatibleUnion<Invite>
 {
+    static Invite? IForwardCompatibleUnion<Invite>.NewUnsupported(
+        int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)
+        // An invite this build can neither render nor redeem is worth less than the list it's in.
+        => null;
+
     [DataMember, Key(2)] public string CreatedBy { get; init; } = "";
     [DataMember, Key(3)] public Moment CreatedAt { get; init; }
     [DataMember, Key(4)] public Moment ExpiresOn { get; init; }

--- a/src/dotnet/Api/Module/ApiAotSource.cs
+++ b/src/dotnet/Api/Module/ApiAotSource.cs
@@ -1,0 +1,23 @@
+using ActualChat.Aot;
+using ActualChat.Chat;
+using ActualChat.Serialization.Internal;
+
+namespace ActualChat.Module;
+
+internal partial class ApiAotSource
+{
+    static ApiAotSource()
+    {
+        if (CodeKeeper.AlwaysTrue)
+            return;
+
+        // Reached only via AppMessagePackResolverSettings.Formatters, which the generator can't
+        // see - ApiModuleInitializer registers these at runtime. Same reason CoreAotSource keeps
+        // Size2DMessagePackFormatter.
+        CodeKeeper.Keep<ForwardCompatibleUnionFormatter<ChatEntry>>();
+        CodeKeeper.Keep<ForwardCompatibleUnionFormatter<SystemEntry>>();
+        CodeKeeper.Keep<ForwardCompatibleUnionFormatter<Markup>>();
+        CodeKeeper.Keep<ForwardCompatibleUnionFormatter<Notifications.Notification>>();
+        CodeKeeper.Keep<ForwardCompatibleUnionFormatter<Invite.Invite>>();
+    }
+}

--- a/src/dotnet/Api/Module/ApiAotSource.g.cs
+++ b/src/dotnet/Api/Module/ApiAotSource.g.cs
@@ -95,6 +95,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.Translation>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.TranslationDiff>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.UnparsedTextMarkup>();
+        CodeKeeper.KeepSerializable<global::ActualChat.Chat.UnsupportedSystemEntry>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.UrlMarkup>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.UserMention>();
         CodeKeeper.KeepSerializable<global::ActualChat.Chat.VisualMediaItem>();
@@ -163,6 +164,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.KeepSerializable<global::ActualChat.MentionRef>();
         CodeKeeper.KeepSerializable<global::ActualChat.NotificationId>();
         CodeKeeper.KeepSerializable<global::ActualChat.Notifications.AttentionNotification>();
+        CodeKeeper.KeepSerializable<global::ActualChat.Notifications.BeepMemory>();
         CodeKeeper.KeepSerializable<global::ActualChat.Notifications.CallNotification>();
         CodeKeeper.KeepSerializable<global::ActualChat.Notifications.ConversationNotification>();
         CodeKeeper.KeepSerializable<global::ActualChat.Notifications.InvitationNotification>();
@@ -565,6 +567,9 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnparsedTextMarkup>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnparsedTextMarkup>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnparsedTextMarkup>>>>();
+        CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnsupportedSystemEntry>>();
+        CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnsupportedSystemEntry>>>();
+        CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UnsupportedSystemEntry>>>>();
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UrlMarkup>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UrlMarkup>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Chat.UrlMarkup>>>>();
@@ -862,6 +867,12 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.AttentionNotification>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.AttentionNotification>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.AttentionNotification>>>>();
+        CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory>>();
+        CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory>>>();
+        CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory>>>>();
+        CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory[]>>();
+        CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory[]>>>();
+        CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.BeepMemory[]>>>>();
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.CallNotification>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.CallNotification>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualChat.Notifications.CallNotification>>>>();
@@ -1189,6 +1200,9 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Emoji>>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Emoji>>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Emoji>>>>>();
+        CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.BeepMemory>>>();
+        CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.BeepMemory>>>>();
+        CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.BeepMemory>>>>>();
         CodeKeeper.Keep<global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.Notification>>>();
         CodeKeeper.Keep<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.Notification>>>>();
         CodeKeeper.Keep<global::System.Linq.Expressions.Expression<global::System.Func<global::MessagePack.MessagePackSerializerOptions, global::System.Type, global::ActualLab.Serialization.MessagePackByteSerializer<global::ActualLab.Api.ApiArray<global::ActualChat.Notifications.Notification>>>>>();
@@ -1514,6 +1528,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Chat.RecentMention, ActualChat.Api]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.ChatEntryId, ActualChat.Api]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Emoji, ActualChat.Api]], ActualLab.Core");
+        CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Notifications.BeepMemory, ActualChat.Api]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Notifications.Notification, ActualChat.Api]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Notifications.NotificationAction, ActualChat.Api]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualChat.Notifications.NotificationMessage, ActualChat.Api]], ActualLab.Core");
@@ -1525,6 +1540,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Chat.RecentMention, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.ChatEntryId, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Emoji, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
+        CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Notifications.BeepMemory, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Notifications.Notification, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Notifications.NotificationAction, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
         CodeKeeper.Keep("ActualLab.Api.Internal.ApiArrayMessagePackFormatter`1[[ActualLab.Api.ApiArray`1[[ActualChat.Notifications.NotificationMessage, ActualChat.Api]], ActualLab.Core]], ActualLab.Core");
@@ -1601,6 +1617,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Language, ActualChat.Api]], MessagePack");
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Mathematics.Range`1[[System.Int64, System.Private.CoreLib]], ActualChat.Core]], MessagePack");
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Media.LinkPreview, ActualChat.Api]], MessagePack");
+        CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Notifications.BeepMemory, ActualChat.Api]], MessagePack");
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Notifications.Notification, ActualChat.Api]], MessagePack");
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Notifications.NotificationAction, ActualChat.Api]], MessagePack");
         CodeKeeper.Keep("MessagePack.Formatters.ArrayFormatter`1[[ActualChat.Notifications.NotificationMessage, ActualChat.Api]], MessagePack");
@@ -1745,6 +1762,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+TranslationDiffFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+TranslationFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+UnparsedTextMarkupFormatter, ActualChat.Api");
+        CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+UnsupportedSystemEntryFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+UrlMarkupFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+UrlMarkupKindFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Chat+UserMentionFormatter, ActualChat.Api");
@@ -1809,6 +1827,7 @@ internal partial class ApiAotSource : IAotSource
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Media+RecordingPartFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Media+UploadFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Notifications+AttentionNotificationFormatter, ActualChat.Api");
+        CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Notifications+BeepMemoryFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Notifications+CallNotificationFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Notifications+ConversationNotificationFormatter, ActualChat.Api");
         CodeKeeper.Keep("MessagePack.GeneratedMessagePackResolver+ActualChat+Notifications+InvitationNotificationFormatter, ActualChat.Api");
@@ -1962,6 +1981,7 @@ internal partial class ApiAotSource : IAotSource
             (typeof(global::ActualChat.Chat.Translation), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.TranslationDiff), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.UnparsedTextMarkup), AotTypeKind.Serializable),
+            (typeof(global::ActualChat.Chat.UnsupportedSystemEntry), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.UrlMarkup), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.UserMention), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Chat.VisualMediaItem), AotTypeKind.Serializable),
@@ -2030,6 +2050,7 @@ internal partial class ApiAotSource : IAotSource
             (typeof(global::ActualChat.MentionRef), AotTypeKind.Serializable),
             (typeof(global::ActualChat.NotificationId), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Notifications.AttentionNotification), AotTypeKind.Serializable),
+            (typeof(global::ActualChat.Notifications.BeepMemory), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Notifications.CallNotification), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Notifications.ConversationNotification), AotTypeKind.Serializable),
             (typeof(global::ActualChat.Notifications.InvitationNotification), AotTypeKind.Serializable),

--- a/src/dotnet/Api/Module/ApiModuleInitializer.cs
+++ b/src/dotnet/Api/Module/ApiModuleInitializer.cs
@@ -1,5 +1,6 @@
 using ActualChat.Aot;
 using ActualChat.Internal;
+using ActualChat.Serialization.Internal;
 
 namespace ActualChat.Module;
 
@@ -22,6 +23,17 @@ public static partial class ApiModuleInitializer
         // are stored in our DB, and this option enables their legacy serialization mode.
         StringAsSymbolMemoryPackFormatterAttribute.IsEnabled = true;
 
+        // Union roots that tolerate a member this build has no tag for. The shared Formatters
+        // table covers both the keyed and the keyless resolver in one registration, and both
+        // consult it before their own resolver chains.
+        // StoredSettings is deliberately absent: tolerance alone wouldn't fix its actual bug,
+        // which is that an unreadable row is dropped on write-back.
+        RegisterForwardCompatibleUnion<ChatEntry>();
+        RegisterForwardCompatibleUnion<SystemEntry>();
+        RegisterForwardCompatibleUnion<Markup>();
+        RegisterForwardCompatibleUnion<Notifications.Notification>();
+        RegisterForwardCompatibleUnion<Invite.Invite>();
+
         // Custom MemoryPack formatters.
         // Only identifiers reachable from the two remaining MemoryPack read paths are registered:
         // legacy flow state (Core.Server/Flows/FlowData.cs) and legacy server KVAS values
@@ -42,4 +54,11 @@ public static partial class ApiModuleInitializer
         // External contact hashing
         MemoryPackFormatterProvider.Register(new StringLikeMemoryPackFormatter<ExternalContactId>());
     }
+
+    // Private methods
+
+    private static void RegisterForwardCompatibleUnion<TBase>()
+        where TBase : class, IForwardCompatibleUnion<TBase>
+        => AppMessagePackResolverSettings.Formatters[typeof(TBase)] =
+            typeof(ForwardCompatibleUnionFormatter<TBase>);
 }

--- a/src/dotnet/Api/Notifications/Notification.cs
+++ b/src/dotnet/Api/Notifications/Notification.cs
@@ -22,8 +22,13 @@ namespace ActualChat.Notifications;
 public abstract partial record Notification(
     [property: DataMember(Order = 0), Key(0)] NotificationId Id,
     [property: DataMember(Order = 1), Key(1)] long Version = 0
-    ) : IHasId<NotificationId>, IHasVersion<long>, ISanitized
+    ) : IHasId<NotificationId>, IHasVersion<long>, ISanitized, IForwardCompatibleUnion<Notification>
 {
+    static Notification? IForwardCompatibleUnion<Notification>.NewUnsupported(
+        int tag, ref MessagePackReader payload, MessagePackSerializerOptions options)
+        // A notification nobody can render isn't worth showing - the caller drops the null.
+        => null;
+
     [DataMember(Order = 2), Key(2)]
     public string Title {
         get => Sanitizer.MaybeSanitize<Sanitizers.PrefixAndLengthHint>(field); init;

--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -10,6 +10,9 @@ namespace ActualChat.Chat;
 /// </summary>
 public partial class Chats(IServiceProvider services) : IChats
 {
+    private static readonly Version LastToleratedApiVersion =
+        Version.Parse(ApiConstants.LastVersionWithoutUnionTolerance);
+
     private IAccounts Accounts { get; } = services.GetRequiredService<IAccounts>();
     private IAuthors Authors { get; } = services.GetRequiredService<IAuthors>();
     private IAvatars Avatars { get; } = services.GetRequiredService<IAvatars>();
@@ -87,6 +90,20 @@ public partial class Chats(IServiceProvider services) : IChats
     {
         await RequireCanRead(session, chatId, cancellationToken).ConfigureAwait(false);
         return await Backend.GetTile(chatId, lidTileRange, false, cancellationToken).ConfigureAwait(false);
+    }
+
+    // [ComputeMethod]
+    [Obsolete("2026.09: Use GetTile - this one only drops entry kinds a pre-2.19 client can't read.")]
+    public virtual async Task<ChatTile> GetLegacyTile(
+        Session session,
+        ChatId chatId,
+        Range<long> lidTileRange,
+        CancellationToken cancellationToken)
+    {
+        // A separate compute method rather than a per-peer projection of GetTile: Fusion's result
+        // cache isn't peer-scoped, so the filtering has to have a cache slot of its own.
+        var tile = await GetTile(session, chatId, lidTileRange, cancellationToken).ConfigureAwait(false);
+        return tile.WithoutEntriesUnknownTo(LastToleratedApiVersion);
     }
 
     public async Task<ChatTile> GetTileNonComputed(

--- a/src/dotnet/Chat.Service/Db/DbChatEntry.cs
+++ b/src/dotnet/Chat.Service/Db/DbChatEntry.cs
@@ -116,12 +116,16 @@ public class DbChatEntry : IHasId<string>, IHasVersion<long>, IRequirementTarget
                     TargetAuthorId = nm.AuthorId,
                     TargetAuthorName = nm.AuthorName,
                 },
-                _ => throw StandardError.Internal($"Unknown system entry option: {legacy.Option?.GetType().Name}"),
+                // A row written by a later release - a rollback past it would otherwise take out
+                // every chat holding one. Same placeholder the wire format's unknown tags get.
+                _ => new UnsupportedSystemEntry(id, Version),
             };
         }
         else {
             baseEntry = new TextEntry(id, Version);
         }
+        if (baseEntry is UnsupportedSystemEntry)
+            flags |= ChatEntryFlags.IsUnsupported;
         return baseEntry with {
             Flags = flags,
             AuthorId = ActualChat.AuthorId.Parse(AuthorId),

--- a/src/dotnet/Core/Serialization/IForwardCompatibleUnion.cs
+++ b/src/dotnet/Core/Serialization/IForwardCompatibleUnion.cs
@@ -1,0 +1,22 @@
+namespace ActualChat.Serialization;
+
+/// <summary>
+/// A <c>[Union]</c> root that survives reading a member this build doesn't know:
+/// <see cref="NewUnsupported"/> turns an unrecognized tag into a placeholder instead of
+/// letting the whole surrounding payload fail. Registered via
+/// <c>ForwardCompatibleUnionFormatter&lt;TSelf&gt;</c>.
+/// </summary>
+public interface IForwardCompatibleUnion<TSelf>
+    where TSelf : class, IForwardCompatibleUnion<TSelf>
+{
+    /// <param name="tag">The union tag this build has no member for.</param>
+    /// <param name="payload">
+    /// Positioned at the unknown member's payload — an array of its <c>[Key(N)]</c> values, or a
+    /// map keyed by member name under the keyless resolver. Reading from it is optional; the
+    /// caller skips the whole envelope afterwards either way.
+    /// </param>
+    static abstract TSelf? NewUnsupported(
+        int tag,
+        ref MessagePackReader payload,
+        MessagePackSerializerOptions options);
+}

--- a/src/dotnet/Core/Serialization/Internal/ForwardCompatibleUnionFormatter.cs
+++ b/src/dotnet/Core/Serialization/Internal/ForwardCompatibleUnionFormatter.cs
@@ -1,0 +1,89 @@
+using System.Collections.Frozen;
+using MessagePack.Formatters;
+
+namespace ActualChat.Serialization.Internal;
+
+// Deliberately not a try/catch around the inner formatter: catching
+// MessagePackSerializationException would swallow genuine corruption too and turn it into a
+// silently missing value. Only a tag this build has no member for is tolerated.
+
+/// <summary>
+/// Reads a <c>[Union]</c> value whose tag this build may not know. A known tag is handed to the
+/// standard union formatter untouched; an unknown one becomes
+/// <see cref="IForwardCompatibleUnion{TSelf}.NewUnsupported"/>'s placeholder.
+/// </summary>
+public sealed class ForwardCompatibleUnionFormatter<TBase> : IMessagePackFormatter<TBase?>
+    where TBase : class, IForwardCompatibleUnion<TBase>
+{
+    private static readonly FrozenSet<int> KnownTags = typeof(TBase)
+        .GetCustomAttributes<UnionAttribute>()
+        .Select(x => x.Key)
+        .ToFrozenSet();
+    private static readonly ConcurrentDictionary<IFormatterResolver, IMessagePackFormatter<TBase?>> InnerFormatters = new();
+
+    // False when [Union] attributes aren't readable at runtime, which is possible under Native
+    // AOT: the source-generated union formatter bakes the tags into code and never reads the
+    // attributes, so the trimmer is free to drop them and leave this the only reader. Losing them
+    // has to degrade to today's behaviour rather than to the opposite of it - an empty set would
+    // make *every* tag unknown, turning every message in every chat into a placeholder. Silently,
+    // and on mobile only.
+    public static bool IsTolerant => KnownTags.Count != 0;
+
+    static ForwardCompatibleUnionFormatter()
+    {
+        if (!IsTolerant)
+            StaticLog.For<ForwardCompatibleUnionFormatter<TBase>>().LogError(
+                "No [Union] attributes on {Type} at runtime - tolerance is off for it. "
+                + "An unknown member will fail to deserialize, as it did before this formatter.",
+                typeof(TBase).GetName());
+    }
+
+    public void Serialize(ref MessagePackWriter writer, TBase? value, MessagePackSerializerOptions options)
+        => GetInnerFormatter(options).Serialize(ref writer, value, options);
+
+    public TBase? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        var innerFormatter = GetInnerFormatter(options);
+        // A copy of the reader is a free bookmark: MessagePackReader is a struct over an
+        // in-memory sequence, so peeking costs nothing and leaves the real reader untouched.
+        var peek = reader;
+        if (!TryReadUnknownTag(ref peek, out var tag))
+            return innerFormatter.Deserialize(ref reader, options);
+
+        var result = TBase.NewUnsupported(tag, ref peek, options);
+        reader.Skip();
+        return result;
+    }
+
+    // Private methods
+
+    private static bool TryReadUnknownTag(ref MessagePackReader peek, out int tag)
+    {
+        tag = 0;
+        if (!IsTolerant)
+            return false;
+        if (peek.NextMessagePackType != MessagePackType.Array)
+            return false; // Nil, or not an envelope at all - the inner formatter decides what that means
+        if (peek.ReadArrayHeader() != 2)
+            return false;
+        if (peek.NextMessagePackType != MessagePackType.Integer)
+            return false;
+
+        tag = peek.ReadInt32();
+        return !KnownTags.Contains(tag);
+    }
+
+    private static IMessagePackFormatter<TBase?> GetInnerFormatter(MessagePackSerializerOptions options)
+        => InnerFormatters.GetOrAdd(options.Resolver, static resolver => {
+            // Resolving through the app resolver would find this formatter again and recurse,
+            // so the union formatter comes from the chain the app resolver is built on.
+            var chain = ReferenceEquals(resolver, AppMessagePackKeylessResolver.Instance)
+                ? AppMessagePackKeylessResolver.Settings.Resolvers
+                : AppMessagePackResolverSettings.StandardResolvers;
+            foreach (var r in chain)
+                if (r.GetFormatter<TBase?>() is { } formatter)
+                    return formatter;
+
+            throw StandardError.Internal($"No union formatter for {typeof(TBase).GetName()}.");
+        });
+}

--- a/src/dotnet/Localization/Resources/LocalizedEmptyEntryMarkupBuilder.cs
+++ b/src/dotnet/Localization/Resources/LocalizedEmptyEntryMarkupBuilder.cs
@@ -22,6 +22,7 @@ public sealed class LocalizedEmptyEntryMarkupBuilder(IStringLocalizer l) : Empty
     protected override string SentLiveLocation => l.EmptyEntry_SentLiveLocation;
     protected override string YourLocation => l.EmptyEntry_YourLocation;
     protected override string QuoteAttachment => l.EmptyEntry_QuoteAttachment;
+    protected override string Unsupported => l.EmptyEntry_Unsupported;
     protected override string SentImages(int count) => l.EmptyEntry_SentImages(count, count.Format());
     protected override string YourImages(int count) => l.EmptyEntry_YourImages(count);
     protected override string SentVideos(int count) => l.EmptyEntry_SentVideos(count, count.Format());

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -1234,6 +1234,7 @@ public static class LocalizedStringsLocalizerExt
         public string EmptyEntry_SentAttachments(long count, object arg0)
             => l.Plural("EmptyEntry_SentAttachments", count, arg0);
         public string EmptyEntry_YourAttachments(long count) => l.Plural("EmptyEntry_YourAttachments", count);
+        public string EmptyEntry_Unsupported => l["EmptyEntry_Unsupported"].Value;
         public string Search_In => l["Search_In"].Value;
         public string Search_CloseSearch => l["Search_CloseSearch"].Value;
         public string Search_ShowLess => l["Search_ShowLess"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "вашия файл|вашите файлове",
   "EmptyEntry_SentAttachments": "Изпратен е {0} прикачен файл|Изпратени са {0} прикачени файла",
   "EmptyEntry_YourAttachments": "вашия прикачен файл|вашите прикачени файлове",
+  "EmptyEntry_Unsupported": "Обновете приложението, за да видите това съобщение",
   "Search_In": "В",
   "Search_CloseSearch": "Затворете търсенето",
   "Search_ShowMore": "Покажете още",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "vaš fajl|vaše fajlove",
   "EmptyEntry_SentAttachments": "Poslan {0} prilog|Poslana {0} priloga|Poslano {0} priloga",
   "EmptyEntry_YourAttachments": "vaš prilog|vaše priloge",
+  "EmptyEntry_Unsupported": "Ažurirajte aplikaciju da vidite ovu poruku",
   "Search_In": "U",
   "Search_CloseSearch": "Zatvorite pretragu",
   "Search_ShowMore": "Prikažite više",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "vaš fajl|vaše fajlove",
   "EmptyEntry_SentAttachments": "Poslan {0} prilog|Poslana {0} priloga|Poslano {0} priloga",
   "EmptyEntry_YourAttachments": "vaš prilog|vaše priloge",
+  "EmptyEntry_Unsupported": "Ažurirajte aplikaciju da vidite ovu poruku",
   "Search_In": "U",
   "Search_CloseSearch": "Zatvorite pretragu",
   "Search_ShowMore": "Prikažite više",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "váš soubor|vaše soubory",
   "EmptyEntry_SentAttachments": "Odeslána {0} příloha|Odeslány {0} přílohy|Odesláno {0} příloh",
   "EmptyEntry_YourAttachments": "vaši přílohu|vaše přílohy",
+  "EmptyEntry_Unsupported": "Aktualizujte aplikaci, abyste tuto zprávu viděli",
   "Search_In": "V",
   "Search_CloseSearch": "Zavřít hledání",
   "Search_ShowMore": "Zobrazit více",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "Ihre Datei|Ihre Dateien",
   "EmptyEntry_SentAttachments": "{0} Anhang gesendet|{0} Anhänge gesendet",
   "EmptyEntry_YourAttachments": "Ihren Anhang|Ihre Anhänge",
+  "EmptyEntry_Unsupported": "Aktualisiere die App, um diese Nachricht zu sehen",
   "Search_In": "In",
   "Search_CloseSearch": "Suche schließen",
   "Search_ShowMore": "Mehr anzeigen",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -1399,6 +1399,7 @@
   "EmptyEntry_YourFiles": "your file|your files",
   "EmptyEntry_SentAttachments": "Sent {0} attachment|Sent {0} attachments",
   "EmptyEntry_YourAttachments": "your attachment|your attachments",
+  "EmptyEntry_Unsupported": "Update the app to see this message",
 
   // The search result list: the "In <chat>" label on a hit, and its expand/collapse toggle.
   "Search_In": "In",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "tu archivo|tus archivos",
   "EmptyEntry_SentAttachments": "{0} adjunto enviado|{0} adjuntos enviados",
   "EmptyEntry_YourAttachments": "tu adjunto|tus adjuntos",
+  "EmptyEntry_Unsupported": "Actualiza la aplicación para ver este mensaje",
   "Search_In": "En",
   "Search_CloseSearch": "Cerrar la búsqueda",
   "Search_ShowMore": "Mostrar más",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "votre fichier|vos fichiers",
   "EmptyEntry_SentAttachments": "{0} pièce jointe envoyée|{0} pièces jointes envoyées",
   "EmptyEntry_YourAttachments": "votre pièce jointe|vos pièces jointes",
+  "EmptyEntry_Unsupported": "Mettez à jour l'application pour voir ce message",
   "Search_In": "Dans",
   "Search_CloseSearch": "Fermer la recherche",
   "Search_ShowMore": "Afficher plus",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "आपकी फ़ाइल|आपकी फ़ाइलों",
   "EmptyEntry_SentAttachments": "{0} अटैचमेंट भेजा गया|{0} अटैचमेंट भेजे गए",
   "EmptyEntry_YourAttachments": "आपके अटैचमेंट",
+  "EmptyEntry_Unsupported": "यह संदेश देखने के लिए ऐप अपडेट करें",
   "Search_In": "इसमें:",
   "Search_CloseSearch": "खोज बंद करें",
   "Search_ShowMore": "और दिखाएँ",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "vaš datoteka|vaše datoteke",
   "EmptyEntry_SentAttachments": "Poslan {0} prilog|Poslana {0} priloga|Poslano {0} priloga",
   "EmptyEntry_YourAttachments": "vaš prilog|vaše priloge",
+  "EmptyEntry_Unsupported": "Ažurirajte aplikaciju da vidite ovu poruku",
   "Search_In": "U",
   "Search_CloseSearch": "Zatvorite pretragu",
   "Search_ShowMore": "Prikažite više",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "file Anda",
   "EmptyEntry_SentAttachments": "Mengirim {0} lampiran",
   "EmptyEntry_YourAttachments": "lampiran Anda",
+  "EmptyEntry_Unsupported": "Perbarui aplikasi untuk melihat pesan ini",
   "Search_In": "Di",
   "Search_CloseSearch": "Tutup pencarian",
   "Search_ShowMore": "Tampilkan lebih banyak",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "il tuo file|i tuoi file",
   "EmptyEntry_SentAttachments": "{0} allegato inviato|{0} allegati inviati",
   "EmptyEntry_YourAttachments": "il tuo allegato|i tuoi allegati",
+  "EmptyEntry_Unsupported": "Aggiorna l'app per vedere questo messaggio",
   "Search_In": "In",
   "Search_CloseSearch": "Chiudi la ricerca",
   "Search_ShowMore": "Mostra altro",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "ファイル",
   "EmptyEntry_SentAttachments": "{0} 件の添付ファイルを送信しました",
   "EmptyEntry_YourAttachments": "添付ファイル",
+  "EmptyEntry_Unsupported": "このメッセージを表示するにはアプリを更新してください",
   "Search_In": "場所:",
   "Search_CloseSearch": "検索を閉じる",
   "Search_ShowMore": "もっと見る",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "내 파일",
   "EmptyEntry_SentAttachments": "첨부 파일 {0}개를 보냈습니다",
   "EmptyEntry_YourAttachments": "내 첨부 파일",
+  "EmptyEntry_Unsupported": "이 메시지를 보려면 앱을 업데이트하세요",
   "Search_In": "위치:",
   "Search_CloseSearch": "검색 닫기",
   "Search_ShowMore": "더 보기",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -526,7 +526,7 @@
   "Search_TypeGroups": "グループ",
   "Search_TypePlaces": "プレイス",
   "Search_TypeMessages": "Повідомлення",
-  "Search_TypeMyMessages": "Мої повідомлення",
+  "Search_TypeMyMessages": "Minhas mensagens",
   "Search_TabTags": "Etiquetas",
   "Search_RecentSearches": "Ostatnie wyszukiwania",
   "Search_RecentlyViewed": "Недавно просмотренные",
@@ -1399,6 +1399,7 @@
   "EmptyEntry_YourFiles": "вашите файлове",
   "EmptyEntry_SentAttachments": "{0} 件の添付ファイルを送信しました",
   "EmptyEntry_YourAttachments": "вашите прикачени файлове",
+  "EmptyEntry_Unsupported": "このメッセージを表示するにはアプリを更新してください",
 
   // The search result list: the "In <chat>" label on a hit, and its expand/collapse toggle.
   "Search_In": "Şurada:",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "Twój plik|Twoje pliki",
   "EmptyEntry_SentAttachments": "Wysłano {0} załącznik|Wysłano {0} załączniki|Wysłano {0} załączników",
   "EmptyEntry_YourAttachments": "Twój załącznik|Twoje załączniki",
+  "EmptyEntry_Unsupported": "Zaktualizuj aplikację, aby zobaczyć tę wiadomość",
   "Search_In": "W",
   "Search_CloseSearch": "Zamknij wyszukiwanie",
   "Search_ShowMore": "Pokaż więcej",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "seu arquivo|seus arquivos",
   "EmptyEntry_SentAttachments": "{0} anexo enviado|{0} anexos enviados",
   "EmptyEntry_YourAttachments": "seu anexo|seus anexos",
+  "EmptyEntry_Unsupported": "Atualize o aplicativo para ver esta mensagem",
   "Search_In": "Em",
   "Search_CloseSearch": "Fechar a pesquisa",
   "Search_ShowMore": "Mostrar mais",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "ваш файл|ваши файлы",
   "EmptyEntry_SentAttachments": "Отправлено {0} вложение|Отправлено {0} вложения|Отправлено {0} вложений",
   "EmptyEntry_YourAttachments": "ваше вложение|ваши вложения",
+  "EmptyEntry_Unsupported": "Обновите приложение, чтобы увидеть это сообщение",
   "Search_In": "В",
   "Search_CloseSearch": "Закрыть поиск",
   "Search_ShowMore": "Показать ещё",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "ваш фајл|ваше фајлове",
   "EmptyEntry_SentAttachments": "Послан {0} прилог|Послана {0} прилога|Послано {0} прилога",
   "EmptyEntry_YourAttachments": "ваш прилог|ваше прилоге",
+  "EmptyEntry_Unsupported": "Ажурирајте апликацију да видите ову поруку",
   "Search_In": "У",
   "Search_CloseSearch": "Затворите претрагу",
   "Search_ShowMore": "Прикажите више",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "Dosyanız",
   "EmptyEntry_SentAttachments": "{0} ek gönderildi",
   "EmptyEntry_YourAttachments": "Ekiniz",
+  "EmptyEntry_Unsupported": "Bu mesajı görmek için uygulamayı güncelleyin",
   "Search_In": "Şurada:",
   "Search_CloseSearch": "Aramayı kapatın",
   "Search_ShowMore": "Daha fazla gösterin",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "ваш файл|ваші файли",
   "EmptyEntry_SentAttachments": "Надіслано {0} вкладення|Надіслано {0} вкладення|Надіслано {0} вкладень",
   "EmptyEntry_YourAttachments": "ваше вкладення|ваші вкладення",
+  "EmptyEntry_Unsupported": "Оновіть застосунок, щоб побачити це повідомлення",
   "Search_In": "У",
   "Search_CloseSearch": "Закрити пошук",
   "Search_ShowMore": "Показати ще",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "tệp của bạn",
   "EmptyEntry_SentAttachments": "Đã gửi {0} tệp đính kèm",
   "EmptyEntry_YourAttachments": "tệp đính kèm của bạn",
+  "EmptyEntry_Unsupported": "Cập nhật ứng dụng để xem tin nhắn này",
   "Search_In": "Trong",
   "Search_CloseSearch": "Đóng tìm kiếm",
   "Search_ShowMore": "Xem thêm",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -1190,6 +1190,7 @@
   "EmptyEntry_YourFiles": "你的文件",
   "EmptyEntry_SentAttachments": "已发送 {0} 个附件",
   "EmptyEntry_YourAttachments": "你的附件",
+  "EmptyEntry_Unsupported": "更新应用以查看此消息",
   "Search_In": "位于",
   "Search_CloseSearch": "关闭搜索",
   "Search_ShowMore": "显示更多",

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
@@ -174,6 +174,11 @@
                 }
                 @if (message.Kind is ChatMessageKind.AudioRecordingMessage) {
                     <StreamingEntryBadge ChatId="@ChatId" IsVoiceActive="@false" IsLanguageKnown="@false"/>
+                } else if (entry.IsUnsupported) {
+                    <div class="chat-message-unsupported">
+                        <i class="icon-alert-triangle text-lg text-warning"></i>
+                        <span>@L.EmptyEntry_Unsupported</span>
+                    </div>
                 } else {
                     <ChatEntryMessageInternalView
                         Markup="@markup"

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -219,6 +219,11 @@ body.hoverable .chat-message.mention:hover .chat-message-timestamp-on-hover {
 .chat-message-markup.empty {
     @apply hidden;
 }
+.chat-message-unsupported {
+    @apply flex-x items-center gap-x-1.5;
+    @apply mb-0.5 pr-1.5;
+    @apply text-02 text-text-1;
+}
 .playable-text-markup,
 .plain-text-markup {
     animation: var(--text-animation, none);

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -1203,6 +1203,10 @@ public partial class ChatUI
             foreach (var e in tile.Entries) {
                 if (idRangesToSkip.Any(range => range.Contains(e.Id.LocalId)))
                     continue;
+                // A system event this build has no member for renders as nothing at all: putting
+                // "update your app" where "X joined the chat" belongs trades a small loss for a nag.
+                if (e is { IsUnsupported: true, IsSystemEntry: true })
+                    continue;
                 // A non-joined viewer never sees the call's live transcript, and the range covering it
                 // runs to long.MaxValue - so hiding by lid alone also swallowed everything typed during
                 // the call, including the viewer's own just-posted message. Only what was spoken hides,

--- a/tests/Chat.UI.Blazor.UnitTests/SystemEntryLocalizationTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/SystemEntryLocalizationTest.cs
@@ -17,8 +17,11 @@ public class SystemEntryLocalizationTest
         // otherwise ship unlocalized - SystemEntryMarkupBuilder renders it as empty markup.
 
         // arrange
+        // UnsupportedSystemEntry is the one kind with nothing to localize: it stands in for a kind
+        // this build doesn't have, and renders as nothing rather than as a nag to update.
         var kinds = typeof(SystemEntry).GetCustomAttributes<UnionAttribute>()
             .Select(a => a.SubType)
+            .Where(t => t != typeof(UnsupportedSystemEntry))
             .ToHashSet();
 
         // act

--- a/tests/Chat.UnitTests/ForwardCompatibleUnionTest.cs
+++ b/tests/Chat.UnitTests/ForwardCompatibleUnionTest.cs
@@ -193,6 +193,48 @@ public class ForwardCompatibleUnionTest(ITestOutputHelper @out) : TestBase(@out)
     }
 
     [Fact]
+    public void ATileShouldDropEntriesThePeerCannotRead()
+    {
+        // arrange
+        var lastIntolerant = Version.Parse(ApiConstants.LastVersionWithoutUnionTolerance);
+        var text = NewTextEntry();
+        var unsupported = new UnsupportedSystemEntry(ChatEntryId.New(TestChatId, 2), 8) {
+            BeginsAt = new Moment(DateTime.UnixEpoch),
+            Flags = ChatEntryFlags.IsUnsupported,
+        };
+        var tile = new ChatTile(new Range<long>(1, 3), false, [text, unsupported]);
+
+        // act
+        var forOldPeer = tile.WithoutEntriesUnknownTo(lastIntolerant);
+        var forNewPeer = tile.WithoutEntriesUnknownTo(ApiConstants.Version);
+
+        // assert
+        forOldPeer.Entries.Should().ContainSingle().Which.Should().BeSameAs(text);
+        forOldPeer.LidTileRange.Should()
+            .Be(tile.LidTileRange, "a dropped entry leaves a gap, not a shorter tile");
+        forNewPeer.Should().BeSameAs(tile, "nothing to drop means no copy");
+    }
+
+    [Fact]
+    public void EveryTagAddedAfterToleranceShouldDeclareItsVersion()
+    {
+        // A new member that skips the table is invisible to the filtering, so a peer too old to
+        // read it gets it anyway - and fails on the whole tile, which is what this all prevents.
+
+        // act
+        var undeclared = typeof(ChatEntry).GetCustomAttributes<UnionAttribute>()
+            .Where(x => x.Key > 2 && ChatEntry.GetUnionTagSince(x.Key) is null)
+            .Select(x => $"{x.SubType.Name} (tag {x.Key})")
+            .ToList();
+
+        // assert
+        undeclared.Should().BeEmpty(
+            "every union member added after tolerance shipped must say which release it came "
+            + "in:\n{0}",
+            string.Join("\n", undeclared));
+    }
+
+    [Fact]
     public void NoMemberShouldReuseAKeyTheBaseDeclares()
     {
         // Prefix recovery reads payload slots 0..3 as the base's own. A member that took one of

--- a/tests/Chat.UnitTests/ForwardCompatibleUnionTest.cs
+++ b/tests/Chat.UnitTests/ForwardCompatibleUnionTest.cs
@@ -1,0 +1,288 @@
+using System.Buffers;
+using ActualChat.Hashing;
+using ActualChat.Notifications;
+using ActualChat.Serialization.Internal;
+using MessagePack;
+
+namespace ActualChat.Chat.UnitTests;
+
+public class ForwardCompatibleUnionTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private const int UnknownMessageTag = 50;
+    private const int UnknownSystemTag = 105;
+
+    private static readonly MessagePackSerializerOptions KeyedOptions = new (AppMessagePackResolver.Instance);
+    private static readonly MessagePackSerializerOptions KeylessOptions = new (AppMessagePackKeylessResolver.Instance);
+    private static readonly ChatId TestChatId = ChatId.Parse("the-actual-one");
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void KnownTagsShouldRoundTripUnchanged(bool isKeyed)
+    {
+        var options = Options(isKeyed);
+        var textEntry = RoundTrip<ChatEntry>(NewTextEntry(), options);
+        textEntry.Should().BeOfType<TextEntry>();
+        textEntry.Id.Should().Be(NewTextEntry().Id);
+        textEntry.Flags.Should().Be(ChatEntryFlags.IsRemoved);
+        textEntry.Content.Should().Be("Hello, world!");
+
+        var systemEntry = RoundTrip<ChatEntry>(NewMembersChangedEntry(), options);
+        systemEntry.Should().BeOfType<MembersChangedEntry>();
+        systemEntry.IsSystemEntry.Should().BeTrue();
+        ((MembersChangedEntry)systemEntry).TargetAuthorName.Should().Be("Someone");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UnknownMessageTagShouldBecomeAnUnsupportedTextEntry(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var bytes = WithTag(MessagePackSerializer.Serialize<ChatEntry>(NewTextEntry(), options), UnknownMessageTag);
+
+        // act
+        var entry = MessagePackSerializer.Deserialize<ChatEntry>(bytes, options);
+
+        // assert
+        entry.Should().BeOfType<TextEntry>();
+        entry.IsSystemEntry.Should().BeFalse();
+        entry.Flags.Should().HaveFlag(ChatEntryFlags.IsUnsupported);
+        entry.Flags.Should().HaveFlag(ChatEntryFlags.IsRemoved, "the recovered prefix carries the flags");
+        entry.Id.Should().Be(NewTextEntry().Id, "a tile is keyed and ordered by entry id");
+        entry.Version.Should().Be(7);
+        entry.AuthorId.Should().Be(AuthorId.New(TestChatId, 10));
+        entry.Content.Should().BeEmpty("an unsupported entry's content is not ours to render");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UnknownSystemTagShouldBecomeAnUnsupportedSystemEntry(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var bytes = WithTag(MessagePackSerializer.Serialize<ChatEntry>(NewTextEntry(), options), UnknownSystemTag);
+
+        // act
+        var entry = MessagePackSerializer.Deserialize<ChatEntry>(bytes, options);
+
+        // assert
+        entry.Should().BeOfType<UnsupportedSystemEntry>();
+        entry.IsSystemEntry.Should().BeTrue("the consumers that skip system entries must skip this one too");
+        entry.Flags.Should().HaveFlag(ChatEntryFlags.IsUnsupported);
+        entry.Id.Should().Be(NewTextEntry().Id);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TheSystemPlaceholderShouldSurviveBeingServed(bool isKeyed)
+    {
+        // A server rolled back past the release that wrote a row reads one of these out of the
+        // database and fans it out, so the placeholder has to be writable, not read-only.
+
+        // arrange
+        var options = Options(isKeyed);
+        var placeholder = new UnsupportedSystemEntry(ChatEntryId.New(TestChatId, 3), 9) {
+            AuthorId = AuthorId.New(TestChatId, -1),
+            Flags = ChatEntryFlags.IsUnsupported,
+        };
+
+        // act
+        var entry = RoundTrip<ChatEntry>(placeholder, options);
+
+        // assert
+        entry.Should().BeOfType<UnsupportedSystemEntry>();
+        entry.Id.Should().Be(placeholder.Id);
+        entry.Version.Should().Be(9);
+        entry.IsUnsupported.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AnUnknownEntryShouldNotBreakTheTileAroundIt(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var known = MessagePackSerializer.Serialize<ChatEntry>(NewTextEntry(), options);
+        var unknown = WithTag(known, UnknownSystemTag);
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteArrayHeader(3);
+        writer.Flush();
+        var bytes = Concat(buffer.WrittenSpan.ToArray(), known, unknown, known);
+
+        // act
+        var entries = MessagePackSerializer.Deserialize<ChatEntry[]>(bytes, options);
+
+        // assert
+        entries.Should().HaveCount(3);
+        entries[0].Should().BeOfType<TextEntry>();
+        entries[1].Should().BeOfType<UnsupportedSystemEntry>();
+        entries[2].Should().BeOfType<TextEntry>();
+        entries[2].Content.Should().Be("Hello, world!", "the entry after the unknown one is read normally");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CorruptionWithAKnownTagShouldStillThrow(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var bytes = MessagePackSerializer.Serialize<ChatEntry>(NewTextEntry(), options);
+        var truncated = bytes[..(bytes.Length / 2)];
+
+        // act & assert
+        var act = () => MessagePackSerializer.Deserialize<ChatEntry>(truncated, options);
+        act.Should().Throw<MessagePackSerializationException>(
+            "tolerance is for unknown tags only - corruption must stay an error");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UnknownMarkupShouldContributeNothing(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var bytes = WithTag(MessagePackSerializer.Serialize<Markup>(new PlainTextMarkup("Hi"), options), 99);
+
+        // act
+        var markup = MessagePackSerializer.Deserialize<Markup>(bytes, options);
+
+        // assert
+        markup.Should().BeSameAs(PlainTextMarkup.Empty);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UnknownNotificationShouldBecomeNull(bool isKeyed)
+    {
+        // arrange
+        var options = Options(isKeyed);
+        var notificationId = NotificationId.New(UserId.Parse("dmitrii"), NotificationKind.Message, "the-actual-one");
+        var notification = new MessageNotification(notificationId);
+        var bytes = WithTag(MessagePackSerializer.Serialize<Notifications.Notification>(notification, options), 99);
+
+        // act
+        var result = MessagePackSerializer.Deserialize<Notifications.Notification>(bytes, options);
+
+        // assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EverySystemMemberShouldCarryASystemTag()
+    {
+        // act
+        var members = typeof(ChatEntry).GetCustomAttributes<UnionAttribute>().ToList();
+
+        // assert
+        members.Should().NotBeEmpty();
+        foreach (var member in members)
+            ChatEntry.IsSystemUnionTag(member.Key)
+                .Should()
+                .Be(typeof(SystemEntry).IsAssignableFrom(member.SubType),
+                    $"{member.SubType.Name} is tagged {member.Key}, and tags "
+                    + $"{ChatEntry.FirstSystemUnionTag}..{ChatEntry.LastSystemUnionTag} are the system-entry range");
+    }
+
+    [Fact]
+    public void NoMemberShouldReuseAKeyTheBaseDeclares()
+    {
+        // Prefix recovery reads payload slots 0..3 as the base's own. A member that took one of
+        // those keys wouldn't throw - it would make the placeholder read that member's value as an
+        // id, and the result would look perfectly plausible.
+
+        // arrange
+        var baseKeys = DeclaredKeys(typeof(ChatEntry));
+        var baseNames = DeclaredNames(typeof(ChatEntry));
+
+        // act
+        var collisions = new List<string>();
+        foreach (var member in typeof(ChatEntry).GetCustomAttributes<UnionAttribute>().Select(x => x.SubType))
+            for (var type = member; type != null && type != typeof(ChatEntry); type = type.BaseType) {
+                collisions.AddRange(DeclaredKeys(type)
+                    .Where(baseKeys.Contains)
+                    .Select(key => $"{type.Name} reuses base key {key}"));
+                collisions.AddRange(DeclaredNames(type)
+                    .Where(baseNames.Contains)
+                    .Select(name => $"{type.Name} reuses base member name '{name}'"));
+            }
+
+        // assert
+        collisions.Should().BeEmpty(
+            "the base prefix must stay the base's:\n{0}", string.Join("\n", collisions));
+    }
+
+    // Private methods
+
+    private static HashSet<int> DeclaredKeys(Type type)
+        => KeyedProperties(type)
+            .Select(x => x.GetCustomAttribute<KeyAttribute>()!.IntKey)
+            .Where(x => x.HasValue)
+            .Select(x => x!.Value)
+            .ToHashSet();
+
+    private static HashSet<string> DeclaredNames(Type type)
+        => KeyedProperties(type).Select(x => x.Name).ToHashSet();
+
+    private static IEnumerable<PropertyInfo> KeyedProperties(Type type)
+        => type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(x => x.GetCustomAttribute<KeyAttribute>() is not null);
+
+    private static MessagePackSerializerOptions Options(bool isKeyed)
+        => isKeyed ? KeyedOptions : KeylessOptions;
+
+    private static T RoundTrip<T>(T value, MessagePackSerializerOptions options)
+        => MessagePackSerializer.Deserialize<T>(MessagePackSerializer.Serialize(value, options), options);
+
+    private static byte[] WithTag(byte[] envelope, int tag)
+    {
+        var reader = new MessagePackReader(envelope);
+        reader.ReadArrayHeader();
+        reader.ReadInt32();
+        var payload = envelope[(int)reader.Consumed..];
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteArrayHeader(2);
+        writer.Write(tag);
+        writer.Flush();
+        return Concat(buffer.WrittenSpan.ToArray(), payload);
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var result = new byte[parts.Sum(x => x.Length)];
+        var offset = 0;
+        foreach (var part in parts) {
+            part.CopyTo(result, offset);
+            offset += part.Length;
+        }
+        return result;
+    }
+
+    private static TextEntry NewTextEntry()
+        => new (ChatEntryId.New(TestChatId, 1), 7) {
+            AuthorId = AuthorId.New(TestChatId, 10),
+            BeginsAt = new Moment(DateTime.UnixEpoch),
+            Content = "Hello, world!",
+            ContentHash = HashString.None,
+            Flags = ChatEntryFlags.IsRemoved,
+        };
+
+    private static MembersChangedEntry NewMembersChangedEntry()
+        => new (ChatEntryId.New(TestChatId, 2), 8) {
+            AuthorId = AuthorId.New(TestChatId, -1),
+            BeginsAt = new Moment(DateTime.UnixEpoch),
+            ContentHash = HashString.None,
+            TargetAuthorId = AuthorId.New(TestChatId, 10),
+            TargetAuthorName = "Someone",
+        };
+}

--- a/tests/Chat.UnitTests/LegacyTileRoutingTest.cs
+++ b/tests/Chat.UnitTests/LegacyTileRoutingTest.cs
@@ -1,0 +1,86 @@
+using ActualLab.Rpc;
+
+namespace ActualChat.Chat.UnitTests;
+
+/// <summary>
+/// The pair of <c>[LegacyName]</c> attributes that sends a peer too old to read a new entry kind
+/// to the filtering tile method. Mistyping one of them fails silently — the old peer keeps
+/// getting the unfiltered tile and dies on it.
+/// </summary>
+public class LegacyTileRoutingTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly Version Boundary = Version.Parse(ApiConstants.LastVersionWithoutUnionTolerance);
+    private static readonly Version JustAfterBoundary = new (2, 19);
+
+    [Fact]
+    public void AnOldPeerShouldReachTheFilteringMethod()
+    {
+        // act
+        var legacyName = LegacyNameOf(nameof(IChats.GetLegacyTile), Boundary);
+
+        // assert
+        legacyName?.Name.Should().Be(nameof(IChats.GetTile),
+            "a peer at or below the boundary calls the wire name GetTile and must land on the filtering method");
+    }
+
+    [Fact]
+    public void AnOldPeerShouldNotReachTheUnfilteredMethod()
+    {
+        // act
+        var legacyName = LegacyNameOf(nameof(IChats.GetTile), Boundary);
+
+        // assert
+        legacyName?.Name.Should().NotBe(nameof(IChats.GetTile),
+            "the unfiltered method must be renamed out of an old peer's reach at the boundary");
+    }
+
+    [Fact]
+    public void ANewPeerShouldReachTheUnfilteredMethod()
+    {
+        // act
+        var unfiltered = LegacyNameOf(nameof(IChats.GetTile), JustAfterBoundary);
+        var filtering = LegacyNameOf(nameof(IChats.GetLegacyTile), JustAfterBoundary);
+
+        // assert
+        unfiltered.Should().BeNull("past the boundary GetTile keeps its own name");
+        filtering.Should().BeNull("and the filtering method stops answering to it");
+    }
+
+    [Fact]
+    public void BothSidesOfThePairShouldShareOneBoundary()
+    {
+        // act
+        var versions = new[] { nameof(IChats.GetTile), nameof(IChats.GetLegacyTile) }
+            .SelectMany(x => MethodOf(x).GetCustomAttributes<LegacyNameAttribute>())
+            .Select(x => x.MaxVersion)
+            .Distinct()
+            .ToList();
+
+        // assert
+        versions.Should().Equal([ApiConstants.LastVersionWithoutUnionTolerance],
+            "a split boundary routes one of the two methods to the wrong peers");
+    }
+
+    [Fact]
+    public void ThePairShouldStayInterchangeable()
+    {
+        // act
+        var parameters = new[] { nameof(IChats.GetTile), nameof(IChats.GetLegacyTile) }
+            .Select(x => MethodOf(x).GetParameters().Select(p => p.ParameterType).ToArray())
+            .ToList();
+
+        // assert
+        parameters[0].Should().Equal(parameters[1],
+            "an old peer's call is decoded against whichever method it lands on");
+        MethodOf(nameof(IChats.GetTile)).ReturnType
+            .Should().Be(MethodOf(nameof(IChats.GetLegacyTile)).ReturnType);
+    }
+
+    // Private methods
+
+    private static LegacyName? LegacyNameOf(string methodName, Version version)
+        => new LegacyNames(MethodOf(methodName))[version];
+
+    private static MethodInfo MethodOf(string name)
+        => typeof(IChats).GetMethod(name)!;
+}

--- a/tests/Chat.UnitTests/UnionEnvelopeTest.cs
+++ b/tests/Chat.UnitTests/UnionEnvelopeTest.cs
@@ -1,0 +1,84 @@
+using ActualChat.Hashing;
+using ActualChat.Serialization.Internal;
+using MessagePack;
+
+namespace ActualChat.Chat.UnitTests;
+
+/// <summary>
+/// Pins the wire shape a tolerant union formatter depends on: a union value is a
+/// two-element <c>[tag, payload]</c> array, and <see cref="MessagePackReader.Skip"/>
+/// walks it whole without knowing the payload's type.
+/// </summary>
+public class UnionEnvelopeTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly MessagePackSerializerOptions KeyedOptions = new (AppMessagePackResolver.Instance);
+    private static readonly MessagePackSerializerOptions KeylessOptions = new (AppMessagePackKeylessResolver.Instance);
+    private static readonly ChatId TestChatId = ChatId.Parse("the-actual-one");
+
+    [Fact]
+    public void TextEntryShouldBeWrappedInAnEnvelope()
+        => Dump(NewTextEntry());
+
+    [Fact]
+    public void MembersChangedEntryShouldBeWrappedInAnEnvelope()
+        => Dump(NewMembersChangedEntry());
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SkipShouldWalkTheWholeEnvelope(bool isKeyed)
+    {
+        // arrange
+        var options = isKeyed ? KeyedOptions : KeylessOptions;
+        var bytes = MessagePackSerializer.Serialize<ChatEntry>(NewTextEntry(), options);
+
+        // act
+        var peek = new MessagePackReader(bytes);
+        var count = peek.ReadArrayHeader();
+        var tag = peek.ReadInt32();
+        var reader = new MessagePackReader(bytes);
+        reader.Skip();
+
+        // assert
+        Out.WriteLine($"envelope: count={count}, tag={tag}");
+        count.Should().Be(2, "the tolerant formatter reads the tag out of a [tag, payload] array");
+        tag.Should().Be(0, "TextEntry is [Union(0)] on ChatEntry");
+        reader.End.Should().BeTrue("Skip must walk an envelope whose payload type is unknown");
+    }
+
+    // Private methods
+
+    private void Dump(ChatEntry entry)
+    {
+        foreach (var (name, options) in new[] { ("keyed", KeyedOptions), ("keyless", KeylessOptions) }) {
+            Write($"{name} as {entry.GetType().Name}", entry, options);
+            Write($"{name} as ChatEntry", (ChatEntry)entry, options);
+            if (entry is SystemEntry systemEntry)
+                Write($"{name} as SystemEntry", systemEntry, options);
+        }
+    }
+
+    private void Write<T>(string title, T value, MessagePackSerializerOptions options)
+    {
+        var bytes = MessagePackSerializer.Serialize(value, options);
+        Out.WriteLine($"{title}: {MessagePackSerializer.ConvertToJson(bytes, options)}");
+    }
+
+    private static TextEntry NewTextEntry()
+        => new (ChatEntryId.New(TestChatId, 1), 7) {
+            AuthorId = AuthorId.New(TestChatId, 10),
+            BeginsAt = new Moment(DateTime.UnixEpoch),
+            Content = "Hello, world!",
+            ContentHash = HashString.None,
+            Flags = ChatEntryFlags.IsRemoved,
+        };
+
+    private static MembersChangedEntry NewMembersChangedEntry()
+        => new (ChatEntryId.New(TestChatId, 2), 8) {
+            AuthorId = AuthorId.New(TestChatId, -1),
+            BeginsAt = new Moment(DateTime.UnixEpoch),
+            ContentHash = HashString.None,
+            TargetAuthorId = AuthorId.New(TestChatId, 10),
+            TargetAuthorName = "Someone",
+        };
+}

--- a/tests/Chat.UnitTests/UnionToleranceCoverageTest.cs
+++ b/tests/Chat.UnitTests/UnionToleranceCoverageTest.cs
@@ -1,0 +1,110 @@
+using ActualChat.Serialization;
+using ActualChat.Serialization.Internal;
+using MessagePack;
+
+namespace ActualChat.Chat.UnitTests;
+
+/// <summary>
+/// A new <c>[Union]</c> hierarchy that ships closed makes its first added member a compatibility
+/// event for every peer. This is what notices, before a release does.
+/// </summary>
+public class UnionToleranceCoverageTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    private static readonly Dictionary<Type, string> Exempt = new() {
+        [typeof(StoredSettings)] =
+            "Tolerance alone doesn't fix its bug - an unreadable row is dropped on write-back, "
+            + "which is a change to the settings write path. Its own task.",
+        [typeof(Live.MuxedAudioStreamItem)] =
+            "A live stream item has no placeholder that means less than a throw: the demuxer keys "
+            + "off StreamIndex, so a null in its place is a different failure, not a lesser one. "
+            + "Tolerating one needs a skip path through the demuxer, which is its own design.",
+        [typeof(Media.MediaFrame)] =
+            "Same as MuxedAudioStreamItem - a frame the pipeline can't decode isn't a frame it can "
+            + "carry as null past the timestamping and A/V sync that read it.",
+    };
+
+    [Fact]
+    public void EveryUnionRootShouldBeTolerantOrExempt()
+    {
+        // arrange
+        ApiModuleInitializerLoad();
+        var roots = ApiAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .Where(t => t.GetCustomAttributes<UnionAttribute>().Any())
+            .OrderBy(t => t.FullName)
+            .ToList();
+
+        // act
+        var untreated = roots
+            .Where(t => !Exempt.ContainsKey(t) && !IsRegisteredAsTolerant(t))
+            .Select(t => t.GetName())
+            .ToList();
+
+        // assert
+        roots.Should().NotBeEmpty("the scan must actually find the union roots");
+        Out.WriteLine($"Union roots: {roots.Count}, exempt: {Exempt.Count}");
+        untreated.Should().BeEmpty(
+            "every [Union] root either tolerates an unknown member or is listed in Exempt with a "
+            + "reason:\n{0}",
+            string.Join("\n", untreated));
+    }
+
+    [Fact]
+    public void EveryTolerantRootShouldKnowItsOwnTags()
+    {
+        // The known-tag set comes from [Union] attributes read at runtime, and a formatter that
+        // can't read them falls back to intolerance rather than treating every tag as unknown.
+        // Under JIT this can only pass - it's the AOT build where the attributes are at risk, and
+        // this states the invariant that build has to hold up.
+
+        // arrange
+        ApiModuleInitializerLoad();
+
+        // act
+        var intolerant = AppMessagePackResolverSettings.Formatters
+            .Where(kv => kv.Value.IsGenericType
+                && kv.Value.GetGenericTypeDefinition() == typeof(ForwardCompatibleUnionFormatter<>))
+            .Where(kv => !IsTolerant(kv.Value))
+            .Select(kv => kv.Key.GetName())
+            .ToList();
+
+        // assert
+        intolerant.Should().BeEmpty(
+            "a registered root with no readable [Union] attributes silently loses its "
+            + "tolerance:\n{0}",
+            string.Join("\n", intolerant));
+    }
+
+    [Fact]
+    public void ExemptRootsShouldStillBeUnionRoots()
+    {
+        // act
+        var stale = Exempt.Keys
+            .Where(t => !t.GetCustomAttributes<UnionAttribute>().Any())
+            .Select(t => t.GetName())
+            .ToList();
+
+        // assert
+        stale.Should().BeEmpty("an exemption for a type that is no longer a union root is dead weight");
+    }
+
+    // Private methods
+
+    private static void ApiModuleInitializerLoad()
+        // Touching an Api type runs its module initializer, which is what registers the formatters.
+        => _ = ChatEntry.Removed(ChatEntryId.New(ChatId.Parse("the-actual-one"), 1));
+
+    private static IEnumerable<Assembly> ApiAssemblies()
+        => AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.GetName().Name?.StartsWith("ActualChat.") == true);
+
+    private static bool IsTolerant(Type formatter)
+        => (bool)formatter.GetProperty(nameof(ForwardCompatibleUnionFormatter<ChatEntry>.IsTolerant))!
+            .GetValue(null)!;
+
+    private static bool IsRegisteredAsTolerant(Type root)
+        => AppMessagePackResolverSettings.Formatters.TryGetValue(root, out var formatter)
+            && formatter.IsGenericType
+            && formatter.GetGenericTypeDefinition() == typeof(ForwardCompatibleUnionFormatter<>)
+            && typeof(IForwardCompatibleUnion<>).MakeGenericType(root).IsAssignableFrom(root);
+}


### PR DESCRIPTION
Adding a member to a `[Union]` hierarchy is currently a breaking change for every peer that doesn't yet know the new tag — and not just for that value: the reader can't know the payload's shape, so it can't even skip it, and the *whole surrounding payload* fails. For a `ChatEntry` that means a tile of a chat rather than one message.

`Markup` has grown to 23 members and `StoredSettings` to 25. These are open sets modelled as closed ones, and every new member has been a compatibility event. This makes an unknown tag survivable, once, for every future member.

## What's here

**`ForwardCompatibleUnionFormatter<TBase>`** reads the tag from a copy of the reader — `MessagePackReader` is a struct over an in-memory sequence, so a copy is a free bookmark. A known tag goes to the standard union formatter untouched, so behaviour on the happy path is bit-for-bit what it was. An unknown one becomes a per-root placeholder, and the envelope is skipped.

Deliberately **not** a try/catch around the inner formatter: that would swallow genuine corruption and turn it into a silently missing message. Corruption with a *known* tag still throws, and there's a test for it.

**Tolerant roots:** `ChatEntry`, `SystemEntry`, `Markup`, `Notification`, `Invite`. `StoredSettings` is deliberately out — tolerance alone doesn't fix its actual bug, which is the unreadable row dropped on write-back, and that's a change to the settings write path. `MuxedAudioStreamItem` and `MediaFrame` are out too: a live stream item has no placeholder that means *less* than a throw, since the demuxer keys off it.

**Per-root policy** is a static abstract interface member (`IForwardCompatibleUnion<TSelf>.NewUnsupported`), so each root's policy lives with the root and `ActualChat.Core` stays free of any API type.

**An unknown `ChatEntry` tag is classified by range** — 100..199 are `SystemEntry` descendants. That matters because `IsSystemEntry` is `this is SystemEntry` and some forty call sites branch on it: a plain `TextEntry` placeholder would take the author-group rendering of a real message and stand as the chat's last message in the list. Both placeholders recover the base prefix — id, version, flags, author — so a tile keeps its keying and an unknown *removed* entry still reads as removed.

**Server-side filtering for peers that can't tolerate anything.** Clients already in the wild don't have the formatter and nothing shipped later can give it to them, so the server stops sending them what they can't read: `GetTile` gains a `LegacyName` twin that drops entries whose kind postdates the peer's API version. A twin rather than a per-peer projection because Fusion's result cache isn't peer-scoped — two methods means two cache slots, and the RPC layer picks which one a peer reaches from the handshake version. Same shape as the `GetNews` / `GetFullNews` pair already in `IChats`.

**Database.** `DbChatEntry.ToModel` no longer throws on a system-entry row whose option it doesn't recognize — a rollback past the writing release used to take out every chat holding one.

## Verified

- `UnionEnvelopeTest` pins the `[tag, payload]` envelope against this codebase's own resolvers rather than assuming it from how MessagePack works. It also turned up that the keyless layout writes derived members *first*, so there is no prefix there and recovery must read by name — anything positional would have silently read a member's field as an id.
- `UnionToleranceCoverageTest` fails any `[Union]` root that is neither tolerant nor exempt with a reason. It immediately found three roots the design had missed.
- `[Union]` attributes survive ILLink trimming: an Android Release publish was linked and its `ActualChat.Api.dll` read out of `obj/.../linked/` — counts identical to the untrimmed assembly. That covers both shipping configurations, since `UseNativeAot` defaults to false and Apple links SDK-only.
- If those attributes are ever trimmed away regardless, `IsTolerant` turns tolerance *off* rather than treating every tag as unknown — the difference between behaving exactly as before this branch and replacing every message in every chat with a placeholder.
- 2 425 unit tests across ten projects, `ActualChat.CI.slnf` builds.

## Before merging

`ApiConstants.LastVersionWithoutUnionTolerance` is `"2.18.9999"`, which assumes this lands in **2.19**. If it slips to 2.20 it must become `"2.19.9999"`, or 2.19 clients get the unfiltered tile.

## Not in scope

`CallOutcomeSystemEntry` is a separate task and becomes the first member that costs nothing beyond its own implementation. Unifying how an entry is stored — `Content` plus a binary `Data` plus a registered discriminator — is its own task too.
