### PR TITLE
feat(chat-view): add a navigate-to-unread-reaction button

### DIFF
--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -1277,6 +1277,7 @@ public static class LocalizedStringsLocalizerExt
         public string ChatView_CollapseSummary => l["ChatView_CollapseSummary"].Value;
         public string ChatView_ExpandSummary => l["ChatView_ExpandSummary"].Value;
         public string ChatView_GoToLastMessage => l["ChatView_GoToLastMessage"].Value;
+        public string ChatView_GoToReaction => l["ChatView_GoToReaction"].Value;
         public string ChatView_GoToUnread => l["ChatView_GoToUnread"].Value;
         public string ChatView_UnknownAuthor => l["ChatView_UnknownAuthor"].Value;
         public string ChatView_UnknownChat => l["ChatView_UnknownChat"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Свий обобщението",
   "ChatView_ExpandSummary": "Разгъни обобщението",
   "ChatView_GoToUnread": "Към непрочетената част",
+  "ChatView_GoToReaction": "Към непрочетената реакция",
   "ChatView_GoToLastMessage": "Към последното съобщение",
   "ChatView_UnknownChat": "Непознат чат",
   "ChatView_UnknownAuthor": "Непознат автор",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Skupi sažetak",
   "ChatView_ExpandSummary": "Proširi sažetak",
   "ChatView_GoToUnread": "Idite na nepročitani dio",
+  "ChatView_GoToReaction": "Idite na nepročitanu reakciju",
   "ChatView_GoToLastMessage": "Idite na zadnju poruku",
   "ChatView_UnknownChat": "Nepoznat chat",
   "ChatView_UnknownAuthor": "Nepoznat autor",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Skupi sažetak",
   "ChatView_ExpandSummary": "Proširi sažetak",
   "ChatView_GoToUnread": "Idite na nepročitani dio",
+  "ChatView_GoToReaction": "Idite na nepročitanu reakciju",
   "ChatView_GoToLastMessage": "Idite na zadnju poruku",
   "ChatView_UnknownChat": "Nepoznat chat",
   "ChatView_UnknownAuthor": "Nepoznat autor",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Sbalit shrnutí",
   "ChatView_ExpandSummary": "Rozbalit shrnutí",
   "ChatView_GoToUnread": "Přejít na nepřečtené",
+  "ChatView_GoToReaction": "Přejít na nepřečtenou reakci",
   "ChatView_GoToLastMessage": "Přejít na poslední zprávu",
   "ChatView_UnknownChat": "Neznámý chat",
   "ChatView_UnknownAuthor": "Neznámý autor",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Zusammenfassung einklappen",
   "ChatView_ExpandSummary": "Zusammenfassung ausklappen",
   "ChatView_GoToUnread": "Zum ungelesenen Teil springen",
+  "ChatView_GoToReaction": "Zur ungelesenen Reaktion springen",
   "ChatView_GoToLastMessage": "Zur letzten Nachricht springen",
   "ChatView_UnknownChat": "Unbekannter Chat",
   "ChatView_UnknownAuthor": "Unbekannter Autor",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -1458,6 +1458,7 @@
   "ChatView_CollapseSummary": "Collapse summary",
   "ChatView_ExpandSummary": "Expand summary",
   "ChatView_GoToUnread": "Go to the unread part",
+  "ChatView_GoToReaction": "Go to the unread reaction",
   "ChatView_GoToLastMessage": "Go to the last message",
   "ChatView_UnknownChat": "Unknown chat",
   "ChatView_UnknownAuthor": "Unknown author",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Contraer el resumen",
   "ChatView_ExpandSummary": "Expandir el resumen",
   "ChatView_GoToUnread": "Ir a la parte no leída",
+  "ChatView_GoToReaction": "Ir a la reacción no leída",
   "ChatView_GoToLastMessage": "Ir al último mensaje",
   "ChatView_UnknownChat": "Chat desconocido",
   "ChatView_UnknownAuthor": "Autor desconocido",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Réduire le résumé",
   "ChatView_ExpandSummary": "Développer le résumé",
   "ChatView_GoToUnread": "Aller à la partie non lue",
+  "ChatView_GoToReaction": "Aller à la réaction non lue",
   "ChatView_GoToLastMessage": "Aller au dernier message",
   "ChatView_UnknownChat": "Discussion inconnue",
   "ChatView_UnknownAuthor": "Auteur inconnu",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "सारांश संक्षिप्त करें",
   "ChatView_ExpandSummary": "सारांश विस्तृत करें",
   "ChatView_GoToUnread": "अपठित हिस्से पर जाएँ",
+  "ChatView_GoToReaction": "अपठित प्रतिक्रिया पर जाएँ",
   "ChatView_GoToLastMessage": "अंतिम संदेश पर जाएँ",
   "ChatView_UnknownChat": "अज्ञात चैट",
   "ChatView_UnknownAuthor": "अज्ञात लेखक",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Skupi sažetak",
   "ChatView_ExpandSummary": "Proširi sažetak",
   "ChatView_GoToUnread": "Idite na nepročitani dio",
+  "ChatView_GoToReaction": "Idite na nepročitanu reakciju",
   "ChatView_GoToLastMessage": "Idite na zadnju poruku",
   "ChatView_UnknownChat": "Nepoznat chat",
   "ChatView_UnknownAuthor": "Nepoznat autor",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Ciutkan ringkasan",
   "ChatView_ExpandSummary": "Bentangkan ringkasan",
   "ChatView_GoToUnread": "Buka bagian yang belum dibaca",
+  "ChatView_GoToReaction": "Buka reaksi yang belum dibaca",
   "ChatView_GoToLastMessage": "Buka pesan terakhir",
   "ChatView_UnknownChat": "Obrolan tidak dikenal",
   "ChatView_UnknownAuthor": "Penulis tidak dikenal",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Comprimi il riepilogo",
   "ChatView_ExpandSummary": "Espandi il riepilogo",
   "ChatView_GoToUnread": "Vai alla parte non letta",
+  "ChatView_GoToReaction": "Vai alla reazione non letta",
   "ChatView_GoToLastMessage": "Vai all'ultimo messaggio",
   "ChatView_UnknownChat": "Chat sconosciuta",
   "ChatView_UnknownAuthor": "Autore sconosciuto",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "要約を折りたたむ",
   "ChatView_ExpandSummary": "要約を展開",
   "ChatView_GoToUnread": "未読の位置へ移動",
+  "ChatView_GoToReaction": "未読のリアクションへ移動",
   "ChatView_GoToLastMessage": "最後のメッセージへ移動",
   "ChatView_UnknownChat": "不明なチャット",
   "ChatView_UnknownAuthor": "不明な投稿者",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "요약 접기",
   "ChatView_ExpandSummary": "요약 펼치기",
   "ChatView_GoToUnread": "읽지 않은 부분으로 이동",
+  "ChatView_GoToReaction": "읽지 않은 반응으로 이동",
   "ChatView_GoToLastMessage": "마지막 메시지로 이동",
   "ChatView_UnknownChat": "알 수 없는 채팅",
   "ChatView_UnknownAuthor": "알 수 없는 작성자",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -1458,6 +1458,7 @@
   "ChatView_CollapseSummary": "Zusammenfassung einklappen",
   "ChatView_ExpandSummary": "Zusammenfassung ausklappen",
   "ChatView_GoToUnread": "Buka bagian yang belum dibaca",
+  "ChatView_GoToReaction": "Перейти к непрочитанной реакции",
   "ChatView_GoToLastMessage": "Перейти до останнього повідомлення",
   "ChatView_UnknownChat": "Cuộc trò chuyện không xác định",
   "ChatView_UnknownAuthor": "Tác giả không xác định",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Zwiń podsumowanie",
   "ChatView_ExpandSummary": "Rozwiń podsumowanie",
   "ChatView_GoToUnread": "Przejdź do nieprzeczytanych",
+  "ChatView_GoToReaction": "Przejdź do nieprzeczytanej reakcji",
   "ChatView_GoToLastMessage": "Przejdź do ostatniej wiadomości",
   "ChatView_UnknownChat": "Nieznany czat",
   "ChatView_UnknownAuthor": "Nieznany autor",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Recolher o resumo",
   "ChatView_ExpandSummary": "Expandir o resumo",
   "ChatView_GoToUnread": "Ir para a parte não lida",
+  "ChatView_GoToReaction": "Ir para a reação não lida",
   "ChatView_GoToLastMessage": "Ir para a última mensagem",
   "ChatView_UnknownChat": "Chat desconhecido",
   "ChatView_UnknownAuthor": "Autor desconhecido",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Свернуть сводку",
   "ChatView_ExpandSummary": "Развернуть сводку",
   "ChatView_GoToUnread": "Перейти к непрочитанному",
+  "ChatView_GoToReaction": "Перейти к непрочитанной реакции",
   "ChatView_GoToLastMessage": "Перейти к последнему сообщению",
   "ChatView_UnknownChat": "Неизвестный чат",
   "ChatView_UnknownAuthor": "Неизвестный автор",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Скупи сажетак",
   "ChatView_ExpandSummary": "Прошири сажетак",
   "ChatView_GoToUnread": "Идите на непрочитани дио",
+  "ChatView_GoToReaction": "Идите на непрочитану реакцију",
   "ChatView_GoToLastMessage": "Идите на задњу поруку",
   "ChatView_UnknownChat": "Непознат чет",
   "ChatView_UnknownAuthor": "Непознат аутор",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Özeti daraltın",
   "ChatView_ExpandSummary": "Özeti genişletin",
   "ChatView_GoToUnread": "Okunmamış kısma gidin",
+  "ChatView_GoToReaction": "Okunmamış tepkiye gidin",
   "ChatView_GoToLastMessage": "Son mesaja gidin",
   "ChatView_UnknownChat": "Bilinmeyen sohbet",
   "ChatView_UnknownAuthor": "Bilinmeyen yazar",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Згорнути зведення",
   "ChatView_ExpandSummary": "Розгорнути зведення",
   "ChatView_GoToUnread": "Перейти до непрочитаного",
+  "ChatView_GoToReaction": "Перейти до непрочитаної реакції",
   "ChatView_GoToLastMessage": "Перейти до останнього повідомлення",
   "ChatView_UnknownChat": "Невідомий чат",
   "ChatView_UnknownAuthor": "Невідомий автор",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "Thu gọn tóm tắt",
   "ChatView_ExpandSummary": "Mở rộng tóm tắt",
   "ChatView_GoToUnread": "Đến phần chưa đọc",
+  "ChatView_GoToReaction": "Đến phản ứng chưa đọc",
   "ChatView_GoToLastMessage": "Đến tin nhắn cuối",
   "ChatView_UnknownChat": "Cuộc trò chuyện không xác định",
   "ChatView_UnknownAuthor": "Tác giả không xác định",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -1230,6 +1230,7 @@
   "ChatView_CollapseSummary": "收起摘要",
   "ChatView_ExpandSummary": "展开摘要",
   "ChatView_GoToUnread": "跳转到未读部分",
+  "ChatView_GoToReaction": "跳转到未读的表情回应",
   "ChatView_GoToLastMessage": "跳转到最新消息",
   "ChatView_UnknownChat": "未知聊天",
   "ChatView_UnknownAuthor": "未知作者",

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/ChatViewNavigationPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/ChatViewNavigationPanel.razor
@@ -7,7 +7,12 @@
 @if (m.ShowSearchResultsNavigator) {
     <NavigateToNextOrPrevSearchResult />
 } else {
-    <NavigateToUnreadOrEnd />
+    <div class="chat-view-navigation-panel">
+        <div class="c-content">
+            <NavigateToUnreadReaction />
+            <NavigateToUnreadOrEnd />
+        </div>
+    </div>
 }
 
 @code {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/NavigateToUnreadReaction.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/NavigateToUnreadReaction.razor
@@ -1,0 +1,108 @@
+@using ActualChat.Notifications
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits ComputedStateComponent<AppUIHub, NavigateToUnreadReaction.Model?>
+@{
+    var m = State.Value;
+    if (m is null)
+        return;
+
+    _animator.State = m.IsVisible;
+    if (_animator.MustHideComponent || m.Target is not { } target)
+        return;
+
+    var emoji = target.LastEmoji ?? target.Emojis.LastOrDefault();
+}
+
+<div class="navigate-to-reaction @_animator.Class">
+    <div class="c-content">
+        <Badge Class="unread-counter" Click="OnClick">@m.Count.FormatK()</Badge>
+        <ButtonRound Tooltip="@L.ChatView_GoToReaction" Click="OnClick">
+            <EmojiIcon Emoji="@emoji" HasPreview="false"/>
+        </ButtonRound>
+    </div>
+</div>
+
+@code {
+    private ShowHideAnimator _animator = null!;
+
+    private Chat Chat => ChatContext.Chat;
+    private NotificationsUI NotificationsUI => Hub.NotificationsUI;
+
+    [CascadingParameter] public ChatView ChatView { get; set; } = null!;
+    [CascadingParameter] public ChatContext ChatContext { get; set; } = null!;
+    [CascadingParameter] public RegionVisibility RegionVisibility { get; set; } = null!;
+
+    protected override void OnInitialized()
+        => _animator = new (this, TimeSpan.FromMilliseconds(300));
+
+    public override ValueTask DisposeAsync() {
+        _animator.Dispose();
+        return base.DisposeAsync();
+    }
+
+    protected override ComputedState<Model?>.Options GetStateOptions()
+        => ComputedStateComponent.GetStateOptions(GetType(),
+            static t => new ComputedState<Model?>.Options() {
+                UpdateDelayer = FixedDelayer.NextTick,
+                Category = GetStateCategory(t),
+            });
+
+    protected override async Task<Model?> ComputeState(CancellationToken cancellationToken) {
+        var chatId = Chat.Id;
+        var chatView = ChatView;
+
+        if (!await RegionVisibility.IsVisible.Use(cancellationToken).ConfigureAwait(false))
+            return null;
+
+        var reactions = await NotificationsUI.ListChatReactions(chatId, cancellationToken).ConfigureAwait(false);
+        if (reactions.Count == 0)
+            return Model.None;
+
+        await chatView.WhenInitialized.ConfigureAwait(false);
+        var itemVisibility = await chatView.ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
+        var target = SelectClosest(reactions, itemVisibility);
+        if (target is null)
+            return Model.None;
+
+        return new(true, target, reactions.Count);
+    }
+
+    // A reaction whose entry is already on screen is about to be dismissed by SeenNotificationDismisser,
+    // so only the off-screen ones are worth a jump; the nearest to the viewport goes first, and the
+    // newer one wins a tie.
+    private static ReactionNotification? SelectClosest(
+        IReadOnlyList<ReactionNotification> reactions,
+        ChatViewItemVisibility itemVisibility)
+    {
+        var visibleLids = itemVisibility.VisibleMessageLids;
+        var viewportLid = itemVisibility.IsEmpty
+            ? long.MaxValue
+            : (itemVisibility.MinMessageLid + itemVisibility.MaxMessageLid) / 2;
+        return reactions
+            .Where(x => !visibleLids.Contains(x.EntryLid))
+            .OrderBy(x => Math.Abs(x.EntryLid - viewportLid))
+            .ThenByDescending(x => x.EntryLid)
+            .FirstOrDefault();
+    }
+
+    private void OnClick() {
+        if (State.Value is not { IsVisible: true, Target: { } target })
+            return;
+
+        // Dismissed here as well as by SeenNotificationDismisser, so the next click moves on
+        // even when the jump doesn't end with the entry on screen (e.g. it was deleted).
+        _ = Hub.UICommander.Run(new Notifications_Dismiss { Session = Session, NotificationId = target.Id });
+        _ = ChatView.NavigateTo(target.EntryLid, true);
+    }
+
+    // Nested types
+
+    public sealed record Model(bool IsVisible, ReactionNotification? Target, Trimmed<int> Count)
+    {
+        public static readonly Model None = new(false, null, default);
+
+        // This record relies on referential equality
+        public bool Equals(Model? other) => ReferenceEquals(this, other);
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/chat-view-navigation-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/chat-view-navigation-panel.css
@@ -1,0 +1,60 @@
+.chat-view-navigation-panel {
+    @apply relative z-button;
+}
+/* The column exists even with nothing to show, so it must not swallow taps on the chat below it */
+.chat-view-navigation-panel > .c-content {
+    @apply absolute bottom-3 md:bottom-0 right-3 z-10;
+    @apply flex-y items-center justify-center gap-y-2;
+    @apply pointer-events-none;
+    @apply shadow-scrollbar;
+}
+.chat-view-navigation-panel > .c-content > * {
+    @apply pointer-events-auto;
+}
+body.hoverable .chat-view-navigation-panel > .c-content {
+    @apply right-0;
+    @apply p-3 pl-8;
+}
+body.narrow:has(.audio-panel-header) .chat-view-navigation-panel > .c-content {
+    @apply bottom-18;
+}
+
+/* ── Navigate to reaction ── */
+
+.navigate-to-reaction .btn {
+    transform-origin: center center;
+}
+.navigate-to-reaction.off-to-on .btn,
+.navigate-to-reaction.off-to-on .unread-counter {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    transition: opacity 150ms ease-in-out, transform 300ms ease-in-out;
+}
+.navigate-to-reaction.on-to-off .btn,
+.navigate-to-reaction.on-to-off .unread-counter {
+    opacity: 0;
+    transform: scale(0) translateY(1rem);
+    transition: opacity 300ms ease-in-out, transform 150ms ease-in-out;
+}
+.navigate-to-reaction.off .btn,
+.navigate-to-reaction.off .unread-counter {
+    opacity: 0;
+    transform: scale(0) translateY(1rem);
+}
+.navigate-to-reaction > .c-content {
+    @apply flex-y items-center justify-center;
+}
+.navigate-to-reaction .unread-counter {
+    @apply z-10;
+    @apply -mb-2;
+    @apply text-06;
+    @apply cursor-pointer;
+}
+.navigate-to-reaction .btn.btn-round {
+    @apply rounded-full border border-modal;
+    @apply bg-modal;
+    @apply shadow-modal-wide;
+}
+.navigate-to-reaction .btn.btn-round img {
+    @apply h-6 w-6;
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/navigate-to-unread-or-end.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/navigate-to-unread-or-end.css
@@ -25,16 +25,7 @@
 }
 
 .navigate-to-end > .c-content {
-    @apply absolute bottom-3 md:bottom-0 right-3 z-10;
     @apply flex-y items-center justify-center;
-    @apply shadow-scrollbar;
-}
-body.hoverable .navigate-to-end > .c-content {
-    @apply right-0;
-    @apply p-3 pl-8;
-}
-body.narrow:has(.audio-panel-header) .navigate-to-end > .c-content {
-    @apply bottom-18;
 }
 .navigate-to-end .unread-counter {
     @apply z-10;

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppAotSource.g.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppAotSource.g.cs
@@ -295,6 +295,7 @@ internal partial class BlazorUIAppAotSource : IAotSource
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NavbarPlaceButtons>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NavigateToNextOrPrevSearchResult>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NavigateToUnreadOrEnd>();
+        CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NavigateToUnreadReaction>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NewChatModal>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NewChatModalMembers>();
         CodeKeeper.Keep<global::ActualChat.UI.Blazor.App.Components.NewChatModalProps>();
@@ -1067,6 +1068,7 @@ internal partial class BlazorUIAppAotSource : IAotSource
             (typeof(global::ActualChat.UI.Blazor.App.Components.NavbarPlaceButtons), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.NavigateToNextOrPrevSearchResult), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.NavigateToUnreadOrEnd), AotTypeKind.Component),
+            (typeof(global::ActualChat.UI.Blazor.App.Components.NavigateToUnreadReaction), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.NewChatModal), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.NewChatModalMembers), AotTypeKind.Component),
             (typeof(global::ActualChat.UI.Blazor.App.Components.NewChatModalProps), AotTypeKind.Component),

--- a/src/dotnet/UI.Blazor.App/Services/NotificationsUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationsUI.cs
@@ -17,7 +17,10 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
         NotificationKind kind, CancellationToken cancellationToken = default)
     {
         var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
-        return SelectByKind(active, kind);
+        return active
+            .Where(x => x.Kind == kind)
+            .OrderByDescending(x => x.SentAt)
+            .ToApiArray();
     }
 
     [ComputeMethod]
@@ -25,7 +28,26 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
         ChatId chatId, CancellationToken cancellationToken = default)
     {
         var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
-        return SelectReactionState(active, chatId);
+        var newest = active
+            .OfType<ReactionNotification>()
+            .Where(x => x.ChatId == chatId)
+            .MaxBy(x => x.SentAt);
+        return newest is null
+            ? default
+            // LastEmoji is null on notifications persisted before it existed; the accumulated set is the fallback.
+            : new ChatReactionState(newest.LastEmoji ?? newest.Emojis.LastOrDefault(), newest.SentAt);
+    }
+
+    [ComputeMethod]
+    public virtual async Task<IReadOnlyList<ReactionNotification>> ListChatReactions(
+        ChatId chatId, CancellationToken cancellationToken = default)
+    {
+        var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
+        return active
+            .OfType<ReactionNotification>()
+            .Where(x => x.ChatId == chatId)
+            .OrderBy(x => x.EntryLid)
+            .ToList();
     }
 
     [ComputeMethod]
@@ -43,7 +65,10 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
     public virtual async Task<Moment?> GetAttentionAt(ChatId chatId, CancellationToken cancellationToken = default)
     {
         var active = await Notifications.ListActive(Session, cancellationToken).ConfigureAwait(false);
-        return SelectAttentionAt(active, chatId);
+        return active
+            .OfType<AttentionNotification>()
+            .Where(x => x.ChatId == chatId)
+            .Max(x => (Moment?)x.SentAt);
     }
 
     [ComputeMethod]
@@ -56,35 +81,6 @@ public class NotificationsUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), IComp
             .Distinct()
             .ToApiArray();
     }
-
-    // Protected/internal methods
-
-    // Internal rather than private so the projections can be tested without a hub.
-    internal static ApiArray<Notification> SelectByKind(ApiArray<Notification> active, NotificationKind kind)
-        => active
-            .Where(x => x.Kind == kind)
-            .OrderByDescending(x => x.SentAt)
-            .ToApiArray();
-
-    internal static ChatReactionState SelectReactionState(ApiArray<Notification> active, ChatId chatId)
-    {
-        var newest = active
-            .OfType<ReactionNotification>()
-            .Where(x => x.ChatId == chatId)
-            .MaxBy(x => x.SentAt);
-        if (newest is null)
-            return default;
-
-        // LastEmoji is null on notifications persisted before it existed; the accumulated set is the fallback.
-        return new ChatReactionState(newest.LastEmoji ?? newest.Emojis.LastOrDefault(), newest.SentAt);
-    }
-
-    internal static Moment? SelectAttentionAt(ApiArray<Notification> active, ChatId chatId)
-        => active
-            .OfType<AttentionNotification>()
-            .Where(x => x.ChatId == chatId)
-            .Select(x => (Moment?)x.SentAt)
-            .Max();
 }
 
 public readonly record struct ChatReactionState(Emoji? Emoji, Moment SentAt);

--- a/src/dotnet/UI.Blazor.App/styles.css
+++ b/src/dotnet/UI.Blazor.App/styles.css
@@ -32,6 +32,7 @@
 @import './Components/ChatView/PinnedBar/pinned-bar.css';
 @import './Components/ChatView/chat-view.css';
 @import './Components/ClientUpgradeCover/client-upgrade-cover.css';
+@import './Components/ChatView/Navigation/chat-view-navigation-panel.css';
 @import './Components/ChatView/Navigation/navigate-to-unread-or-end.css';
 @import './Components/ChatView/Navigation/chat-view-search-results-navigator.css';
 @import './Components/ChatMessageEditor/chat-message-editor.css';

--- a/tests/Chat.UI.Blazor.UnitTests/NotificationsUIProjectionTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/NotificationsUIProjectionTest.cs
@@ -1,33 +1,38 @@
+using ActualChat.Hosting;
 using ActualChat.Notifications;
+using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.App.Services;
+using ActualChat.UI.Blazor.Services;
+using Microsoft.Extensions.Hosting;
 using Notification = ActualChat.Notifications.Notification;
 
 namespace ActualChat.Chat.UI.Blazor.UnitTests;
 
-public sealed class NotificationsUIProjectionTest
+public sealed class NotificationsUIProjectionTest(ITestOutputHelper @out) : TestBase(@out)
 {
     private static readonly UserId TestUserId = UserId.New();
     private static readonly ChatId ChatA = ChatId.Parse("the-actual-one");
     private static readonly ChatId ChatB = ChatId.Parse(GroupChatId.New().Value);
 
     [Fact]
-    public void ListByKindShouldFilterAndSortNewestFirst()
+    public async Task ListByKindShouldFilterAndSortNewestFirst()
     {
         // arrange
         var older = NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1));
         var newer = NewReaction(2, Moment.EpochStart + TimeSpan.FromSeconds(2));
         var mention = MentionNotification.New(TestUserId, ChatEntryId.New(ChatA, 3));
-        var active = ApiArray.New<Notification>(older, mention, newer);
+        await using var scope = NewScope(older, mention, newer);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var result = NotificationsUI.SelectByKind(active, NotificationKind.Reaction);
+        var result = await notificationsUI.ListByKind(NotificationKind.Reaction);
 
         // assert
         result.Select(x => x.Id).Should().Equal([newer.Id, older.Id]);
     }
 
     [Fact]
-    public void ReactionStateShouldTakeNewestReactionForChat()
+    public async Task ReactionStateShouldTakeNewestReactionForChat()
     {
         // arrange
         var older = NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1)) with {
@@ -36,10 +41,11 @@ public sealed class NotificationsUIProjectionTest
         var newer = NewReaction(2, Moment.EpochStart + TimeSpan.FromSeconds(2)) with {
             Emojis = ApiArray.New(Emojis.Party),
         };
-        var active = ApiArray.New<Notification>(older, newer);
+        await using var scope = NewScope(older, newer);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var state = NotificationsUI.SelectReactionState(active, ChatA);
+        var state = await notificationsUI.GetReactionState(ChatA);
 
         // assert
         state.Emoji.Should().Be(Emojis.Party);
@@ -47,78 +53,138 @@ public sealed class NotificationsUIProjectionTest
     }
 
     [Fact]
-    public void ReactionStateShouldPreferLastEmojiOverAccumulatedOrder()
+    public async Task ReactionStateShouldPreferLastEmojiOverAccumulatedOrder()
     {
         // arrange - an out-of-order merge leaves the newest emoji in the middle of the accumulated set
         var notification = NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(2)) with {
             Emojis = ApiArray.New(Emojis.Party, Emojis.Awesome),
             LastEmoji = Emojis.Party,
         };
-        var active = ApiArray.New<Notification>(notification);
+        await using var scope = NewScope(notification);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var state = NotificationsUI.SelectReactionState(active, ChatA);
+        var state = await notificationsUI.GetReactionState(ChatA);
 
         // assert
         state.Emoji.Should().Be(Emojis.Party);
     }
 
     [Fact]
-    public void ReactionStateShouldFallBackToAccumulatedSetWithoutLastEmoji()
+    public async Task ReactionStateShouldFallBackToAccumulatedSetWithoutLastEmoji()
     {
         // arrange - a notification persisted before LastEmoji existed
         var notification = NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1)) with {
             Emojis = ApiArray.New(Emojis.Awesome, Emojis.Party),
         };
-        var active = ApiArray.New<Notification>(notification);
+        await using var scope = NewScope(notification);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var state = NotificationsUI.SelectReactionState(active, ChatA);
+        var state = await notificationsUI.GetReactionState(ChatA);
 
         // assert
         state.Emoji.Should().Be(Emojis.Party);
     }
 
     [Fact]
-    public void ReactionStateShouldBeDefaultForChatWithoutReactions()
+    public async Task ReactionStateShouldBeDefaultForChatWithoutReactions()
     {
+        // arrange
+        await using var scope = NewScope();
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
+
         // act
-        var state = NotificationsUI.SelectReactionState(ApiArray<Notification>.Empty, ChatA);
+        var state = await notificationsUI.GetReactionState(ChatA);
 
         // assert
         state.Should().Be(default(ChatReactionState));
     }
 
     [Fact]
-    public void AttentionAtShouldTakeNewestPingForChat()
+    public async Task ChatReactionsShouldFilterByChatAndSortByEntry()
+    {
+        // arrange
+        var later = NewReaction(5, Moment.EpochStart + TimeSpan.FromSeconds(1));
+        var earlier = NewReaction(2, Moment.EpochStart + TimeSpan.FromSeconds(2));
+        var otherChat = ReactionNotification.New(TestUserId, ChatEntryId.New(ChatB, 1));
+        var mention = MentionNotification.New(TestUserId, ChatEntryId.New(ChatA, 3));
+        await using var scope = NewScope(later, otherChat, mention, earlier);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
+
+        // act
+        var result = await notificationsUI.ListChatReactions(ChatA);
+
+        // assert
+        result.Select(x => x.EntryLid).Should().Equal([2, 5]);
+    }
+
+    [Fact]
+    public async Task AttentionAtShouldTakeNewestPingForChat()
     {
         // arrange
         var older = NewAttention(ChatA, 1, Moment.EpochStart + TimeSpan.FromSeconds(1));
         var newer = NewAttention(ChatA, 2, Moment.EpochStart + TimeSpan.FromSeconds(2));
         var otherChatPing = NewAttention(ChatB, 1, Moment.EpochStart + TimeSpan.FromSeconds(3));
-        var active = ApiArray.New<Notification>(older, otherChatPing, newer);
+        await using var scope = NewScope(older, otherChatPing, newer);
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var attentionAt = NotificationsUI.SelectAttentionAt(active, ChatA);
+        var attentionAt = await notificationsUI.GetAttentionAt(ChatA);
 
         // assert
         attentionAt.Should().Be(newer.SentAt);
     }
 
     [Fact]
-    public void AttentionAtShouldBeNullForChatWithoutPings()
+    public async Task AttentionAtShouldBeNullForChatWithoutPings()
     {
         // arrange
-        var active = ApiArray.New<Notification>(NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1)));
+        await using var scope = NewScope(NewReaction(1, Moment.EpochStart + TimeSpan.FromSeconds(1)));
+        var notificationsUI = scope.ServiceProvider.GetRequiredService<NotificationsUI>();
 
         // act
-        var attentionAt = NotificationsUI.SelectAttentionAt(active, ChatA);
+        var attentionAt = await notificationsUI.GetAttentionAt(ChatA);
 
         // assert
         attentionAt.Should().BeNull();
     }
 
     // Private methods
+
+    // A scoped container around a NotificationsUI whose INotifications.ListActive returns exactly
+    // the given set, so the tests go through the public compute methods rather than their internals.
+    private AsyncServiceScope NewScope(params Notification[] active)
+    {
+        var notifications = new Mock<INotifications>();
+        notifications
+            .Setup(x => x.ListActive(It.IsAny<Session>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiArray.New(active));
+        var hostInfo = new HostInfo {
+            HostKind = HostKind.MauiApp,
+            AppKind = AppKind.Ios,
+            Environment = Environments.Development,
+            BaseUrl = $"https://{Constants.Hosts.LocalVoxt}",
+            IsTested = true,
+        };
+        var scope = new ServiceCollection()
+            .AddTestLogging(Out)
+            .AddSingleton(_ => hostInfo)
+            .AddSingleton(c => new Features(c))
+            .AddSingleton(_ => new UrlMapper(hostInfo))
+            .AddSingleton(notifications.Object)
+            .AddScoped<UIHub>()
+            .AddScoped<AppUIHub>()
+            .AddFusion(fusion => {
+                fusion.AddBlazor();
+                fusion.AddService<NotificationsUI>(ServiceLifetime.Scoped);
+            })
+            .BuildServiceProvider()
+            .CreateAsyncScope();
+        // Fusion's scoped SessionResolver starts empty, and the hub throws on the first Session read otherwise
+        scope.ServiceProvider.GetRequiredService<ISessionResolver>().Session = Session.New();
+        return scope;
+    }
 
     private static ReactionNotification NewReaction(long entryLid, Moment sentAt)
         => ReactionNotification.New(TestUserId, ChatEntryId.New(ChatA, entryLid)) with { SentAt = sentAt };

--- a/tests/ts/e2e/reaction-navigation.test.ts
+++ b/tests/ts/e2e/reaction-navigation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * E2E test: the "navigate to unread reaction" button in the chat view.
+ *
+ * Alice posts a target message and enough filler to scroll it out of view; Bob reacts to
+ * the target and to one filler message. Alice reopens the chat at its tail and sees the
+ * button with a "2" badge; each click jumps to the closest reacted message and, once it's
+ * on screen, the reaction is dismissed and the badge counts down until the button hides.
+ *
+ * Run:
+ *   AC_E2E_SERVER=external npx vitest run tests/ts/e2e/reaction-navigation.test.ts --config vitest.config.e2e.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { BrowserContext, Page } from 'playwright';
+import {
+    BASE_URL, TEST_EMAIL, TEST_EMAIL_2, connectBrowser, newUserContext, screenshot,
+    skipOnboarding, waitForChatReady, waitForEditor, type BrowserConnection,
+} from './helpers';
+
+const shot = (name: string) => screenshot('e2e-reaction-nav', name);
+
+const CHAT_URL = `${BASE_URL}/chat/the-actual-one`;
+// A 720px viewport shows ~22 one-line messages: the two reacted messages must sit more than
+// a screen apart from each other and from the tail, or one of them is on screen at the moment
+// it's expected to be a jump target - and gets dismissed as seen instead.
+const FILLER_COUNT = 60;
+const SECOND_INDEX = 28;
+
+async function openChat(page: Page, url: string = CHAT_URL) {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await waitForChatReady(page);
+    await skipOnboarding(page);
+
+    const joinButton = page.locator('button:has-text("Join this chat")');
+    if (await joinButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await joinButton.click();
+        await page.waitForTimeout(1500);
+    }
+    await waitForEditor(page);
+}
+
+async function post(page: Page, text: string) {
+    const messageInput = page.locator('#message-input .editor-content[contenteditable="true"]').first();
+    await messageInput.click({ force: true });
+    await messageInput.evaluate(el => {
+        el.innerHTML = '';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.keyboard.type(text);
+    await messageInput.dispatchEvent('keypress', {
+        key: 'Enter', code: 'Enter', bubbles: true, cancelable: true,
+    });
+    await page.locator(`.chat-message-markup:has-text("${text}")`).first()
+        .waitFor({ state: 'visible', timeout: 15_000 });
+}
+
+async function waitInViewport(page: Page, entryLid: number) {
+    await expect.poll(() => page.locator(`[data-chat-entry-id$=":${entryLid}"]`).first().evaluate(el => {
+        const r = el.getBoundingClientRect();
+        return r.top >= 0 && r.bottom <= window.innerHeight;
+    }).catch(() => false), { timeout: 15_000 }).toBe(true);
+}
+
+// Reaction notifications outlive a failed run, so each run starts by clicking through
+// whatever is left - every click dismisses one.
+async function drainReactions(page: Page) {
+    const button = page.locator('.navigate-to-reaction .btn-round').first();
+    for (let i = 0; i < 20; i++) {
+        if (!await button.isVisible({ timeout: 3_000 }).catch(() => false))
+            return;
+
+        await button.click({ force: true }).catch(() => { /* ignore */ });
+        await page.waitForTimeout(1_000);
+    }
+}
+
+async function entryLidOf(page: Page, text: string): Promise<number> {
+    const entryId = await page.locator(`[data-chat-entry-id]:has(.chat-message-markup:has-text("${text}"))`)
+        .first()
+        .getAttribute('data-chat-entry-id');
+    expect(entryId).toBeTruthy();
+    return Number(entryId!.split(':').pop());
+}
+
+// The hover menu's first button reacts with a thumbs-up right away.
+async function reactTo(page: Page, entryLid: number) {
+    const message = page.locator(`[data-chat-entry-id$=":${entryLid}"] .chat-message`).first();
+    await message.waitFor({ state: 'visible', timeout: 15_000 });
+    await message.hover();
+    const reactButton = page.locator('.message-hover-menu-new .btn-round').first();
+    await reactButton.waitFor({ state: 'visible', timeout: 5_000 });
+    await reactButton.click();
+    await page.locator(`[data-chat-entry-id$=":${entryLid}"] .message-reactions`).first()
+        .waitFor({ state: 'visible', timeout: 15_000 });
+}
+
+describe('navigate to unread reaction', () => {
+    let conn: BrowserConnection;
+    let aliceCtx: BrowserContext;
+    let bobCtx: BrowserContext;
+    let alice: Page;
+    let bob: Page;
+
+    beforeAll(async () => {
+        conn = await connectBrowser();
+        ({ context: aliceCtx, page: alice } = await newUserContext(conn, TEST_EMAIL));
+        ({ context: bobCtx, page: bob } = await newUserContext(conn, TEST_EMAIL_2));
+    }, 180_000);
+
+    afterAll(async () => {
+        await aliceCtx.close().catch(() => { /* ignore */ });
+        await bobCtx.close().catch(() => { /* ignore */ });
+        if (conn.ownsBrowser) {
+            await conn.context.close().catch(() => { /* ignore */ });
+            await conn.browser.close().catch(() => { /* ignore */ });
+        }
+    });
+
+    it('jumps to each reacted message in turn and counts the badge down', async () => {
+        // arrange — Alice posts a target and fillers, Bob reacts to the target and a filler
+        const stamp = Date.now();
+        const targetText = `rx-target-${stamp}`;
+        await openChat(alice);
+        await drainReactions(alice);
+        await post(alice, targetText);
+        const targetLid = await entryLidOf(alice, targetText);
+        let secondText = '';
+        for (let i = 0; i < FILLER_COUNT; i++) {
+            const text = `rx-filler-${stamp}-${i}`;
+            await post(alice, text);
+            if (i === SECOND_INDEX)
+                secondText = text;
+        }
+        const secondLid = await entryLidOf(alice, secondText);
+
+        await openChat(bob, `${CHAT_URL}?n=${targetLid}`);
+        await reactTo(bob, targetLid);
+        await openChat(bob, `${CHAT_URL}?n=${secondLid}`);
+        await reactTo(bob, secondLid);
+        await bob.screenshot({ path: shot('bob-reacted') });
+
+        // act — Alice reopens the chat at its tail
+        await openChat(alice);
+        const button = alice.locator('.navigate-to-reaction .btn-round').first();
+        const badge = alice.locator('.navigate-to-reaction .unread-counter').first();
+        await button.waitFor({ state: 'visible', timeout: 30_000 });
+        await expect.poll(() => badge.textContent(), { timeout: 15_000 }).toMatch(/2/);
+        await alice.screenshot({ path: shot('alice-badge-2') });
+
+        // assert — the first click lands on the closest reacted message (the filler), the
+        // reaction gets dismissed, and the badge drops to 1
+        await button.click();
+        await waitInViewport(alice, secondLid);
+        await expect.poll(() => badge.textContent().catch(() => ''), { timeout: 15_000 }).toMatch(/1/);
+        await alice.waitForTimeout(1000);
+        await alice.screenshot({ path: shot('alice-after-first-click') });
+
+        // the second click lands on the target, and the button goes away
+        await button.click();
+        await waitInViewport(alice, targetLid);
+        await alice.locator('.navigate-to-reaction').first()
+            .waitFor({ state: 'hidden', timeout: 15_000 });
+        await alice.screenshot({ path: shot('alice-after-second-click') });
+    }, 300_000);
+});


### PR DESCRIPTION
## Summary

Closes #4403.

When someone reacts to one of your messages, the chat list shows the emoji badge, but inside the chat there was no way to find that message short of scrolling back through the history. Reactions land on old messages far more often than on the tail, so the badge pointed at something the chat view could not take you to.

## Fix

`NavigateToUnreadReaction` is a new button in `ChatViewNavigationPanel`, stacked above the navigate-to-end arrow. It shows the target reaction's emoji and a counter badge, exactly like the chat list badge and the end button do.

- **Source of truth is the active notification set.** `NotificationsUI.ListChatReactions(chatId)` projects `INotifications.ListActive` to the chat's `ReactionNotification`s, ordered by entry. No new server state; the count matches what the chat list and the reactions tab already show.
- **Target = the closest off-screen reacted entry** to the viewport center. Entries already on screen are skipped because `SeenNotificationDismisser` clears them anyway, so the button never points at something you are looking at.
- **A click navigates and dismisses.** The dismiss is explicit (same as a tap on the reactions tab), so the next click moves on even if the entry never lands on screen, e.g. it was deleted. The badge counts down and the button hides at zero.
- **The panel now owns the button column.** `chat-view-navigation-panel.css` carries the absolute positioning that used to live in `navigate-to-unread-or-end.css`, so the two buttons stack and the reaction button takes the bottom slot when the arrow is hidden. The container is `pointer-events: none` so an empty column never swallows taps on the last message.
- New l10n key `ChatView_GoToReaction` in all hand-written catalogs, BCMS and Max regenerated.

Invariants for reviewers: `ListChatReactions` returns a plain `IReadOnlyList` (client-local data, per CODING_STYLE item 13); the `Model` record relies on referential equality like `NavigateToUnreadOrEnd`'s, so every recompute re-renders.

## Testing

- `NotificationsUIProjectionTest` + `AppLocalizationTest`: 24/24 green.
- New e2e `tests/ts/e2e/reaction-navigation.test.ts`: two users, one posts a target and 60 fillers, the other reacts to two messages more than a screen apart; the first user's badge reads 2 → 1 → hidden, with the viewport verified to land on each reacted entry. Green at 1280x720 and in a one-off 390x844 run.
- Not verified: MAUI (iOS/Android/Mac) builds; the change is Razor/CSS only and the AOT source is registered, but no device pass was done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
