### PR TITLE
feat(skills): add /track-issue to tie a task to its GitHub issue and the board

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,18 +1,22 @@
 ---
-allowed-tools: Bash, Read, mcp__github__issue_write, mcp__github__get_me, mcp__github__list_issues, mcp__github__search_issues
-description: Create a GitHub issue, assign to current user, and set status to In Progress
-argument-hint: <title> [-- <body>]
+allowed-tools: Bash, Read, AskUserQuestion
+description: Create a GitHub issue, assign to current user, and set status to In Progress (or ToDo with --todo)
+argument-hint: [--todo] <title> [-- <body>]
 ---
 
 # Create GitHub Issue
 
-Create a GitHub issue in `Actual-Chat/actual-chat`, assign it to the current user, and add it to the org's GitHub Project board with **In Progress** status.
+Create a GitHub issue in `Actual-Chat/actual-chat`, assign it to the current user, and add it to the org's GitHub Project board with **In Progress** status — or **ToDo** when `--todo` is given (work that is claimed but not yet started; `/track-issue` passes this).
+
+Everything runs through `gh`, which is authenticated in every AgentCli environment (`GH_TOKEN` comes from `AC_GITHUB_TOKEN` in Docker). Do not depend on a GitHub MCP server — it is not wired up in most sessions.
 
 ## Arguments
 
-The argument is the issue title. Optionally, use `--` to separate title from body:
-- `/issue Fix login redirect loop` — title only
-- `/issue Fix login redirect loop -- The redirect happens when...` — title + body
+- `--todo` — optional, first token only: land the issue in **ToDo** instead of **In Progress**.
+- The rest is the issue title. Optionally, use `--` to separate title from body:
+  - `/issue Fix login redirect loop` — title only
+  - `/issue Fix login redirect loop -- The redirect happens when...` — title + body
+  - `/issue --todo avatar upload` — claimed, not started
 
 If no arguments are provided, ask the user for at least a title.
 
@@ -24,12 +28,12 @@ Split the argument on ` -- ` (space-dash-dash-space):
 - Everything before `--` is the **title input**
 - Everything after `--` is the **body** (optional)
 
-**Title must be laconic** — short, punchy, lowercase (except proper nouns). Strip filler words. Examples:
-- "There is an issue where the login page redirects in a loop" → `fix login redirect loop`
-- "We need to add the ability to upload avatars" → `avatar upload`
-- "The chat message list is very slow when there are many messages" → `fix chat list perf with many messages`
+**Title must be laconic** — short, punchy, a sentence fragment that starts with a capital letter. Strip filler words. **No `fix:`/`feat:`/`chore:` prefixes** — those are commit and branch conventions, an issue title is plain English (the issue *type* carries the Bug/Feature/Task distinction). Examples:
+- "There is an issue where the login page redirects in a loop" → `Login page redirects in a loop`
+- "We need to add the ability to upload avatars" → `Avatar upload`
+- "The chat message list is very slow when there are many messages" → `Chat list is slow with many messages`
 
-Use standard prefixes when intent is clear: `fix:`, `feat:`, `refactor:`, `chore:`. If the user already provided a short title, keep it as-is.
+If the user already provided a short title, keep its wording; only capitalize the first letter and drop a commit-style prefix.
 
 ### 1b. Craft the body
 
@@ -37,12 +41,16 @@ An issue describes the **problem**, not the solution. Cover the symptom (what's 
 
 Same laconic register as the title: short sections, no filler. Skip "Open follow-ups" / "Future work" sections unless the user asked for them — separate issues are better than to-do lists tucked inside one.
 
+Write the body to a file under the project's `tmp/` (never the repo root) and pass it with `--body-file`.
+
 ### 2. Check for similar issues
 
-Before creating, search for existing issues that might be duplicates or related. Use `mcp__github__search_issues` with key words from the title:
+Before creating, search for existing open issues that might be duplicates or related, with the 2–3 most distinctive keywords from the title:
 
-- `owner`: `"Actual-Chat"`, `repo`: `"actual-chat"`
-- `query`: 2-3 most distinctive keywords from the title
+```bash
+gh search issues --repo Actual-Chat/actual-chat --state open "<keywords>" \
+  --json number,title,assignees,url --limit 10
+```
 
 If similar **open** issues are found, list them to the user with number, title, and URL. Ask whether to:
 - **Skip** — the issue already exists
@@ -53,80 +61,60 @@ If no similar issues are found, proceed silently.
 
 ### 3. Get current user
 
-Use `mcp__github__get_me` to get the authenticated user's login.
+```bash
+gh api user --jq .login
+```
 
 ### 4. Create the issue
 
-Pick the org-level **issue type** (not labels — labels are ignored in this repo). Try `mcp__github__list_issue_types` with `owner: "Actual-Chat"` to get valid values. If the call returns 403 (PAT can't read org issue types), ask the user which type to use rather than guessing.
-
-Use `mcp__github__issue_write` with:
-- `method`: `"create"`
-- `owner`: `"Actual-Chat"`
-- `repo`: `"actual-chat"`
-- `title`: from arguments
-- `body`: from arguments (if provided)
-- `assignees`: `[current_user_login]`
-- `type`: org issue type name (e.g. `Bug` for defects)
-
-Do **not** pass `labels` — this repo doesn't use them for triage.
-
-Record the created issue number from the response.
-
-### 5. Add to project board with "In Progress" status
-
-Run the following bash commands (`GH_TOKEN` is set automatically by `ai.ps1` from `AC_GITHUB_TOKEN`).
-
-#### 4a. Find the org project
-
 ```bash
-gh project list --owner Actual-Chat --format json --limit 10
+gh issue create --repo Actual-Chat/actual-chat --assignee @me \
+  --title "<title>" --body-file tmp/issue-body.md
 ```
 
-Pick the first open project. Note the project **number**.
+Record the issue number from the returned URL.
 
-#### 4b. Add issue to project
+Then set the org-level **issue type** (not labels — labels are ignored in this repo). The org defines `Task`, `Bug`, and `Feature`; `gh issue create` has no flag for them, so fetch the ids and set the type with one mutation:
 
 ```bash
-gh project item-add <PROJECT_NUMBER> --owner Actual-Chat --url https://github.com/Actual-Chat/actual-chat/issues/<ISSUE_NUMBER> --format json
+gh api graphql -f query='{ organization(login:"Actual-Chat"){ issueTypes(first:10){ nodes{ id name } } } }'
+ISSUE_ID=$(gh api graphql -F n=<NUMBER> -f query='query($n:Int!){ repository(owner:"Actual-Chat",name:"actual-chat"){ issue(number:$n){ id } } }' --jq .data.repository.issue.id)
+gh api graphql -F id="$ISSUE_ID" -F typeId=<TYPE_ID> \
+  -f query='mutation($id:ID!,$typeId:ID!){ updateIssue(input:{id:$id, issueTypeId:$typeId}){ issue{ number issueType{name} } } }'
 ```
 
-Record the item **id** from the response.
+Pick `Bug` for defects, `Feature` for new user-visible capability, `Task` for everything else. If the type query returns 403 (token cannot read org issue types), ask the user which type to use rather than guessing — and if they cannot help, leave the type unset and say so.
 
-#### 4c. Get the Status field ID and "In Progress" option ID
+Do **not** pass `--label` — this repo doesn't use labels for triage.
+
+### 5. Add to project board and set Status
+
+The board is the org's **Team project**, number `1`. Its ids are stable; re-fetch with `gh project view 1 --owner Actual-Chat --format json` and `gh project field-list 1 --owner Actual-Chat --format json` only if a command below says it cannot resolve one.
+
+| What | Value |
+|---|---|
+| Project node id | `PVT_kwDOBSwBWs4AA3Ej` |
+| Status field id | `PVTSSF_lADOBSwBWs4AA3EjzgAc2xg` |
+| `In Progress` option | `47fc9ee4` |
+| `ToDo` option | `f75ad846` |
 
 ```bash
-gh project field-list <PROJECT_NUMBER> --owner Actual-Chat --format json
+ITEM=$(gh project item-add 1 --owner Actual-Chat \
+  --url https://github.com/Actual-Chat/actual-chat/issues/<NUMBER> --format json --jq .id)
+gh project item-edit --project-id PVT_kwDOBSwBWs4AA3Ej --id "$ITEM" \
+  --field-id PVTSSF_lADOBSwBWs4AA3EjzgAc2xg --single-select-option-id 47fc9ee4   # f75ad846 with --todo
 ```
 
-Find the field named "Status" and get its **id**. Then get the option ID for "In Progress":
+`item-edit` exits 0 even with a wrong option id, so verify the column landed:
 
 ```bash
-gh api graphql -f query='
-query($projectId: ID!) {
-  node(id: $projectId) {
-    ... on ProjectV2 {
-      field(name: "Status") {
-        ... on ProjectV2SingleSelectField {
-          id
-          options { id name }
-        }
-      }
-    }
-  }
-}' -f projectId="<PROJECT_NODE_ID>"
-```
-
-Note: The project node ID can be obtained from `gh project view <NUMBER> --owner Actual-Chat --format json`.
-
-#### 4d. Set status to "In Progress"
-
-```bash
-gh project item-edit --project-id <PROJECT_NODE_ID> --id <ITEM_ID> --field-id <STATUS_FIELD_ID> --single-select-option-id <IN_PROGRESS_OPTION_ID>
+gh api graphql -F n=<NUMBER> -f query='query($n:Int!){ repository(owner:"Actual-Chat",name:"actual-chat"){ issue(number:$n){
+  projectItems(first:5){ nodes{ fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue{ name } } } } } } }'
 ```
 
 ### 6. Error handling
 
-- If project board operations fail (e.g., token lacks `project` scope), still report the created issue as success and warn that the project board update failed. Suggest the user regenerate their PAT with Organization > Projects: Read and write permission (see `docs-internal/set-local-env.ps1`).
+- If project board operations fail (e.g., token lacks `project` scope), still report the created issue as success and warn that the project board update failed. Suggest `gh auth refresh -s project`, or regenerating the PAT with Organization > Projects: Read and write permission (see `docs-internal/set-local-env.ps1`).
 - Never fail silently — always show what happened.
 
 ### 7. Output
@@ -134,4 +122,5 @@ gh project item-edit --project-id <PROJECT_NODE_ID> --id <ITEM_ID> --field-id <S
 Report:
 - Issue URL: `https://github.com/Actual-Chat/actual-chat/issues/<NUMBER>`
 - Assignee
+- Issue type
 - Project board status (or warning if it failed)

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -33,6 +33,7 @@ to `/prepare-merge`.
 | Branch has commits over the base | `git log --oneline origin/dev..HEAD` | Nothing to PR. Stop. |
 | No PR already open for it | `gh pr list --head "$(git branch --show-current)" --json url,state` | One exists → do **not** open a second, and do **not** re-announce it. Use `pr list`, not `pr view` — `pr view` errors on a branch with no upstream. |
 | Build/tests actually run | — | You may still PR, but the Testing section must say plainly what was not run. |
+| Branch is linked to its issue | `git config --get "branch.$(git branch --show-current).issue"` | Empty → ask once, via `AskUserQuestion`: run `/track-issue` now, or open the PR without an issue. Never invent a number from the branch name. |
 
 Branch names follow the commit prefixes: `feat/…`, `fix/…`, `refactor/…` — never
 `feature/…`.
@@ -81,7 +82,19 @@ gh pr create --base dev --title "type(scope): summary" --body-file tmp/pr-body.m
 - **Body shape**: `## Summary` (what was broken and why — the mechanism, not a diff
   restatement), `## Fix` (what the change does, and the invariants a reviewer must not
   break), `## Testing` (what ran, green or not, and what is still owed — device passes,
-  manual verification). Then your harness's attribution footer, if it gives you one.
+  manual verification). Then a line `Closes #<N>` with the issue from the preconditions
+  check — that is what moves the issue to Done on merge — and your harness's
+  attribution footer, if it gives you one. No linked issue → no `Closes` line.
+- **Issue still in ToDo?** The PR is proof the work is in progress. Check and move it:
+
+  ```bash
+  gh api graphql -F n=<N> -f query='query($n:Int!){ repository(owner:"Actual-Chat",name:"actual-chat"){ issue(number:$n){
+    projectItems(first:5){ nodes{ id fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue{ name } } } } } } }'
+  gh project item-edit --project-id PVT_kwDOBSwBWs4AA3Ej --id <ITEM> \
+    --field-id PVTSSF_lADOBSwBWs4AA3EjzgAc2xg --single-select-option-id 47fc9ee4   # In Progress
+  ```
+
+  Only ToDo (or Backlog) moves; In Progress and Done are left alone.
 - Say plainly what was *not* verified. "Android device-verified; iOS compiles, device
   test still owed" is the useful sentence.
 
@@ -128,6 +141,7 @@ their own confirmation. Never fold one into this step.
 | `gh pr create --fill` | Write a real Summary/Fix/Testing body |
 | Body file in the repo root | Put it in `tmp/` |
 | Base branch assumed | `gh repo view --json defaultBranchRef` |
+| `Closes #N` guessed from the branch name | Only `branch.<name>.issue` counts; otherwise ask about `/track-issue` |
 | Second PR opened for a branch that already has one | `gh pr list --head` first |
 | "All tests pass" without running them | State what ran and what is owed |
 | Pushing again after `/prepare-merge` | It already pushed; skip step 2 |

--- a/.claude/skills/prepare-merge/SKILL.md
+++ b/.claude/skills/prepare-merge/SKILL.md
@@ -34,6 +34,12 @@ When the user types `/prepare-merge`, run this skill.
 - Working tree is clean (`git status --short` empty).
 - `git fetch origin dev` succeeded.
 
+One more check that **warns rather than aborts**: `git config --get
+"branch.$(git branch --show-current).issue"`. Empty means the branch was never
+tied to its GitHub issue, so the PR that follows will not close anything. Say
+so in one line and offer `/track-issue`; if the user declines, carry on —
+a hotfix must not be held hostage to bookkeeping.
+
 ## Steps
 
 ### 1. Safety backup

--- a/.claude/skills/track-issue/SKILL.md
+++ b/.claude/skills/track-issue/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: track-issue
+description: |
+  Use when work on a task is about to start or has just started — after a design
+  or plan is approved, when a feature branch is created or resumed in a new
+  session, when the first commit lands on a branch that was only claimed — or
+  when the user says "link this to an issue", "find the issue for this", "put it
+  on the board", "claim the issue", or "/track-issue".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# /track-issue — Tie the current work to a GitHub issue and the board
+
+Every task the team works on has one issue in `Actual-Chat/actual-chat`, on the
+org's **Team project** board, assigned to whoever is doing it, in the column
+that says how far along it is. This skill makes the work in front of you match
+that: it finds the issue (or files one through `/issue`), claims it, sets the
+column, and records the issue number on the branch so `/create-pr` and
+`/prepare-merge` find it later.
+
+**Nothing here happens silently.** The pick is always confirmed, and an issue
+that belongs to someone else is never re-assigned without asking. Read-only
+lookups run freely; every mutation is listed in step 6 and nothing else mutates.
+
+## Arguments
+
+`/track-issue` takes zero or one of:
+
+- `#4321` or `4321` — link this issue, skip the search.
+- free words — extra search terms on top of what the conversation already says.
+- `todo` / `in-progress` — force the column (see step 5).
+
+## Constants
+
+These are the org's live ids. If any command below answers with "could not
+resolve", re-fetch with the query in the `Refresh` column — do not guess.
+
+| What | Value | Refresh |
+|---|---|---|
+| Project number / owner | `1` / `Actual-Chat` | `gh project list --owner Actual-Chat` |
+| Project node id | `PVT_kwDOBSwBWs4AA3Ej` | `gh project view 1 --owner Actual-Chat --format json --jq .id` |
+| Status field id | `PVTSSF_lADOBSwBWs4AA3EjzgAc2xg` | `gh project field-list 1 --owner Actual-Chat --format json` |
+| Status option `ToDo` | `f75ad846` | same as above (options are listed under the field) |
+| Status option `In Progress` | `47fc9ee4` | |
+| Status option `Backlog` / `Done` | `86318b0b` / `98236657` | |
+
+## Steps
+
+### 1. Preconditions and the existing link
+
+```bash
+gh auth status                          # must be logged in
+ME=$(gh api user --jq .login)
+BRANCH=$(git branch --show-current)
+git config --get "branch.$BRANCH.issue"  # empty on a fresh branch
+```
+
+If `branch.<name>.issue` is already set, the search is over: take that number,
+skip to step 4, and re-run 4–6 as a check. Re-running the skill on a linked
+branch is idempotent and cheap — do it rather than wondering.
+
+### 2. Work out what the work is
+
+Collect the signal before searching. In order of strength:
+
+1. A number in the branch name (`feat/4362-…`) — a candidate, not a verdict.
+2. What the user said the task is, in this conversation.
+3. `git log --oneline origin/dev..HEAD` subjects and `git status --short` paths.
+4. Any plan or spec the branch adds under `docs/superpowers/` — its title and
+   first paragraph.
+
+Turn that into 2–3 distinctive search terms: a component name, an error
+string, a user-visible symptom. Not "fix", not "bug", not "chat".
+
+### 3. Search, then confirm the pick — always
+
+```bash
+gh search issues --repo Actual-Chat/actual-chat --state open "<terms>" \
+  --json number,title,assignees,updatedAt --limit 10
+```
+
+Run it two or three times with different term sets (the branch number, if any,
+counts as one). Merge and rank: exact symptom match first, then same component
+touched recently, then the rest. Drop anything closed.
+
+Then `AskUserQuestion` with the top 3–5 candidates (number, title, assignee)
+plus two fixed options: **"None of these — create a new issue"** and
+**"Skip — no issue for this work"**. Ask even when one candidate looks perfect
+and even when the branch name carries a number: ~200 open issues make near-misses
+common, and the cost of a wrong link is a wrong `Closes #N` on the PR.
+
+"Create" → step 7. "Skip" → report and stop; store nothing.
+
+### 4. Assignment — never re-assign without asking
+
+Fetch the issue's current state in one query (also used in steps 5–6):
+
+```bash
+gh api graphql -F n=<N> -f query='query($n:Int!){
+  repository(owner:"Actual-Chat",name:"actual-chat"){ issue(number:$n){
+    id state title issueType{name} assignees(first:5){nodes{login}}
+    projectItems(first:5){nodes{ id project{id}
+      fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue{name} } }}
+  }}}'
+```
+
+| Assignees | Action |
+|---|---|
+| none, or only `$ME` | `gh issue edit <N> --add-assignee @me` (no-op if already there) |
+| someone else, with or without `$ME` | `AskUserQuestion`, options in this order: **join as co-assignee** (`--add-assignee @me`), **take it over** (`--add-assignee @me --remove-assignee <them>`), **link without touching assignees**, **abort**. |
+
+The reporter having self-assigned is not a reason to skip the question. It is
+the most common case, and whether they keep it is their call and the user's,
+not yours. If the issue is already **In Progress** under someone else, say so
+in the question — they may be coding it right now, and taking it over is then
+a conversation with them, not a board edit.
+
+### 5. Pick the column
+
+| Evidence | Column |
+|---|---|
+| `$BRANCH` is `dev`/`master`/`release/*`, or the branch has no commits over `origin/dev` and no code changes in the tree | **ToDo** — the work is claimed, not started |
+| Commits over `origin/dev`, or a dirty tree touching code (not just `docs/`) | **In Progress** |
+| Argument `todo` / `in-progress` | that column, overriding the evidence |
+
+Two rules on top:
+
+- **Never move backward.** An issue already In Progress stays there even if the
+  evidence says ToDo. Backlog → ToDo/In Progress is forward.
+- **Never touch Done or a closed issue.** If the pick is closed, say so and go
+  back to step 3 — the user may want a fresh issue.
+
+### 6. Update the board, then persist the link
+
+Every mutation the skill performs is one of these five:
+
+```bash
+# a. assignee (step 4)
+gh issue edit <N> --add-assignee @me [--remove-assignee <them>]
+
+# b. add to the board if step 4's query showed no projectItems on PVT_kwDOBSwBWs4AA3Ej
+ITEM=$(gh project item-add 1 --owner Actual-Chat \
+  --url https://github.com/Actual-Chat/actual-chat/issues/<N> --format json --jq .id)
+
+# c. set Status (skip if step 4 showed it already equal or further along)
+gh project item-edit --project-id PVT_kwDOBSwBWs4AA3Ej --id "$ITEM" \
+  --field-id PVTSSF_lADOBSwBWs4AA3EjzgAc2xg --single-select-option-id <f75ad846|47fc9ee4>
+
+# d. persist the link on the branch
+git config "branch.$BRANCH.issue" <N>
+```
+
+`item-edit` exits 0 on a wrong option id and changes nothing, so **verify**: re-run
+step 4's query and check `fieldValueByName.name` is the column you meant.
+
+**Still on `dev`?** There is no branch to write the link to. `AskUserQuestion`:
+**create the branch now** (first option, with the proposed name) or **stay on
+dev**. The name is `fix/<slug>` for a Bug, `feat/<slug>` for a Feature or Task,
+never `feature/…`; the slug is the title lowercased, non-alphanumerics
+collapsed to `-`, cut to the first four or five words. If a branch of that
+name already exists, append the issue number. On
+"create": `git checkout -b <name>`, then (d). On "stay": say plainly that the
+link is not stored and the skill must be re-run once a branch exists.
+
+### 7. Create path
+
+Run the `/issue` command with a laconic, capitalized, prefix-free title and a
+problem-only body drafted from step 2, and pass `--todo` when step 5 says ToDo (`/issue` defaults to In
+Progress). `/issue` returns the new number; continue at step 6 (d). Assignment
+and the board are already handled by `/issue` — do not redo (a)–(c).
+
+## Report
+
+Four lines, always:
+
+```
+Issue   #4397 Search does not find devops chat — https://github.com/Actual-Chat/actual-chat/issues/4397
+Assign  alexis-kochetov (frolyo kept as co-assignee)
+Board   Team project · ToDo (was: not on board)
+Link    branch fix/search-devops-chat → branch.fix/search-devops-chat.issue = 4397
+```
+
+Say what was *not* done: "link not stored — still on dev", "board update failed:
+token lacks `project` scope (run `gh auth refresh -s project`)".
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Linking the single "obvious" match without asking | Step 3 always asks, even for one candidate |
+| Adding yourself to someone else's issue because "they're just the reporter" | Step 4 asks; the answer is theirs and the user's |
+| In Progress before a line of code exists | Step 5: claimed = ToDo; code = In Progress |
+| Moving In Progress back to ToDo | Never backward |
+| Trusting `item-edit`'s exit code | Re-query and read the Status name |
+| Linking a closed issue | Closed → say so, return to step 3 |
+| Forgetting `git config` because the board is already right | The link is the deliverable `/create-pr` needs; (d) runs every time |
+| Running on `dev` and reporting success | No branch = no link; offer the branch or say it is not stored |
+| Re-filing an issue `/issue` already searched for | The create path delegates; do not duplicate its duplicate check |

--- a/.claude/skills/track-issue/SKILL.md
+++ b/.claude/skills/track-issue/SKILL.md
@@ -137,7 +137,7 @@ Two rules on top:
 
 ### 6. Update the board, then persist the link
 
-Every mutation the skill performs is one of these five:
+Every mutation the skill performs is one of these four:
 
 ```bash
 # a. assignee (step 4)
@@ -158,7 +158,8 @@ git config "branch.$BRANCH.issue" <N>
 `item-edit` exits 0 on a wrong option id and changes nothing, so **verify**: re-run
 step 4's query and check `fieldValueByName.name` is the column you meant.
 
-**Still on `dev`?** There is no branch to write the link to. `AskUserQuestion`:
+**Still on `dev`?** Links are never stored on `dev`, `master` or `release/*`
+— a task's link belongs to the branch that will carry its PR. `AskUserQuestion`:
 **create the branch now** (first option, with the proposed name) or **stay on
 dev**. The name is `fix/<slug>` for a Bug, `feat/<slug>` for a Feature or Task,
 never `feature/…`; the slug is the title lowercased, non-alphanumerics

--- a/AGENTS-Source.md
+++ b/AGENTS-Source.md
@@ -96,6 +96,18 @@ The only exception is when `/server-loop` is running - in this case you should t
 
 **Running the server (direct)**: Use `/server-start`, `/server-restart`, `/server-stop`. Use `--watch` flag for auto-reload.
 
+## When work on a task starts
+
+Every task maps to one GitHub issue on the org's Team project board. Run the
+`/track-issue` skill (`.claude/skills/track-issue/SKILL.md`) **before the
+first code change** of a task — right after a design or plan is approved, and
+whenever a session starts on a feature branch that has no
+`branch.<name>.issue` git config yet. It finds or files the issue, assigns it,
+sets the board column (ToDo when claimed, In Progress once code exists), and
+stores the number on the branch so `/create-pr` can add `Closes #N`. Running
+it on an already-linked branch is cheap and idempotent; do it rather than
+assuming. It never links or re-assigns anything without asking.
+
 ## Before merging a feature branch to dev
 
 When work reaches "ready for PR / merge / final review", ask the developer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,18 @@ The only exception is when `/server-loop` is running - in this case you should t
 
 **Running the server (direct)**: Use `/server-start`, `/server-restart`, `/server-stop`. Use `--watch` flag for auto-reload.
 
+## When work on a task starts
+
+Every task maps to one GitHub issue on the org's Team project board. Run the
+`/track-issue` skill (`.claude/skills/track-issue/SKILL.md`) **before the
+first code change** of a task — right after a design or plan is approved, and
+whenever a session starts on a feature branch that has no
+`branch.<name>.issue` git config yet. It finds or files the issue, assigns it,
+sets the board column (ToDo when claimed, In Progress once code exists), and
+stores the number on the branch so `/create-pr` can add `Closes #N`. Running
+it on an already-linked branch is cheap and idempotent; do it rather than
+assuming. It never links or re-assigns anything without asking.
+
 ## Before merging a feature branch to dev
 
 When work reaches "ready for PR / merge / final review", ask the developer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,18 @@ The only exception is when `/server-loop` is running - in this case you should t
 
 **Running the server (direct)**: Use `/server-start`, `/server-restart`, `/server-stop`. Use `--watch` flag for auto-reload.
 
+## When work on a task starts
+
+Every task maps to one GitHub issue on the org's Team project board. Run the
+`/track-issue` skill (`.claude/skills/track-issue/SKILL.md`) **before the
+first code change** of a task — right after a design or plan is approved, and
+whenever a session starts on a feature branch that has no
+`branch.<name>.issue` git config yet. It finds or files the issue, assigns it,
+sets the board column (ToDo when claimed, In Progress once code exists), and
+stores the number on the branch so `/create-pr` can add `Closes #N`. Running
+it on an already-linked branch is cheap and idempotent; do it rather than
+assuming. It never links or re-assigns anything without asking.
+
 ## Before merging a feature branch to dev
 
 When work reaches "ready for PR / merge / final review", ask the developer


### PR DESCRIPTION
## Summary

Work regularly starts in a Claude session without a corresponding GitHub issue, or with one that sits unassigned in Backlog while the code is already being written. The Team project board then lags reality: columns are moved by hand or not at all, issues stay on the reporter, and PRs land without `Closes #N`, so nothing reaches Done on merge. The existing `/issue` command only files a new issue straight into In Progress, and it depends on a GitHub MCP server that is not loaded in most sessions.

## Fix

- **New `/track-issue` skill** (`.claude/skills/track-issue/SKILL.md`). Finds the issue for the work at hand (or files one through `/issue`), claims it, sets the board column and stores the number in `branch.<name>.issue` git config. Invariants a reviewer should hold it to:
  - The pick is always confirmed via `AskUserQuestion`, even for a single obvious match.
  - An issue assigned to someone else is never re-assigned without asking; co-assign is offered before take-over, and an In Progress issue held by someone else is called out as "they may be coding it".
  - ToDo when the work is only claimed, In Progress once code exists on the branch; never moves backward, never touches Done or closed issues.
  - Every board write is verified by re-query, because `gh project item-edit` exits 0 on a bad option id.
- **`/issue`** now runs on `gh` alone, sets the org issue type through GraphQL, takes `--todo`, and requires plain-English titles: capital first letter, no `fix:`/`feat:` prefix (the issue type carries Bug/Feature/Task).
- **`/create-pr`** reads the branch link, adds `Closes #N`, and moves a ToDo issue to In Progress; without a link it asks once about running `/track-issue`.
- **`/prepare-merge`** warns, but does not abort, when no link exists.
- **AGENTS-Source.md** gets a "When work on a task starts" rule asking for `/track-issue` before a task's first code change; `AGENTS.md`/`CLAUDE.md` regenerated with `ai update-md`.

## Testing

- Baseline vs. skill, dry-run subagents on the same scenario ("link the devops-search work"): without the skill the agent silently co-assigned itself on frolyo's issue and stored no link; with the skill it confirmed the pick, asked about the assignment, respected never-move-backward and stored the link.
- Live run on this very branch: issue #4409 created as Task, assigned, ToDo, moved to In Progress after the first commit, each column verified by GraphQL query. This PR's `Closes #4409` line is the first live test of the `/create-pr` half; the Done transition on merge is still owed.
- No C#/TS touched; no build run.

Closes #4409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019E95MLCKNJACpFtq4VT65t
