### PR TITLE
fix(attachments): seed the attachment item's initial model with the real attachment

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/AttachmentItemBase.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/AttachmentItemBase.cs
@@ -13,7 +13,9 @@ public abstract class AttachmentItemBase : ComputedRenderStateComponent<AppUIHub
     [Parameter] public EventCallback RestartClick { get; set; }
 
     protected override ComputedState<Model>.Options GetStateOptions()
-        => new() { InitialValue = Model.None };
+        // Parameters are set by the time the state is created, so the first render already shows
+        // the real attachment in its not-ready look instead of a placeholder
+        => new() { InitialValue = new Model(Attachment, AttachmentPreview.NoPreview, AttachmentProgress.New) };
 
     protected override async Task<Model> ComputeState(CancellationToken cancellationToken)
     {
@@ -26,8 +28,6 @@ public abstract class AttachmentItemBase : ComputedRenderStateComponent<AppUIHub
     // Nested types
     public record Model(Attachment Attachment, AttachmentPreview Preview, AttachmentProgress Progress)
     {
-        public static readonly Model None = new(null!, AttachmentPreview.NoPreview, AttachmentProgress.New);
-
         public bool NoAccess => Preview.State == PreviewAccessState.NoFileAccess;
 
         // Custom preview is a generated thumbnail (e.g., iOS MOV thumbnail) with content:// scheme


### PR DESCRIPTION
## Summary

Pasting an image into the message editor in the macOS AppKit app looked like it did nothing except "reload" the chat view (#4387). The paste itself worked: the DOM `paste` event carried the `image/png` file and the editor added the attachment. What failed was the first render of the new `AttachmentItem`: its state's `InitialValue` was `Model.None`, whose `Attachment` was `null!`, and the razor dereferenced it (`attachment.IsSupportedImage`). Blazor's first render never consults `ShouldRender`, and on every MAUI host the first `ComputeState` is dispatched to the main queue asynchronously (both the official `MauiDispatcher` and the labs `MacOSBlazorDispatcher` post instead of running inline), so that first render always sees the initial model. The NullReferenceException hit the error barrier around the page content, which re-created the chat view.

The same failure reproduces on Mac Catalyst for both paste and the "+" attachment picker, so it is latent on all MAUI hosts, not AppKit-specific. WASM computes the state inline and Blazor Server's dispatcher runs inline on its sync context, which is why the web app never showed it. The `null!` sentinel dates from the MOV-preview refactor in March (816fc5235d); the initial-model render pattern from January (99d659a962).

## Fix

`AttachmentItemBase.GetStateOptions` now seeds the initial model with the real `Attachment` parameter plus `AttachmentPreview.NoPreview` / `AttachmentProgress.New`, and `Model.None` is gone. The `Attachment` parameter is `[EditorRequired]` and is set before Fusion creates the state, so the first render shows the actual item in its not-ready look and the computed state refines it a moment later.

Invariant for reviewers: the three razors deriving from `AttachmentItemBase` (`AttachmentItem`, `UploadAttachmentItem`, `FileUploadAttachment`) read `State.Value.Attachment` on every render, including the first, so the initial model must never carry a null attachment. Don't reintroduce a `Model.None`-style sentinel there.

## Testing

- AppKit Debug build (`net11.0-macos`): image paste and the attachment picker both show the tile immediately and keep the chat view; user-verified on device.
- Mac Catalyst Debug build: the failure was reproduced before the fix (paste and picker, same NullReferenceException at `AttachmentItem.razor:14`); the fixed build was not re-run on Catalyst.
- iOS/Android/Windows: same code path, not run.
- No unit tests cover this render path; none were added. No TypeScript changes, so `npm run build:Verify` was not needed.
- Unrelated: the same logs show a pre-existing NullReferenceException in `ChatSidePanelHeader.Chat` (error barrier "ChatSidePanel"); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
