### PR TITLE
fix(notifications): emoji glyph in FCM banners + reaction notifications that never clear

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -67,9 +67,15 @@ re-shows it.
 - **Reconciliation** — `src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs`
   prunes stale and creates missing notifications from `ListActive` (prune+create
   on web/Android, prune-only on iOS).
-- **In-app feed** — none. There is no rendered component that displays the active
-  set; it surfaces only as OS notifications, the app-icon badge, and incoming-call
-  rings. `/test/notifications` dumps it as JSON for diagnostics.
+- **Clearing an `OnView` kind** — `SeenNotificationDismisser.cs` dismisses reactions
+  and attention pings once their anchor entry is on screen. It runs off both
+  `ChatUI.ItemVisibility` *and* `ListActive`: a reaction to an entry the reader is
+  already looking at changes nothing the visibility state depends on. The reactions
+  tab dismisses on tap too — a tap doesn't guarantee the entry ends up visible.
+- **In-app feed** — only the reactions tab of the notifications panel
+  (`ChatList/ReactionNotifications/`) renders part of the active set. Everything else
+  surfaces as OS notifications, the app-icon badge, and incoming-call rings.
+  `/test/notifications` dumps the whole set as JSON for diagnostics.
 
   Note what this set is *not*: unread counts on chats and places drive the navbar
   and the bell panel, and are deliberately a different calculation. `ListActive`

--- a/src/dotnet/Api/Chat/Markup/MentionMarkup.cs
+++ b/src/dotnet/Api/Chat/Markup/MentionMarkup.cs
@@ -63,10 +63,11 @@ public abstract partial class MentionMarkup(MentionRef id, string name = "") : M
 
     private static string FormatEmojiReadable(EmojiMention em)
     {
-        // A standard unicode emoji copies as its glyph; a custom one copies as :its-id:.
+        // A known emoji reads as its glyph, including the custom variants, whose id is a slug
+        // ("ginger-clown"); an unknown one has no glyph to fall back on and reads as :its-id:.
         var text = em.EmojiRef.Text;
-        if (Emojis.BySymbol.ContainsKey(text))
-            return text;
+        if (Emojis.TryGetByIdOrSymbol(text) is { } emoji)
+            return emoji.Symbol;
 
         return ":" + text + ":";
     }

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -691,7 +691,10 @@ public class NotificationsBackend(IServiceProvider services)
             ? $"\"{authoredText}\""
             : entryContent.Render(l);
 
-        var content = new SharedNotificationContent(l.Notification_Reaction_Format(reaction.Emoji, text));
+        // Symbol, not the emoji itself: its Id is a slug for the custom variants ("ginger-clown"),
+        // and a push banner is plain text with no picker svg to render it with.
+        var content = new SharedNotificationContent(
+            l.Notification_Reaction_Format(reaction.Emoji.Symbol, text));
         await EnqueueMessageRelatedNotifications(
             entry.ChatId, entry.Id, reactionAuthor, content,
             NotificationKind.Reaction, similarityKey, "", userIds, (reaction.Emoji, text), cancellationToken)

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ReactionNotifications/ReactionNotificationItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ReactionNotifications/ReactionNotificationItem.razor
@@ -48,6 +48,10 @@
         return chat?.Title ?? "";
     }
 
-    private void OnClick()
-        => _ = History.NavigateTo(Notification.GetChatLink());
+    private void OnClick() {
+        // Dismissed here rather than left to SeenNotificationDismisser: it clears the notification
+        // only once the reacted-to entry is actually on screen, which a tap doesn't guarantee.
+        _ = Hub.UICommander.Run(new Notifications_Dismiss { Session = Session, NotificationId = Notification.Id });
+        _ = History.NavigateTo(Notification.GetChatLink());
+    }
 }

--- a/src/dotnet/UI.Blazor.App/Services/SeenNotificationDismisser.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SeenNotificationDismisser.cs
@@ -10,16 +10,21 @@ namespace ActualChat.UI.Blazor.App.Services;
 // you seen this".
 public sealed class SeenNotificationDismisser(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub)
 {
-    private readonly HashSet<NotificationId> _dismissed = [];
+    private readonly Dictionary<NotificationId, Moment> _dismissedSentAt = new();
 
     protected override Task OnRun(CancellationToken cancellationToken)
-        => AsyncChain.From(DismissSeen)
+        => Task.WhenAll(
+            RunChain(DismissOnVisibilityChanges, cancellationToken),
+            RunChain(DismissOnActiveChanges, cancellationToken));
+
+    private Task RunChain(Func<CancellationToken, Task> loop, CancellationToken cancellationToken)
+        => AsyncChain.From(loop)
             .Log(LogLevel.Debug, Log)
             .RetryForever(RetryDelaySeq.Exp(1, 60), Log)
             .CycleForever()
             .RunIsolated(cancellationToken);
 
-    private async Task DismissSeen(CancellationToken cancellationToken)
+    private async Task DismissOnVisibilityChanges(CancellationToken cancellationToken)
     {
         var cVisibility = await Computed
             .Capture(() => Hub.ChatUI.ItemVisibility.Use(cancellationToken), cancellationToken)
@@ -28,35 +33,67 @@ public sealed class SeenNotificationDismisser(AppUIHub hub) : UIWorkerBase<AppUI
             if (c.HasError)
                 continue;
 
-            var visibility = c.Value;
-            if (visibility.IsEmpty)
+            var active = await Hub.Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
+            await DismissSeen(active, c.Value, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // A reaction to an entry that's already on screen moves nothing the visibility state depends on,
+    // so on its own the visibility loop would leave it up until its lifespan runs out.
+    private async Task DismissOnActiveChanges(CancellationToken cancellationToken)
+    {
+        var cActive = await Computed
+            .Capture(() => Hub.Notifications.ListActive(Session, cancellationToken), cancellationToken)
+            .ConfigureAwait(false);
+        await foreach (var c in cActive.Changes(cancellationToken).ConfigureAwait(false)) {
+            if (c.HasError)
                 continue;
 
-            var active = await Hub.Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
-            var seen = active
-                .Where(n => n.DismissMode == NotificationDismissMode.OnView && IsSeen(n, visibility))
-                .ToList();
-            foreach (var notification in seen)
-                await Dismiss(notification, cancellationToken).ConfigureAwait(false);
+            await DismissSeen(c.Value, Hub.ChatUI.ItemVisibility.LastNonErrorValue, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task DismissSeen(
+        ApiArray<Notification> active,
+        ChatViewItemVisibility visibility,
+        CancellationToken cancellationToken)
+    {
+        if (visibility.IsEmpty)
+            return;
+
+        foreach (var notification in active) {
+            if (notification.DismissMode != NotificationDismissMode.OnView || !IsSeen(notification, visibility))
+                continue;
+
+            await Dismiss(notification, cancellationToken).ConfigureAwait(false);
         }
     }
 
     private async Task Dismiss(Notification notification, CancellationToken cancellationToken)
     {
         // ListActive lags the dismissal, so the same notification would otherwise be re-dismissed
-        // on every visibility change until it drops out.
+        // on every visibility change until it drops out. Keyed by SentAt rather than by id alone:
+        // a reaction's id is (user, entry), so the next reaction to the same entry reuses it and
+        // has to be dismissable again.
+        var id = notification.Id;
+        var sentAt = notification.SentAt;
         lock (Lock) {
-            if (!_dismissed.Add(notification.Id))
+            if (_dismissedSentAt.TryGetValue(id, out var dismissedSentAt) && dismissedSentAt >= sentAt)
                 return;
+
+            _dismissedSentAt[id] = sentAt;
         }
         try {
-            var command = new Notifications_Dismiss { Session = Session, NotificationId = notification.Id };
+            var command = new Notifications_Dismiss { Session = Session, NotificationId = id };
             await Commander.Call(command, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e) when (!e.IsCancellationOf(cancellationToken)) {
-            lock (Lock)
-                _dismissed.Remove(notification.Id);
-            Log.LogWarning(e, "Failed to dismiss seen notification {NotificationId}", notification.Id);
+            lock (Lock) {
+                if (_dismissedSentAt.TryGetValue(id, out var dismissedSentAt) && dismissedSentAt == sentAt)
+                    _dismissedSentAt.Remove(id);
+            }
+            Log.LogWarning(e, "Failed to dismiss seen notification {NotificationId}", id);
         }
     }
 

--- a/tests/Chat.UnitTests/MarkupFormatterTest.cs
+++ b/tests/Chat.UnitTests/MarkupFormatterTest.cs
@@ -44,6 +44,20 @@ public class MarkupFormatterTest
     }
 
     [Fact]
+    public void EmojiMentionShouldReadAsGlyph()
+    {
+        // act & assert
+        FormatEmoji(EmojiRef.New(Emojis.Clown)).Should().Be(Emojis.Clown.Symbol);
+        // A custom variant's id is a slug, so only its substitute symbol is readable
+        FormatEmoji(EmojiRef.New(Emojis.ClownGinger)).Should().Be(Emojis.ClownGinger.Symbol);
+        FormatEmoji(EmojiRef.FromText("no-such-emoji")).Should().Be(":no-such-emoji:");
+        return;
+
+        static string FormatEmoji(EmojiRef emojiRef)
+            => MarkupFormatter.ReadableUnstyled.Format(new EmojiMention(MentionRef.NewEmoji(emojiRef)));
+    }
+
+    [Fact]
     public void SpoilerShouldMaskMentionInside()
     {
         // arrange


### PR DESCRIPTION
Two reported issues with emoji (reaction) notifications.

## 1. FCM banner showed `ginger-clown` instead of 🤡

`Notification_Reaction_Format` was handed the `Emoji` object, whose `ToString()` is its **Id**. For the custom variants (`ClownGinger`, legacy `ClownYellow`) that Id is a slug, so the push read `ginger-clown to "Интересно. Окей."`. It now formats from `Emoji.Symbol`.

The same leak lived in `MentionMarkup.FormatEmojiReadable`: a custom emoji *inside* a message body rendered as `:ginger-clown:`, which reaches push bodies, quotes and chat-list previews. It now resolves through `Emojis.TryGetByIdOrSymbol` and keeps `:id:` only for an emoji with no glyph to fall back on.

## 2. Reaction notifications that don't disappear when clicked

A reaction's `DismissMode` is `OnView`, so nothing clears it except `SeenNotificationDismisser` seeing the anchor entry on screen. Three gaps let one sit there until its 1-day `ReactionLifespan` ran out:

- **The re-dismissal guard was keyed by `NotificationId` alone**, but a reaction's id is `(user, entry)`. Once an entry's reaction notification had been dismissed, *every later reaction to that same message was permanently undismissable*. Now keyed by `SentAt` per id.
- **It only ran off `ChatUI.ItemVisibility` changes.** A reaction to an entry the reader is already looking at moves nothing that state depends on, so it was never evaluated. A second loop now runs off `ListActive` changes too — same two-chain shape as `NotificationReconciler`.
- **The reactions tab only navigated on tap**, leaving dismissal to the entry showing up on screen, which a tap doesn't guarantee. `ReactionNotificationItem` now dismisses explicitly.

`docs/notifications.md` picks up the dismissal path; its "In-app feed — none" line was already stale (the reactions tab does render part of the active set).

## Test plan

- `Chat.UnitTests` — 607 passed, incl. a new `MarkupFormatterTest.EmojiMentionShouldReadAsGlyph`
- `Chat.UI.Blazor.UnitTests` — 814 passed
- `UI.Blazor.App` and `Notifications.Service` build clean
- Not exercised on a device: needs a second account reacting twice to the same message to hit the guard bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAY2P9ctSFnmueANWxMby8