### PR TITLE
docs: write down three rules that only lived in agent memory

### DIFF
--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -228,6 +228,12 @@ Search for `<Using>` to get the full list. Avoid adding explicit usings for glob
 - **Fields and properties storing a `Lazy`/`LazySlim`**: name them `XxxLazy`
   (`_userIdResolverLazy`, `InstanceLazy`) — as with tasks, the name must say it's a
   lazy rather than the value it produces.
+- **Synchronous companion of a `[ComputeMethod]`**: suffix it `NonComputed`, not
+  `Now`/`Sync`/etc. Next to `[ComputeMethod] virtual Task<T> Foo(...)` the
+  non-reactive accessor (typically reading `MutableState.Value` or other state
+  that is never `Use`d) is `FooNonComputed`; the compute method keeps the bare
+  name. Established by `ChatAudioUI.GetListenerNonComputed` /
+  `GetReplayerNonComputed` (`UI.Blazor.App/Services/ChatAudioUI.Players.cs`).
 
 ### Braces and Formatting
 

--- a/docs/architecture/service-design.md
+++ b/docs/architecture/service-design.md
@@ -233,6 +233,30 @@ public virtual async Task<Chat?> Get(ChatId chatId, CancellationToken cancellati
 public virtual async Task<Chat?> Get(Session session, ChatId chatId, CancellationToken cancellationToken)
 ```
 
+### Never mutate a returned result
+
+A `[ComputeMethod]` / `[RemoteComputeMethod]` result is cached, and **the same
+instance is handed to every caller**. Mutating it in place corrupts the cache for
+all consumers and produces parity-dependent bugs — right on the 1st call, wrong on
+the 2nd, right on the 3rd.
+
+```csharp
+// WRONG — corrupts the cached array for every other consumer
+var items = await Chats.GetVisualMediaPeriod(...).ConfigureAwait(false);
+Array.Reverse(items);
+
+// RIGHT — transform into a new array
+var items = await Chats.GetVisualMediaPeriod(...).ConfigureAwait(false);
+var newestFirst = items.Reverse().ToArray();
+```
+
+This is not hypothetical: `VisualMediaGallery` reversed the cached
+`VisualMediaItem[]` from `IChats.GetVisualMediaPeriod` in place, so every other
+open of the media viewer showed the gallery in reversed order — and it silently
+corrupted the right-panel grid (`ContentListPlumbing`), which reads the same
+cached instance. Never call `Array.Reverse` / `Array.Sort` or edit elements of a
+compute-method result; copy first.
+
 ### Dependency Tracking
 
 Dependencies are automatically tracked when one computed method calls another:

--- a/docs/running-voxt.md
+++ b/docs/running-voxt.md
@@ -54,6 +54,34 @@ docker compose up -d --build --wait
 > on. Run `b` with no arguments for an interactive menu, or `b tree -o` for the
 > full command list.
 
+### Querying the databases
+
+Every service DbContext calls `UseSnakeCaseNaming()` in `OnModelCreating`
+(`Db/ModelBuilderExt.cs`), so the C# model is PascalCase but **the SQL is
+snake_case**: `[Table("Devices")]` with a `DeviceType Type` property becomes table
+`devices`, column `type`.
+
+Postgres treats quoted identifiers as case-sensitive, so a hand-written
+`SELECT "Type" FROM "Devices"` fails with *relation/column does not exist* and the
+table looks empty or missing. Always query snake_case:
+
+```sql
+SELECT type, accessed_at, user_id FROM devices;
+```
+
+Database names follow `ac_{instance_}{context}` (see `DefaultDb` in App.Server's
+`appsettings.Development.json`). So `ac_ws2_notification` is instance `ws2`,
+context `notification` — and `ac_ws2_2_notification` is a *different* instance
+`ws2_2`, not a variant of the same one. The `ShardScheme` N=12
+(`Backend/Sharding/ShardScheme.cs`) is logical command routing only: there is one
+database per (instance, context), not twelve shard databases.
+
+`psql` lives inside the infra container, not on the host:
+
+```bash
+docker exec -e PGPASSWORD=postgres actual-chat-infra-postgres-1 psql -U postgres -d <db>
+```
+
 ## Building
 
 Use the CI solution filter to exclude MAUI projects (unless you have MAUI workloads installed):


### PR DESCRIPTION
Three rules had been recorded only as agent memories, where they reach one assistant's recall and nobody else. They are project rules, so this moves them into the docs the team and every agent already read. Docs only — no code changes.

## What's added

**`docs/CODING_STYLE.md` → Naming Conventions.** The synchronous companion of a `[ComputeMethod]` takes the `NonComputed` suffix, not `Now`/`Sync`. Established by `ChatAudioUI.GetListenerNonComputed` / `GetReplayerNonComputed`.

**`docs/architecture/service-design.md` → new "Never mutate a returned result" under Computed Methods.** A `[ComputeMethod]` result is cached and the *same instance* goes to every caller, so mutating it in place corrupts the cache for everyone and produces parity-dependent bugs — right on the 1st call, wrong on the 2nd, right on the 3rd. With a wrong/right example.

This one is not hypothetical. `VisualMediaGallery` called `Array.Reverse` on the cached `VisualMediaItem[]` from `IChats.GetVisualMediaPeriod`, so every other open of the media viewer showed the gallery reversed — and it silently corrupted the right-panel grid (`ContentListPlumbing`), which reads the same cached instance.

**`docs/running-voxt.md` → new "Querying the databases" under Initial Setup.** Every service DbContext calls `UseSnakeCaseNaming()`, so the C# model is PascalCase but the SQL is snake_case: a hand-written `SELECT "Type" FROM "Devices"` fails with *relation does not exist* and the table looks missing. Plus the `ac_{instance_}{context}` name template — `ac_ws2_notification` and `ac_ws2_2_notification` are different instances, not variants — the note that `ShardScheme` N=12 is command routing rather than 12 shard databases, and the `docker exec … psql` invocation, since `psql` isn't on the host.

## Review notes

Additive only: 58 lines added, none removed, no existing text touched. Each rule states the trap and the fix rather than restating the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAgXHnaVdsYdcVtkSg1upc
