### PR TITLE
fix(notifications): headline group message banners with the chat, not the sender

### DIFF
--- a/src/dotnet/Notifications.Service/NotificationHelper.cs
+++ b/src/dotnet/Notifications.Service/NotificationHelper.cs
@@ -31,8 +31,20 @@ public static class NotificationHelper
             _ => throw new ArgumentOutOfRangeException($"{nameof(chat)}.{nameof(chat.Kind)}", chat.Kind, null),
         };
 
-    public static string GetTitle(string senderName, string groupTitle)
-        => groupTitle.IsNullOrEmpty() ? senderName : $"{senderName} @ {groupTitle}";
+    public static string GetTitle(NotificationKind kind, string senderName, string groupTitle)
+        // A group banner of a coalescing kind names each message's author in its body (see
+        // ComposeAggregatedText), so headlining it with the sender too would name them twice - and
+        // it gets the chat headline from its very first message, or the same banner would re-title
+        // itself once a second author arrives. The other kinds have a plain body, so the sender
+        // stays in their headline.
+        => groupTitle.IsNullOrEmpty()
+            ? senderName
+            : IsCoalescing(kind)
+                ? groupTitle
+                : $"{senderName} @ {groupTitle}";
+
+    public static bool IsCoalescing(NotificationKind kind)
+        => kind is NotificationKind.Message or NotificationKind.Reply or NotificationKind.Thread;
 
     public static string GetIconUrl(Chat.Chat chat, AuthorFull author, UrlMapper urlMapper)
         // Unsized, the generator draws its 80px base, which an avatar slot on a 3x screen upscales.
@@ -60,7 +72,7 @@ public static class NotificationHelper
         if (messages.IsEmpty)
             return notification.LeadText.IsNullOrEmpty() ? notification.Text : notification.LeadText;
 
-        // One banner holds several authors, and the headline names only the newest.
+        // One banner holds several authors, and the headline names the chat (see GetTitle).
         var showAuthorNames = notification.ChatId.GetThreadOutermostParentOrSelf().Kind
             is ChatKind.Group or ChatKind.Place;
         var lines = new List<string>(messages.Count + 1);

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -1358,7 +1358,7 @@ public class NotificationsBackend(IServiceProvider services)
 
         var chat = await ChatsBackend.Get(chatId, cancellationToken).Require().ConfigureAwait(false);
         var (senderName, groupTitle) = NotificationHelper.GetTitleParts(chat, changeAuthor);
-        var title = NotificationHelper.GetTitle(senderName, groupTitle);
+        var title = NotificationHelper.GetTitle(kind, senderName, groupTitle);
         var iconUrl = NotificationHelper.GetIconUrl(chat, changeAuthor, UrlMapper);
         var now = Clocks.CoarseSystemClock.Now;
         var entryLid = entryId?.LocalId ?? 0;
@@ -1384,7 +1384,7 @@ public class NotificationsBackend(IServiceProvider services)
             var userGroupTitle = groupTitleByUserId?[otherUserId] ?? groupTitle;
             var userTitle = groupTitleByUserId is null
                 ? title
-                : NotificationHelper.GetTitle(senderName, userGroupTitle);
+                : NotificationHelper.GetTitle(kind, senderName, userGroupTitle);
 
             ChatNotification notification = kind switch {
                 NotificationKind.Message => MessageNotification.New(otherUserId, chatId, entryLid, changeAuthor.Id),

--- a/src/swift/VoxtNotificationService/README.md
+++ b/src/swift/VoxtNotificationService/README.md
@@ -2,10 +2,11 @@
 
 A `UNNotificationServiceExtension` (`.appex`) that rewrites every chat push into an iOS
 **communication notification**: the chat or author avatar replaces the app icon on the banner.
-The headline stays the server's title — the sender, or `"<sender> @ <chat>"` in a group — the
-same one web and Mac show and the same shape Android's `MessagingStyle` renders (sender as the
-person, chat as the conversation). A coalesced banner names each line's author in the body,
-since one banner then holds several authors; a single-entry push doesn't repeat the sender.
+The headline stays the server's title, the same one web and Mac show: the sender in a peer chat,
+and in a group either the chat — for a message banner, whose body names each line's author,
+since one banner can hold several — or `"<sender> @ <chat>"` for a mention, reaction or
+attention push, whose body has no author line. Android renders the same parts from its own
+`MessagingStyle` slots (sender as the person, chat as the conversation).
 
 ## Why the extension has to exist
 
@@ -39,8 +40,9 @@ sender's name, giving a two-line header (sender, then chat) — and it only rend
 a conversation iOS considers a group, which nothing but `recipients.count > 1` makes it. So
 with a bare sender name as the title it silently vanished, which was issue #4305. Carrying the
 whole composed title as the display name keeps the chat name on the banner without that rule.
-(#4305 first answered this by headlining the chat and naming the sender only in the body — but
-a mention or reaction has no body author line, so those banners lost their sender.)
+(#4305 first answered this by headlining every group push with the chat and naming the sender
+only in the body — but a mention or reaction has no body author line, so those banners lost
+their sender. #4385 keeps the chat headline for message banners only.)
 
 **`conversationIdentifier` must equal `content.threadIdentifier`.** `updating(from:)` rewrites
 the thread id from the conversation id, and `AppDelegate.RemoveDeliveredNotifications` matches
@@ -142,8 +144,8 @@ What to look for:
 
 | Result | Meaning |
 |---|---|
-| Circular chat avatar, `"<sender> @ <chat>"` title, `Author: text` lines on a coalesced banner | working |
-| App icon and a `"<sender> @ <chat>"` title | either `updating(from:)` failed — check the entitlement on **both** the app and the appex — or the extension didn't run at all — check `PlugIns/VoxtNotificationService.appex` exists and is signed. The Console log (subsystem `ai.voxt.notification-service`) tells the two apart |
+| Circular chat avatar; `"<chat>"` title with `Author: text` lines on a message banner, `"<sender> @ <chat>"` on a mention or reaction | working |
+| App icon and the same title | either `updating(from:)` failed — check the entitlement on **both** the app and the appex — or the extension didn't run at all — check `PlugIns/VoxtNotificationService.appex` exists and is signed. The Console log (subsystem `ai.voxt.notification-service`) tells the two apart |
 
 The extension is a separate process, so the app's debugger session won't stop in it — attach
 to `VoxtNotificationService` explicitly, or read its `os_log` output with

--- a/tests/Notifications.IntegrationTests/NotificationContentTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationContentTest.cs
@@ -1,3 +1,4 @@
+using ActualChat.Localization;
 using ActualChat.Testing.Host;
 using ActualChat.Uploads;
 
@@ -27,7 +28,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
 
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
-        aliceNotification.Title.Should().Be($"Bobby @ {chat.Title}");
+        aliceNotification.Title.Should().Be(chat.Title);
         aliceNotification.SenderName.Should().Be("Bobby");
         aliceNotification.GroupTitle.Should().Be(chat.Title);
         aliceNotification.Text.Should().Be("Bobby: Ok!");
@@ -89,7 +90,7 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
 
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
-        aliceNotification.Title.Should().Be("Bobby @ Design @ Voxt");
+        aliceNotification.Title.Should().Be("Design @ Voxt");
         aliceNotification.SenderName.Should().Be("Bobby");
         aliceNotification.GroupTitle.Should().Be("Design @ Voxt");
     }
@@ -113,12 +114,69 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
 
         // assert
         var aliceNotification = await GetNotification(alice, entry.Id);
-        aliceNotification.Title.Should().Be("Bobby @ Good chat");
+        aliceNotification.Title.Should().Be("Good chat");
         aliceNotification.Text.Should().Be("Bobby: Sent 1 image");
 
         var bobNotification = await GetNotification(bob, entry.Id);
         bobNotification.Title.Should().Be("Alice @ Good chat");
         bobNotification.Text.Should().Be("❤️ to your image");
+    }
+
+    [Fact]
+    public async Task ShouldTitleAMentionWithTheSender()
+    {
+        // arrange
+        var alice = await Tester.SignInAsUniqueAlice();
+        var bob = await Tester.SignInAsUniqueBob();
+        var (chatId, inviteId) = await Tester.CreateChat(false, "Mention chat");
+        await Tester.SignIn(alice);
+        await Tester.JoinChat(chatId, inviteId);
+
+        // act
+        await Tester.SignIn(bob);
+        var entry = await Tester.CreateTextEntry(chatId, $"ping @u:{alice.Id} !");
+
+        // assert
+        var composer = AppHost.Services.GetRequiredService<NotificationTextComposer>();
+        var (content, _) = await composer.Compose(entry, MarkupConsumer.Notification, CancellationToken.None);
+        var notification = await GetNotification(alice, entry.Id);
+        notification.Should().BeOfType<MentionNotification>();
+        notification.Title.Should().Be("Bobby @ Mention chat");
+        notification.SenderName.Should().Be("Bobby");
+        notification.GroupTitle.Should().Be("Mention chat");
+        notification.Text.Should().Be(content.Render(LanguageStringLocalizer.Get(Languages.English)));
+    }
+
+    [Fact]
+    public async Task ShouldTitleAnAttentionRequestWithTheSender()
+    {
+        // arrange
+        var alice = await Tester.SignInAsUniqueAlice();
+        var bob = await Tester.SignInAsUniqueBob();
+        var (chatId, inviteId) = await Tester.CreateChat(false, "Attention chat");
+        await Tester.SignIn(alice);
+        await Tester.JoinChat(chatId, inviteId);
+
+        // act
+        await Tester.SignIn(bob);
+        var entry = await Tester.CreateTextEntry(chatId, "Everyone, look here");
+        await Tester.Commander.Call(new NotificationsBackend_NotifyMembers(bob.Id, chatId, entry.LocalId));
+
+        // assert
+        // The same entry yields both banners, and only the message one is titled with the chat.
+        AttentionNotification attention = null!;
+        MessageNotification message = null!;
+        await TestExt.When(async () => {
+            var info = await Tester.NotificationsBackend.GetUserNotificationInfo(alice.Id, CancellationToken.None);
+            attention = info.Items.OfType<AttentionNotification>().Should().ContainSingle().Subject;
+            message = info.Items.OfType<MessageNotification>().Should().ContainSingle().Subject;
+        }, TimeSpan.FromSeconds(10));
+        attention.Title.Should().Be("Bobby @ Attention chat");
+        attention.SenderName.Should().Be("Bobby");
+        attention.GroupTitle.Should().Be("Attention chat");
+        attention.Text.Should().Be("Bobby asks for attention");
+        message.Title.Should().Be("Attention chat");
+        message.Text.Should().Be("Bobby: Everyone, look here");
     }
 
     [Fact]
@@ -220,7 +278,8 @@ public class NotificationContentTest(AppHostFixture fixture, ITestOutputHelper @
         // Save media with user scope (for avatar pictures)
         var mediaSaver = Tester.AppServices.GetRequiredService<IMediaSaver>();
         var mediaId = MediaId.New(ownAccount.Id.Value);
-        await mediaSaver.Save(mediaId, TestImages.GetUploadedImage(TestImages.DefaultJpg), null, MediaKind.UserAvatarPicture, default);
+        await mediaSaver.Save(
+            mediaId, TestImages.GetUploadedImage(TestImages.DefaultJpg), null, MediaKind.UserAvatarPicture, default);
 
         // Create avatar with custom picture for bob
         var avatarWithPicture = await Tester.Commander.Call(new Avatars_Change {

--- a/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
+++ b/tests/Notifications.IntegrationTests/NotificationLocalizationTest.cs
@@ -209,8 +209,8 @@ public class NotificationLocalizationTest(AppHostFixture fixture, ITestOutputHel
         var l = LanguageStringLocalizer.Get(Language.Parse("en"));
         var composer = AppHost.Services.GetRequiredService<NotificationTextComposer>();
         var (content, _) = await composer.Compose(entry, MarkupConsumer.Notification, CancellationToken.None);
-        // The sender is the banner's headline on every platform, so a single-entry text must not
-        // repeat it: author lines belong only to coalesced banners, which hold several authors.
+        // A mention banner is headlined with the sender on every platform, so its text must not
+        // repeat it: author lines belong only to message banners, which can hold several authors.
         var expectedText = content.Render(l);
         await TestExt.When(async () => {
             var info = await Tester.NotificationsBackend.GetUserNotificationInfo(mentioned.Id, CancellationToken.None);


### PR DESCRIPTION
## Summary

Every Message, Reply and Thread notification carries a transcript from the moment it's enqueued, and in a group chat the aggregated text names each line's author (`Bobby: Ok!`). The banner was also headlined `<sender> @ <chat>`, so every group message named the sender twice, not only once several had coalesced: `Bobby @ Good chat` over `Bobby: Ok!`. Web, Mac and iOS all render that title; Android reads the separate sender/group keys and was fine.

Follows up on #4385, which put the sender back into the iOS headline for every kind.

## Fix

`NotificationHelper.GetTitle` now takes the notification kind. In a group or place chat the coalescing kinds (Message, Reply, Thread) are titled with the chat alone; Mention, Reaction, Attention and Invitation keep `<sender> @ <chat>`, since their body has no author line. Peer chats are unchanged.

Invariants a reviewer should keep:

- The chat headline applies from the very first message of a coalescing kind, not once a second author arrives, so a banner never re-titles itself in place.
- `SenderName` / `GroupTitle` still go out as separate data keys, so Android's `MessagingStyle` rendering doesn't change.
- The iOS service extension keeps using the push title as the intent sender's display name, now paired with the chat avatar it already used, so no Swift change.

The extension README describes the per-kind headline.

## Testing

- `NotificationContentTest` pins the chat title on message notifications, and two new tests pin the sender headline on a mention and on an attention request (the latter contrasted with the message banner for the same entry).
- Full `Notifications.IntegrationTests` project: 206 green before the two new tests; content tests + mention text test re-run afterwards, 11/11 green.
- Not verified on an iOS device yet: the extension is unchanged, but the new banner shape hasn't been seen on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
