### PR TITLE
fix(chat): stop two chat-list oscillations, plus three rendering bugs

### DIFF
--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -752,8 +752,8 @@ holding the view somewhere. Then two tiers:
   user scrolled to, and the nearest place it puts content on screen is where scrolling itself would have
   stopped.
 
-Deliberately **not** gated on the height animations that `applyLayout`'s own clamp waits for: the limits
-are built from the model, which carries settled heights (§3.10), so the guard reads the same numbers the
+Deliberately **not** gated on height animations — and neither is `applyLayout`'s own clamp any more: the
+limits are built from the model, which carries settled heights (§3.10), so both read the same numbers the
 settled pass would. Persistence across checks is what separates a fault from a frame in transit.
 
 It is a backstop, not the mechanism: with the collapse handled where it happens (§3.9) and the settled
@@ -765,11 +765,42 @@ cases we have not found.
 `clampToLimits` always **snaps**. It early-returns while a finger is down or an excursion is open, and
 `applyLayout` skips it while the list is pinned.
 
-**Mid-animation it is deferred, not skipped.** The clamp needs the real sizes and the DOM does not have
-them yet, so `applyLayout` books the settled pass instead — which an unpinned list has to book for
-itself, `repinWhenStable` otherwise being reached only from the pinned path. Left to that path alone, a
-block collapsing under a view that is not at an edge got no clamp at all: the render skipped it for the
-animation, and nothing re-ran it afterwards.
+**Mid-animation it still clamps, and books the settled pass as well.** The settled pass owns the re-pin
+and the drift check; it does not own the clamp. Deferring the clamp to it was safe only while animations
+were things that end. A live transcript renews an animation hold on every rewrite, so `whenStable` never
+resolves and a deferred clamp is never delivered — while the limits move regardless, being built from
+the model, which already carries settled heights (§3.10). A free list has no follow to answer that with,
+so it sits still while the limits walk past it and the blank under the newest message grows, until the
+position guard pays the whole of it in one frame. `applyLayout` still books `repinWhenStable` for an
+unpinned list, which is otherwise reached only from the pinned path.
+
+**A clamp is deferred, never dropped.** All three clamp sites — the layout, the settled pass and the
+standing guard — share one predicate, `canClamp`: the position is this list's to move
+(`canCorrectPosition`), no follow and no jump is already booked, and no screen or interactive anchor is
+deliberately holding the view. The follow is in there because it carries a delta measured before the
+clamp would run: clamping first leaves that delta describing a distance the view no longer has, and the
+pair lands twice. The layout and the settled pass go through `clampOrRetry`, which re-arms at
+`FollowRetryHz` when the predicate refuses, for the same reason the follow retries — everything that
+blocks a clamp clears on its own, and nothing re-runs the layout that produced no correction. The
+standing guard needs no retry; it is already on a clock.
+
+One consequence to know before touching `canClamp`: the layout clamp used to be unconditional for an
+unpinned, non-animating list, so sharing the predicate also makes it yield to the two anchors. Collapsing
+a block from its sticky header while reading deep inside it, in a chat with nothing else moving, now waits
+for `watchScreenAnchor` to release — a blank of roughly 200ms where there was none. Under a live
+transcript the same case is still strictly better, because the old code never clamped there at all.
+
+What this does **not** fix is the size of a single correction. The model carries the settled height from
+the moment the height controller writes it, so one large shrink target is one large clamp, taken at once
+rather than a second later; the reader's row still steps. Measured on a live chat, unpinned 40px above
+the End, one 200px shrink of an item above the reader with a second item keeping animations alive:
+before, the reader's row drifted **203px up** over the transition, sat **351ms** with the view **160px**
+out of band and a blank beneath it, then snapped back in one frame; after, the upward excursion is
+**44px**, the view is never out of band (peak 0.3px, 0 frames), and the correction is a single **159px**
+frame. Continuous churn is where the difference is largest: 44% of frames out of band and a stored-up
+214px discharge, against 0 frames and no discharge. Making the correction *track* the transition rather
+than its endpoint would mean measuring the rendered shortfall per frame, which `followBy` cannot express
+— it clamps to the same model limits.
 
 Handing an out-of-band position to the return instead looked like the gentler option and was
 tried, and it produced the Android "stops at random places while you spin it" bug: `applyLayout` clamps

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -29,6 +29,9 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     private MutableState<long> _shownReadEntryLid = null!;
     private bool _wasChatViewVisible = true;
     private MutableState<ChatViewNavigation?> _nextNavigation = null!;
+    // What entitles GetData to move the reader to the first unread message - see that redirect. Reactive
+    // and identity-compared like _nextNavigation, so retiring it invalidates the builds that read it.
+    private MutableState<ChatViewActivation?> _activation = null!;
     // Both are touched by GetData on the pool, by UpdateReadState's chain and by the visibility report on the
     // dispatcher: the line bookkeeping is one immutable snapshot swapped as a reference, the lid is Interlocked
     private NewMessagesLineState _newMessagesLineState = NewMessagesLineState.None;
@@ -109,6 +112,11 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             _nextNavigation = StateFactory.NewMutable(
                 (ChatViewNavigation?)null,
                 StateCategories.Get(type, nameof(_nextNavigation)));
+            // Opening the view is itself an activation - that's what puts a chat with unread messages
+            // on its first unread one.
+            _activation = StateFactory.NewMutable(
+                (ChatViewActivation?)new ChatViewActivation(),
+                StateCategories.Get(type, nameof(_activation)));
             _shownReadEntryLid = StateFactory.NewMutable(
                 0L,
                 StateCategories.Get(type, nameof(ShownReadEntryLid)));
@@ -313,6 +321,10 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
         var lastItemVisibility = ItemVisibility.Value;
         var itemVisibility = new ChatViewItemVisibility(virtualListItemVisibility);
+        // Content is on screen, so there is nothing left for an activation to restore. Above the identity
+        // check below, because a report that repeats the previous one says that just as well.
+        if (!itemVisibility.IsEmpty && _activation is { Value: not null })
+            _activation.Value = null;
         if (itemVisibility.IsIdenticalTo(lastItemVisibility)
             && !ReferenceEquals(lastItemVisibility, ChatViewItemVisibility.Empty))
             return;
@@ -389,6 +401,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
         // Back on screen: unread tracking starts over
         _shownReadEntryLid.Value = ReadPosition.Value.EntryLid;
         ResetNewMessagesLineState();
+        _activation.Value = new ChatViewActivation();
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
@@ -519,6 +532,12 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             ?? (isFirstRender && hasViewEntry ? new ChatViewNavigation(viewEntryLid, false, false, true) : null);
         if (ReferenceEquals(nav, renderedData.NavigationState)) // Handles null case as well
             nav = null;
+        // Spent the way nav is: only a rendered result counts, so one ComputeState discards - taking the
+        // redirect with it - doesn't consume the activation.
+        var renderedActivation = (renderedData.Metadata as ChatViewMetadata)?.Activation;
+        var activation = await _activation.Use(cancellationToken).ConfigureAwait(false);
+        if (ReferenceEquals(activation, renderedActivation))
+            activation = null;
 
         var mustScrollToEntry = nav != null && ItemVisibility.Value.IsScrollRequired(nav.EntryLid);
         if (isFirstGetData)
@@ -680,8 +699,11 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 .FirstOrDefault(message => !message.ShouldSkipKey)
                 ?.Key.Value;
         if (firstUnreadKey != null) {
-            if (scrollToKey == null && itemVisibility.IsEmpty) {
-                // Tab resume: no explicit nav, viewport empty — scroll to first unread
+            if (scrollToKey == null && itemVisibility.IsEmpty && activation != null) {
+                // Activated with nothing on screen: put the reader on the first unread message. Gated on
+                // the activation, not on the empty visibility alone - a fling into history that outruns
+                // the loader empties the viewport the same way, and the redirect then teleports the
+                // reader back to the unread line, which empties it again on their next fling.
                 scrollToKey = firstUnreadKey;
                 scrollToKeyInTheMiddle = true;
             }
@@ -693,6 +715,10 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 scrollToKeyInTheMiddle = true;
             }
         }
+
+        // Content on screen spends it too, not just an accepted position: a region that flips back over
+        // a full viewport emits no report, so the retire in OnItemVisibilityChanged never runs.
+        var usedActivation = scrollToKey != null || !itemVisibility.IsEmpty ? activation : null;
 
         var buildMs = (long)buildStartedAt.Elapsed.TotalMilliseconds;
         if (buildMs > 1000)
@@ -712,7 +738,7 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             ScrollToKeyInTheMiddle = scrollToKeyInTheMiddle,
             NavigationState = nav ?? renderedData.NavigationState,
             ItemVisibilityState = ItemVisibility.Value,
-            Metadata = new ChatViewMetadata(chat.IsSummarized ?? false),
+            Metadata = new ChatViewMetadata(chat.IsSummarized ?? false, usedActivation ?? renderedActivation),
         };
 
         if (isFirstGetData)
@@ -720,7 +746,9 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
                 $"{items.Count} items, build={buildMs}ms, scrollToKey={scrollToKey}");
 
         // do not return new instance if data is the same to prevent re-renders
-        return !mustScrollToEntry && result.IsSimilarTo(renderedData)
+        // IsSimilarTo ignores Metadata, so a spent activation has to keep the result alive itself -
+        // dropped here, no later build could tell it apart from one that was never spent.
+        return !mustScrollToEntry && usedActivation == null && result.IsSimilarTo(renderedData)
             ? renderedData
             : result;
     }
@@ -967,7 +995,18 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
     // Nested types
 
-    private sealed record ChatViewMetadata(bool IsSummarized);
+    private sealed record ChatViewMetadata(bool IsSummarized, ChatViewActivation? Activation = null);
+
+    /// <summary>
+    /// One activation of the view - opening it, or its region coming back from hidden - entitled to one
+    /// automatic move to the first unread message. It carries nothing but its identity.
+    /// </summary>
+    private sealed record ChatViewActivation
+    {
+        // This record relies on referential equality
+        public bool Equals(ChatViewActivation? other) => ReferenceEquals(this, other);
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+    }
 
     private sealed record NewMessagesLineState(
         CpuTimestamp ShownAt,

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -839,8 +839,12 @@ body.narrow .chat-view.virtual-list > .c-wrapper > ul.c-virtual-container > li {
     @apply text-text-1;
 }
 
+/* Wraps where the markup under it wraps, or the two paint as a smear: `inset: 0` is the padding box,
+   and .playable-text-markup / .plain-text-markup lay their text out under `break-spaces`. */
 .temporary-container {
     @apply absolute inset-0 z-minus;
+    @apply whitespace-break-spaces;
+    padding-right: inherit;
     animation: smoothHide 0.5s ease-in forwards;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/UrlMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/UrlMarkupView.razor
@@ -6,8 +6,9 @@
 
 @if (_isGifImage) {
     <div class="gif-message-wrapper">
-        <img class="gif-message" src="@_gifSrc" alt="" loading="lazy"/>
-        <img class="gif-watermark" src="/dist/images/klipy/klipy-light-text.png" alt="KLIPY" draggable="false" aria-hidden="true"/>
+        <image-skeleton class="gif-message" src="@_gifSrc" initial-state="skeleton"/>
+        <img class="gif-watermark" src="/dist/images/klipy/klipy-light-text.png"
+             alt="KLIPY" draggable="false" aria-hidden="true"/>
     </div>
     return;
 }
@@ -84,13 +85,16 @@
         }
     }
 
+    // Protected/internal methods
+
     internal static string GetHrefUrl(UrlMarkup markup)
         => markup.Kind is UrlMarkupKind.Www && markup.Url.StartsWith("www.")
             ? "https://" + markup.Url
             : markup.Url;
 
-    private LocalUrl? TryGetLocalUrl(string url)
-    {
+    // Private methods
+
+    private LocalUrl? TryGetLocalUrl(string url) {
         url = url.EnsureSuffix("/");
         if (url.StartsWith(Nav.BaseUri))
             return new LocalUrl(Nav.ToBaseRelativePath(url));
@@ -107,5 +111,6 @@
     }
 
     // Nested types
+
     private enum LinkRenderMode { Default, LinkPreview, Local }
 }

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
@@ -106,6 +106,21 @@
     @apply max-w-64 md:max-w-96 max-h-64 md:max-h-80;
     @apply rounded-lg;
 }
+/* Nothing to size to until the bitmap arrives, so the box is held square meanwhile. Width tracks the
+   height cap per breakpoint - a wider one would be clipped back to a rectangle by max-h. */
+.gif-message:not([data-image-state="original"]) {
+    @apply w-64 md:w-80;
+    aspect-ratio: 1 / 1;
+}
+.gif-message[data-image-state="original"] {
+    @apply w-fit;
+}
+/* image-skeleton fills its host and crops by default, which is right for an avatar and wrong for a GIF. */
+.gif-message[data-image-state="original"] .image {
+    @apply w-auto h-auto;
+    @apply object-contain;
+    @apply max-w-64 md:max-w-96 max-h-64 md:max-h-80;
+}
 .gif-watermark {
     @apply absolute bottom-1 left-1;
     @apply h-3 w-auto;

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -111,9 +111,8 @@ export interface RemoteStreamDiagnostics {
     bytesReceived: number;
     // Cumulative frames presented.
     presented: number;
-    // Per-tick instantaneous rates, computed at the latency-tap boundary
-    // (≈ 1 Hz) where the wall-clock dt is known. Display these directly to
-    // avoid the beat-frequency artifact from cross-cadence sampling.
+    // Per-tick instantaneous rates over the latency-tap's own sample window
+    // (≈ 1 Hz). Display these directly rather than re-deriving from the counters.
     presentedPerSec: number;
     bytesPerSec: number;
     // Per-FrameDropStage drop rates; same provenance as presentedPerSec.
@@ -212,19 +211,17 @@ export class VideoPlayer {
 
     // Diagnostics counters
     private renderFrameCount = 0;       // bumped from worker latency reports (frames presented)
-    // Mirror of worker-side PlayerStats.presented, updated on every
-    // latency-tap sample. Captured separately because `renderFrameCount`
-    // is incremented once per sample (≈ 1 Hz), so it can't drive
-    // per-second FPS readouts on its own.
+    // Mirror of worker-side PlayerStats.presented. Separate from `renderFrameCount`,
+    // which is bumped once per sample (≈ 1 Hz) and so can't drive an FPS readout.
     private presentedFrameCount = 0;
-    // Per-tick instantaneous rates computed at the latency-tap boundary
-    // where the wall-clock dt is known. Resampling cumulative counters at a
-    // different cadence creates a beat-frequency artifact — same class of
-    // bug as on the sender side; same fix applied uniformly across every
-    // cumulative counter (presented, bytesReceived, per-stage drops).
+    // Per-tick instantaneous rates over the latency-tap's own `sampledAtMs`
+    // window; dividing by main-thread arrival gaps instead inflates them.
     private presentedPerSec = 0;
     private bytesPerSec = 0;
     private readonly dropPerSec = new Map<number, number>();
+    // Shortest window a rate may be computed over. latencyTap also fires out of
+    // cadence on a rotation change, which is far too narrow to divide by.
+    private static readonly minRateWindowMs = 100;
     private lastLatencyTickMs = 0;
     private lastPresentedAtTick = 0;
     private lastBytesAtTick = 0;
@@ -239,10 +236,8 @@ export class VideoPlayer {
     private receivedKeyframeCount = 0;
     private receivedBytes = 0;
     private firstFrameReceivedTime = 0;
-    // Ring buffer of (atMs, cumulativeBytes) samples for a windowed
-    // IncomingByteRate. Cumulative-since-start would let an initial keyframe
-    // burst dominate the rate for many seconds and the receiver-side QC peak
-    // would lock the allocator into the wrong layer.
+    // Ring buffer of (atMs, cumulativeBytes) for a windowed IncomingByteRate:
+    // cumulative-since-start lets a keyframe burst lock QC into the wrong layer.
     private readonly bytesSamples: { atMs: number; bytes: number }[] = [];
     private static readonly bytesWindowMs = 3000;
     private forwardedLayerId = -1;
@@ -1402,34 +1397,32 @@ export class VideoPlayer {
         if (this.restartAttempts > 0)
             this.restartAttempts = 0;
 
-        const nowMs = performance.now();
-        if (this.lastLatencyTickMs > 0) {
-            const dt = nowMs - this.lastLatencyTickMs;
-            if (dt > 0) {
-                const scale = 1000 / dt;
-                this.presentedPerSec = Math.max(0, this.presentedFrameCount - this.lastPresentedAtTick) * scale;
-                this.bytesPerSec = Math.max(0, this.receivedBytes - this.lastBytesAtTick) * scale;
-                const framesDelta = Math.max(0,
-                    sample.playerStats.framesDecoded - this.lastFramesDecodedAtTick);
-                // Deficit must count only frames that were lost, not frames still
-                // in flight. Subtracting decoderQueueSize (in-flight) from arrived
-                // makes input and output deltas line up under bursty/jittery
-                // delivery, so a non-empty pipeline that keeps pace reads 0 — and
-                // the stale-spike-at-queue-0 artifact disappears as the queue drains.
-                const effectiveChunks =
-                    sample.playerStats.chunksReceived - sample.playerStats.decoderQueueSize;
-                const effectiveChunksDelta = Math.max(0, effectiveChunks - this.lastEffectiveChunks);
-                this.decodeDeficitTicker.tick(framesDelta, effectiveChunksDelta);
-                this.dropPerSec.clear();
-                for (const [stage, count] of sample.playerStats.dropTrace) {
-                    const prev = this.lastDropAtTick.get(stage) ?? 0;
-                    const rate = Math.max(0, count - prev) * scale;
-                    if (rate > 0) this.dropPerSec.set(stage as number, rate);
-                }
+        const tickMs = sample.sampledAtMs;
+        const dt = tickMs - this.lastLatencyTickMs;
+        if (this.lastLatencyTickMs > 0 && dt >= VideoPlayer.minRateWindowMs) {
+            const scale = 1000 / dt;
+            this.presentedPerSec = Math.max(0, this.presentedFrameCount - this.lastPresentedAtTick) * scale;
+            this.bytesPerSec = Math.max(0, this.receivedBytes - this.lastBytesAtTick) * scale;
+            const framesDelta = Math.max(0,
+                sample.playerStats.framesDecoded - this.lastFramesDecodedAtTick);
+            // Deficit must count only frames that were lost, not frames still
+            // in flight. Subtracting decoderQueueSize (in-flight) from arrived
+            // makes input and output deltas line up under bursty/jittery
+            // delivery, so a non-empty pipeline that keeps pace reads 0 — and
+            // the stale-spike-at-queue-0 artifact disappears as the queue drains.
+            const effectiveChunks =
+                sample.playerStats.chunksReceived - sample.playerStats.decoderQueueSize;
+            const effectiveChunksDelta = Math.max(0, effectiveChunks - this.lastEffectiveChunks);
+            this.decodeDeficitTicker.tick(framesDelta, effectiveChunksDelta);
+            this.dropPerSec.clear();
+            for (const [stage, count] of sample.playerStats.dropTrace) {
+                const prev = this.lastDropAtTick.get(stage) ?? 0;
+                const rate = Math.max(0, count - prev) * scale;
+                if (rate > 0) this.dropPerSec.set(stage as number, rate);
             }
         }
 
-        this.lastLatencyTickMs = nowMs;
+        this.lastLatencyTickMs = tickMs;
         this.lastPresentedAtTick = this.presentedFrameCount;
         this.lastBytesAtTick = this.receivedBytes;
         this.lastChunksReceivedAtTick = sample.playerStats.chunksReceived;

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -1378,13 +1378,16 @@ export class VideoPlayer {
         // this `IncomingByteRate` was always 0, VideoQualityUI verdict
         // pegged at -1, and the allocator capped every stream at L0.
         this.receivedBytes = sample.bytesReceived;
-        const nowMsForSample = performance.now();
+        // Main clock, and it has to stay that way: streamAgeMs subtracts it from performance.now().
+        const mainNowMs = performance.now();
         if (this.firstFrameReceivedTime === 0) {
-            this.firstFrameReceivedTime = nowMsForSample;
+            this.firstFrameReceivedTime = mainNowMs;
             this.placeholderEl?.classList.add('has-frame');
         }
-        this.bytesSamples.push({ atMs: nowMsForSample, bytes: this.receivedBytes });
-        const cutoff = nowMsForSample - VideoPlayer.bytesWindowMs;
+        // Tap clock, because the byte counts come from the same worker snapshot. Stamped on delivery
+        // instead, a main-thread stall evicts the window and prices ~1s of bytes over ~0.5ms.
+        this.bytesSamples.push({ atMs: sample.sampledAtMs, bytes: this.receivedBytes });
+        const cutoff = sample.sampledAtMs - VideoPlayer.bytesWindowMs;
         while (this.bytesSamples.length > 1 && this.bytesSamples[0].atMs < cutoff)
             this.bytesSamples.shift();
 

--- a/src/dotnet/UI.Blazor.App/Services/Video/operators/latency-tap.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/operators/latency-tap.ts
@@ -6,6 +6,9 @@ import type { RotationQuarter } from 'orientation';
 const { debugLog } = getLogs('VideoPipeline');
 
 export interface LatencySample {
+    // Worker-local `performance.now()` at sample time. Rate deltas must divide by
+    // this, not by main-thread arrival times — jank compresses those to microseconds.
+    sampledAtMs: number;
     frameAgeMs: number;
     // Cross-clock approximation: sender/receiver MonotonicClocks share a Unix anchor
     // but drift independently — soft KPI, not an SLO.
@@ -61,11 +64,13 @@ export function latencyTap(opts: LatencyTapOptions): PipeOperator<DecodedFrame, 
         try {
             const nowMs = now();
             const rotationChanged = envelope.rotation !== lastReportedRotation;
-            if (!rotationChanged && nowMs - lastReportAtMs < intervalMs) return;
+            if (!rotationChanged && nowMs - lastReportAtMs < intervalMs)
+                return;
 
             lastReportAtMs = nowMs;
             lastReportedRotation = envelope.rotation;
             report({
+                sampledAtMs: nowMs,
                 frameAgeMs: nowMs - envelope.decodedAt.timeMs,
                 e2eLatencyMs: nowMs - envelope.capturedAt.timeMs,
                 capturedAtMs: envelope.capturedAt.timeMs,

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -250,6 +250,7 @@ export class InfiniteList extends VirtualList {
     // echo from the user.
     private isFollowScheduled = false;
     private isFollowDeferred = false;
+    private isClampScheduled = false;
     private lastFollowTop: number | null = null;
     private pendingJump: Jump | null = null;
     private isAwaitingStability = false;
@@ -841,14 +842,17 @@ export class InfiniteList extends VirtualList {
         if (this.pinnedEdge != null)
             return;
 
-        // Clamping needs the real sizes, and mid-animation the DOM does not have them yet, so it waits
-        // for the settled pass instead - which an unpinned list has to book for itself. Left to the
-        // pinned path alone, a block that collapses under a view that is not at an edge got no clamp
-        // at all: the render skipped it for the animation, and nothing re-ran it afterwards.
+        // The settled pass is still booked - it owns the re-pin and the drift check - but the clamp no
+        // longer waits for it. Waiting was safe only while animations were things that end: a live
+        // transcript renews a hold every time it rewrites a message, so whenStable never resolves and
+        // the clamp deferred to it is never delivered. The limits move all the same, being built from
+        // the model, which already carries settled heights - and a free list, having no follow to
+        // answer with, sits still while they walk past it. What the user gets is a blank growing under
+        // the newest message until the position guard pays the whole of it in one frame, measured at
+        // 332px against a live transcript.
         if (this.stability.isAnimating)
             this.repinWhenStable();
-        else
-            this.scrollController.clampToLimits();
+        this.clampOrRetry();
     }
 
     // Sticky elements are clamped during layout, against the real scroll position, and the band's
@@ -1244,6 +1248,41 @@ export class InfiniteList extends VirtualList {
             && !this.scrollController.isOverscrollActive;
     }
 
+    // Whether a clamp of the list's own may land: the position is this list's to move, and nothing
+    // else already owns it - a follow or a jump already booked, or a click deliberately holding the
+    // view. The follow matters because it carries a delta measured before this would run: clamping
+    // first leaves that delta describing a distance the view no longer has, and it lands twice.
+    private get canClamp(): boolean {
+        return this.canCorrectPosition
+            && !this.isFollowScheduled
+            && this.pendingJump == null
+            && !this.hasFreshScreenAnchor()
+            && this.getFreshInteractiveAnchorKey() == null;
+    }
+
+    // A clamp the list may not make yet is retried rather than dropped: everything that blocks one -
+    // a gesture settling, an excursion, a booked correction, an anchor being held - clears on its own,
+    // and nothing re-runs the layout that produced no correction. Same rate and the same reason as the
+    // follow's retry. Costs nothing when there is nothing to clamp: clampToLimits is a no-op in band.
+    private clampOrRetry(): void {
+        if (this.canClamp) {
+            this.scrollController.clampToLimits();
+            return;
+        }
+        if (this.isClampScheduled)
+            return;
+
+        this.isClampScheduled = true;
+        fastRaf({
+            hz: FollowRetryHz,
+            write: () => {
+                this.isClampScheduled = false;
+                if (!this.isDisposed)
+                    this.clampOrRetry();
+            },
+        });
+    }
+
     private measureFollow(): number {
         const edge = this.pinnedEdge;
         if (this.isDisposed || edge == null || this.items.length === 0)
@@ -1289,8 +1328,8 @@ export class InfiniteList extends VirtualList {
     }
 
     // Anything that had to wait for the list to stop moving: the edge re-pin an animation grew away
-    // from, the clamp that needed the settled sizes, and the direction switch that would have written
-    // scrollTop mid-gesture.
+    // from, and the direction switch that would have written scrollTop mid-gesture. Not the clamp -
+    // it reads the model's settled heights, so it no longer waits for anything to settle.
     private repinWhenStable(): void {
         if (this.isAwaitingStability)
             return;
@@ -1302,11 +1341,10 @@ export class InfiniteList extends VirtualList {
                 return;
 
             this.repinEdge('settled');
-            // Not when the re-pin booked a follow for the next frame: that write is the correction, and
-            // a clamp landing first is exactly the scroll write the re-pin exists to avoid. The follow
-            // clamps into the limits itself, and the next settle runs this again.
-            if (!this.isFollowScheduled)
-                this.scrollController.clampToLimits();
+            // A follow booked for the next frame is the correction, and a clamp landing first is
+            // exactly the scroll write the re-pin exists to avoid - canClamp holds this off until that
+            // write has landed, rather than dropping it.
+            this.clampOrRetry();
             this.checkModelDrift('settled');
         });
     }
@@ -2266,22 +2304,15 @@ export class InfiniteList extends VirtualList {
         });
     }
 
-    // The standing check on where the view actually is. Every other correction runs off an event -
-    // a render, a settle, a scroll - and the case none of them covers is a block collapsing under an
-    // unpinned view: the render's clamp waits for the settled sizes, the settle it waits for is a
-    // pinned list's, and what the user is left looking at is blank, which gives them nothing to scroll
-    // with to raise the scroll event that would fix it. So this asks on its own clock instead.
+    // The standing check on where the view actually is: every other correction runs off an event, and
+    // a block collapsing under an unpinned view leaves blank that the user cannot scroll to raise one.
     private checkPosition(): void {
         if (this.isDisposed || this.items.length === 0 || !this.isInitiallyPlaced)
             return;
         // A finger, a fling, a bounce or a correction already booked all own the position, and a
         // fresh anchor means a click of the user's is deliberately holding it somewhere.
-        if (!this.canCorrectPosition
-            || this.scrollController.isOverscrollRecent(PositionGuardOverscrollQuietMs)
-            || this.pendingJump != null
-            || this.isFollowScheduled
-            || this.hasFreshScreenAnchor()
-            || this.getFreshInteractiveAnchorKey() != null)
+        if (!this.canClamp
+            || this.scrollController.isOverscrollRecent(PositionGuardOverscrollQuietMs))
             return;
 
         const clientHeight = this.ref.clientHeight;

--- a/tests/ts/unit/operators/latency-tap.test.ts
+++ b/tests/ts/unit/operators/latency-tap.test.ts
@@ -134,6 +134,26 @@ describe('latencyTap', () => {
         expect(samples[0].layerId).toBe(2);
     });
 
+    it('sampledAtMs carries the tap clock, so the consumer can size its rate window', async () => {
+        const stats = createEmptyPlayerStats();
+        const samples: LatencySample[] = [];
+        const nowValues = [1_000, 2_000];
+        let nowIdx = 0;
+        const items = nowValues.map((t, i) => makeEnvelope(stats, i, {
+            capturedTimeMs: t - 50,
+            decodedTimeMs: t - 5,
+        }));
+
+        const op = latencyTap({
+            intervalMs: 1_000,
+            now: () => nowValues[nowIdx++],
+            report: s => samples.push(s),
+        });
+        await drain(op(source(items)));
+
+        expect(samples.map(s => s.sampledAtMs)).toEqual(nowValues);
+    });
+
     it('default intervalMs is 1000 ms; default now is Date.now', async () => {
         const stats = createEmptyPlayerStats();
         const samples: LatencySample[] = [];


### PR DESCRIPTION
## Summary

Five rendering bugs found in three bug reports under `tmp/bugs/` (two screen recordings and a screenshot). Two of them are chat-list oscillations — closed feedback loops, not one-shot glitches — and they are independent of each other.

**1. The list stopped clamping while item heights animated.** An unpinned list handed its clamp to `repinWhenStable()` whenever `stability.isAnimating`. That is safe only while animations are things that end: a live transcript renews the hold every time it rewrites a message, so `whenStable` never resolves and the clamp is never delivered. The limits move anyway — they are built from the model, which already carries settled heights — so a free list sits still while they walk past it. A blank opens under the newest message and grows until a backstop pays the whole accumulated error in one frame (measured discharges 108 → 332px). The legs do not cancel (up 204px, down 160px), so every trip costs ~43px of reading position. The decisive evidence was a negative: eight `applyLayout('relayout')` calls and **zero** `clampToLimits` across an 800ms 496px excursion.

**2. An empty viewport was read as "the tab was just resumed".** `GetData` redirected the reader to the first unread message whenever `itemVisibility.IsEmpty`. A fling into history that outruns the loader empties the viewport identically: every item leaves the chain into the start spacer (whose children *are* the skeletons), the redirect fires, the list teleports back to the unread line, and the next fling empties it again. The branch re-derived on every build, so it re-armed continuously. Captured two full cycles in one run — `CONTENT → SKEL → jump +5029px → CONTENT → SKEL → jump +6780px` — each jump preceded by a render carrying `ScrollToKey`, `visible:0`. The control run is what pins it: same chat, same unread separator, same flings, loads fast → `vis==0` on 0 of 2431 frames, no target emitted, no jump.

**3. The fade-out overlay wrapped differently than the text it covered.** When a message stops streaming, the last streamed transcript is kept as `.temporary-container` and faded out over the incoming final markup. `inset: 0` resolves against the padding box, making the overlay 6px wider than `.chat-message-markup`'s content box, and its bare `<span>` wraps under `normal` while the markup wraps under `break-spaces`. Either difference pulls a word onto the previous line, and once one line breaks differently every line below it does — the two copies paint as a smear for the length of the fade.

**4. The fps badge divided a worker's frame delta by the main thread's delivery gap.** `latencyTap` stamps the counters in the player worker; `onWorkerLatencyReport` measured `dt` with the main thread's `performance.now()`, which is the gap between *message deliveries*. Each worker message is its own task, so when the main thread stalls the 1 Hz reports queue and drain back-to-back: the numerator still covers a second of frames while the denominator collapses. Both observed readings reduce to the same physically correct ~20-frame numerator — `44286 fps` is dt = 0.45ms, `335 fps` is dt = 59.7ms — which is what rules out a counter reset, a wraparound, or a zero dt.

**5. A failed GIF left a blank row that still showed its reactions.** A trusted GIF URL renders as an `<img>` through the image proxy and returns early, so the link is never rendered. The `<img>` has an empty `alt` and no reserved size, so a failed proxy fetch collapses it to 0×0; the KLIPY watermark, absolute to the now zero-height wrapper, is clipped. Reactions survive because they are read from the entry, not the markup. Confirmed against the real entry rather than inferred — a bare `static.klipy.com/….gif` URL, `isRemoved: false`, no attachments, no LID gap.

## Fix

Six commits, one per distinct concern. Review follow-ups are folded into the commits they fix, and the branch was cleaned up before merge — an earlier GIF attempt built its own error handling and failed-src memo, and that dead end is folded away rather than landing in `dev` for the next commit to delete.

- **`infinite-list.ts`** — the settled pass still owns the re-pin and the drift check; the clamp no longer waits for it. The three clamp sites share one `canClamp` predicate, and a clamp that may not land yet is retried at `FollowRetryHz` rather than dropped, because nothing re-runs the layout that produced no correction. `docs/ui/virtual-list.md` updated to match. **This does not remove the single-frame step** (159px worst case): the model carries the settled height as a whole, so a large shrink is still a large clamp — taken at once instead of a second later.
- **`ChatView.razor.cs`** — the entitlement to move the reader is now explicit. A `ChatViewActivation` token is armed when the view opens and when its region returns from hidden, and spent by an accepted position **or by content already being on screen**. Reactive and identity-compared like `_nextNavigation`, so retiring it invalidates in-flight builds. **Two invariants a reviewer must not break:** the token has to be retired above the `IsIdenticalTo` early-return in `OnItemVisibilityChanged`; and `IsSimilarTo` ignores `Metadata`, so a spent activation keeps the result alive itself — drop that and no later build can tell a spent token from one never spent. Spending on content is what makes the retire independent of a JS visibility report, which a region flip over a full viewport never emits.
- **`chat-view.css`** — `.temporary-container` gets `whitespace-break-spaces` and `padding-right: inherit`.
- **`latency-tap.ts` / `video-player.ts`** — `LatencySample` carries `sampledAtMs`, the tap's own clock at the instant it read the counters, so both ends of the window come from one clock. The `dt > 0` guard becomes a 100ms floor, which also drops the deliberately out-of-cadence rotation sample from the rate.
- **`video-player.ts`, the byte-rate window** — `peekWindowedBytesPerSec` had the **same clock mismatch**, but its output feeds `VideoQualityUI` layer allocation rather than a readout: a stall longer than the 3s window evicted every prior sample and priced ~1s of bytes over the ~0.5ms gap between two queued reports, handing the allocator a bitrate spike of three orders of magnitude. The ring is now stamped with the tap clock. **`firstFrameReceivedTime` deliberately stays on the main clock** — `streamAgeMs` subtracts it from `performance.now()`, so moving both would have recreated the very bug being fixed; the local is renamed `mainNowMs` to keep that visible.
- **`UrlMarkupView.razor` / `markup-parts.css`** — the GIF renders through the existing `<image-skeleton>` Lit component instead of a bare `<img>`, the same one avatars, attachments and the media viewer use. It already owns the error handling, the failed-src memo, and a retry this path never had: backoff over 10 attempts, re-fetching via `fetch`+blob so a transient proxy failure recovers, holding a skeleton while it does. A GIF has no dimensions until its bitmap arrives, so the box is held square meanwhile — width tracking the **height** cap per breakpoint, since `md:w-96` under `max-h-80` would be clipped back to a rectangle. `image-skeleton`'s own `.image` fills and crops, right for an avatar and wrong here, so it sizes naturally under the original caps once loaded. A GIF that never loads stays a skeleton; no link is rendered.

Bugs 1 and 2 were each worked jointly with Codex as navigator, which is worth knowing because it changed both outcomes: it killed the first hypothesis and the first proposed fix on bug 1 ("more frequent clamping reduces delay, not necessarily displacement" — confirmed, the worst single move went *up*, 126 → 159px), and objected to the first patch on bug 2 with four lifecycle holes, all of which are closed here.

## Testing

Ran and green:

- `dotnet build` — 0 errors, no new warnings in any changed file
- `tsc --noEmit` and eslint — clean
- TS unit tests — **656 passed** across 70 files

**Verified at runtime**, against the built bundle on a real server (chrome-devtools MCP, two Chrome profiles for the multi-user case):

| Bug | How it was exercised | Result |
|---|---|---|
| GIF placeholder | posted a `static.klipy.com/….gif` through the real composer; proxy 404s | `<image-skeleton data-image-state="skeleton">`, **320×320 exactly square**, `bg-05` fill, `pulse` running, `rounded-lg`, watermark anchored, **0 links rendered** |
| Overlay wrap | injected a `.temporary-container` into a live `.chat-message-markup`, with a simulated pre-fix copy as control | `inherit` resolves to **6px**; fixed copy's first line **674px** = the real markup's **674px**; pre-fix control **692px** |
| Clamp while animating | renewed `stability.holdAnimation` every 120ms, as `item-height-controller.ts:469` does per height write | `isAnimating` true **100%** of a 4s window, **9 `clampToLimits` calls** landed (pre-fix that branch could only reach `repinWhenStable`) |
| Unread redirect | second user posted to create a real `New messages` separator; `?vlloaddelay=1500`; flung into history, then stopped writing entirely | **28/117 quiet frames with zero visible keys** — all three trigger conditions held — net drift **0**, largest jump **0**, no teleport |

The fps fix is the one **not** exercised at runtime; it needs a live call plus an induced main-thread stall.

Caveat on the unread-redirect row: the patch was not reverted to watch it fail in the same rig, so that is "the trigger conditions held and nothing moved", not a before/after. The two reproduced cycles plus a fast-load control from the investigation carry that half.

## Review

Both halves were reviewed by a second model, read-only. Fix 1 (`infinite-list.ts`) signed off after tracing `computeScrollLimits` end to end and confirming it reads nothing rendered — the comment this PR deletes conflated DOM with model, so the clamp never needed the settled pass. Fix 2 was **objected to** and the objection is now fixed: a fifth lifecycle hole where a region flip over a full viewport emits no visibility report, leaving the token armed until the next fling. That is the reported symptom on the reported platform, so the first version of that fix was incomplete. Both the closure and the comment/spec corrections are folded into the commits they belong to — the latter mattering because three comments and a spec paragraph still said the render's clamp waits for settled sizes, which would have led the next reader to restore the gate this PR removes.

Known and deliberately not addressed here:

- `LinkRenderMode.LinkPreview` has the same blank-row *shape* as the GIF path, but a different cause — it renders nothing and depends on `entry.LinkPreviews` being filled by an async crawl, so the blank is missing data rather than a slow image. Deliberately left for its own change.
- The new `latency-tap` test asserts a direct assignment and is close to a tautology; the divisor, the 100ms floor and the negative-dt path are untested.
- The branch has not been through `tools/virtual-list-rig/rig.mjs` (all / nolock / takeover, long and short chats), and no device pass has been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DUtTYVVMXL6BS1gSKZChh
