### PR TITLE
fix(ptt): play incoming PTT audio on iOS in the background

### DIFF
--- a/docs/live-audio/10-push-to-talk.md
+++ b/docs/live-audio/10-push-to-talk.md
@@ -407,6 +407,43 @@ wake. An invalid payload still returns a `PTParticipant` and schedules
 `ClearActiveParticipant` after `PhantomWakeClearDelay` (5 s), or the system UI
 would show the channel as receiving forever.
 
+**Self-initiated playback.** An app joined to the channel may not activate its
+own `AVAudioSession` in the background: `SetActive(true)` answers
+`AVAudioSessionErrorCode.CannotInterruptOthers` (`'!int'`, 560557684), and so
+does `AVAudioEngine.start`. That is exactly the position of an armed app that is
+already listening when the next utterance arrives over RPC — the server skips
+active participants and dedups wakes per `PttWakeTtl`, so no push comes, yet
+the stream does. `AudioSession` therefore treats that refusal as a request:
+`ReconfigureUnsafe` / `ReactivateUnsafe` return a setup with
+`IsPttActivationPending`, and `AudioSession.RequestPttActivation` asks the
+framework through the hooks `IosPtt` registers in `Initialize`
+(`SetPttPlaybackHooks`: joined-check, request, release). The request,
+`RequestPlaybackActivation`, calls `SetActiveRemoteParticipant(new
+PTParticipant(channelTitle))` — the system activates the session for a set
+participant even in the background, Apple's stated contract for PTT apps — and
+`DidActivateAudioSession` completes it. `AppleAudioFocusUI.SetModeUnsafe`,
+`RecoverInternal` and `RebuildInternal` await it before resuming the engines,
+and `AudioEngine.EnsureRunning` retries a start refused with `'!int'` after the
+same request, because a player that outruns the focus acquisition is where the
+refusal surfaces first. Concurrent callers share one request
+(`_pttActivationTask`), bounded by `PttActivationTimeout` (5 s). The rules
+around it: no request without a joined channel (then the refusal is somebody
+else's non-mixable session and the old throw-and-retry path applies) and none
+for a `Recording` mode (the framework would show the app's own mic as an
+incoming receive; a background mic is a transmit's business); no short-circuit
+on a PTT owner, since a caller only gets here with an inactive session, which
+a `PttPlayback` owner also is while the previous burst's deactivation is in
+flight; `DidDeactivateAudioSession` never completes a request, for the same
+reason; and the request bumps the wake generation so a pending phantom-wake
+clear can't take its participant down. The release is symmetric:
+`DeactivateUnsafe`, reached when the last focus scope goes, calls the release
+hook (`ClearActiveParticipant`) whenever the owner is `PttPlayback` — or a
+request is still pending, which would otherwise activate a session nothing
+wants — and a request that ends without an activation releases too, so the
+framework's "receiving" state ends with the burst instead of lingering until
+the owner watchdog. Android needs none of this — a foreground-service app plays
+whenever it likes — which is why the silence was iOS-only.
+
 ### The background idle drop
 
 `ChatAudioUI.StateSync`'s `StopListeningWhenIdleInBackground` runs only on

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioCapture.cs
@@ -117,7 +117,7 @@ public class AppleAudioCapture(AppUIHub hub) : IAudioCapture
                     Log.LogWarning("Dropped the pre-roll: format changed since it was captured");
             }
             using var _2 = engine.Input.Tap(HandleSamples);
-            engine.EnsureRunning();
+            await engine.EnsureRunning(cancellationToken).ConfigureAwait(false);
             // Voice processing activation can route audio to the earpiece — fix it
             await AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
 

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -202,6 +202,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         AudioSessionSetup setup;
         try {
             setup = await AudioSession.Reconfigure(mode).ConfigureAwait(false);
+            setup = await WaitForPttActivation(setup, mode).ConfigureAwait(false);
         }
         catch (Exception) {
             // Nothing else resumes the engines, so a session call that fails - which is what a
@@ -233,10 +234,22 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         var mode = _activeScopes.GetMode();
         Log.LogInformation("Recover: reactivating session in {Mode}", mode);
         var setup = await AudioSession.Reactivate(mode).ConfigureAwait(false);
+        setup = await WaitForPttActivation(setup, mode).ConfigureAwait(false);
         (_isSessionConfigured, _isSessionActivated) = (setup.IsConfigured, setup.IsActivated);
         AudioEngines.Resume(mode);
         InvokeRestoreUnsafe();
         _isSuspended = false;
+    }
+
+    private async Task<AudioSessionSetup> WaitForPttActivation(AudioSessionSetup setup, AudioFocusMode mode)
+    {
+        if (!setup.IsPttActivationPending)
+            return setup;
+
+        var isActivated = await AudioSession.RequestPttActivation().ConfigureAwait(false);
+        Log.LogInformation("SetMode: {Mode} - the PTT framework {Result} the session",
+            mode, isActivated ? "activated" : "didn't activate");
+        return setup with { IsActivated = isActivated, IsPttActivationPending = false };
     }
 
     private void InvokeLostFocusUnsafe(bool mayRecover, bool canDuck)
@@ -322,6 +335,7 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         // to dispose and rebuild. Pause/Resume left zombies, so the "rebuild" restarted nothing.
         AudioEngines.Release();
         var setup = await AudioSession.Reconfigure(mode).ConfigureAwait(false);
+        setup = await WaitForPttActivation(setup, mode).ConfigureAwait(false);
         (_isSessionConfigured, _isSessionActivated) = (setup.IsConfigured, setup.IsActivated);
         // No Resume: Release cleared _isStarted, so it'd no-op. Recovery is the restore handlers
         // below plus the capture stall and buffer-low timeouts, which rebuild what was live.

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioPlaybackEngine.cs
@@ -55,7 +55,7 @@ public sealed class AppleAudioPlaybackEngine(
             Log,
             "Failed to decode/feed iOS audio",
             _decodeFeedCts.Token);
-        _voicePlayer.Play();
+        await _voicePlayer.Play(cancellationToken).ConfigureAwait(false);
         // After Play(), not before: starting the player is what builds the engine and moves the route.
         await hub.AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
     }
@@ -67,13 +67,13 @@ public sealed class AppleAudioPlaybackEngine(
         return Task.CompletedTask;
     }
 
-    public Task Resume(CancellationToken cancellationToken)
+    public async Task Resume(CancellationToken cancellationToken)
     {
         DebugLog?.LogInformation("#{PlayerId}.Resume", playerId);
-        _voicePlayer.Play();
+        await _voicePlayer.Play(cancellationToken).ConfigureAwait(false);
         // Same reason as Play(): resuming restarts the engine, and a restart that lands after
         // voice processing came up needs the route restated.
-        return hub.AudioFocusUI.EnsureOutputRoute(cancellationToken);
+        await hub.AudioFocusUI.EnsureOutputRoute(cancellationToken).ConfigureAwait(false);
     }
 
     public Task End(bool abort, CancellationToken cancellationToken)

--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
@@ -41,7 +41,7 @@ public sealed class AppleTuneUI(UIHub hub) : MauiTuneUI(hub)
             var audioFile = audioFileLease.Resource;
 
             using var node = engine.NewPlayer(audioFile.ProcessingFormat);
-            engine.EnsureRunning();
+            await engine.EnsureRunning(cancellationToken).ConfigureAwait(false);
             node.Play();
             // A tune started while the recording engine's VoiceProcessingIO runs is a source
             // started after it, so it lands on the earpiece unless the route is restated - and

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -14,12 +14,18 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
     private static readonly TimeSpan OwnerWatchdogPeriod = TimeSpan.FromSeconds(30);
     // A heartbeat, not a hold - so unlike a leaked latch it can't wedge the watchdog.
     private static readonly TimeSpan PlaybackActivityTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan PttActivationTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Lock OwnerLock = new();
     private static int _owner;
     private static long _ownerChangedAt;
     private static int _isOwnerWatchdogRunning;
     private static Action? _ownerWatchdogRecovery;
+    private static Func<bool>? _isPttActivationAvailable;
+    private static Func<Task<bool>>? _pttActivationRequester;
+    private static Action? _pttPlaybackRelease;
+    private static Task<bool>? _pttActivationTask;
+    private static int _isPttReleasePending;
     private static long _playbackActivityAt;
 
     private AppUIHub Hub { get; } = hub;
@@ -41,6 +47,85 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
 
     public static void SetOwnerWatchdogRecovery(Action recovery)
         => Volatile.Write(ref _ownerWatchdogRecovery, recovery);
+
+    public static void SetPttPlaybackHooks(
+        Func<bool> isActivationAvailable, Func<Task<bool>> requestActivation, Action releaseActivation)
+    {
+        Volatile.Write(ref _isPttActivationAvailable, isActivationAvailable);
+        Volatile.Write(ref _pttActivationRequester, requestActivation);
+        Volatile.Write(ref _pttPlaybackRelease, releaseActivation);
+    }
+
+    public static Task<bool> RequestPttActivation()
+    {
+        // An app joined to its PTT channel may not activate its own session in the background -
+        // SetActive answers CannotInterruptOthers - but the framework activates it for a set
+        // participant, and reports that through DidActivateAudioSession. One request serves
+        // every caller that runs into the refusal meanwhile - including one that arrives after
+        // the activation already happened: the framework activates once per participant, so a
+        // second request would wait for a callback that never comes. A PTT owner therefore
+        // answers "active" - unless its release is still in flight, in which case the session
+        // is on its way down and only a fresh participant brings it back.
+        if (Volatile.Read(ref _pttActivationRequester) is not { } requester)
+            return ActualLab.Async.TaskExt.FalseTask;
+
+        TaskCompletionSource<bool> source;
+        lock (OwnerLock) {
+            if (_pttActivationTask is { IsCompleted: false } pending)
+                return pending;
+            if (Owner != AudioSessionOwner.App && Volatile.Read(ref _isPttReleasePending) == 0)
+                return ActualLab.Async.TaskExt.TrueTask;
+
+            source = TaskCompletionSourceExt.New<bool>();
+            _pttActivationTask = source.Task;
+        }
+        // The availability check takes the PTT lock, which SetOwner is called under - so it, like
+        // the request itself, stays outside OwnerLock.
+        if (!IsPttActivationAvailable) {
+            source.TrySetResult(false);
+            return source.Task;
+        }
+
+        _ = BackgroundTask.Run(async () => {
+            var isActivated = false;
+            try {
+                isActivated = await requester.Invoke().WaitAsync(PttActivationTimeout).ConfigureAwait(false);
+            }
+            catch (Exception e) {
+                OwnerLog.LogWarning(e, "The PTT framework didn't activate the audio session");
+            }
+            // The participant the request set would otherwise keep the framework's "receiving"
+            // state, and its flag, until the owner watchdog fires.
+            if (!isActivated && Owner == AudioSessionOwner.App)
+                ReleasePttPlayback();
+            source.TrySetResult(isActivated);
+        }, OwnerLog, "PTT activation request failed", CancellationToken.None);
+        return source.Task;
+    }
+
+    private static bool IsPttActivationAvailable
+        => Volatile.Read(ref _isPttActivationAvailable)?.Invoke() == true;
+
+    private static bool IsPttActivationPending
+        => Volatile.Read(ref _pttActivationTask) is { IsCompleted: false };
+
+    private static void ReleasePttPlayback()
+    {
+        // Never lets a throw out: the request's completion, and DeactivateUnsafe, sit behind it.
+        // The flag stays up until the owner comes back to App (DidDeactivateAudioSession), so a
+        // request landing in between asks for a fresh participant instead of trusting the owner.
+        if (Owner != AudioSessionOwner.App)
+            Volatile.Write(ref _isPttReleasePending, 1);
+        try {
+            Volatile.Read(ref _pttPlaybackRelease)?.Invoke();
+        }
+        catch (Exception e) {
+            OwnerLog.LogWarning(e, "Couldn't release the PTT playback participant");
+        }
+    }
+
+    public static bool IsCannotInterruptOthers(NSError error)
+        => (AVAudioSessionErrorCode)(long)error.Code == AVAudioSessionErrorCode.CannotInterruptOthers;
 
     public static void NotifyPlaybackActivity()
         => Volatile.Write(ref _playbackActivityAt, CpuTimestamp.Now.Value);
@@ -113,6 +198,8 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         // lock before reverting - otherwise a callback landing mid-decision is silently clobbered.
         Volatile.Write(ref _ownerChangedAt, CpuTimestamp.Now.Value);
         Volatile.Write(ref _owner, (int)owner);
+        if (owner == AudioSessionOwner.App)
+            Volatile.Write(ref _isPttReleasePending, 0);
     }
 
     private static void ArmOwnerWatchdog()
@@ -216,6 +303,9 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
             return new AudioSessionSetup(isConfigured, false);
 
         if (!session.SetActive(true, out var error)) {
+            if (TryRequestPttActivation(error, mode))
+                return new AudioSessionSetup(isConfigured, false, true);
+
             Log.LogWarning("Failed to re-activate audio session: {Error}", error.LocalizedDescription);
             // Deactivate and retry
             var deactivateOptions = mode is AudioFocusMode.Tune
@@ -255,9 +345,29 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
             : 0;
         session.SetActive(false, deactivateOptions).Assert("Failed to deactivate session");
         ConfigureUnsafe(session, minMode);
-        session.SetActive(true).Assert("Failed to activate session");
+        if (!session.SetActive(true, out var error)) {
+            if (TryRequestPttActivation(error, minMode))
+                return new AudioSessionSetup(true, false, true);
+
+            error.Assert("Failed to activate session");
+        }
         ApplyOutputRouteUnsafe(minMode);
         return new AudioSessionSetup(true, true);
+    }
+
+    private bool TryRequestPttActivation(NSError error, AudioFocusMode mode)
+    {
+        // Without a joined PTT channel the refusal is somebody else's non-mixable session. A
+        // recording is not asked for either: the framework would show it as an incoming receive,
+        // and the app's own mic in the background is a transmit's business, not this path's.
+        if (mode is AudioFocusMode.Recording || !IsCannotInterruptOthers(error) || !IsPttActivationAvailable)
+            return false;
+
+        Log.LogInformation(
+            "Activate({Mode}): refused as CannotInterruptOthers, asking the PTT framework to activate the session",
+            mode);
+        _ = RequestPttActivation();
+        return true;
     }
 
     private void DeactivateUnsafe()
@@ -266,9 +376,19 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         // running for as long as it's held, whether or not anything is attached to it. Measured
         // on an iPhone 13 Pro: audiomxd sits at 0.27 cores after a call with every engine
         // verifiably stopped, and is absent both before the first call and once the app exits.
-        if (!AudioSessionOwnership.MayActivate(Owner))
+        var owner = Owner;
+        if (!AudioSessionOwnership.MayActivate(owner)) {
+            // Nothing wants the session any more: a playback the framework activated goes back to
+            // it here, or the "receiving" it shows stays up until the owner watchdog fires.
+            if (owner == AudioSessionOwner.PttPlayback)
+                ReleasePttPlayback();
             return;
+        }
 
+        // A request still in flight would activate a session nothing wants any more, with no
+        // scope left to hand it back.
+        if (IsPttActivationPending)
+            ReleasePttPlayback();
         var session = AVAudioSession.SharedInstance();
         if (!session.SetActive(false, AVAudioSessionSetActiveOptions.NotifyOthersOnDeactivation, out var error))
             Log.LogWarning("Failed to deactivate audio session: {Error}", error.LocalizedDescription);
@@ -393,6 +513,10 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
 /// <summary>
 /// What a <see cref="AudioSession.Reconfigure"/> / <see cref="AudioSession.Reactivate"/> call
 /// actually achieved. Under a PTT owner the app may configure the session without being allowed
-/// to activate it, so the two have to be tracked apart.
+/// to activate it, so the two have to be tracked apart; a pending PTT activation is one the
+/// framework was asked for, to be awaited via <see cref="AudioSession.RequestPttActivation"/>.
 /// </summary>
-public readonly record struct AudioSessionSetup(bool IsConfigured, bool IsActivated);
+public readonly record struct AudioSessionSetup(
+    bool IsConfigured,
+    bool IsActivated,
+    bool IsPttActivationPending = false);

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using ActualChat.UI.Blazor.App.Services;
 using ActualChat.UI.Blazor.Services;
 using AVFoundation;
+using Foundation;
 
 namespace ActualChat.App.Maui.Audio;
 
@@ -73,15 +75,21 @@ public sealed class AudioEngine : IDisposable
         _isRunning.DisposeSilently();
     }
 
-    public void EnsureRunning()
+    public async Task EnsureRunning(CancellationToken cancellationToken = default)
     {
-        lock (_lock) {
-            if (_isDisposed)
-                return;
+        if (TryEnsureRunning(out var error))
+            return;
 
-            EnsureEngineRunningUnsafe();
-        }
-        _isRunning.Invalidate();
+        // A PTT-joined app in the background may not activate its own session, and a player
+        // that outruns the focus acquisition is where that refusal surfaces first. Not for the
+        // recording engine - see AudioSession.TryRequestPttActivation.
+        if (Mode is not AudioFocusMode.Recording
+            && AudioSession.IsCannotInterruptOthers(error)
+            && await AudioSession.RequestPttActivation().WaitAsync(cancellationToken).ConfigureAwait(false)
+            && TryEnsureRunning(out error))
+            return;
+
+        error.Assert($"{Mode}: failed to start the engine");
     }
 
     public void Pause()
@@ -107,7 +115,7 @@ public sealed class AudioEngine : IDisposable
             if (!_isStarted)
                 return;
 
-            if (!TryEnsureEngineRunningUnsafe()) {
+            if (!TryEnsureEngineRunningUnsafe(out _)) {
                 Log.LogWarning("{Mode}.Resume: Engine failed, attempting reset", Mode);
                 ResetEngineUnsafe();
                 EnsureEngineRunningUnsafe();
@@ -138,7 +146,7 @@ public sealed class AudioEngine : IDisposable
                 if (_silentOutputNode is { } silentOutputNode)
                     engine.Connect(silentOutputNode, engine.MainMixerNode, SilentOutputFormat);
             }
-            if (!TryEnsureEngineRunningUnsafe()) {
+            if (!TryEnsureEngineRunningUnsafe(out _)) {
                 Log.LogWarning("{Mode}.Reconnect: Engine failed, attempting reset", Mode);
                 ResetEngineUnsafe();
                 EnsureEngineRunningUnsafe();
@@ -293,16 +301,25 @@ public sealed class AudioEngine : IDisposable
         node.DisposeSilently();
     }
 
+    private bool TryEnsureRunning([NotNullWhen(false)] out NSError? error)
+    {
+        bool isRunning;
+        lock (_lock) {
+            if (_isDisposed) {
+                error = null;
+                return true;
+            }
+
+            isRunning = TryEnsureEngineRunningUnsafe(out error);
+        }
+        _isRunning.Invalidate();
+        return isRunning;
+    }
+
     private void EnsureEngineRunningUnsafe()
     {
-        var engine = EngineUnsafe;
-        EnsureSilentOutputUnsafe();
-        if (!engine.Running) {
-            Log.LogInformation("{Mode}.EnsureEngineRunningUnsafe: Engine not running, starting", Mode);
-            engine.StartAndReturnError(out var nsError);
-            nsError.Assert();
-        }
-        _isStarted = true;
+        if (!TryEnsureEngineRunningUnsafe(out var error))
+            error.Assert($"{Mode}: failed to start the engine");
     }
 
     private void EnsureSilentOutputUnsafe()
@@ -318,18 +335,18 @@ public sealed class AudioEngine : IDisposable
         engine.Connect(_silentOutputNode, engine.MainMixerNode, SilentOutputFormat);
     }
 
-    private bool TryEnsureEngineRunningUnsafe()
+    private bool TryEnsureEngineRunningUnsafe([NotNullWhen(false)] out NSError? error)
     {
+        error = null;
         var engine = EngineUnsafe;
         EnsureSilentOutputUnsafe();
-        if (engine.Running)
-            return true;
-
-        Log.LogInformation("{Mode}.TryEnsureEngineRunningUnsafe: Engine not running, attempting to start", Mode);
-        if (!engine.StartAndReturnError(out var nsError)) {
-            Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}",
-                Mode, nsError.LocalizedDescription);
-            return false;
+        if (!engine.Running) {
+            Log.LogInformation("{Mode}.TryEnsureEngineRunningUnsafe: Engine not running, attempting to start", Mode);
+            if (!engine.StartAndReturnError(out error)) {
+                Log.LogWarning("{Mode}.TryEnsureEngineRunningUnsafe: Failed to start: {Error}",
+                    Mode, error.LocalizedDescription);
+                return false;
+            }
         }
         _isStarted = true;
         return true;

--- a/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/VoicePlayer.cs
@@ -35,10 +35,10 @@ public class VoicePlayer : IDisposable
         Node.DisposeSilently();
     }
 
-    public void Play()
+    public async Task Play(CancellationToken cancellationToken)
     {
         DebugLog?.LogInformation("#{Id}.Play", Id);
-        Engine.EnsureRunning();
+        await Engine.EnsureRunning(cancellationToken).ConfigureAwait(false);
         Node.Play();
     }
 

--- a/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
@@ -31,11 +31,14 @@ public static class IosPtt
     private static ManagerDelegate? _managerDelegate;
     private static RestorationDelegate? _restorationDelegate;
     private static volatile string _pttToken = "";
+    private static volatile string _channelTitle = ChannelName;
     private static volatile PendingWake? _pendingWake;
+    private static TaskCompletionSource<bool>? _activationSource;
     private static Transmission? _transmission;
     private static bool _isJoinRequested;
     private static bool _isStopTransmitRequested;
     private static int _isTransmitEnabled;
+    private static int _isJoined;
     private static int _isRemoteParticipantActive;
     private static int _lastWakeGeneration;
     private static ILogger Log => field ??= StaticLog.For(typeof(IosPtt));
@@ -53,6 +56,7 @@ public static class IosPtt
         // process launched by PTT never runs the WebView scope that would otherwise set it.
         Volatile.Write(ref _isTransmitEnabled, LoadIsTransmitEnabled() ? 1 : 0);
         AudioSession.SetOwnerWatchdogRecovery(OnOwnerWatchdogFired);
+        AudioSession.SetPttPlaybackHooks(IsJoined, RequestPlaybackActivation, ClearActiveParticipant);
         PTChannelManager.Create(_managerDelegate, _restorationDelegate, (manager, error) => {
             if (error is not null) {
                 Log.LogError("PTChannelManager.Create failed: {Error}", error.LocalizedDescription);
@@ -66,6 +70,7 @@ public static class IosPtt
                 _isStopTransmitRequested = false;
             }
             Log.LogInformation("PTChannelManager ready");
+            Volatile.Write(ref _isJoined, manager.ActiveChannelUuid is not null ? 1 : 0);
             // Everything requested before this point silently no-opped: EnsureJoined and
             // StopTransmitting both need the manager, and nothing else would ever re-drive them.
             if (isJoinRequested)
@@ -147,6 +152,7 @@ public static class IosPtt
 
     private static void SetDescriptorTitle(string chatTitle)
     {
+        _channelTitle = chatTitle;
         var manager = _manager;
         if (manager?.ActiveChannelUuid is null)
             return;
@@ -283,8 +289,48 @@ public static class IosPtt
         }, Log, "PTT transmit reply failed", CancellationToken.None);
     }
 
+    private static bool IsJoined()
+        // Tracked from the join/leave callbacks: ActiveChannelUuid is a round trip to the PTT
+        // daemon, and this sits on the path between a refused engine start and its retry.
+        => Volatile.Read(ref _isJoined) != 0;
+
+    private static Task<bool> RequestPlaybackActivation()
+    {
+        // Playback the app starts on its own - a stream reaching an already-listening app in the
+        // background: the framework activates the session for a set participant even there, where
+        // the app's own SetActive is refused. Released by ClearActiveParticipant once the last
+        // focus scope goes, see AudioSession.Deactivate.
+        PTChannelManager? manager;
+        TaskCompletionSource<bool> source;
+        lock (Lock) {
+            manager = _manager;
+            if (manager?.ActiveChannelUuid is null)
+                return ActualLab.Async.TaskExt.FalseTask;
+
+            source = _activationSource ??= TaskCompletionSourceExt.New<bool>();
+        }
+
+        Log.LogInformation("Asking the PTT framework to activate the audio session");
+        // This participant is the newest one: a phantom-wake clear scheduled for an older
+        // generation must not take it down mid-playback.
+        Interlocked.Increment(ref _lastWakeGeneration);
+        Volatile.Write(ref _isRemoteParticipantActive, 1);
+        manager.SetActiveRemoteParticipant(new PTParticipant(_channelTitle, null!), ChannelUuid, error => {
+            if (error is null)
+                return;
+
+            Log.LogWarning("SetActiveRemoteParticipant failed: {Error}", error.LocalizedDescription);
+            // Nothing is receiving, so a transmit ending later must hand the session to the app,
+            // not to a playback that never started.
+            Volatile.Write(ref _isRemoteParticipantActive, 0);
+            CompleteActivation(false);
+        });
+        return source.Task;
+    }
+
     private static void OnChannelLeft()
     {
+        CompleteActivation(false);
         OnTransmitEnded();
         lock (Lock)
             // A transmission that never reached StartTransmitReply has no reply task left to
@@ -393,6 +439,7 @@ public static class IosPtt
         if (abandoned is not null)
             AbandonTransmission(abandoned);
 
+        CompleteActivation(true);
         if (mustStart)
             StartTransmitReply(transmission!);
 
@@ -446,6 +493,14 @@ public static class IosPtt
 
         return transmission.IsEndPending
             || transmission.CreatedAt.Elapsed > Constants.Audio.PttTransmitStartupTimeout;
+    }
+
+    private static void CompleteActivation(bool isActivated)
+    {
+        TaskCompletionSource<bool>? source;
+        lock (Lock)
+            (source, _activationSource) = (_activationSource, null);
+        source?.TrySetResult(isActivated);
     }
 
     private static void ScheduleClearActiveParticipant(int generation)
@@ -532,12 +587,14 @@ public static class IosPtt
             PTChannelManager channelManager, NSUuid channelUuid, PTChannelJoinReason reason)
         {
             Log.LogInformation("PTT channel joined ({Reason})", reason);
+            Volatile.Write(ref _isJoined, 1);
             ApplyTransmissionMode(channelManager, channelUuid, Volatile.Read(ref _isTransmitEnabled) != 0);
         }
 
         public override void DidLeaveChannel(
             PTChannelManager channelManager, NSUuid channelUuid, PTChannelLeaveReason reason)
         {
+            Volatile.Write(ref _isJoined, 0);
             OnChannelLeft();
             // A leave can tear the session down without DidDeactivateAudioSession, and a stuck
             // PTT owner permanently disables the app's own session activation.
@@ -626,6 +683,9 @@ public static class IosPtt
 
         public override void DidDeactivateAudioSession(PTChannelManager channelManager, AVAudioSession audioSession)
         {
+            // No CompleteActivation here: this may be the previous burst's teardown landing
+            // after a fresh request was made, whose own activation is still to come. A request
+            // that never gets one is bounded by AudioSession's timeout.
             Log.LogInformation("PTT audio session deactivated");
             AudioSession.ReleaseOwner(AudioSessionRelease.Deactivated);
             Volatile.Write(ref _isRemoteParticipantActive, 0);


### PR DESCRIPTION
## Summary

Armed PTT chats were silent on iOS while they played fine on Android. Device logs (iPhone 13, iOS 26.3.1) showed the stream arriving over RPC, then `AVAudioSession.SetActive` and `AVAudioEngine.start` refused with `'!int'` (`AVAudioSessionErrorCodeCannotInterruptOthers`): an app joined to a `PTChannelManager` channel may not activate its own audio session in the background. Two things put the app there:

- The server never sent the PTT wake. A listening client reports `ParticipationKind.AudioListen`, `OnSpeechStartedEvent` dropped every active participant, and dev logs confirmed it ("2 active skipped" on each utterance). Only a wake makes the framework activate the session.
- The client had no fallback: with owner `App` it tried to activate the session itself, which iOS refuses for a PTT-joined app in the background. Android is unaffected (foreground service + AudioTrack), which is why it "worked on Android".

## Fix

- **Server**: `SendPttWake` skips only the Android devices of an active participant and still wakes its iOS PTT devices. Invariant: an iOS PTT device must be woken whenever someone speaks in an armed chat, listening or not.
- **Client (shared)**: a wake for a chat the app is already listening to skips the explicit cue and the catch-up anchor, so the extra pushes neither chime through a conversation nor replay audio on the next reconnect.
- **Client (iOS)**: `AudioSession` treats the `'!int'` refusal as a request. `Reconfigure`/`Reactivate` report `IsPttActivationPending`, `RequestPttActivation` asks the framework through the hook `IosPtt` registers (`SetActiveRemoteParticipant`, honoured even in the background per Apple DTS), and `DidActivateAudioSession` completes it. `AppleAudioFocusUI` awaits it before resuming the engines; `AudioEngine.EnsureRunning` (now async) retries a refused start after the same request, since a player can outrun the focus acquisition. Concurrent callers share one request, bounded by 5 s. When the last focus scope goes, `DeactivateUnsafe` clears the participant so the system's "receiving" state ends with the burst. Mac Catalyst registers no hook and keeps the old behaviour. Invariant to keep: `RequestPttActivation` must never run the hook under `OwnerLock` (the hook takes the PTT lock that `SetOwner` is called under).
- Docs: `docs/live-audio/10-push-to-talk.md` updated for the fan-out rule and the self-initiated playback path.

## Testing

- `Notifications.IntegrationTests` `PttPushTest`: 18/18 green, including the new `ActiveParticipantWithIosPttDeviceGetsApnsWakeOnly`.
- iOS build on the Mac, installed on an iPhone 13: background utterance into an armed chat now plays (session owner `PttPlayback`, playback position advancing); foreground utterance plays as before. The device run exercised only the client self-activation path.
- Not verified: the push path end to end. Dev has no `NotificationsSettings__ApplePush*` settings (server logs "ApplePush settings are not configured"), so no iOS PTT wake can be sent there until the APNs key is configured; note the sandbox/production host must match the app's `aps-environment`, since a mismatch answers `BadDeviceToken` and deregisters the device. Mac Catalyst not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01894zcK7KyMp19kn3y5t36P
