### PR TITLE
fix(chat): keep the loaded window when the sent message lands past the query's end

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -824,7 +824,22 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
             // fold and loads it back on the next render, which unloads the groups up there - and a group's
             // avatar is sticky, so it is pinned to the top line right until its group leaves the DOM.
             // Every own new entry navigates (see the entry observer), so that is once per sent message.
-            if (dataQuery.Covers(navigation.EntryLid)) {
+            // Covers reads the offsets as lid deltas, and they can't see entries created since the render
+            // this query is built from - so the message just sent reads as one lid past the end and misses.
+            // Once the tail is loaded there is nowhere else for that entry to be, hence the separate test.
+            var isAtLoadedTail = oldData.HasVeryLastItem
+                && navigation.EntryLid >= dataQuery.ExistingLidRange.End;
+            if (isAtLoadedTail) {
+                caseName += "+navigation-at-tail";
+                // A query the list issued itself carries its scroll deltas, and standing still makes
+                // EndOffset zero - which would leave the target outside the zone by a tile boundary.
+                // At the tail there is nothing past the end to load, so this only rounds the zone up.
+                dataQuery = dataQuery with {
+                    EndOffset = Math.Max(dataQuery.EndOffset, ChatUI.HalfLoadLimit),
+                    Navigation = navigation,
+                };
+            }
+            else if (dataQuery.Covers(navigation.EntryLid)) {
                 caseName += "+navigation-in-range";
                 dataQuery = dataQuery with { Navigation = navigation };
             }


### PR DESCRIPTION
## Summary

Follow-up to #4406, which stopped a sent message unloading the window above the
fold. Measuring the merged fix on `dev` showed it only lands about half the time:
the narrow `scrollToKey` render still appeared in 3 of 6 sends, collapsing the
window from ~85 items to ~30 and back.

`ChatDataQuery.Covers` reads the query's offsets as lid deltas, so it only sees
the entries the render it was built from already knew about. The message the user
just sent is one lid past that end. Whether that matters depends on which branch
of `GetChatDataQuery` produced the query, and the debug log makes the split plain:

```
case=has-query,                         result={"start":190,"end":217}@[-35-0]
case=no-query+has-data+hasVeryLastItem, result={"start":197,"end":215}@[-40-40]
```

A query the list issued itself carries its own scroll deltas, and standing still
makes `EndOffset` zero — so `Covers` reports "not covered" and the navigation
branch throws the whole loaded window away. The other branch carries
`+HalfLoadLimit` and absorbs the off-by-one, which is why half the sends were fine.

## Fix

At the tail there is nowhere else for a new entry to be, so test that directly
rather than through the offsets: the loaded data already has the very last item
(`oldData.HasVeryLastItem`) and the target sits at or past `ExistingLidRange.End`.

In that branch `EndOffset` is rounded up to `HalfLoadLimit` so the target can't
fall outside the load zone on a tile boundary — past the end of the chat there is
nothing to load, so this widens the zone on paper only. `StartOffset` is
untouched, which is the whole point: the window above the fold stays.

Invariants a reviewer should hold onto: the new test must stay gated on
`HasVeryLastItem` (without it, a post from far up the chat would stop re-aiming
and the target might never load), and `StartOffset` must not be widened here —
growing the zone upward would reintroduce the load the fix exists to avoid.

## Testing

Local WASM build with the debug log on, chat grown past the load zone:

| Case | Case in log | Query | Result |
|---|---|---|---|
| Sending at the tail | `+navigation-at-tail` | `{197,215}@[-40-40]` | 2 renders, window monotone `63 → 64 → 64` |
| Sending from the top of the chat | `+navigation` | `{215,220}@[-21-43]` | window re-aimed, jumped to entry 217 |

The second row is the one that matters for regressions: when the tail isn't
loaded, behaviour is byte-for-byte what it was before.

`dotnet build ActualChat.CI.slnf` is green. **No automated test covers this** —
`GetChatDataQuery` is a private method on a Blazor component and nothing here is
reachable from the unit suites.

**What was not verified:** the `has-query` + navigation path itself. That
`Covers` misses there is arithmetic (`EndOffset = 0`, target `End + 1`), not a
guess, but there is no end-to-end run of it: locally it doesn't reproduce, since
the test chat is smaller than the load zone and the list's own query only appears
on scroll, never coinciding with a send. That measurement is owed on `dev` after
this merges — same as it was for #4406, where the equivalent measurement is what
turned up this bug.

Also still owed from #4406: a pass on a real phone. The end anchor is 48px in the
narrow layout rather than 4px, and that changes which arrivals fall past the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011thmMDSfxk8yvomgmfzJGp
