### PR TITLE
fix(ios-ptt): prepare the audio session before the framework activates it

### DIFF
--- a/docs/live-audio/10-push-to-talk.md
+++ b/docs/live-audio/10-push-to-talk.md
@@ -481,20 +481,30 @@ re-driven from the create callback.
 
 `IncomingPushResult` must return synchronously and fast, so it only parses the
 payload, persists the wake (`SaveLastWake`), sets the channel descriptor title,
-and either parks the wake in `_pendingWake` when
-`AudioSession.Owner == AudioSessionOwner.App` — the session is still
-App-owned, so an activation callback will follow and dispatch it then — or
-dispatches it immediately otherwise, because a session that is already
-PTT-owned gets no further activation callback to dispatch on.
+prepares the session (`AudioSession.PrepareForPttSession`: category
+`PlayAndRecord`, mode `VoiceChat` — the framework activates the session with
+whatever category it finds, and it won't activate a mixable one such as the
+`Ambient` an idle app rests in while in the background), and either parks the
+wake in `_pendingWake` when `AudioSession.Owner == AudioSessionOwner.App` — the
+session is still App-owned, so an activation callback will follow and dispatch
+it then — or dispatches it immediately otherwise, because a session that is
+already PTT-owned gets no further activation callback to dispatch on.
 `DidActivateAudioSession` → `OnAudioSessionActivated` then drains the pending
-wake. An invalid payload still returns a `PTParticipant` and schedules
+wake. A parked wake that sees no activation within `ParkedWakeTimeout` (5 s) is
+dispatched anyway: its playback is refused, and that refusal is what asks the
+framework again with a fresh participant (see *Self-initiated playback*). The
+same preparation runs at `DidBeginTransmitting` (a listening burst leaves
+`Playback`, whose input node reports no sample rate, and the pre-roll and the
+recorder both need a live input) and before a self-initiated activation. An invalid payload still returns a `PTParticipant` and schedules
 `ClearActiveParticipant` after `PhantomWakeClearDelay` (5 s), or the system UI
 would show the channel as receiving forever.
 
 **Self-initiated playback.** An app joined to the channel may not activate its
 own `AVAudioSession` in the background: `SetActive(true)` answers
-`AVAudioSessionErrorCode.CannotInterruptOthers` (`'!int'`, 560557684), and so
-does `AVAudioEngine.start`. That is exactly the position of an armed app that is
+`AVAudioSessionErrorCode.CannotInterruptOthers` (`'!int'`, 560557684) for an
+app that just went to the background, or `MissingEntitlement` (`'ent?'`,
+1701737535) for one resumed from suspension, and so does `AVAudioEngine.start`;
+`AudioSession.IsActivationRefused` covers both. That is exactly the position of an armed app that is
 already listening when the next utterance arrives over RPC — the server skips
 active participants and dedups wakes per `PttWakeTtl`, so no push comes, yet
 the stream does. `AudioSession` therefore treats that refusal as a request:

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -124,6 +124,19 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         }
     }
 
+    public static void PrepareForTransmit()
+    {
+        // Before the framework activates the transmit session: it takes the category as it finds
+        // it, and a listening burst leaves Playback, whose input node reports no sample rate -
+        // the pre-roll and the recorder that follow both need a live input.
+        try {
+            ConfigureRecordingUnsafe(AVAudioSession.SharedInstance(), AudioSessionOwner.PttTransmit);
+        }
+        catch (Exception e) {
+            OwnerLog.LogWarning(e, "Couldn't configure the session for a PTT transmit");
+        }
+    }
+
     public static bool IsCannotInterruptOthers(NSError error)
         => (AVAudioSessionErrorCode)(long)error.Code == AVAudioSessionErrorCode.CannotInterruptOthers;
 
@@ -488,25 +501,29 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
     private void ConfigureUnsafe(AVAudioSession session, AudioFocusMode mode)
     {
         Log.LogInformation("Configure: mode={Mode}", mode);
-        if (mode is AudioFocusMode.Recording) {
-            // VoiceChat carries the PTT call's AEC under a PTT owner. VideoChat, not Default, for
-            // ours: SetVoiceProcessingEnabled replaces Default and drops DefaultToSpeaker with it.
-            var sessionMode = Owner == AudioSessionOwner.App
-                ? AVAudioSessionMode.VideoChat
-                : AVAudioSessionMode.VoiceChat;
-            session.SetCategory(AVAudioSessionCategory.PlayAndRecord,
-                    sessionMode,
-                    AVAudioSessionCategoryOptions.DefaultToSpeaker
-                    | AVAudioSessionCategoryOptions.AllowBluetooth
-                    | AVAudioSessionCategoryOptions.AllowBluetoothA2DP)
-                .Assert($"{mode}: failed to set category");
-            session.SetPreferredIOBufferDuration(Constants.Audio.OpusFrameDuration.TotalSeconds, out var error);
-            error.Assert("Failed to set preferred IO buffer duration");
-        }
+        if (mode is AudioFocusMode.Recording)
+            ConfigureRecordingUnsafe(session, Owner);
         else if (mode is AudioFocusMode.Playback or AudioFocusMode.Listening)
             session.SetCategory(AVAudioSessionCategory.Playback).Assert($"{mode}: failed to set category");
         else
             session.SetCategory(AVAudioSessionCategory.Ambient).Assert($"{mode}: failed to set category");
+    }
+
+    private static void ConfigureRecordingUnsafe(AVAudioSession session, AudioSessionOwner owner)
+    {
+        // VoiceChat carries the PTT call's AEC under a PTT owner. VideoChat, not Default, for
+        // ours: SetVoiceProcessingEnabled replaces Default and drops DefaultToSpeaker with it.
+        var sessionMode = owner == AudioSessionOwner.App
+            ? AVAudioSessionMode.VideoChat
+            : AVAudioSessionMode.VoiceChat;
+        session.SetCategory(AVAudioSessionCategory.PlayAndRecord,
+                sessionMode,
+                AVAudioSessionCategoryOptions.DefaultToSpeaker
+                | AVAudioSessionCategoryOptions.AllowBluetooth
+                | AVAudioSessionCategoryOptions.AllowBluetoothA2DP)
+            .Assert("Recording: failed to set category");
+        session.SetPreferredIOBufferDuration(Constants.Audio.OpusFrameDuration.TotalSeconds, out var error);
+        error.Assert("Failed to set preferred IO buffer duration");
     }
 }
 

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -124,21 +124,27 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         }
     }
 
-    public static void PrepareForTransmit()
+    public static void PrepareForPttSession(AudioSessionOwner owner)
     {
-        // Before the framework activates the transmit session: it takes the category as it finds
-        // it, and a listening burst leaves Playback, whose input node reports no sample rate -
-        // the pre-roll and the recorder that follow both need a live input.
+        // Before the framework activates a session, for a transmit or an incoming push alike: it
+        // takes the category as it finds it. A listening burst leaves Playback, whose input node
+        // reports no sample rate, and an idle app leaves Ambient, which is mixable and which the
+        // framework won't activate in the background at all.
         try {
-            ConfigureRecordingUnsafe(AVAudioSession.SharedInstance(), AudioSessionOwner.PttTransmit);
+            ConfigureRecordingUnsafe(AVAudioSession.SharedInstance(), owner);
+            OwnerLog.LogInformation("Session prepared for {Owner}", owner);
         }
         catch (Exception e) {
-            OwnerLog.LogWarning(e, "Couldn't configure the session for a PTT transmit");
+            OwnerLog.LogWarning(e, "Couldn't prepare the session for {Owner}", owner);
         }
     }
 
-    public static bool IsCannotInterruptOthers(NSError error)
-        => (AVAudioSessionErrorCode)(long)error.Code == AVAudioSessionErrorCode.CannotInterruptOthers;
+    public static bool IsActivationRefused(NSError error)
+        // CannotInterruptOthers ('!int') for an app that just went to the background,
+        // MissingEntitlement ('ent?') for one resumed from suspension - both mean the app may
+        // not activate its own session there and only the PTT framework can.
+        => (AVAudioSessionErrorCode)(long)error.Code
+            is AVAudioSessionErrorCode.CannotInterruptOthers or AVAudioSessionErrorCode.MissingEntitlement;
 
     public static void NotifyPlaybackActivity()
         => Volatile.Write(ref _playbackActivityAt, CpuTimestamp.Now.Value);
@@ -373,12 +379,12 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         // Without a joined PTT channel the refusal is somebody else's non-mixable session. A
         // recording is not asked for either: the framework would show it as an incoming receive,
         // and the app's own mic in the background is a transmit's business, not this path's.
-        if (mode is AudioFocusMode.Recording || !IsCannotInterruptOthers(error) || !IsPttActivationAvailable)
+        if (mode is AudioFocusMode.Recording || !IsActivationRefused(error) || !IsPttActivationAvailable)
             return false;
 
         Log.LogInformation(
-            "Activate({Mode}): refused as CannotInterruptOthers, asking the PTT framework to activate the session",
-            mode);
+            "Activate({Mode}): refused ({Error}), asking the PTT framework to activate the session",
+            mode, error.LocalizedDescription);
         _ = RequestPttActivation();
         return true;
     }

--- a/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/EngineWrapper/AudioEngine.cs
@@ -84,7 +84,7 @@ public sealed class AudioEngine : IDisposable
         // that outruns the focus acquisition is where that refusal surfaces first. Not for the
         // recording engine - see AudioSession.TryRequestPttActivation.
         if (Mode is not AudioFocusMode.Recording
-            && AudioSession.IsCannotInterruptOthers(error)
+            && AudioSession.IsActivationRefused(error)
             && await AudioSession.RequestPttActivation().WaitAsync(cancellationToken).ConfigureAwait(false)
             && TryEnsureRunning(out error))
             return;

--- a/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
@@ -25,6 +25,7 @@ public static class IosPtt
     private const string LastWakeAtKey = "Voxt.Ptt.LastWakeAt";
     private static readonly NSUuid ChannelUuid = new("f3b9a7e2-4c15-4a8e-9f2d-7b6c5d4e3f21");
     private static readonly TimeSpan PhantomWakeClearDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ParkedWakeTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Lock Lock = new();
     private static PTChannelManager? _manager;
@@ -203,7 +204,7 @@ public static class IosPtt
     private static void OnTransmitBegan()
     {
         BlazorWebViewApp.EnsureStarted();
-        AudioSession.PrepareForTransmit();
+        AudioSession.PrepareForPttSession(AudioSessionOwner.PttTransmit);
         Transmission transmission;
         Transmission? superseded;
         bool isSessionActive;
@@ -312,6 +313,7 @@ public static class IosPtt
         }
 
         Log.LogInformation("Asking the PTT framework to activate the audio session");
+        AudioSession.PrepareForPttSession(AudioSessionOwner.PttPlayback);
         // This participant is the newest one: a phantom-wake clear scheduled for an older
         // generation must not take it down mid-playback.
         Interlocked.Increment(ref _lastWakeGeneration);
@@ -465,6 +467,8 @@ public static class IosPtt
                 .DispatchToMainThread(() => UIApplication.SharedApplication.ApplicationState
                     == UIApplicationState.Active)
                 .ConfigureAwait(false);
+            Log.LogInformation("PTT wake dispatched for chat #{ChatId}, isForeground={IsForeground}, owner={Owner}",
+                chatId, isForeground, AudioSession.Owner);
             await PttSession.HandleWake(chatId, startedAt, isForeground, IosPlatform.Instance)
                 .ConfigureAwait(false);
         }, Log, "PTT wake failed", CancellationToken.None);
@@ -503,6 +507,20 @@ public static class IosPtt
             (source, _activationSource) = (_activationSource, null);
         source?.TrySetResult(isActivated);
     }
+
+    private static void ScheduleParkedWakeDispatch(PendingWake wake)
+        => _ = BackgroundTask.Run(async () => {
+            await Task.Delay(ParkedWakeTimeout).ConfigureAwait(false);
+            // No DidActivateAudioSession came: the framework couldn't activate the session for
+            // this push. The wake still runs - its playback is refused, and that refusal is what
+            // asks the framework again with a fresh participant.
+            if (Interlocked.CompareExchange(ref _pendingWake, null, wake) != wake)
+                return;
+
+            Log.LogWarning("PTT push for chat #{ChatId}: no audio session activation in {Timeout}, dispatching anyway",
+                wake.ChatId, ParkedWakeTimeout);
+            DispatchWake(wake.ChatId, wake.StartedAt);
+        }, Log, "Dispatching a parked PTT wake failed", CancellationToken.None);
 
     private static void ScheduleClearActiveParticipant(int generation)
         => _ = BackgroundTask.Run(async () => {
@@ -666,10 +684,17 @@ public static class IosPtt
             var startedAt = new Moment(epochMs * 10_000);
             SaveLastWake(vChatId, startedAt);
             SetDescriptorTitle(chatTitle);
+            AudioSession.PrepareForPttSession(AudioSessionOwner.PttPlayback);
             // No activation follows a push that lands while the session is already PTT-owned, so
             // parking the wake for OnAudioSessionActivated would drop it.
-            if (AudioSession.Owner == AudioSessionOwner.App)
-                _pendingWake = new PendingWake(vChatId, startedAt);
+            var isParked = AudioSession.Owner == AudioSessionOwner.App;
+            Log.LogInformation("PTT push received for chat #{ChatId}, owner={Owner}, parked={IsParked}",
+                vChatId, AudioSession.Owner, isParked);
+            if (isParked) {
+                var wake = new PendingWake(vChatId, startedAt);
+                _pendingWake = wake;
+                ScheduleParkedWakeDispatch(wake);
+            }
             else
                 DispatchWake(vChatId, startedAt);
 

--- a/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Ptt/IosPtt.cs
@@ -203,6 +203,7 @@ public static class IosPtt
     private static void OnTransmitBegan()
     {
         BlazorWebViewApp.EnsureStarted();
+        AudioSession.PrepareForTransmit();
         Transmission transmission;
         Transmission? superseded;
         bool isSessionActive;

--- a/src/dotnet/UI.Blazor/Services/AudioSessionOwnership.cs
+++ b/src/dotnet/UI.Blazor/Services/AudioSessionOwnership.cs
@@ -43,8 +43,10 @@ public static class AudioSessionOwnership
             AudioSessionOwner.App => true,
             // The framework configured the session for a live call. Raising it to PlayAndRecord
             // for the app's own mic is compatible with that; lowering it to Playback or Ambient
-            // is what cuts the incoming voice out.
-            AudioSessionOwner.PttPlayback => mode is AudioFocusMode.Recording,
+            // is what cuts the incoming voice out. A transmit records through the app's own
+            // engine, and the framework activated its session with whatever category the app
+            // last set - after a listening burst that's Playback, whose input has no sample rate.
+            AudioSessionOwner.PttPlayback or AudioSessionOwner.PttTransmit => mode is AudioFocusMode.Recording,
             _ => false,
         };
 }

--- a/tests/UI.Blazor.UnitTests/AudioSessionOwnershipTest.cs
+++ b/tests/UI.Blazor.UnitTests/AudioSessionOwnershipTest.cs
@@ -105,10 +105,17 @@ public class AudioSessionOwnershipTest
             .Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData(AudioFocusMode.Tune)]
-    [InlineData(AudioFocusMode.Playback)]
-    [InlineData(AudioFocusMode.Recording)]
-    public void ATransmitOwnerBlocksEveryConfiguration(AudioFocusMode mode)
-        => AudioSessionOwnership.MayConfigure(AudioSessionOwner.PttTransmit, mode).Should().BeFalse();
+    [Fact]
+    public void ATransmitOwnerBlocksOnlyCategoryLowering()
+    {
+        // The framework activates the transmit session with whatever category the app last set,
+        // and a listening burst leaves Playback - whose input has no sample rate - so the mic
+        // path must be allowed to raise it to PlayAndRecord.
+        AudioSessionOwnership.MayConfigure(AudioSessionOwner.PttTransmit, AudioFocusMode.Tune)
+            .Should().BeFalse();
+        AudioSessionOwnership.MayConfigure(AudioSessionOwner.PttTransmit, AudioFocusMode.Playback)
+            .Should().BeFalse();
+        AudioSessionOwnership.MayConfigure(AudioSessionOwner.PttTransmit, AudioFocusMode.Recording)
+            .Should().BeTrue("a transmit records through the app's own engine, which needs PlayAndRecord");
+    }
 }


### PR DESCRIPTION
## Summary

Two iOS PTT failures on the dev TestFlight build (2.20.23), both traced through Sentry breadcrumbs from the device:

- **Talk press records nothing and plays the failure cue.** A listening burst leaves the session category at `Playback`. The framework activates the transmit session with whatever category it finds, so the input node reports no sample rate; the pre-roll bails and every capture dies on `IsFormatSampleRateAndChannelCountValid`, three retries, then the cue. Under owner `PttTransmit` the app was not allowed to raise the category, so nothing could recover. A press right after an in-app recording worked only because that recording had left `PlayAndRecord` behind.
- **No sound once the app is suspended in the background.** The PTT push reached the phone (resumed 0.75 s after the server sent it), but the framework never activated the session: the app rests in `Ambient`, a mixable category the framework won't activate in the background. The wake stayed parked waiting for a callback that never came, the stream arrived over RPC anyway, and its playback was refused with `MissingEntitlement` (`'ent?'`), which the self-activation fallback from #4386 didn't recognise (it only knew `'!int'`).

## Fix

- `AudioSession.PrepareForPttSession(owner)` sets `PlayAndRecord`/`VoiceChat` before every framework activation: at `DidBeginTransmitting`, in `IncomingPushResult`, and before a self-initiated `SetActiveRemoteParticipant`. Invariant: the framework activates the session with the category it finds; the app must never hand it `Ambient` or `Playback`.
- `MayConfigure` lets a transmit owner raise the category to `PlayAndRecord`, as a playback owner already could (unit test updated).
- `AudioSession.IsActivationRefused` treats `'ent?'` like `'!int'`, so a resumed-from-suspension app also asks the framework instead of failing.
- A wake parked for `ParkedWakeTimeout` (5 s) without an activation is dispatched anyway; its refused playback re-asks the framework with a fresh participant.
- The push receipt (with owner and parked state) and the wake dispatch are logged at Information, so the next Sentry trace shows the whole path.
- `docs/live-audio/10-push-to-talk.md` updated.

## Testing

- `AudioSessionOwnershipTest` written first and green (17/17). `net11.0-ios` compiles.
- Not device-verified. The push path exists only on a production-signed build, so verification is the next dev TestFlight build: Talk press after a listening burst should record; an utterance from another account while the app is suspended should play, and the Sentry breadcrumbs should show "PTT push received … parked=True" followed by "PTT audio session activated".

Part of #4414 (tracking issue, intentionally not closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrPhPBeorKW6bWHRZWoqnq
