### PR TITLE
fix(reactions): don't notify when a reaction is removed

### DIFF
--- a/src/dotnet/Chat.Service/ReactionsBackend.cs
+++ b/src/dotnet/Chat.Service/ReactionsBackend.cs
@@ -89,6 +89,7 @@ public class ReactionsBackend(IServiceProvider services)
                 var dbSummary = await UpsertDbSummary(emoji, false).ConfigureAwait(false);
                 if (dbSummary.Count > 0)
                     mustUpdateHasReactions = false; // Some reactions are still there
+                changeKind = ChangeKind.Remove;
             }
             else {
                 var oldEmoji = Emoji.Parse(dbReaction.Emoji);
@@ -98,10 +99,10 @@ public class ReactionsBackend(IServiceProvider services)
                 await UpsertDbSummary(oldEmoji, false).ConfigureAwait(false);
                 await UpsertDbSummary(emoji, true).ConfigureAwait(false);
                 mustUpdateHasReactions = false; // Author replaced one reaction with another
+                changeKind = ChangeKind.Update;
             }
 
             reaction = dbReaction.ToModel();
-            changeKind = ChangeKind.Update;
         }
 
         await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Notifications.IntegrationTests/NotificationContentTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationContentTest.cs
@@ -8,6 +8,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
     : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
 {
     private IWebClientTester Tester { get; } = fixture.AppHost.NewWebClientTester(@out);
+    private FirebaseMessagingTestSink Sink => AppHost.Services.GetRequiredService<FirebaseMessagingTestSink>();
 
     [Fact]
     public async Task ShouldSendNotificationForReaction()
@@ -34,6 +35,43 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be($"Alice @ {chat.Title}");
         bobNotification.Text.Should().Be("❤️ to \"Ok!\"");
+    }
+
+    [Fact]
+    public async Task ShouldNotSendNotificationWhenReactionIsRemoved()
+    {
+        // arrange
+        var bob = await Tester.SignInAsBob();
+        var alice = await Tester.SignInAsAlice();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "Reaction removal chat");
+        await Tester.InviteToChat(chat.Id, bob);
+        var deviceId = await RegisterDevice(alice.Id);
+        var entry1 = await Tester.CreateTextEntry(chat.Id, "first");
+        var entry2 = await Tester.CreateTextEntry(chat.Id, "second");
+
+        await Tester.SignIn(bob);
+        await Tester.React(entry1.Id, Emojis.Love);
+        var notification = await GetNotification(alice, entry1.Id);
+        await Commander.Call(new NotificationsBackend_Dismiss(notification.Id));
+        await TestExt.When(async () => {
+            var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+            info.Items.Should().BeEmpty();
+        }, TimeSpan.FromSeconds(10));
+        Sink.Clear();
+
+        // act - the same emoji again removes the reaction; the reaction to entry2 is the drain sentinel
+        await Tester.React(entry1.Id, Emojis.Love);
+        await Tester.React(entry2.Id, Emojis.Love);
+
+        // assert
+        await GetNotification(alice, entry2.Id);
+        var aliceInfo = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+        aliceInfo.Items.OfType<ReactionNotification>().Should().NotContain(n => n.EntryLid == entry1.LocalId);
+        Sink.Messages
+            .Where(m => !m.IsDismissal && m.DeviceIds.Contains(deviceId))
+            .Select(m => m.Notification)
+            .OfType<ReactionNotification>()
+            .Should().NotContain(n => n.EntryLid == entry1.LocalId);
     }
 
     [Fact]
@@ -212,6 +250,14 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         // Should use content URL for custom avatar, not generated avatar
         notification.IconUrl.Should().NotContain("api/avatars/");
         notification.IconUrl.Should().Contain("api/content/");
+    }
+
+    private async Task<Symbol> RegisterDevice(UserId userId)
+    {
+        var deviceId = new Symbol("test-device-" + userId.Value);
+        await Commander.Call(
+            new NotificationsBackend_RegisterDevice(userId, deviceId, DeviceType.WebBrowser, Symbol.Empty));
+        return deviceId;
     }
 
     private async Task<ChatNotification> GetNotification(AccountFull user, ChatEntryId entryId)


### PR DESCRIPTION
## Summary

Removing a reaction pushed a notification to the message author. `ReactionsBackend.OnReact` toggles a reaction off when the same emoji arrives again, but that path raised `ReactionChangedEvent` with `ChangeKind.Update`, the same kind as switching to a different emoji. `NotificationsBackend.OnReactionChangedEvent` already skips `ChangeKind.Remove`, so the guard never fired. Once the author had dismissed the original reaction notification, the removal created a fresh one and pushed it.

## Fix

The toggle-off branch now raises `ChangeKind.Remove`; the emoji-switch branch keeps `Update`. `NotificationsBackend` is the only consumer of the event, so nothing else changes. Keep the kinds distinct: an emoji switch still deserves a notification, a removal never does.

## Testing

- New `NotificationContentTest.ShouldNotSendNotificationWhenReactionIsRemoved`: react, dismiss the notification, remove the reaction, then react to a second entry as a drain sentinel. Asserts no notification item and no push for the first entry. Fails on the unpatched backend, passes with the fix.
- `NotificationContentTest` + `NotificationModeTest`: 31/31 green locally.
- No manual/device verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
