### PR TITLE
fix(chat): stop a sent message unloading the window above the fold

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -820,15 +820,25 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
 
         // If we are scrolling somewhere within idRange, let's extend the range to navigation & nearby entries.
         if (navigation != null && chatLidRange.Contains(navigation.EntryLid)) {
-            caseName += "+navigation";
-            // The anchor lands at the top of the viewport unless ShowInTheMiddle, so most of the load zone
-            // is needed below it - hence the 1:2 split rather than an even one.
-            dataQuery = new ChatDataQuery(
-                entryTiles.GetTile(navigation.EntryLid).Range,
-                -initialLoadLimit / 3,
-                initialLoadLimit * 2 / 3) {
-                    Navigation = navigation,
-            };
+            // Re-aiming the range at a target the query already reaches throws away the window above the
+            // fold and loads it back on the next render, which unloads the groups up there - and a group's
+            // avatar is sticky, so it is pinned to the top line right until its group leaves the DOM.
+            // Every own new entry navigates (see the entry observer), so that is once per sent message.
+            if (dataQuery.Covers(navigation.EntryLid)) {
+                caseName += "+navigation-in-range";
+                dataQuery = dataQuery with { Navigation = navigation };
+            }
+            else {
+                caseName += "+navigation";
+                // The anchor lands at the top of the viewport unless ShowInTheMiddle, so most of the load
+                // zone is needed below it - hence the 1:2 split rather than an even one.
+                dataQuery = new ChatDataQuery(
+                    entryTiles.GetTile(navigation.EntryLid).Range,
+                    -initialLoadLimit / 3,
+                    initialLoadLimit * 2 / 3) {
+                        Navigation = navigation,
+                };
+            }
         }
 
         DebugLog?.LogDebug(

--- a/src/dotnet/UI.Blazor.App/Services/ChatDataQuery.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatDataQuery.cs
@@ -13,6 +13,11 @@ public record ChatDataQuery(Range<long> ExistingLidRange, int StartOffset, int E
     // Currently-visible entry id range. The loaded set must always cover it, so the offsets (which can
     // contract the range — and do so inaccurately next to a very large item) can never drop a visible item.
     public Range<long> VisibleLidRange { get; init; }
+    public bool Covers(long entryLid)
+        // Offsets are item counts read as lid deltas - the same approximation GetData makes when it
+        // decides whether to take a dependency on the chat's id range.
+        => entryLid >= ExistingLidRange.Start + StartOffset
+            && entryLid <= ExistingLidRange.End + EndOffset;
 
     public string Format()
 #pragma warning disable MA0076

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -989,6 +989,18 @@ export class InfiniteList extends VirtualList {
         return this.endAnchorSize - this.honouredEndAnchorSize;
     }
 
+    // Where the view sits once the pinned edge has been followed, which is not where it sits mid-render:
+    // against the live position the fold is still at the chain's old end.
+    private get pinnedScrollOffset(): number {
+        const edge = this.pinnedEdge;
+        if (edge == null)
+            return this.scrollOffset;
+
+        return edge === VirtualListEdge.End
+            ? this.chainEnd + this.honouredEndAnchorSize - this.ref.clientHeight
+            : this.chainStart;
+    }
+
     private applyRenderIntent(rs: VirtualListRenderState): void {
         const scrollToKey = rs.scrollToKey;
         if (!this.isContainerRevealed && scrollToKey != null)
@@ -1607,6 +1619,7 @@ export class InfiniteList extends VirtualList {
         const maxAt = ops.reduce((acc, x, i) => x.kind !== 'add' ? i : acc, -1);
         // Walked in chain order, i.e. top to bottom: the height controller hands out its animation
         // budget in call order, and the items nearest the top are the ones worth spending it on.
+        const scrollOffset = this.pinnedScrollOffset;
         let hasParked = false;
         for (let i = minAt; i <= maxAt; i++) {
             const op = ops[i];
@@ -1614,7 +1627,7 @@ export class InfiniteList extends VirtualList {
                 continue;
 
             const index = this.indexByKey.get(op.key);
-            if (index == null || !this.isKeyOnScreen(op.key))
+            if (index == null || !this.isKeyOnScreen(op.key, scrollOffset))
                 continue;
 
             // The key was on screen a moment ago, so this is the source having dropped it and put it
@@ -2211,7 +2224,7 @@ export class InfiniteList extends VirtualList {
         UpdateViewportIntervalMs,
         'default');
 
-    private isKeyOnScreen(key: string): boolean {
+    private isKeyOnScreen(key: string, scrollOffset = this.scrollOffset): boolean {
         const index = this.indexByKey.get(key);
         if (index == null)
             return false;
@@ -2220,7 +2233,6 @@ export class InfiniteList extends VirtualList {
         if (clientHeight <= 0)
             return false;
 
-        const scrollOffset = this.scrollOffset;
         const top = this.chainStart + this.offsets[index];
         return top + this.items[index].height > scrollOffset && top < scrollOffset + clientHeight;
     }


### PR DESCRIPTION
## Summary

Sending a message made the list arrive in steps rather than slide in, and the avatar of
the topmost group dropped out of the top line and came back. Both are the same render
path seen from two ends.

`ChatView`'s entry observer calls `NavigateTo(lastEntryLid)` for **every own new entry**,
and the navigation branch of `GetChatDataQuery` replaced the query wholesale with a
window aimed at the target — discarding whatever was already loaded above the fold. The
next render loaded it back. So one sent message cost three or four renders, unloaded and
rebuilt the author groups above the fold, and produced 200–430ms windows in which the
browser painted no frames at all. A group's avatar is `position: sticky`, so it sits on
the top line while its group is almost entirely above the fold — which is what made this
visible as the avatar blinking on every message sent.

Separately, `applyAppearances` decided "is this key on screen" against the live scroll
position, but it runs before `applyLayout` and the edge follow. Mid-render the model
already carries the new items while the view is still where it was, with the fold at the
chain's old end. The first item a render appends passes only by `honouredEndAnchorSize`
(4px on a wide layout) and everything after it reads as off screen — so a render carrying
two arrivals (a confirmed entry plus the next send's placeholder) always wrote the second
one in at full height instead of growing it in, stepping the whole list by that item's
height in one frame.

## Fix

**`GetChatDataQuery`** takes the navigation branch only when the target lies outside the
load zone the ordinary query already asks for. Otherwise the query stands and only
`Navigation` is attached, which `ChatUI` needs to auto-expand the target's conversation.
The new `ChatDataQuery.Covers(entryLid)` reads the offsets as lid deltas — the same
approximation `GetData` already makes when it decides whether to depend on the chat's id
range. The error is one-sided: each item consumes at least one lid, so a false "covered"
is impossible and a false "not covered" only falls back to today's behaviour.

The scroll intent is untouched — `scrollToKey` comes from `nav`, not from
`dataQuery.Navigation` — so posting while scrolled away still re-aims and jumps.

**`applyAppearances`** tests against `pinnedScrollOffset`: where the view sits once the
pinned edge has been followed, computed by the same arithmetic the pin itself uses. When
nothing is pinned it stays the live position.

Invariants a reviewer should hold onto: `Covers` must stay conservative on both ends (a
false positive means a navigation target that never loads), and `pinnedScrollOffset` is
only for the mid-render question — the height controller's own visibility check runs after
layout and deliberately keeps the live position.

## Testing

Measured on `dev.voxt.ai` and on a local build, frame by frame, following a real item by
key rather than `scrollTop`:

- Renders per sent message **3–4 → 1**; window size monotone (`77→72`, `72→68`) instead of
  `90→72→26→85`.
- Sticky avatars in the DOM constant instead of collapsing from 16 to 4; the top-line
  avatar present in **103 of 103** and **161 of 161** frames.
- Worst per-frame step of the item above the fold **24.0px → 5.4px**, with both arrivals
  growing in together over 9 frames (A/B on dev, predicate patched at runtime, same chat).
- Posting while scrolled to the top still produces the narrow window (`count=26`) and
  jumps to the new message.

`npm run build:Verify` and `dotnet build ActualChat.CI.slnf` are green after the rebase
onto `dev`. **No automated test covers this** — the virtual list has no test for
appearance geometry, and nothing here is reachable from the unit suites. Verified by
measurement in a browser only; a pass on a real phone is still owed, since the end anchor
is 48px in the narrow layout rather than 4px and that changes which arrivals fall past the
fold.

A third commit — dropping the appearance's 100ms settle delay — was written, measured, and
**deliberately left out**: on today's `dev` the delay turns out to be waiting out the
render's own stall, so removing it traded a 260ms standstill for a 24–32px step. It is
worth revisiting once the render cost is down, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011thmMDSfxk8yvomgmfzJGp
