### PR TITLE
perf(ui): cut the WebKit style-recalc stall on navbar switches

### DIFF
--- a/postcss-tw-property.js
+++ b/postcss-tw-property.js
@@ -1,0 +1,171 @@
+// @ts-check
+"use strict";
+// Moves Tailwind v3's composition defaults off every element.
+//
+// Tailwind builds one CSS property out of several independent utilities, so `rotate-90` alone has
+// to leave the other five transform variables defined - an unresolvable var() with no fallback
+// makes the whole declaration invalid at computed-value time, and `transform` would be dropped
+// rather than partially applied. v3 guarantees that by declaring all 51 variables on every element
+// and pseudo. WebKit builds a per-element custom-property map for every element whose style it
+// resolves, and a navbar switch in this app creates ~1500 fresh elements, so that block is the
+// single largest CSS-side cost in the profile.
+//
+// Before - 51 declarations landing on every element, twice more for the pseudos:
+//
+//   *, ::before, ::after { --tw-translate-x: 0; --tw-rotate: 0; --tw-blur: ; ...48 more }
+//   ::backdrop           { ...the same 51 }
+//   .rotate-180 { --tw-rotate: 180deg;
+//                 transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+//                            rotate(var(--tw-rotate)) ... scaleX(var(--tw-scale-x)) ... }
+//   .blur       { --tw-blur: blur(8px); filter: var(--tw-blur) var(--tw-brightness) ... }
+//
+// After - the defaults live in the property registry and at the point of use, nowhere on elements:
+//
+//   @property --tw-rotate { syntax: "*"; inherits: false; }
+//   .rotate-180 { --tw-rotate: 180deg;
+//                 transform: translate(var(--tw-translate-x, 0), var(--tw-translate-y, 0))
+//                            rotate(var(--tw-rotate, 0)) ... scaleX(var(--tw-scale-x, 1)) ... }
+//   .blur       { --tw-blur: blur(8px);
+//                 filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) ... }
+//
+// The fallback does what the declaration did; `inherits: false` does what re-declaring on every
+// element did, keeping a parent's --tw-blur from reaching its children. Registering with no
+// initial-value leaves an unset property guaranteed-invalid, which is exactly what makes the
+// fallback apply. initial-value is unusable here: 34 of the 51 defaults are Tailwind's empty
+// "space toggle" (`--tw-blur: ;`), and @property cannot express an empty initial value.
+//
+// On this bundle: 52 names found, 41 registered, 11 that no emitted utility reads dropped
+// outright, 444 declarations rewritten. Measured on an iPhone 13 Pro over a navbar switch, mean
+// stall 188 -> 119ms and median 202 -> 138ms; in the Time Profiler, Document::resolveStyle falls
+// from 63% to 40% of WebContent main-thread CPU, applyMatchedProperties from 31% to 8%,
+// custom-property self time from 893ms to 52ms, and applyCustomPropertyImpl - the hottest symbol
+// in the whole profile before - leaves the top 30 entirely. Verified by replaying the transform on
+// the live CSSOM of the running app: 4238 elements x 19 properties, zero computed-style diffs.
+const UniversalSelectors = new Set(['*', '::before', ':before', '::after', ':after', '::backdrop', '::-ms-backdrop']);
+const Prefix = '--tw-';
+
+function isUniversal(rule) {
+  if (rule.type !== 'rule')
+    return false;
+  const parts = rule.selector.split(',').map(s => s.trim()).filter(Boolean);
+  return parts.length !== 0 && parts.every(s => UniversalSelectors.has(s));
+}
+
+// Adds `fallback` to every var(--name) that does not already carry one.
+function addFallbacks(value, defaults) {
+  let out = '';
+  let i = 0;
+  while (i < value.length) {
+    const at = value.indexOf('var(', i);
+    if (at < 0) {
+      out += value.slice(i);
+      break;
+    }
+    out += value.slice(i, at);
+    let depth = 0, j = at + 3;
+    for (; j < value.length; j++) {
+      const c = value[j];
+      if (c === '(') depth++;
+      else if (c === ')') { depth--; if (depth === 0) break; }
+    }
+    if (j >= value.length) {
+      out += value.slice(at);
+      break;
+    }
+    const inner = value.slice(at + 4, j);
+    const comma = inner.indexOf(',');
+    const name = (comma < 0 ? inner : inner.slice(0, comma)).trim();
+    if (comma < 0 && defaults.has(name))
+      out += 'var(' + name + ', ' + defaults.get(name) + ')';
+    else if (comma < 0)
+      out += 'var(' + name + ')';
+    else
+      out += 'var(' + name + ', ' + addFallbacks(inner.slice(comma + 1), defaults) + ')';
+    i = j + 1;
+  }
+  return out;
+}
+
+const plugin = () => ({
+  postcssPlugin: 'tw-property',
+  OnceExit(root, { result, postcss }) {
+    if (process.env.AC_TW_PROPERTY === '0')
+      return;
+
+    const defaults = new Map();
+    const universalDecls = [];
+    root.walkRules(rule => {
+      if (!isUniversal(rule))
+        return;
+      for (const node of rule.nodes) {
+        if (node.type !== 'decl' || !node.prop.startsWith(Prefix))
+          continue;
+        // Later blocks repeat the same names with the same values; first one wins, and a
+        // disagreement means the assumption behind this pass is wrong.
+        const value = node.value.trim();
+        if (defaults.has(node.prop) && defaults.get(node.prop) !== value)
+          throw rule.error(`${node.prop} has conflicting universal defaults: `
+            + `'${defaults.get(node.prop)}' and '${value}'`);
+        defaults.set(node.prop, value);
+        universalDecls.push(node);
+      }
+    });
+    if (defaults.size === 0)
+      return;
+
+    // Only names something actually reads are worth registering; the rest just go.
+    const referenced = new Set();
+    root.walkDecls(decl => {
+      if (universalDecls.includes(decl))
+        return;
+      for (const m of decl.value.matchAll(/var\(\s*(--[\w-]+)/g))
+        referenced.add(m[1]);
+    });
+
+    let rewritten = 0;
+    root.walkDecls(decl => {
+      if (!decl.value.includes('var(') || universalDecls.includes(decl))
+        return;
+      const next = addFallbacks(decl.value, defaults);
+      if (next !== decl.value) {
+        decl.value = next;
+        rewritten++;
+      }
+    });
+
+    for (const decl of universalDecls) {
+      const rule = decl.parent;
+      decl.remove();
+      if (rule.nodes.length === 0)
+        rule.remove();
+    }
+
+    let registered = 0;
+    for (const [name] of defaults) {
+      if (!referenced.has(name))
+        continue;
+      root.prepend(postcss.atRule({
+        name: 'property',
+        params: name,
+        nodes: [
+          postcss.decl({ prop: 'syntax', value: '"*"' }),
+          postcss.decl({ prop: 'inherits', value: 'false' }),
+        ],
+      }));
+      registered++;
+    }
+
+    const dropped = defaults.size - registered;
+    result.messages.push({
+      type: 'tw-property',
+      plugin: 'tw-property',
+      text: `registered ${registered} composition properties, dropped ${dropped} unread, `
+        + `rewrote ${rewritten} declarations`,
+    });
+    if (process.env.AC_TW_PROPERTY_LOG === '1')
+      console.log(`[tw-property] ${registered} registered, ${dropped} unread dropped, `
+        + `${rewritten} declarations rewritten`);
+  },
+});
+plugin.postcss = true;
+module.exports = plugin;

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -6,6 +6,7 @@ export default {
         'autoprefixer': {
             overrideBrowserslist: ['last 2 versions', '>0.2%'],
         },
+        './postcss-tw-property.js': {},
         // '@tailwindcss/postcss': {},
         ...(process.env.NODE_ENV === 'production' ? {
             'cssnano': {

--- a/src/dotnet/Api/Chat/Markup/Markup.cs
+++ b/src/dotnet/Api/Chat/Markup/Markup.cs
@@ -30,6 +30,7 @@ namespace ActualChat.Chat;
 [Union(20, typeof(TableMarkup))]
 [Union(21, typeof(TableRowMarkup))]
 [Union(22, typeof(TableCellMarkup))]
+[Union(23, typeof(MarkupSuffix))]
 public abstract class Markup : ISanitized, IForwardCompatibleUnion<Markup>
 {
     protected static ArrayPool<Markup> MarkupArrayPool = ArrayPool<Markup>.Shared;

--- a/src/dotnet/Api/Chat/Markup/MarkupSuffix.cs
+++ b/src/dotnet/Api/Chat/Markup/MarkupSuffix.cs
@@ -1,0 +1,17 @@
+using ActualLab.Fusion.Blazor;
+
+namespace ActualChat.Chat;
+
+/// <summary>
+/// Marks where a message's trailing marks - sending status, translation - are rendered.
+/// Carries nothing itself: <see cref="MarkupSuffixInjector"/> places it, and the view renders
+/// whatever the render context supplies.
+/// </summary>
+[ParameterComparer(typeof(ByRefParameterComparer))]
+[DataContract, MessagePackObject]
+public sealed class MarkupSuffix : Markup
+{
+    public static readonly MarkupSuffix Instance = new();
+
+    public override string Format() => "";
+}

--- a/src/dotnet/Api/Chat/Markup/Visitors/MarkupSuffixInjector.cs
+++ b/src/dotnet/Api/Chat/Markup/Visitors/MarkupSuffixInjector.cs
@@ -1,0 +1,61 @@
+namespace ActualChat.Chat;
+
+/// <summary>
+/// Appends a <see cref="MarkupSuffix"/> to the end of the last thing a message renders, so the
+/// trailing marks sit on its last line.
+/// </summary>
+/// <remarks>
+/// Only the spine down to that point is rebuilt - every other subtree is reused by reference, which
+/// is what keeps <see cref="ByRefParameterComparer"/> from re-rendering it. So the cost is the depth
+/// of the tree, not its size.
+/// </remarks>
+public static class MarkupSuffixInjector
+{
+    public static Markup Inject(Markup markup)
+        => Append(markup);
+
+    private static Markup Append(Markup markup)
+    {
+        switch (markup) {
+        case MarkupSeq seq: {
+            var items = seq.Items;
+            var last = LastRenderedIndex(items);
+            if (last < 0)
+                return new MarkupSeq(markup, MarkupSuffix.Instance);
+
+            var newItems = items.ToArray();
+            newItems[last] = Append(items[last]);
+            return new MarkupSeq(newItems);
+        }
+        case ParagraphMarkup paragraph:
+            return new ParagraphMarkup(Append(paragraph.Content));
+        // An empty header renders a <br/> to keep its line height, and that branch tests for a
+        // TextMarkup - so descending into one would cost it the line. Pair it instead.
+        case HeaderMarkup header when header.Content is not TextMarkup { Text.Length: 0 }:
+            return new HeaderMarkup(header.Level, Append(header.Content));
+        case BlockQuoteMarkup blockQuote:
+            return new BlockQuoteMarkup(Append(blockQuote.Content));
+        case ListMarkup list when list.Items.Length != 0: {
+            var items = list.Items;
+            var newItems = items.ToArray();
+            newItems[^1] = new ListItemMarkup(Append(items[^1].Content));
+            return new ListMarkup(newItems);
+        }
+        default:
+            // A leaf, or a block that can't hold inline content (a code block, a table). Pairing it
+            // with the suffix rather than growing the parent keeps every allocation here small, and
+            // a nested MarkupSeq renders exactly as its items do.
+            return new MarkupSeq(markup, MarkupSuffix.Instance);
+        }
+    }
+
+    // MarkupSeqView drops trailing blank paragraphs, so the suffix must not land in one.
+    private static int LastRenderedIndex(Markup[] items)
+    {
+        for (var i = items.Length - 1; i >= 0; i--)
+            if (items[i] is not ParagraphMarkup { IsEmpty: true })
+                return i;
+
+        return items.Length - 1;
+    }
+}

--- a/src/dotnet/App.Maui/App.Maui.csproj
+++ b/src/dotnet/App.Maui/App.Maui.csproj
@@ -41,7 +41,7 @@
 
     <!-- Original defaults for MAUI project: -->
     <!--
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">16.4</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/src/dotnet/Core/Text/StringExt.cs
+++ b/src/dotnet/Core/Text/StringExt.cs
@@ -17,9 +17,6 @@ public static partial class StringExt
     [GeneratedRegex(@"(?<line>[^\r\n]*)\r?\n", RegexOptions.ExplicitCapture)]
     private static partial Regex NewLineRegexFactory();
 
-    [GeneratedRegex(@"\s*(\S+)\s*$")]
-    private static partial Regex LastWordRegexFactory();
-
     [GeneratedRegex(@"([a-z0-9])([A-Z])|([A-Z])([A-Z][a-z])")]
     private static partial Regex KebabCaseRegexFactory();
 
@@ -28,7 +25,6 @@ public static partial class StringExt
     private static readonly Regex CamelCaseRegex = CamelCaseRegexFactory();
     private static readonly Regex NewLineRegex = NewLineRegexFactory();
 #pragma warning restore MA0023
-    private static readonly Regex LastWordRegex = LastWordRegexFactory();
     private static readonly Regex KebabCaseRegex = KebabCaseRegexFactory();
 
     public static string RequireNonEmpty(this string? source, [CallerArgumentExpression(nameof(source))] string name = "")
@@ -233,20 +229,6 @@ public static partial class StringExt
         => WebUtility.HtmlDecode(input);
     public static string HtmlDecode(this Symbol input)
         => WebUtility.HtmlDecode(input);
-
-    public static (string Head, string? Last) SplitLastWord(this string text)
-    {
-        if (text.IsNullOrEmpty())
-            return ("", null);
-
-        var match = LastWordRegex.Match(text);
-        if (!match.Success)
-            return (text, null);
-
-        var lastWord = match.Groups[1].Value;
-        var prefix = text[..match.Index];
-        return (prefix, lastWord);
-    }
 
     // ParseXxx
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
@@ -27,6 +27,7 @@
 
 <div @ref="Ref"
      class="chat-activity-panel @cls"
+     data-child="@(isListening ? "listening-activity" : null)"
      role="button"
      tabindex="0"
      @onclick:preventDefault="true"

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanel.razor
@@ -15,11 +15,16 @@
     var isActive = m.IsAnyoneTalking;
     var iconMode = m.HasRemoteStreams ? "video" : "audio";
     var cls = isListening ? " listening" : "";
-    if (m.HasRemoteStreams)
+    var childNames = isListening ? "listening-activity" : "";
+    if (m.HasRemoteStreams) {
         cls += " video-streaming";
+        childNames += " video-streaming";
+    }
     // not-participating is the narrow "join muted" bordered-box affordance
     if (m.CanJoinCall)
         cls += " not-participating";
+    else
+        childNames += " participating-activity";
     if (isWatchingHere)
         cls += " watching";
     var joinButtonText = L.Call_JoinMuted;
@@ -27,7 +32,7 @@
 
 <div @ref="Ref"
      class="chat-activity-panel @cls"
-     data-child="@(isListening ? "listening-activity" : null)"
+     data-child="@(childNames.Length != 0 ? childNames : null)"
      role="button"
      tabindex="0"
      @onclick:preventDefault="true"

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/ChatActivityPanelNarrowScreenWrapper.razor
@@ -5,7 +5,7 @@
         return;
 }
 
-<div class="header-activity-panel-wrapper">
+<div class="header-activity-panel-wrapper" data-child="activity-panel">
     <ChatActivityPanel MaxCount="3" Click="@Click"/>
 </div>
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
@@ -182,7 +182,7 @@ body.narrow .c-film-strip {
 /* Clip the film strip poking above the header, but keep the bottom open so the
    video panel's drag handle (top: 100%) isn't cut off - overflow: hidden would
    clip both ends. */
-body.narrow .layout-header:has(.video-streaming) {
+body.narrow .layout-header[data-has-video-streaming] {
     clip-path: inset(0 0 -100vh 0);
 }
 /* Hide film strip when watching — it advertises "video is streaming", which

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.css
@@ -192,10 +192,10 @@ body.narrow .layout-header:has(.video-streaming) {
 .chat-activity-panel.watching .c-film-strip {
     @apply hidden;
 }
-.layout-header.collapsed:not(.has-visible-video-panel) .c-film-strip {
+.layout-header.collapsed:not([data-has-visible-video-panel]) .c-film-strip {
     @apply opacity-0;
 }
-.layout-header.collapsed:not(.has-visible-video-panel) .c-film-strip::after {
+.layout-header.collapsed:not([data-has-visible-video-panel]) .c-film-strip::after {
     animation-play-state: paused;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.ts
+++ b/src/dotnet/UI.Blazor.App/Components/ChatActivityPanel/chat-activity-panel.ts
@@ -5,6 +5,9 @@ import { DocumentEvents, tryPreventDefaultForEvent } from 'event-handling';
 import { ScreenSize } from '../../../UI.Blazor/Services/ScreenSize/screen-size';
 import { CompactLayout } from 'compact-layout';
 import { Disposables } from 'disposable';
+import { PresenceTracker } from 'presence-tracker';
+
+const PinnedChild = 'header-pinned';
 
 // Wrapper height (the only animated element for collapse/expand)
 const WRAPPER_HEIGHT_REM = 3.5; // h-14
@@ -146,7 +149,10 @@ export class ChatActivityPanel {
 
         // Blazor calls dispose() even when init bailed out above on a missing header
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        this.header?.classList.remove('expanded', 'collapsed', 'pinned');
+        if (this.header) {
+            this.header.classList.remove('expanded', 'collapsed', 'pinned');
+            this.setPinnedName(false);
+        }
         this.disposed$.next();
         this.disposed$.complete();
     }
@@ -192,16 +198,25 @@ export class ChatActivityPanel {
         this.isPinned = true;
         this.expand();
         this.header.classList.add('pinned');
+        this.setPinnedName(true);
     }
 
     public unpin() {
         this.isPinned = false;
         this.header.classList.remove('pinned');
+        this.setPinnedName(false);
         this.collapse();
     }
 
     public getState() { return this.state; }
     public setLockUntil(value: number) { this.lockUntil = value; }
+
+    // Private methods
+
+    // The presence name .list-view-layout counts for `pinned`.
+    private setPinnedName(isPinned: boolean): void {
+        PresenceTracker.setChild(this.header, PinnedChild, isPinned);
+    }
 }
 
 // Gesture: Drag activity panel down to expand/pin, drag up to unpin.

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioControls/ChatAudioControls.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioControls/ChatAudioControls.razor
@@ -25,7 +25,7 @@
     var ss = remaining % 60;
 }
 
-<div class="chat-audio-controls @Class">
+<div class="chat-audio-controls @Class" data-child="audio-controls">
     @if (isRecording) {
         @if (ShowRecordingToggle) {
             <HeaderButton

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/ChatAudioPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/ChatAudioPanel.razor
@@ -28,7 +28,7 @@
 <OnUIEvent TEvent="@CameraSelectedEvent" Handler="OnCameraSelectedEvent"/>
 <div class="chat-audio-panel">
     @if (IsNarrow && showHeader) {
-        <div class="audio-panel-header">
+        <div class="audio-panel-header" data-child="audio-panel-header">
             <div class="c-left">
                 @if (isOwnCameraRecording) {
                     <ButtonRound

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/ChatAudioPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/ChatAudioPanel.razor
@@ -26,7 +26,7 @@
 }
 
 <OnUIEvent TEvent="@CameraSelectedEvent" Handler="OnCameraSelectedEvent"/>
-<div class="chat-audio-panel">
+<div class="chat-audio-panel" data-children="audio-panel-header record-on record-on-btn">
     @if (IsNarrow && showHeader) {
         <div class="audio-panel-header" data-child="audio-panel-header">
             <div class="c-left">
@@ -147,7 +147,7 @@
             selectedCameraDeviceId);
     }
 
-    // Nested classes
+    // Nested types
 
     public sealed record Model(
         ChatAudioState? AudioState,

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/RecorderToggle.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/RecorderToggle.razor
@@ -7,7 +7,9 @@
     _animator.State = m.IsRecordingHere;
     var hasMicrophonePermission = m.HasMicrophonePermission != false;
     var animatorClass = "record-" + _animator.Class;
-    var transitioningClass = m.IsTransitioning || m is { IsRecordingHere: true, IsConnected: false } ? "applying-changes" : "";
+    var transitioningClass = m.IsTransitioning || m is { IsRecordingHere: true, IsConnected: false }
+        ? "applying-changes"
+        : "";
     var permissionClass = hasMicrophonePermission ? "" : "mic-disabled";
     var status = m.Status;
     var tooltip = status.GetTooltip(L);
@@ -15,6 +17,7 @@
     var autoShowText = status.IsFailure ? tooltip : "";
     var recordingIconSize = ScreenSize.IsNarrow() ? 10 : 8;
     var recBtnCls = "rec-btn ";
+    var isRecordOnBtn = false;
     if (m is { IsAnyoneTalking: true, IsRecordingHere: false } && !IsListening) {
         recBtnCls += "take-phone-btn";
         animatorClass += " take-phone";
@@ -23,16 +26,26 @@
         animatorClass += " listen-only";
     } else if (m.IsRecordingHere) {
         recBtnCls += "record-on-btn";
+        isRecordOnBtn = true;
     } else
         recBtnCls += "record-off-btn";
     if (!hasMicrophonePermission) {
         recBtnCls = "mic-disabled";
         animatorClass = "";
         transitioningClass = "";
+        isRecordOnBtn = false;
     }
+    var isRecordOn = hasMicrophonePermission && _animator.Class == "on";
+    var recorderChild = (isRecordOnBtn, isRecordOn) switch {
+        (true, true) => "record-on-btn record-on",
+        (true, false) => "record-on-btn",
+        (false, true) => "record-on",
+        _ => null,
+    };
 }
 
 <div class="recorder-wrapper @permissionClass @animatorClass @transitioningClass @(Compact ? "compact" : "")"
+     data-child="@recorderChild"
      data-tooltip="@tooltip"
      data-tooltip-position="@(FloatingPosition.Top.ToPositionString())"
      data-tooltip-severity="@(severity.ToSeverityString())"
@@ -143,12 +156,14 @@
         var recordingChatId = await ChatAudioUI.GetRecordingChatId().ConfigureAwait(false);
         var status = await ChatAudioUI.GetRecordingStatus(chatId, cancellationToken).ConfigureAwait(false);
         var recorderState = await AudioRecorder.State.Use(cancellationToken).ConfigureAwait(false);
-        var hasMicrophonePermission = await AudioRecorder.MicrophonePermission.Cached.Use(cancellationToken).ConfigureAwait(false);
+        var hasMicrophonePermission = await AudioRecorder.MicrophonePermission.Cached
+            .Use(cancellationToken).ConfigureAwait(false);
         var isRecordingHere = recordingChatId == chatId;
         var isTransitioning =
             recordingChatId == chatId // The recorder records in this chat
             && recorderState.IsRecording != isRecordingHere; // AND it's state is not in sync with the expected one here
-        var isAnyoneTalking = await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
+        var isAnyoneTalking = await LiveStreamUI
+            .IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         var audioState = await ChatAudioUI.GetState(chatId).ConfigureAwait(false);
 
         return new (

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
@@ -805,10 +805,10 @@ body.narrow .chat-audio-panel .mobile-video-btn.btn-round i {
     @apply duration-150 ease-in-out;
     transition-property: background-color, opacity;
 }
-body.narrow .chat-message-editor:not(.narrow-panel, .text-mode) .chat-audio-panel:has(.audio-panel-header) .volume-settings-btn {
+body.narrow .chat-message-editor:not(.narrow-panel, .text-mode) .chat-audio-panel[data-has-audio-panel-header] .volume-settings-btn {
     @apply hidden;
 }
-body.narrow .chat-audio-panel:has(.record-on) .volume-settings-btn.btn.btn-round > .btn-content i {
+body.narrow .chat-audio-panel[data-has-record-on] .volume-settings-btn.btn.btn-round > .btn-content i {
     background: linear-gradient(180deg, var(--blue-55) -116.66%, var(--magenta-60) 66.08%);
     -webkit-background-clip: text;
     background-clip: text;
@@ -840,12 +840,12 @@ body.narrow .volume-settings-btn.text::before {
     @apply bg-mobile-landscape-audio-panel-button-text;
     margin: -2px;
 }
-body.narrow .chat-audio-panel:has(.record-on-btn) .volume-settings-btn.text > .c-text,
-body.narrow .chat-audio-panel:has(.record-on-btn):not(.text-mode, .narrow-panel) .volume-settings-btn.text > .c-text {
+body.narrow .chat-audio-panel[data-has-record-on-btn] .volume-settings-btn.text > .c-text,
+body.narrow .chat-audio-panel[data-has-record-on-btn]:not(.text-mode, .narrow-panel) .volume-settings-btn.text > .c-text {
     background-image: linear-gradient(to right, var(--magenta-60), 10%, white);
 }
-body.narrow .chat-audio-panel:has(.record-on-btn) .volume-settings-btn.text::before,
-body.narrow .chat-audio-panel:has(.record-on-btn):not(.text-mode, .narrow-panel) .volume-settings-btn.text::before {
+body.narrow .chat-audio-panel[data-has-record-on-btn] .volume-settings-btn.text::before,
+body.narrow .chat-audio-panel[data-has-record-on-btn]:not(.text-mode, .narrow-panel) .volume-settings-btn.text::before {
     background-image: linear-gradient(to right, var(--magenta-60), 25%, var(--mobile-landscape-audio-panel-button-text));
 }
 body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .volume-settings-btn.text > .c-text {

--- a/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatAudioPanel/chat-audio-panel.css
@@ -21,7 +21,7 @@ body.narrow .narrow-panel .chat-audio-panel {
     @apply bottom-2;
     @apply py-1;
 }
-body.narrow .chat-message-editor.has-related-entry:not(.narrow-panel) .chat-audio-panel,
+body.narrow .chat-message-editor[data-has-related-entry]:not(.narrow-panel) .chat-audio-panel,
 body.narrow .chat-message-editor.text-mode:not(.narrow-panel) .chat-audio-panel {
     @apply bottom-2;
     @apply py-1;
@@ -77,8 +77,8 @@ body.hoverable .chat-audio-panel .record-on-btn.btn:hover {
     @apply bg-post-panel md:bg-input;
     @apply text-audio-panel-button-text;
 }
-.list-view-layout.has-listening-activity .chat-audio-panel .language-button .btn.btn-round,
-.list-view-layout.has-listening-activity .chat-audio-panel .video-wrapper .btn.btn-round {
+.list-view-layout[data-has-listening-activity] .chat-audio-panel .language-button .btn.btn-round,
+.list-view-layout[data-has-listening-activity] .chat-audio-panel .video-wrapper .btn.btn-round {
     @apply md:bg-01;
 }
 body.narrow .chat-audio-panel .language-button .btn.btn-round {
@@ -195,24 +195,24 @@ body.narrow .chat-audio-panel .recorder-wrapper {
 body.narrow .narrow-panel .recorder-wrapper::before,
 body.narrow .text-mode .recorder-wrapper::before,
 body.narrow .to-thin .recorder-wrapper::before,
-body.narrow .chat-message-editor.has-related-entry .recorder-wrapper::before,
+body.narrow .chat-message-editor[data-has-related-entry] .recorder-wrapper::before,
 body.narrow .narrow-panel .chat-audio-panel .listen-only-btn.btn::before,
 body.narrow .text-mode .chat-audio-panel .listen-only-btn.btn::before,
 body.narrow .to-thin .chat-audio-panel .listen-only-btn.btn::before,
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .listen-only-btn.btn::before {
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .listen-only-btn.btn::before {
     @apply hidden;
 }
 /* Small language button: white outline + white text (no colored gradient from record state) */
 body.narrow .narrow-panel .chat-audio-panel .volume-settings-btn.text::before,
 body.narrow .text-mode .chat-audio-panel .volume-settings-btn.text::before,
 body.narrow .to-thin .chat-audio-panel .volume-settings-btn.text::before,
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .volume-settings-btn.text::before {
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .volume-settings-btn.text::before {
     background: var(--text-03);
 }
 body.narrow .narrow-panel .chat-audio-panel .volume-settings-btn.text > .c-text,
 body.narrow .text-mode .chat-audio-panel .volume-settings-btn.text > .c-text,
 body.narrow .to-thin .chat-audio-panel .volume-settings-btn.text > .c-text,
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .volume-settings-btn.text > .c-text {
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .volume-settings-btn.text > .c-text {
     background-image: none;
     -webkit-text-fill-color: white;
 }
@@ -284,7 +284,7 @@ body.narrow .to-thick .chat-audio-panel .recorder-wrapper {
 body.narrow .base-panel .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content {
     @apply w-20 h-20;
 }
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper,
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .recorder-wrapper,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper,
 body.narrow .narrow-panel .chat-audio-panel .recorder-wrapper,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper {
@@ -297,14 +297,14 @@ body.narrow .to-thin .chat-audio-panel .recorder-wrapper {
         height 200ms ease-in-out,
         box-shadow 0ms;
 }
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper .btn.btn-round,
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .recorder-wrapper .btn.btn-round,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper .btn.btn-round,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper .btn.btn-round {
     @apply w-8 h-8;
     @apply no-sheen;
     background: transparent;
 }
-body.narrow .chat-message-editor.has-related-entry .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
+body.narrow .chat-message-editor[data-has-related-entry] .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
 body.narrow .text-mode .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content,
 body.narrow .to-thin .chat-audio-panel .recorder-wrapper .btn.btn-round .btn-content {
     @apply w-8 h-8;
@@ -401,8 +401,8 @@ body.narrow .rec-icon,
 body.narrow .rec-icon i {
     @apply text-3.5xl;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon,
-body.narrow .chat-message-editor.has-related-entry .rec-icon i,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon i,
 body.narrow .text-mode .rec-icon,
 body.narrow .text-mode .rec-icon i,
 body.narrow .narrow-panel .rec-icon,
@@ -445,13 +445,13 @@ body.narrow .narrow-panel .rec-icon i {
 body.wide .rec-icon.text-mode-on {
     @apply hidden;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-on,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.text-mode-on,
 body.narrow .text-mode .rec-icon.text-mode-on,
 body.narrow .to-thin .rec-icon.text-mode-on {
     @apply flex;
     @apply pt-0.5;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-off,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.text-mode-off,
 body.narrow .text-mode .rec-icon.text-mode-off,
 body.narrow .to-thin .rec-icon.text-mode-off {
     @apply opacity-0;
@@ -475,7 +475,7 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .rec-icon.text-m
 .record-off .rec-icon.on,
 .record-on .rec-icon.off,
 .narrow-panel .record-on .rec-icon.on.text-mode-off,
-body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-off,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.text-mode-off,
 body.narrow .text-mode .rec-icon.text-mode-off,
 body.narrow .to-thin .rec-icon.text-mode-off,
 body.narrow .to-thick:not(.text-mode) .rec-icon.text-mode-on,
@@ -491,26 +491,26 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .rec-icon.text-m
 }
 
 /* Text-mode rec-icon sizes */
-body.narrow .chat-message-editor.has-related-entry .rec-icon,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon,
 body.narrow .text-mode .rec-icon,
 body.narrow .to-thin .rec-icon {
     @apply w-8 h-8;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.left,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.off i.left,
 body.narrow .text-mode .rec-icon.off i.left,
 body.narrow .to-thin .rec-icon.off i.left,
-body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.right,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.off i.right,
 body.narrow .text-mode .rec-icon.off i.right,
 body.narrow .to-thin .rec-icon.off i.right {
     @apply text-1.5xl text-mobile-landscape-audio-panel-button-text;
     @apply opacity-100;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon.off i.right,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.off i.right,
 body.narrow .text-mode .rec-icon.off i.right,
 body.narrow .to-thin .rec-icon.off i.right {
     @apply always-white;
 }
-body.narrow .chat-message-editor.has-related-entry .rec-icon.text-mode-on,
+body.narrow .chat-message-editor[data-has-related-entry] .rec-icon.text-mode-on,
 body.narrow .text-mode .rec-icon.text-mode-on,
 body.narrow .to-thin .rec-icon.text-mode-on {
     @apply text-2xl text-danger;
@@ -542,7 +542,7 @@ body.narrow .to-thin .rec-icon.text-mode-on {
     @apply text-audio-panel-button-text;
 }
 
-.list-view-layout.has-listening-activity .chat-audio-panel .screencast-wrapper .btn.btn-round {
+.list-view-layout[data-has-listening-activity] .chat-audio-panel .screencast-wrapper .btn.btn-round {
     @apply md:bg-01;
 }
 
@@ -714,7 +714,7 @@ body.narrow .audio-panel-wrapper > * {
 body.narrow .narrow-panel .audio-panel-wrapper {
     @apply px-10;
 }
-body.narrow .chat-message-editor.has-related-entry .audio-panel-wrapper,
+body.narrow .chat-message-editor[data-has-related-entry] .audio-panel-wrapper,
 body.narrow .chat-message-editor.text-mode .audio-panel-wrapper,
 body.narrow .chat-message-editor.narrow-panel .audio-panel-wrapper {
     @apply gap-x-2;
@@ -869,10 +869,10 @@ body.narrow .chat-message-editor:not(.text-mode, .narrow-panel) .volume-settings
 
 /* Video call open: pause the decorative recorder animations — see the
    matching block in chat-activity-panel.css for why. */
-body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-on::before,
-body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
-body.video-panel-shown .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
-body.video-panel-shown .recorder-btn-skeleton {
+body[data-has-video-panel-shown] .chat-audio-panel .recorder-wrapper.record-on::before,
+body[data-has-video-panel-shown] .chat-audio-panel .recorder-wrapper.record-off-to-on::before,
+body[data-has-video-panel-shown] .chat-audio-panel .recorder-wrapper.record-on .record-on-btn.btn,
+body[data-has-video-panel-shown] .recorder-btn-skeleton {
     animation-play-state: paused;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
@@ -7,7 +7,7 @@
 }
 
 @if (m.HasSelection) {
-    <div class="c-content selection-header">
+    <div class="c-content selection-header" data-child="selection-header">
         <SelectionHeader />
     </div>
     return;

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ActiveChats.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ActiveChats.razor
@@ -7,7 +7,7 @@
 }
 
 <div class="c-delimiter"></div>
-<div class="active-chats">
+<div class="active-chats" data-child="active-chats">
     <div class="c-title" data-tooltip="@L.ChatList_ActiveChatsTooltip">@L.ChatList_ActiveChats</div>
 
     <div class="chat-list chat-list-active">

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatList.razor
@@ -9,6 +9,7 @@
     Class="chat-list chat-list-all"
     DataSource="@this"
     IsContentSwapDependency="true"
+    ItemChildren="invite-banner"
     ExpandMultiplier="3"
     SkeletonCount="@_skeletonCount"
     ItemVisibilityChanged="@OnItemVisibilityChanged"

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListItem.razor
@@ -52,7 +52,7 @@
                         }
                         <ChatTypingIndicator ChatId="@chat.Id" IsEnabled="@(!m.CallActivity.HasLiveConversation)">
                             @if (chat.Kind != ChatKind.Peer && !lastTextEntry.IsSystemEntry) {
-                                <span class="c-name">
+                                <span class="c-name" data-children="shrinkable non-shrinkable">
                                     <AuthorName
                                         AuthorId="@m.LastAuthorId"
                                         ShowDetailsOnClick="false"

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListNavbarWidget.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListNavbarWidget.razor
@@ -54,7 +54,7 @@
             </ChildContent>
         </ContentSwap>
     </div>
-    <div class="c-active-chats">
+    <div class="c-active-chats" data-children="active-chats">
         <ActiveChats/>
         <ChatListCreateButton/>
     </div>

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListTabUnreadCount.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListTabUnreadCount.razor
@@ -7,7 +7,7 @@
     var notificationMode = m.IsMuted ? ChatNotificationMode.Muted : ChatNotificationMode.Default;
 }
 
-<div class="c-badge">
+<div class="c-badge" data-child="badge">
     <UnreadCount Value="@m.Count" NotificationMode="@notificationMode" Click="OnUnreadBadgeClick"/>
 </div>
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundGroupListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundGroupListItem.razor
@@ -19,7 +19,7 @@
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chat"/>
-            <div class="c-description">
+            <div class="c-description" data-children="second-line third-line">
                 <div class="c-first-line">
                     <span class="c-title">
                         <SearchMatchHighlighter Match="@m.TitleMatch"/>
@@ -29,12 +29,12 @@
                     </span>
                 </div>
                 @if (m.Place is not null && !IsPlace) {
-                    <div class="c-second-line">
+                    <div class="c-second-line" data-child="second-line">
                         @L.Search_In <span class="c-place-title">@m.Place.Title</span>
                     </div>
                 }
                 @if (!chat.Description.IsNullOrEmpty()) {
-                    <div class="c-third-line">
+                    <div class="c-third-line" data-child="third-line">
                         @chat.Description
                     </div>
                 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundMessageListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundMessageListItem.razor
@@ -22,7 +22,7 @@
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chatState.Chat"/>
-            <div class="c-description">
+            <div class="c-description" data-children="second-line third-line non-shrinkable">
                 <div class="c-first-line">
                     <span class="c-title">
                         @chat.Title
@@ -31,14 +31,14 @@
                 </div>
                 @if (chat.Kind == ChatKind.Peer) {
                     // Peer chat message
-                    <div class="c-second-line">
+                    <div class="c-second-line" data-child="second-line">
                         <div class="c-entry">
                             <SearchMatchHighlighter Match="@m.MessageMatch"/>
                         </div>
                     </div>
                 } else if (chat.Kind == ChatKind.Group) {
                     // Group chat message
-                    <div class="c-second-line">
+                    <div class="c-second-line" data-child="second-line">
                         <span class="c-name">
                             <AuthorName
                                 AuthorId="@m.Entry.AuthorId"
@@ -46,17 +46,17 @@
                                 ShowAsOwn="true"/>
                         </span>
                     </div>
-                    <div class="c-third-line public-chat">
+                    <div class="c-third-line public-chat" data-child="third-line">
                         <SearchMatchHighlighter Match="@m.MessageMatch"/>
                     </div>
                 } else {
                     // Place chat message
                     @if (!IsPlace) {
                         // Global search
-                        <div class="c-second-line message">
+                        <div class="c-second-line message" data-child="second-line">
                             @L.Search_In <span class="c-place-title">@m.Place?.Title</span>
                         </div>
-                        <div class="c-third-line place-chat">
+                        <div class="c-third-line place-chat" data-child="third-line">
                             <span class="c-name">
                                 <AuthorName
                                     AuthorId="@m.Entry.AuthorId"
@@ -70,7 +70,7 @@
                         </div>
                     } else {
                         // Search in place
-                        <div class="c-second-line">
+                        <div class="c-second-line" data-child="second-line">
                             <span class="c-name">
                                 <AuthorName
                                     AuthorId="@m.Entry.AuthorId"
@@ -78,7 +78,7 @@
                                     ShowAsOwn="true"/>
                             </span>
                         </div>
-                        <div class="c-third-line public-chat">
+                        <div class="c-third-line public-chat" data-child="third-line">
                             <SearchMatchHighlighter Match="@m.MessageMatch"/>
                         </div>
                     }

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundPlaceListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundPlaceListItem.razor
@@ -21,7 +21,7 @@
                 IsSquare="@false"
                 AvatarKind="@AvatarKind.Marble"
                 AvatarKey="@place.Id.Value"/>
-            <div class="c-description">
+            <div class="c-description" data-children="second-line">
                 <div class="c-first-line">
                     <span class="c-title">
                         <SearchMatchHighlighter Match="@m.TitleMatch"/>
@@ -30,7 +30,7 @@
                         @L.Place_Members(m.MemberCount, m.MemberCount)
                     </span>
                 </div>
-                <div class="c-second-line two-line">
+                <div class="c-second-line two-line" data-child="second-line">
                     <p class="line-clamp-2">
                         @place.Description
                     </p>

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundUserListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/FoundUserListItem.razor
@@ -20,14 +20,14 @@
     <div class="c-content">
         <div class="c-container">
             <ChatIcon Chat="@chat"/>
-            <div class="c-description">
+            <div class="c-description" data-children="second-line">
                 <div class="c-first-line">
                     <span class="c-title">
                         <SearchMatchHighlighter Match="@m.TitleMatch"/>
                     </span>
                 </div>
                 @if (m.Entry != null) {
-                    <div class="c-second-line">
+                    <div class="c-second-line" data-child="second-line">
                         <div class="c-last-message">
                             <AuthorName
                                 AuthorId="@m.Entry.AuthorId"
@@ -44,7 +44,7 @@
                         </div>
                     </div>
                 } else {
-                    <div class="c-second-line bio">
+                    <div class="c-second-line bio" data-child="second-line">
                         @m.Author?.Avatar.Bio
                     </div>
                 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/found-result.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/FoundResult/found-result.css
@@ -42,10 +42,10 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item .c-container .c-description .c-second-line.bio {
     @apply text-01;
 }
-.found-result.navbar-item .c-container .c-description.has-third-line .c-second-line {
+.found-result.navbar-item .c-container .c-description[data-has-third-line] .c-second-line {
     @apply line-clamp-1;
 }
-.found-result.navbar-item .c-container .c-description.has-second-line .c-third-line {
+.found-result.navbar-item .c-container .c-description[data-has-second-line] .c-third-line {
     @apply line-clamp-1;
 }
 .found-result.navbar-item .c-container .c-description .c-second-line .c-place-title {
@@ -71,15 +71,9 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item .c-last-message .avatar-name {
     @apply text-01;
 }
-.found-result.navbar-item .c-description .c-name.has-non-shrinkable {
-    @apply flex-none inline whitespace-normal;
-}
-.found-result.navbar-item .c-description.has-non-shrinkable-name .c-entry {
+.found-result.navbar-item .c-description[data-has-non-shrinkable] .c-entry {
     @apply inline whitespace-normal;
     @apply ml-0.5;
-}
-.found-result.navbar-item .c-description .c-name.has-shrinkable {
-    @apply min-w-16;
 }
 .found-result.navbar-item .c-description .c-text {
     @apply min-w-8;
@@ -95,10 +89,10 @@ body.hoverable .found-result.navbar-item:hover {
 .found-result.navbar-item.message .c-container .c-description .c-third-line.place-chat {
     @apply line-clamp-2;
 }
-.found-result.navbar-item.message .c-container .c-description.has-second-line .c-third-line.place-chat {
+.found-result.navbar-item.message .c-container .c-description[data-has-second-line] .c-third-line.place-chat {
     @apply flex-x gap-x-0.5;
     -webkit-line-clamp: none;
 }
-.found-result.navbar-item.message .c-container .c-description.has-second-line .c-third-line.place-chat .c-entry {
+.found-result.navbar-item.message .c-container .c-description[data-has-second-line] .c-third-line.place-chat .c-entry {
     @apply truncate;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/InviteFriendsBanner.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/InviteFriendsBanner.razor
@@ -6,7 +6,7 @@
         return;
 }
 
-<div class="invite-friends-banner @(IsCompact ? "compact" : "")">
+<div class="invite-friends-banner @(IsCompact ? "compact" : "")" data-child="invite-banner">
     <div class="c-content">
         <img draggable="false" class="c-image" src="/dist/images/invite-cat.svg" alt=""/>
         <div class="c-text">@L.ChatList_InviteFriends</div>

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/NotificationsTabUnreadCount.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/NotificationsTabUnreadCount.razor
@@ -7,7 +7,7 @@
     var notificationMode = m.IsMuted ? ChatNotificationMode.Muted : ChatNotificationMode.Default;
 }
 
-<div class="c-badge">
+<div class="c-badge" data-child="badge">
     <UnreadCount Value="@m.Count" NotificationMode="@notificationMode"/>
 </div>
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
@@ -292,10 +292,10 @@ body.hoverable .navbar-item:hover .navbar-item-content > .c-container > .c-descr
 .chat-list .navbar-item-content .c-last-message .c-name .avatar-name {
     @apply text-caption-4;
 }
-.chat-list .navbar-item-content .c-last-message .c-name.has-non-shrinkable {
+.chat-list .navbar-item-content .c-last-message .c-name[data-has-non-shrinkable] {
     @apply flex-none;
 }
-.chat-list .navbar-item-content .c-last-message .c-name.has-shrinkable {
+.chat-list .navbar-item-content .c-last-message .c-name[data-has-shrinkable] {
     @apply min-w-16;
 }
 .chat-list .navbar-item-content .c-last-message .c-colon {
@@ -306,13 +306,6 @@ body.hoverable .navbar-item:hover .navbar-item-content > .c-container > .c-descr
     @apply min-w-8;
     @apply truncate;
     @apply pointer-events-none;
-}
-.chat-list .navbar-item-content .c-last-message.has-two-line-text {
-    @apply h-auto;
-}
-.chat-list .navbar-item-content .c-last-message .c-text.two-line {
-    @apply line-clamp-2;
-    @apply whitespace-normal;
 }
 .chat-list .navbar-item-content .c-last-message .c-live-talking {
     @apply flex items-center gap-0.5;
@@ -343,8 +336,8 @@ body.hoverable .chat-list .navbar-item:hover .recording-in-chat.on {
 }
 /* Timer ring around the listen button would be clipped by the ending's
    overflow-hidden — open it up only for rows that actually show the controls. */
-.chat-list .navbar-item .navbar-item-ending.has-audio-controls,
-.chat-list .navbar-item .navbar-item-ending.has-audio-controls .slot,
+.chat-list .navbar-item .navbar-item-ending[data-has-audio-controls],
+.chat-list .navbar-item .navbar-item-ending[data-has-audio-controls] .slot,
 .chat-list .navbar-item .chat-audio-controls,
 .chat-list .navbar-item .chat-audio-controls .c-listening-timer {
     @apply overflow-visible;

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/chat-list.css
@@ -42,12 +42,6 @@
 .navbar-chats .c-all-chats > .c-empty i {
     @apply text-5xl;
 }
-.navbar-chats .c-all-chats:has(.own-chat-list) .tab-panel-tabs {
-    @apply hidden;
-}
-.navbar-chats .c-all-chats .chat-list.own-chat-list {
-    @apply p-2;
-}
 .navbar-chats .c-all-chats > .tab-panel {
     @apply overflow-y-hidden;
     @apply flex-initial;
@@ -93,7 +87,7 @@
 body.narrow .chat-list-fab.btn.btn-round.marked-message .btn-content > i {
     transform: none;
 }
-.navbar-chats .c-active-chats:has(> .active-chats) .chat-list-fab {
+.navbar-chats .c-active-chats[data-has-active-chats] .chat-list-fab {
     @apply bottom-full -mb-7;
 }
 .navbar-chats .chat-list {
@@ -493,7 +487,7 @@ body.hoverable .navbar-item:hover .navbar-item-content > .c-container > .c-descr
 .chat-list.finite-list > .c-wrapper > ul.c-virtual-container {
     @apply flex-1;
 }
-.chat-list.finite-list > .c-wrapper > ul.c-virtual-container > .item:has(> .invite-friends-banner) {
+.chat-list.finite-list > .c-wrapper > ul.c-virtual-container > .item[data-has-invite-banner] {
     @apply flex-1 flex-y;
 }
 .invite-friends-banner {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -25,7 +25,7 @@
 <OnUIEvent TEvent="@MentionButtonClickEvent" Handler="OnMentionButtonClickEvent" />
 <OnUIEvent TEvent="@EmojiButtonClickEvent" Handler="OnEmojiButtonClickEvent" />
 <OnUIEvent TEvent="@ShareLocationButtonClickEvent" Handler="OnShareLocationButtonClickEvent" />
-<div @ref="Ref" class="chat-message-editor has-safe-area-bottom">
+<div @ref="Ref" class="chat-message-editor has-safe-area-bottom" data-children="related-entry">
     <Hotkey Keys="ctrl+e" AriaLabel="@L.Shortcuts_FocusEditor" OnTrigger="OnFocusEditorRequested"/>
     <input class="attachment-web-file-picker" type="file" multiple tabindex="-1"/>
     <MentionListManager @key="@MentionListManagerKey">

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/ChatMessageEditor.razor
@@ -25,7 +25,10 @@
 <OnUIEvent TEvent="@MentionButtonClickEvent" Handler="OnMentionButtonClickEvent" />
 <OnUIEvent TEvent="@EmojiButtonClickEvent" Handler="OnEmojiButtonClickEvent" />
 <OnUIEvent TEvent="@ShareLocationButtonClickEvent" Handler="OnShareLocationButtonClickEvent" />
-<div @ref="Ref" class="chat-message-editor has-safe-area-bottom" data-children="related-entry">
+<div @ref="Ref"
+     class="chat-message-editor has-safe-area-bottom"
+     data-child="safe-area-bottom"
+     data-children="related-entry">
     <Hotkey Keys="ctrl+e" AriaLabel="@L.Shortcuts_FocusEditor" OnTrigger="OnFocusEditorRequested"/>
     <input class="attachment-web-file-picker" type="file" multiple tabindex="-1"/>
     <MentionListManager @key="@MentionListManagerKey">

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/RelatedChatEntryPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/RelatedChatEntryPanel.razor
@@ -6,7 +6,7 @@
         return;
 }
 
-<div class="related-chat-entry-panel">
+<div class="related-chat-entry-panel" data-child="related-entry">
     <RelatedChatEntry Entry="@m.Entry" Kind="@m.Kind" IsOwn="@m.IsOwn"/>
 </div>
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
@@ -158,7 +158,7 @@ body.narrow .narrow-panel .post-panel .c-right-buttons .c-incut {
 body.narrow .post-panel .message-input a {
     @apply text-post-panel-text;
 }
-.ac-bubble-host:has(.ac-bubble) + .base-layout .post-panel .message-input {
+.ac-bubble-host[data-has-bubble] + .base-layout .post-panel .message-input {
     @apply pointer-events-none;
 }
 .post-panel .message-input-label {

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/chat-message-editor.css
@@ -6,7 +6,7 @@
 .chat-message-editor.narrow-panel {
     padding-bottom: 0;
 }
-.list-view-layout.has-listening-activity .chat-message-editor {
+.list-view-layout[data-has-listening-activity] .chat-message-editor {
     @apply bg-transparent;
 }
 
@@ -101,7 +101,7 @@ body.narrow .c-editor-top {
     @apply flex-auto flex-x justify-between items-center md:gap-x-2;
     @apply py-0 px-2;
 }
-body.wide .list-view-layout.has-listening-activity .post-panel {
+body.wide .list-view-layout[data-has-listening-activity] .post-panel {
     @apply bg-01;
 }
 .post-panel.sharp-corners {
@@ -778,17 +778,17 @@ body.hoverable .related-chat-entry-panel .btn.btn-round:hover .btn-content {
 /* With a reply/edit panel floating above the input, shrink the sub-footer's corner fillers to a
    small 0.5rem radius so they hug the bottom corners of the related panel instead of the full 2rem
    curve (which assumes the post-panel is the topmost element). */
-.chat-message-editor.has-related-entry .rounded-sub-footer::before,
-.chat-message-editor.has-related-entry .rounded-sub-footer::after {
+.chat-message-editor[data-has-related-entry] .rounded-sub-footer::before,
+.chat-message-editor[data-has-related-entry] .rounded-sub-footer::after {
     @apply w-2 h-2;
 }
-body.narrow .list-view-layout.has-listening-activity .rounded-sub-footer,
-body.narrow .list-view-layout.has-audio-panel-header .rounded-sub-footer {
+body.narrow .list-view-layout[data-has-listening-activity] .rounded-sub-footer,
+body.narrow .list-view-layout[data-has-audio-panel-header] .rounded-sub-footer {
     @apply h-20 inset-x-0;
     top: calc(-5rem + 1px);
 }
-body.narrow .list-view-layout.has-listening-activity .narrow-panel .rounded-sub-footer,
-body.narrow .list-view-layout.has-audio-panel-header .narrow-panel .rounded-sub-footer {
+body.narrow .list-view-layout[data-has-listening-activity] .narrow-panel .rounded-sub-footer,
+body.narrow .list-view-layout[data-has-audio-panel-header] .narrow-panel .rounded-sub-footer {
     @apply h-12 inset-x-0;
     top: calc(-3rem + 1px);
 }
@@ -798,8 +798,8 @@ body.narrow .list-view-layout.has-audio-panel-header .narrow-panel .rounded-sub-
    and gives the bottom-to-top fade) plus three radial gradients that raise the top contour into a
    bathtub silhouette (tall left/right edges + a small centered bump hugging the round record button).
    Violet tones mirror the active-conversation header gradient (--violet-60-20, main.css). */
-body.narrow .list-view-layout.has-listening-activity .rounded-sub-footer > .bg-layer,
-body.narrow .list-view-layout.has-audio-panel-header .rounded-sub-footer > .bg-layer {
+body.narrow .list-view-layout[data-has-listening-activity] .rounded-sub-footer > .bg-layer,
+body.narrow .list-view-layout[data-has-audio-panel-header] .rounded-sub-footer > .bg-layer {
     background:
         linear-gradient(var(--violet-50-10), var(--violet-50-10)),
         linear-gradient(var(--background-01), var(--background-01));

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
@@ -37,17 +37,19 @@
             foreach (var childItem in expandedConversationMessage.Items) {
                 @if (childItem is ConversationHeader or LiveConversationHeader) {
                     <div @key="@childItem.Key" class="item expanded" data-key="@childItem.Key" data-skip="true"
+                         data-children="conversation-message live-card live-footer live-header show-author conversation-header vl-sticky"
                          data-vl-h-transition="@(childItem.MustAnimateAppearance ? null : "change")">
                         @RenderChatMessage!((childItem, chatContext))
                     </div>
                 }
                 else if (childItem.IsGroup) {
-                    <div @key="@childItem.Key" class="group" >
+                    <div @key="@childItem.Key" class="group" data-children="live-block unjoined-live-block live-block-dissolving joined-live-card">
                         @RenderChatMessage!((childItem, chatContext))
                     </div>
                 }
                 else {
                     <div @key="@childItem.Key" class="item" data-key="@childItem.Key" data-skip="@childItem.ShouldSkipKey"
+                         data-children="conversation-message live-card live-footer live-header show-author conversation-header vl-sticky"
                          data-vl-h-transition="@(childItem.MustAnimateAppearance ? null : "change")">
                         @RenderChatMessage!((childItem, chatContext))
                     </div>
@@ -72,6 +74,8 @@
         DataSource="@this"
         Identity="@Chat.Id.Value"
         IsContentSwapDependency="true"
+        GroupChildren="live-block unjoined-live-block live-block-dissolving joined-live-card"
+        ItemChildren="conversation-message live-card live-footer live-header show-author conversation-header vl-sticky"
         SkipPreRenderGetDataCall="@HasUrlEntryLid"
         DefaultEdge="@VirtualListEdge.End"
         RenderDirection="@VirtualListRenderDirection.Reverse"

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor
@@ -76,7 +76,6 @@
         IsContentSwapDependency="true"
         GroupChildren="live-block unjoined-live-block live-block-dissolving joined-live-card"
         ItemChildren="conversation-message live-card live-footer live-header show-author conversation-header vl-sticky"
-        SkipPreRenderGetDataCall="@HasUrlEntryLid"
         DefaultEdge="@VirtualListEdge.End"
         RenderDirection="@VirtualListRenderDirection.Reverse"
         AnimateItemHeight="true"

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ChatView.razor.cs
@@ -60,12 +60,6 @@ public partial class ChatView : ComponentBase, IVirtualListDataSource<ChatMessag
     private CancellationToken DisposeToken { get; }
     private ILogger Log => field ??= Hub.LogFor(GetType());
 
-    private bool HasUrlEntryLid
-        // NOTE: ?n= means NavigateToUrlFragment is about to set _nextNavigation, and it races the list's
-        // initial GetData - ComponentBase renders before OnParametersSetAsync's task completes
-        => new LocalUrl(History.Uri).IsChat(out var chatId, out long entryLid)
-            && entryLid > 0
-            && chatId == Chat.Id;
     private ILogger? DebugLog => Log.IfEnabled(LogLevel.Debug);
     private bool IsNewMessagesLineDebounceActive
         => Volatile.Read(ref _newMessagesLineState).IsDebounceActive;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryAuthorGroupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryAuthorGroupView.razor
@@ -21,7 +21,7 @@
     </div>
     <div class="c-group-items">
         @foreach (var item in Message.Items) {
-            <div @key="@item.Key" class="item" data-key="@item.Key">
+            <div @key="@item.Key" class="item" data-key="@item.Key" data-children="conversation-message live-card live-footer live-header show-author conversation-header vl-sticky">
                 <ChatEntryMessageView ChatContext="@ChatContext" Message="@item" ShowAuthorBadge="false"/>
             </div>
         }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -82,7 +82,7 @@
         && m.Translation == TranslationState.None
         && status == ChatMessageSendingStatus.MessageStatus.Default;
 }
-<div @ref="Ref" class="chat-message-markup @translationCls @streamingCls @(isEmptyMarkup ? "empty" : "")">
+<div @ref="Ref" class="chat-message-markup @translationCls @streamingCls @(isEmptyMarkup ? "empty" : "")" data-children="code-block">
     @if (m.IsStreaming) {
         @if (IsOwnMessage && sm.IsTextEmpty && !HasNewerStreamingEntry()) {
             <StreamingEntryBadge

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageInternalView/ChatEntryMessageInternalView.razor
@@ -63,6 +63,10 @@
     // still shows its own status — it's a separate ChatListItem render).
     var hideInlineStatus = entry.HasLocation || isGifOnly || isEmojiOnly;
 
+    // Both marks can be absent, and then there is nothing to place - no suffix node, no span.
+    var hasSuffix = m.Translation != TranslationState.None
+        || (status != ChatMessageSendingStatus.MessageStatus.Default && !hideInlineStatus);
+
     // Should be named __builder
     // ReSharper disable once VariableHidesOuterVariable UnusedParameter.Local
     RenderFragment statusFragment = (__builder) => {
@@ -125,10 +129,10 @@
             </div>
         }
         <CascadingValue Value="@entry" IsFixed="true">
-            <CascadingValue Value="@statusFragment">
+            <CascadingValue Value="@(new MarkupRenderContext(hasSuffix ? statusFragment : null))">
                 @* A lone emoji mention (the whole message is one EmojiMention) renders large. *@
                 <CascadingValue Value="@isSoleEmojiMention" Name="IsSoleEmojiMention" IsFixed="true">
-                    <MarkupView Markup="@markup"/>
+                    <MarkupView Markup="@WithSuffix(markup)"/>
                 </CascadingValue>
             </CascadingValue>
         </CascadingValue>
@@ -139,6 +143,23 @@
 </div>
 
 @code {
+    // The injected tree is memoized against the markup it came from: Markup compares by reference
+    // (ByRefParameterComparer), so handing MarkupView a fresh object every render would re-render
+    // the whole spine on every status change. The suffix node is injected whether or not there is
+    // anything to render in it, so the last leaf's component type never changes and its view keeps
+    // its instance - a PlayableTextMarkupView would otherwise be disposed and re-created, taking a
+    // JS round trip and its playback highlighting with it.
+    private Markup? _markupSource;
+    private Markup? _markupWithSuffix;
+
+    private Markup WithSuffix(Markup markup)
+    {
+        if (!ReferenceEquals(_markupSource, markup)) {
+            _markupSource = markup;
+            _markupWithSuffix = MarkupSuffixInjector.Inject(markup);
+        }
+        return _markupWithSuffix!;
+    }
     private static readonly string JSCreateMethod
         = $"{BlazorUIAppModule.ImportName}.ChatEntryMessageInternalView.create";
     private static readonly double AnimationDurationMs = Constants.Transcription.ThrottlePeriod.TotalMilliseconds;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatEntryMessageView.razor
@@ -41,6 +41,7 @@
     var selectionEndClass = m.IsSelectionEnd ? "selection-end" : "";
     var mentionClass = m.IsOwnAuthorMentioned && !isReplyToOwnMessage ? "mention" : "";
     var showAuthorClass = showAuthorBadge ? "show-author" : "";
+    var showAuthorChild = showAuthorBadge ? "show-author" : null;
     var audioRecordingClass = isStateBadge ? "audio-recording-message" : "";
     var cls = $"{systemClass} {forwardedClass} {forwardedBorderClass} {ownMessageClass} {mentionClass} {paddingClass} {unreadBlockClass} {highlightClass} {repliedClass} {selectedClass} {selectionStartClass} {selectionEndClass} {showAuthorClass} {audioRecordingClass} message-wrapper";
 }
@@ -81,7 +82,7 @@
         <div class="chat-message">
             <div class="c-content">
                 <div class="message-content">
-                    <div class="chat-message-markup">
+                    <div class="chat-message-markup" data-children="code-block">
                         <CascadingValue Value="@entry" IsFixed="true">
                             <MarkupView Markup="@markup"/>
                         </CascadingValue>
@@ -101,6 +102,7 @@
     var menuRef = showMenu ? MenuRef.New<MessageMenu>(entry.GetClientId(m.IsOwnMessage), bool.FalseString, "", "").ToString() : null;
 }
 <div class="@cls"
+     data-child="@showAuthorChild"
      data-chat-entry-id="@(isStateBadge ? null : entry.Id.Value)"
      data-menu="@menuRef">
     <div class="chat-message group">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageSendingStatus/chat-message-sending-status.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/ChatMessageSendingStatus/chat-message-sending-status.css
@@ -38,11 +38,11 @@ body.hoverable .navbar-item:hover .chat-message-sending-status {
 
 /*Sending status in attachments and with code markup*/
 .message-attachments .chat-message-sending-status,
-.chat-message-markup.has-code-block .chat-message-sending-status {
+.chat-message-markup[data-has-code-block] .chat-message-sending-status {
     @apply -right-1 bottom-0.5;
 }
 
 .message-attachments .chat-message-sending-status.sending,
-.chat-message-markup.has-code-block .chat-message-sending-status.sending {
+.chat-message-markup[data-has-code-block] .chat-message-sending-status.sending {
     @apply bottom-1.5;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageHeader.razor
@@ -11,6 +11,7 @@
    the header sits inside a group the list doesn't track, and collapsed it is an item whose key the
    expansion removes - so there is no key that survives either way round. *@
 <div class="@cls"
+     data-child="@(IsSeparated ? "conversation-header vl-sticky" : null)"
      data-vl-anchor="@Conversation.Id.Value"
      data-vl-render-script-collapsed-header="@(IsSeparated ? null : Conversation.Id.Value)"
      data-menu="@(MenuRef.New<ConversationMenu>(Conversation.Id.Value, IsSeparated.ToString()))">

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -14,6 +14,11 @@
     var detailsCls = _isOpen ? "show" : "";
     var liveClass = state.IsLive ? (state.IsJoined || state.HasOverlay ? "live joined" : "live") : "";
     var cls = $"conversation-message message-wrapper {openClass} {liveClass}";
+    var childNames = state.IsLive
+        ? state.IsJoined || state.HasOverlay
+            ? "conversation-message live-card joined-live-card"
+            : "conversation-message live-card"
+        : "conversation-message";
     var attachments = conversation.Attachments;
     var hasLiveTitle = !m.Title.Text.IsNullOrEmpty();
     var hasDescription = !m.Description.Markup.ToReadableText().IsNullOrEmpty();
@@ -43,6 +48,7 @@
     }
 }
 <div class="@cls"
+     data-child="@childNames"
      data-menu="@(MenuRef.New<ConversationMenu>(conversation.Id.Value, false.ToString()))">
     @if (state.IsLive) {
         var secondLine = state.IsVoiceOnly

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationFooterView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationFooterView.razor
@@ -1,6 +1,6 @@
 @namespace ActualChat.UI.Blazor.App.Components
 
-<div class="live-conversation-footer"></div>
+<div class="live-conversation-footer" data-child="live-footer"></div>
 
 @code {
     [Parameter, EditorRequired] public ChatContext ChatContext { get; set; } = null!;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -5,16 +5,22 @@
     var s = State.Value;
     var title = s.Title.IsNullOrEmpty() ? s.ParticipantsText : s.Title;
     var cls = "live-conversation-header";
-    if (s.IsDissolving)
+    // The block-level names resolve up to the .group, the item-level ones stop at the .item.expanded
+    var childNames = "live-block live-header vl-sticky";
+    if (s.IsDissolving) {
         cls += " dissolving";
+        childNames += " live-block-dissolving";
+    }
     if (!s.IsAnyoneTalking)
         cls += " quiet";
     // The tint says "you were here", so it can't be keyed on the Join button: that button comes back
     // when you leave, and leaving must not repaint the block as one you never attended.
-    if (!s.IsJoined && !s.HasOverlay)
+    if (!s.IsJoined && !s.HasOverlay) {
         cls += " unjoined";
+        childNames += " unjoined-live-block";
+    }
 }
-<div class="@cls" data-vl-anchor="@Header.Conversation!.Id.Value">
+<div class="@cls" data-child="@childNames" data-vl-anchor="@Header.Conversation!.Id.Value">
     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
     <span class="c-lc-name">@title</span>
     @* Leaving is just "stop listening", so re-joining stays one tap away. *@

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/conversation.css
@@ -11,13 +11,13 @@
 }
 /* The gap goes on the data-key item, the only box the list measures, and as padding, which
    getBoundingClientRect counts - a margin here escapes that box and drifts the list's geometry. */
-.virtual-list .c-virtual-container .item.has-conversation-message {
+.virtual-list .c-virtual-container .item[data-has-conversation-message] {
     @apply pt-4;
 }
 /* ...but inside a block (one carrying the split-out live header) the card follows the header flush -
    no gap between the header and the description. Covers both the joined block and the frozen/unjoined
    (left-the-call) block. */
-.virtual-list .c-virtual-container .group.has-live-block .item.has-live-card {
+.virtual-list .c-virtual-container .group[data-has-live-block] .item[data-has-live-card] {
     @apply pt-0;
 }
 /* Standalone preview card (not inside a block - never joined, no overlay) keeps its own box. */
@@ -29,7 +29,7 @@
    rounding, so a card box here would draw a second box inside the block with the title detached.
    No rounded corners left to clip, so overflow goes visible too - lets the "Show more" pill straddle
    below the card's bottom edge instead of being cut off by the base .conversation-message rule. */
-.virtual-list .c-virtual-container .group.has-live-block .conversation-message.live {
+.virtual-list .c-virtual-container .group[data-has-live-block] .conversation-message.live {
     @apply border-none rounded-none;
     background: none;
     overflow: visible;
@@ -41,23 +41,19 @@
 }
 /* The split header carries the title, so the description card drops its own top padding and butts
    right up under the header - one continuous surface, no gap. */
-.virtual-list .c-virtual-container .group.has-live-block .c-live-card {
+.virtual-list .c-virtual-container .group[data-has-live-block] .c-live-card {
     @apply pt-0;
 }
 /* A card that ends with the faded preview drops its bottom padding so the preview sits flush above
    the footer (mirrors the pt-0 that butts the card under the header) - no gap after the last row.
    Keyed on the preview itself: any collapsed block has one, attended or not. */
-.virtual-list .c-virtual-container .group.has-live-block .c-live-card:has(.last-entries-preview) {
+.virtual-list .c-virtual-container .group[data-has-live-block] .c-live-card:has(.last-entries-preview) {
     @apply pb-0;
 }
-/* When expanded, the split header carries the title so the card renders empty (no .c-live-card child).
-   The item's default min-h-6 would then leave a gap between the header and the first message - collapse
-   the empty card and its item to zero. The :not(:has(.c-live-card)) guard leaves the collapsed card
-   (which still has content) untouched. */
-.virtual-list .c-virtual-container .group.has-live-block .item.has-empty-live-card {
-    @apply min-h-0;
-}
-.virtual-list .c-virtual-container .group.has-live-block .conversation-message.live:empty {
+/* An expanded live card that renders empty used to be collapsed to zero here, but nothing has produced
+   .conversation-message.live:empty since 7538c686bc gave such a card its own .c-live-card-empty element,
+   so both rules were unreachable. Style .c-live-card-empty if the gap ever comes back. */
+.virtual-list .c-virtual-container .group[data-has-live-block] .conversation-message.live:empty {
     @apply min-h-0 mb-0;
 }
 .c-live-card .c-lc-title {
@@ -359,8 +355,8 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    wrapping the sticky header, the scrollable card, the author entries, and the live footer as one box.
    The violet tint is painted by the ::before overlay below - in FRONT of the sticky header so it can
    scroll up off it; position:relative anchors that overlay. */
-.virtual-list .c-virtual-container .group.has-joined-live-card,
-.virtual-list .c-virtual-container .group.has-live-block {
+.virtual-list .c-virtual-container .group[data-has-joined-live-card],
+.virtual-list .c-virtual-container .group[data-has-live-block] {
     @apply relative;
     isolation: isolate;
     /* mx-1 matches the 4px horizontal padding on regular conversation .item wrappers, so the live
@@ -373,8 +369,8 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    header item's z-20) but scrolling with the block. At rest it tints the top; as you scroll it slides up
    off the pinned opaque header, so the header occludes the transcript cleanly. pointer-events:none keeps
    the header's Join/expand buttons clickable through it. */
-.virtual-list .c-virtual-container .group.has-joined-live-card::before,
-.virtual-list .c-virtual-container .group.has-live-block::before {
+.virtual-list .c-virtual-container .group[data-has-joined-live-card]::before,
+.virtual-list .c-virtual-container .group[data-has-live-block]::before {
     @apply content-empty;
     @apply absolute inset-0 z-30;
     @apply pointer-events-none;
@@ -385,7 +381,7 @@ body.hoverable .conversation-attachments .image-attachment:hover {
 /* overflow:clip (not hidden): clips the block content to the rounded corners just like hidden, but
    without making the group a scroll container - so the live header's position:sticky still pins against
    the transcript instead of being trapped inside this group. */
-.virtual-list .c-virtual-container .group.has-live-block {
+.virtual-list .c-virtual-container .group[data-has-live-block] {
     @apply px-0;
     overflow: clip;
 }
@@ -395,7 +391,7 @@ body.hoverable .conversation-attachments .image-attachment:hover {
    carry this, since it comes back when you leave and a leaver's block keeps the joined violet tint.
    Its match set is a strict subset of the base shell rule's expanded arm, so mx-1 cascades in from
    there - only the tint is overridden here, and it wins by coming later. */
-.virtual-list .c-virtual-container .group.has-unjoined-live-block {
+.virtual-list .c-virtual-container .group[data-has-unjoined-live-block] {
     isolation: isolate;
     @apply rounded-2xl;
     background:
@@ -403,12 +399,12 @@ body.hoverable .conversation-attachments .image-attachment:hover {
         linear-gradient(var(--background-01), var(--background-01)) padding-box;
 }
 
-/* Mirrors virtual-list.css's .item.has-conversation-header rule - that one only matches the literal
+/* Mirrors virtual-list.css's .item[data-has-conversation-header] rule - that one only matches the literal
    conversation-header class, not this component's own live-conversation-header. Sticky lives on the
    header's list item - its box in the list, the header row alone (no card). A bare position:sticky on
    the inner .live-conversation-header would be confined to this same item and never pin. Transparent:
    the block's own top tint shows through, and the pinned header overlaps the content sliding under it. */
-.virtual-list .c-virtual-container .item.has-live-header {
+.virtual-list .c-virtual-container .item[data-has-live-header] {
     @apply sticky -top-px z-20;
 }
 
@@ -463,24 +459,24 @@ body.hoverable .virtual-list .c-virtual-container .live-conversation-header .c-l
 }
 /* The footer band is 0.75rem; without this its item keeps the default min-h-6, leaving ~12px of dead
    space between the last message and the rounded bottom. Collapse the item so the footer sits flush. */
-.virtual-list .c-virtual-container .group.has-live-block .item.has-live-footer {
+.virtual-list .c-virtual-container .group[data-has-live-block] .item[data-has-live-footer] {
     @apply min-h-0;
 }
 /* The unjoined block is a compact preview card that the group's own rounding already closes, so its
    footer band would just add empty space below the last preview row - collapse it to nothing. */
-.virtual-list .c-virtual-container .group.has-unjoined-live-block .live-conversation-footer {
+.virtual-list .c-virtual-container .group[data-has-unjoined-live-block] .live-conversation-footer {
     @apply h-0;
 }
 
 /* Tier-1 dissolve: a too-short session leaves no card, so its block fades + collapses its chrome
    (border, tint, header, card, footer) out while the entries stay put, then it's removed and they
    drop to plain messages. Duration is kept in sync with LiveBlockUI.DissolveDuration (300ms). */
-.virtual-list .c-virtual-container .group.has-live-block-dissolving {
+.virtual-list .c-virtual-container .group[data-has-live-block-dissolving] {
     animation: lc-dissolve-frame 300ms ease forwards;
 }
-.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.expanded,
-.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.has-live-card,
-.virtual-list .c-virtual-container .group.has-live-block-dissolving > .item.has-live-footer {
+.virtual-list .c-virtual-container .group[data-has-live-block-dissolving] > .item.expanded,
+.virtual-list .c-virtual-container .group[data-has-live-block-dissolving] > .item[data-has-live-card],
+.virtual-list .c-virtual-container .group[data-has-live-block-dissolving] > .item[data-has-live-footer] {
     overflow: hidden;
     animation: lc-dissolve-chrome 300ms ease forwards;
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LocalLinkPreview.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/LocalLinkPreview.razor
@@ -34,7 +34,7 @@
     var inChatSuffix = entry is null ? "" : L.LinkPreview_InChat_Suffix;
 }
 
-<div class="link-preview local-link unfocusable @cls">
+<div class="link-preview local-link unfocusable @cls" data-children="local-link-top">
     @if (showBg) {
         <div class="c-bg">
             <ChatIcon Chat="@chat" Size="SquareSize.SizeFull" IsSquare="@true" IsBlurred="@true"/>
@@ -61,16 +61,19 @@
                 AvatarKey="@place.Id.Value"/>
         }
     </div>
-    <div class="c-info">
+    <div class="c-info" data-children="local-link-top">
         @if (entry is not null) {
-            <div class="c-top">
-                @if (author != null) {
+            <div class="c-top" data-child="local-link-top">
+                @if (author is not null) {
                     <div class="c-author-header">
                         <AuthorName AuthorId="@author.Id" Class="chat-message-author-name"/>
                         <LiveTimeDeltaText Class="chat-message-timestamp min-w-fit" Moment="@entry.BeginsAt"/>
                     </div>
                 }
-                <a class="c-description" href="@url" @onclick:preventDefault="true" @onclick="NavigateToUrl">@entry.Content</a>
+                <a class="c-description"
+                   href="@url"
+                   @onclick:preventDefault="true"
+                   @onclick="NavigateToUrl">@entry.Content</a>
             </div>
 
             @if (entry.Attachments.Length > 0) {
@@ -97,7 +100,10 @@
                 <span>@inChatPrefix</span>
             }
             @if (user is not null) {
-                <a class="domain-link" href="@Data.LocalUrl.Value" @onclick:preventDefault="true" @onclick="NavigateToUrl">@user.Avatar.Name</a>
+                <a class="domain-link"
+                   href="@Data.LocalUrl.Value"
+                   @onclick:preventDefault="true"
+                   @onclick="NavigateToUrl">@user.Avatar.Name</a>
             } else if (chat is not null) {
                 var linkText = chat.Title;
                 if (place?.Id is not null)
@@ -105,9 +111,15 @@
 
                 var useDirectChatLink = entry is not null;
                 var chatLink = useDirectChatLink ? Links.Chat(chat.Id) : Data.LocalUrl;
-                <a class="domain-link" href="@chatLink" @onclick:preventDefault="true" @onclick="@(() => NavigateTo(chatLink))">@linkText</a>
+                <a class="domain-link"
+                   href="@chatLink"
+                   @onclick:preventDefault="true"
+                   @onclick="@(() => NavigateTo(chatLink))">@linkText</a>
             } else if (place is not null) {
-                <a class="domain-link" href="@Data.LocalUrl.Value" @onclick:preventDefault="true" @onclick="NavigateToUrl">@place.Title</a>
+                <a class="domain-link"
+                   href="@Data.LocalUrl.Value"
+                   @onclick:preventDefault="true"
+                   @onclick="NavigateToUrl">@place.Title</a>
             }
             @if (!inChatSuffix.IsNullOrEmpty()) {
                 <span>@inChatSuffix</span>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/link-preview.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/LinkPreview/link-preview.css
@@ -163,7 +163,7 @@ body.narrow .message-link-preview .link-more-btn {
     @apply h-full;
 }
 /* Name-only local links (chat / place / user, no message body) center vertically. */
-.link-preview.local-link:not(:has(.c-top)) {
+.link-preview.local-link:not([data-has-local-link-top]) {
     @apply items-center;
 }
 /* Blurred chat icon background */
@@ -190,10 +190,10 @@ body.device-ios .link-preview.local-link > .c-bg {
     @apply gap-y-0.5;
     @apply pl-0 pr-2 py-1;
 }
-.link-preview.local-link .c-info:not(:has(.c-top)) {
+.link-preview.local-link .c-info:not([data-has-local-link-top]) {
     @apply justify-center;
 }
-.link-preview.local-link .c-info:not(:has(.c-top)) .c-domain {
+.link-preview.local-link .c-info:not([data-has-local-link-top]) .c-domain {
     @apply mt-0;
 }
 .link-preview.local-link .c-author-header {

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranslationFragments.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/TranslationFragments.razor
@@ -11,25 +11,4 @@
             <translation-svg size="4" isActive="@isActive" />
         </span>
     };
-
-    @* '__builder' is predefined name used by RazorSourceGenerator *@
-    public static RenderFragment<(Markup, RenderFragment)> MarkupWithState = state => __builder => {
-        var markup = state.Item1;
-        var statusFragment = state.Item2;
-        var isSimpleMarkup = markup is PlainTextMarkup or PlayableTextMarkup;
-        if (isSimpleMarkup) {
-            <CascadingValue Value="@statusFragment" IsFixed="true">
-                <MarkupView Markup="@markup"/>
-            </CascadingValue>
-        } else {
-            <MarkupView Markup="@markup"/>
-            @statusFragment
-        }
-    };
-
-    @* '__builder' is predefined name used by RazorSourceGenerator *@
-    public static RenderFragment<TranslatedMarkup> TranslatedMarkupWithMark = state => __builder => {
-        var statusFragment = TranslationMark(state.State);
-        MarkupWithState((state.Markup, statusFragment))(__builder);
-    };
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/chat-view-navigation-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Navigation/chat-view-navigation-panel.css
@@ -15,7 +15,7 @@ body.hoverable .chat-view-navigation-panel > .c-content {
     @apply right-0;
     @apply p-3 pl-8;
 }
-body.narrow:has(.audio-panel-header) .chat-view-navigation-panel > .c-content {
+body.narrow[data-has-audio-panel-header] .chat-view-navigation-panel > .c-content {
     @apply bottom-18;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -271,12 +271,9 @@ body.hoverable .chat-message.mention:hover .chat-message-timestamp-on-hover {
     100% { filter: blur(0px); }
 }
 
+
 .chat-message-markup span {
-    @apply text-text-1;
     -webkit-line-break: after-white-space;
-}
-.chat-message-markup strong span {
-    @apply font-bold;
 }
 
 .chat-message-markup .c-streaming-ellipsis {

--- a/src/dotnet/UI.Blazor.App/Components/ComputedMarkupViewBase.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ComputedMarkupViewBase.cs
@@ -7,7 +7,6 @@ public abstract class ComputedMarkupViewBase<TMarkup, TState>
     where TMarkup : Markup
 {
     [CascadingParameter] public ChatEntry Entry { get; set; } = null!;
-    [CascadingParameter] public RenderFragment? LastFragment { get; set; }
     [Parameter, EditorRequired] public TMarkup Markup { get; set; } = null!;
 
     Markup IMarkupView.Markup => Markup;

--- a/src/dotnet/UI.Blazor.App/Components/ContactSelector/ContactSelectorListView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ContactSelector/ContactSelectorListView.razor
@@ -8,9 +8,11 @@
 <ContentSwap
     LayerKey="@Selector.SelectedPlaceId"
     Class="c-list-swap"
+    Children="contact-list"
+    LayerChildren="contact-list"
     Effect="@_swapDirection.Wipe(Selector.SelectedPlaceIndex)">
     <ChildContent>
-        <div class="contact-selector-list" role="listbox" aria-multiselectable="true">
+        <div class="contact-selector-list" role="listbox" aria-multiselectable="true" data-child="contact-list">
             @foreach (var contact in contacts) {
                 var isSelected = selectedChatIds.Contains(contact.Id);
                 <div class="contact-selector-list-item"

--- a/src/dotnet/UI.Blazor.App/Components/ContactSelector/contact-selector.css
+++ b/src/dotnet/UI.Blazor.App/Components/ContactSelector/contact-selector.css
@@ -120,11 +120,11 @@ body.hoverable .contact-selector-badges > .c-contact:hover .c-remove {
 
 /* The ContentSwap host around the list, so a place-filter change wipes rather than cuts. It takes
    the box the list used to get as a flex item, and each layer has to stand on its own during a swap. */
-.c-list-swap:has(> .c-layer > .contact-selector-list) {
+.c-list-swap[data-has-contact-list] {
     @apply grow;
     @apply min-h-0;
 }
-.c-list-swap > .c-layer:has(> .contact-selector-list) {
+.c-list-swap > .c-layer[data-has-contact-list] {
     @apply flex-y grow;
     @apply min-h-0;
 }

--- a/src/dotnet/UI.Blazor.App/Components/DateVisor/date-visor.css
+++ b/src/dotnet/UI.Blazor.App/Components/DateVisor/date-visor.css
@@ -26,6 +26,6 @@
     @apply drop-shadow-lg;
 }
 /* Extra margin when video panel drag handle is present */
-.list-view-layout:has(.c-drag-handle) .date-visor {
+.list-view-layout[data-has-drag-handle] .date-visor {
     @apply mt-4;
 }

--- a/src/dotnet/UI.Blazor.App/Components/Discover/DiscoverTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Discover/DiscoverTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Discover Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="discover-test-content">
         <DiscoverWideLeftPanel/>
         <DiscoverCenter/>

--- a/src/dotnet/UI.Blazor.App/Components/InaccessiblePlace/InaccessiblePlace.razor
+++ b/src/dotnet/UI.Blazor.App/Components/InaccessiblePlace/InaccessiblePlace.razor
@@ -1,6 +1,6 @@
 @namespace ActualChat.UI.Blazor.App.Components
 
-<div class="chat-panel-skeleton">
+<div class="chat-panel-skeleton" data-child="chat-panel-skeleton">
     <PanelBodySkeleton>
         <chat-view-skeleton class="no-scrollbar" count="14"></chat-view-skeleton>
     </PanelBodySkeleton>

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftPanelChatContentHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftPanelChatContentHeader.razor
@@ -1,7 +1,7 @@
 @namespace ActualChat.UI.Blazor.App.Components
 
 <div class="left-panel-content-header">
-    <div class="c-content">
+    <div class="c-content" data-children="search open-search search-badges">
         <div class="c-title">
             @Title
         </div>

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/LeftSearchPanel/LeftChatSearchInput.razor
@@ -11,13 +11,13 @@
     var showTypeBadge = m.TypeFilter != SearchTypeFilter.Anything;
 }
 
-<div class="left-chat-search-input @cls @placeCls">
+<div class="left-chat-search-input @cls @placeCls" data-child="@(m.IsOpen ? "search open-search" : "search")">
     <Hotkey Keys="ctrl+f" AriaLabel="@L.Common_Search" OnTrigger="OnSearchHotkey"/>
     @if (m.IsOpen) {
         <Hotkey Keys="escape" AriaLabel="@L.Search_CloseSearch" OnTrigger="@(() => OnClick(false))"/>
     }
     <div class="c-search">
-        <div class="search-input">
+        <div class="search-input" data-children="close-btn focused-input">
             <label>
                 <TextInput
                     @ref="_inputRef"
@@ -37,18 +37,17 @@
                     data-menu-placement="@(FloatingPosition.BottomStart.ToPositionString())">
                     <i class="icon-options-2 text-xl"></i>
                 </HeaderButton>
-
                 <ButtonRound Click="@OnSearchButtonClick" Class="c-ai-btn search-btn btn-transparent">
                     <i class="icon-search text-xl"></i>
                 </ButtonRound>
-                <HeaderButton Click="@OnCloseClick" Class="c-close-btn">
+                <HeaderButton Click="@OnCloseClick" Class="c-close-btn" data-child="close-btn">
                     <i class="icon-close text-2xl"></i>
                 </HeaderButton>
             </label>
         </div>
     </div>
     @if (m.IsOpen && (showLocationBadge || showTypeBadge)) {
-        <div class="c-filter-badges">
+        <div class="c-filter-badges" data-child="search-badges">
             @if (showLocationBadge) {
                 <SearchFilterBadge
                     Text="@LocationBadgeText(m.LocationFilter)"
@@ -64,8 +63,8 @@
 </div>
 
 @code {
-    TextInput? _inputRef;
-    bool _hasText;
+    private TextInput? _inputRef;
+    private bool _hasText;
 
     private SearchUI SearchUI => Hub.SearchUI;
     private NavbarUI NavbarUI => Hub.NavbarUI;
@@ -99,12 +98,13 @@
         var typeFilter = await SearchUI.TypeFilter.Use(cancellationToken).ConfigureAwait(false);
         var initialText = SearchUI.Text.Value; // .Value instead of .Use() is intentional here (AY: why?)
         _hasText = !initialText.IsNullOrEmpty();
+
         return new Model(isOpen, initialText, locationFilter, typeFilter);
     }
 
     private void OnClick(bool openPanel) {
         if (!openPanel) {
-            Cancel();
+            _ = Cancel();
             // Escape and Ctrl+F close it while the input still holds focus, so clicking the field
             // again is no focus change and OnFocus - the only thing that reopens it - never fires.
             _ = _inputRef?.Blur();

--- a/src/dotnet/UI.Blazor.App/Components/LeftPanel/left-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/LeftPanel/left-panel.css
@@ -15,7 +15,7 @@
     @apply bg-04;
     @apply md:transition-[width,padding] md:duration-250 md:ease-[cubic-bezier(0.32,0.72,0,1)] lg:transition-none;
 }
-.page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="open"]) .left-panel-buttons {
+.page-with-header-and-footer[data-has-right-panel-open] .left-panel-buttons {
     @apply md:w-24 lg:w-16 xl:w-24;
 }
 .left-panel-buttons > .c-spacer {
@@ -201,17 +201,17 @@ body:not(.narrow) .left-panel-content-header.place > .c-content {
 }
 /* The search box keeps the panel's right edge, and the title truncates against it;
    the open search takes the whole row, which squeezes the title down to nothing. */
-.left-panel-content-header > .c-content:has(> .left-chat-search-input) {
+.left-panel-content-header > .c-content[data-has-search] {
     @apply justify-end;
     @apply pr-0;
 }
-.left-panel-content-header > .c-content:has(> .left-chat-search-input.open) {
+.left-panel-content-header > .c-content[data-has-open-search] {
     @apply gap-x-0;
     @apply px-0;
 }
 /* The filter badges hang below the search row, and the results now sit directly under the header
    rather than behind it - so the header has to grow past the ordinary 56px clamp to keep them apart. */
-.left-panel-content-header > .c-content:has(> .left-chat-search-input > .c-filter-badges) {
+.left-panel-content-header > .c-content[data-has-search-badges] {
     @apply max-h-none;
 }
 .left-panel-content-header > .c-content > .c-title {
@@ -221,7 +221,7 @@ body:not(.narrow) .left-panel-content-header.place > .c-content {
     @apply truncate;
     @apply text-01 text-lg font-medium;
 }
-.left-panel-content-header > .c-content:has(> .left-chat-search-input.open) > .c-title {
+.left-panel-content-header > .c-content[data-has-open-search] > .c-title {
     @apply p-0;
 }
 .left-panel-content-header .left-chat-search-input {

--- a/src/dotnet/UI.Blazor.App/Components/LogView/LogList.razor
+++ b/src/dotnet/UI.Blazor.App/Components/LogView/LogList.razor
@@ -4,6 +4,7 @@
 <InfiniteList
     @key="nameof(LogList)"
     Class="log-list"
+    Child="log-list"
     DataSource="@this"
     Identity="logs"
     DefaultEdge="@VirtualListEdge.End"

--- a/src/dotnet/UI.Blazor.App/Components/LogView/log-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/LogView/log-view.css
@@ -1,4 +1,4 @@
-.page-with-header-and-footer .layout-body-wrapper:has(.log-list) .layout-footer {
+.page-with-header-and-footer .layout-body-wrapper[data-has-log-list] .layout-footer {
     @apply hidden;
 }
 .log-viewer-footer {

--- a/src/dotnet/UI.Blazor.App/Components/MarkupEditor/MarkupEditor.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupEditor/MarkupEditor.razor
@@ -3,7 +3,7 @@
 @implements IAsyncDisposable
 @using ActualChat.UI.Blazor.App.Module
 
-<div @ref="Ref" id="@Id" class="@Class markup-editor">
+<div @ref="Ref" id="@Id" class="@Class markup-editor" data-children="editor-content">
     <div class="c-placeholder">@Placeholder</div>
     <div class="editor-content @ContentClass"
          enterkeyhint="enter"
@@ -145,6 +145,7 @@
     public async Task<string> ParseTextToHtml(string text) {
         if (text.IsNullOrEmpty())
             return "";
+
         var markup = MarkupParser.Parse(text);
         markup = await MentionResolver.Apply(markup, default).ConfigureAwait(false);
         return HtmlConverter.Format(markup);

--- a/src/dotnet/UI.Blazor.App/Components/MarkupEditor/MarkupEditorTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupEditor/MarkupEditorTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Markup Editor Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <EditForm Model="@this" class="flex-y gap-y-4">
     <div>
         <Button Click="OnGetMarkupClick">Get markup</Button>

--- a/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.css
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.css
@@ -73,6 +73,6 @@ body.narrow .markup-editor .editor-content .editor-mention-user {
 body.narrow .markup-editor > .c-placeholder {
     @apply text-text-1;
 }
-.markup-editor:has(.editor-content.has-content) > .c-placeholder {
+.markup-editor[data-has-editor-content] > .c-placeholder {
     @apply hidden;
 }

--- a/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupEditor/markup-editor.ts
@@ -8,6 +8,9 @@ import { UndoStack } from './undo-stack';
 import { getLogs } from 'logging';
 import { ScreenSize } from '../../../UI.Blazor/Services/ScreenSize/screen-size';
 import { fastRaf } from 'fast-raf';
+import { PresenceTracker } from 'presence-tracker';
+
+const EditorContentChild = 'editor-content';
 
 const { debugLog, errorLog } = getLogs('MarkupEditor');
 
@@ -621,10 +624,12 @@ export class MarkupEditor {
         if (hasContent) {
             classList.remove('is-empty');
             classList.add('has-content');
+            PresenceTracker.setChild(this.contentDiv, EditorContentChild, true);
         }
         else {
             classList.remove('has-content');
             classList.add('is-empty');
+            PresenceTracker.setChild(this.contentDiv, EditorContentChild, false);
         }
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/CodeBlockMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/CodeBlockMarkupView.razor
@@ -8,7 +8,7 @@
     var menuRef = MenuRef.New<MessageMenu>(Entry.Id.Value, bool.FalseString, "", Markup.Code).ToString();
 }
 
-<div @ref="_rootRef" class="code-block-markup" data-menu="@menuRef">
+<div @ref="_rootRef" class="code-block-markup" data-child="code-block" data-menu="@menuRef">
     <div class="code-block-header">
         <div class="code-block-language"></div>
         <div class="code-block-actions">

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/ListMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/ListMarkupView.razor
@@ -4,20 +4,9 @@
 }
 
 <ul class="list-markup">
-    @for (var i = 0; i < items.Length; i++) {
-        var item = items[i];
+    @foreach (var item in items) {
         <li>
-            @if (i < items.Length - 1 && LastFragment != null) {
-                <CascadingValue TValue="RenderFragment" Value="@null">
-                    <MarkupView Markup="@item.Content"/>
-                </CascadingValue>
-            } else {
-                <MarkupView Markup="@item.Content"/>
-            }
+            <MarkupView Markup="@item.Content"/>
         </li>
     }
 </ul>
-
-@code {
-    [CascadingParameter] public RenderFragment? LastFragment { get; set; }
-}

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/MarkupSeqView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/MarkupSeqView.razor
@@ -10,18 +10,10 @@
     if (i != lastIndex && IsSkippedBlankLine(items, i))
         continue;
 
-    var item = items[i];
-    @if (i < lastIndex && LastFragment != null) {
-        <CascadingValue TValue="RenderFragment" Value="@null">
-            <MarkupView Markup="@item"/>
-        </CascadingValue>
-    } else {
-        <MarkupView Markup="@item"/>
-    }
+    <MarkupView Markup="@items[i]"/>
 }
 
 @code {
-    [CascadingParameter] public RenderFragment? LastFragment { get; set; }
     // Two kinds of blank lines never reach the DOM:
     // - Any blank line adjacent to a header - a header owns the gap around it, so it looks
     //   the same whether or not the author left them. Every other block keeps its blank

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/MarkupSuffixView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/MarkupSuffixView.razor
@@ -1,0 +1,10 @@
+@inherits MarkupViewBase<MarkupSuffix>
+
+@if (Context?.Suffix is { } suffix) {
+    @* No whitespace before this span: the gap is padding, so there is no break opportunity between
+       the text and the marks and they can never wrap onto a line of their own. *@<span class="markup-suffix">@suffix</span>
+}
+
+@code {
+    [CascadingParameter] public MarkupRenderContext? Context { get; set; }
+}

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlainTextMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlainTextMarkupView.razor
@@ -8,27 +8,13 @@
     <span class="emoji-message">
         <EmojiIcon Emoji="@emoji" Class="c-emoji" HasPreview="false" InlineAnimate="true"/>
     </span>
-    @if (LastFragment != null)
-        @LastFragment
 } else if (m.SearchMatch.IsMatch) {
     <SearchMatchHighlighter
         Match="m.SearchMatch"
         PlainTextClass="plain-text-markup"
         HighlightedClass="plain-text-markup highlight" />
-    @if(LastFragment != null)
-        @LastFragment
 } else {
-    @if (LastFragment != null) {
-        var (head, lastWord) = m.MarkupText.SplitLastWord();
-        if (lastWord != null) {
-            <span class="plain-text-markup">@head</span>
-            <span class="plain-text-markup last-word">@lastWord @LastFragment</span>
-            return;
-        }
-    }
     <span class="plain-text-markup">@m.MarkupText</span>
-    @if (LastFragment != null)
-        @LastFragment
 }
 
 @code {

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlayableTextMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/PlayableTextMarkupView.razor
@@ -10,14 +10,7 @@
 
 <span @ref="Ref" class="@containerCls @colorCls">
     @if (m.Map == null) {
-        if (Markup.Words.Length <= 1 || LastFragment == null)
-            @Markup.Text
-        else {
-            var lastWord = Markup.Words[^1];
-            var firstPart = Markup.Text[..lastWord.TextRange.Start];
-            @firstPart
-            <span class="last-word"><BreakableWord Text="@lastWord.Value"/> @LastFragment</span>
-        }
+        @Markup.Text
     } else {
         var wordCount = Markup.Words.Length;
         RenderFragment<int> renderWord = i =>
@@ -39,9 +32,6 @@
                     @renderWord(i)
                 }</span>
             }
-        }
-        if (LastFragment != null) {
-            <span class="last-word">@(" ")@LastFragment</span>
         }
     }
 </span>

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/PreformattedTextMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/PreformattedTextMarkupView.razor
@@ -4,17 +4,19 @@
     var m = State.Value;
 }
 
-<CopyTrigger Class="!contents" Tooltip="@L.Markup_ClickToCopy" CopyText="@m.MarkupText">
-    <code class="preformatted-text-markup">
-        @if (m.SearchMatch.IsMatch) {
-            <SearchMatchHighlighter
-                Match="m.SearchMatch"
-                HighlightedClass="highlight"/>
-        } else {
-            @m.MarkupText
-        }
-    </code>
-</CopyTrigger>
+@* Delegated copy rather than a CopyTrigger - see copy-trigger.ts. A chat can render hundreds of
+   these, and a component + wrapper element each is what that costs. *@
+<code class="preformatted-text-markup"
+      data-copy-text="@m.MarkupText"
+      data-tooltip="@L.Markup_ClickToCopy">
+    @if (m.SearchMatch.IsMatch) {
+        <SearchMatchHighlighter
+            Match="m.SearchMatch"
+            HighlightedClass="highlight"/>
+    } else {
+        @m.MarkupText
+    }
+</code>
 
 @code {
     protected override ComputedState<Model>.Options GetStateOptions()

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/TableMarkupView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/TableMarkupView.razor
@@ -33,13 +33,6 @@
 </div>
 
 @code {
-    [CascadingParameter] public RenderFragment? LastFragment { get; set; }
     private RenderFragment RenderCell(TableCellMarkup cell, bool isLastCell)
-        // Only the very last cell may render LastFragment - otherwise the entry's status
-        // fragment (timestamp, delivery mark) would repeat in every cell of the table.
-        => isLastCell || LastFragment == null
-            ? @<MarkupView Markup="@cell.Content"/>
-            : @<CascadingValue TValue="RenderFragment" Value="@null">
-                  <MarkupView Markup="@cell.Content"/>
-              </CascadingValue>;
+        => @<MarkupView Markup="@cell.Content"/>;
 }

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/markup-parts.css
@@ -2,6 +2,8 @@
     @apply top-1;
     @apply pl-1;
 }
+/* .markup-suffix supplies the gap itself, so the marker must not add its own on top. */
+.markup-suffix .translation-marker,
 .playable-text-markup .translation-marker,
 .plain-text-markup .translation-marker {
     @apply pl-0;
@@ -17,7 +19,7 @@
     @apply max-w-48 h-5;
     @apply px-1.5;
     @apply rounded-full bg-mention-other;
-    @apply text-mention-other-text font-medium;
+    @apply text-mention-other-text font-normal;
     @apply select-none;
 }
 .mention-markup.dim {
@@ -36,7 +38,7 @@
     @apply max-w-none h-auto;
     @apply px-0;
     @apply bg-transparent;
-    @apply text-primary font-medium;
+    @apply text-primary font-normal;
     @apply no-underline hover:underline;
 }
 .mention-markup.mention-markup-chat > div {
@@ -158,10 +160,6 @@
 }
 .playable-text-markup > span {
     @apply inline;
-}
-.playable-text-markup > span.last-word {
-    @apply inline;
-    white-space: nowrap;
 }
 
 .playable-text-markup .highlight {
@@ -373,8 +371,7 @@ ul.list-markup li::before {
    to what follows. MarkupSeqView drops the blank lines around a header, so `# H` looks the
    same whether or not the author left them.
    No white-space:break-spaces here: .plain-text-markup already has it, and on the container
-   it would also preserve the source indentation PlainTextMarkupView emits between its head
-   and last-word spans, indenting a wrapped header. */
+   it would preserve the source indentation between markup views, indenting a wrapped header. */
 .header-markup {
     --header-markup-gap: 0.75lh;
     word-break: break-word;
@@ -396,29 +393,13 @@ ul.list-markup li::before {
 .header-markup-3 {
     color: var(--header-markup-color-3);
 }
-/* NOTE(AY): Why font-weight lives on descendant <span>, not on .header-markup itself:
-   .chat-message-markup span applies text-text-1, which carries font-weight:400
-   baked in (see tailwind.config.js). That rule sets font-weight directly on the
-   span, so an inherited weight from the .header-markup parent loses.
-   Why two selectors per level:
-   - The .chat-message-markup-prefixed selector raises specificity above
-     `.chat-message-markup span` so it wins inside chat messages.
-   - The bare `.header-markup-N span` selector covers headers rendered outside
-     a chat message (previews, editor, search results) where the prefixed rule
-     wouldn't match.
-  The real reason: Andrey wrote a CSS rule for ".chat-message-markup span",
-  which should never exist in the first place. And now we have to deal with it.
-*/
-.chat-message-markup .header-markup-1 span,
-.header-markup-1 span {
+.header-markup-1 {
     @apply font-black;
 }
-.chat-message-markup .header-markup-2 span,
-.header-markup-2 span {
+.header-markup-2 {
     @apply font-bold;
 }
-.chat-message-markup .header-markup-3 span,
-.header-markup-3 span {
+.header-markup-3 {
     @apply font-medium;
 }
 
@@ -462,4 +443,13 @@ ul.list-markup li::before {
 .chat-message-markup .table-markup th span,
 .table-markup th span {
     @apply font-medium;
+}
+
+/* The trailing marks - sending status, translation. MarkupSuffixView emits no whitespace before
+   this span, so the only gap is the padding and there is no break opportunity between the last
+   word and the marks: they can never wrap onto a line of their own. */
+.markup-suffix {
+    @apply inline;
+    padding-left: 0.25rem;
+    white-space: nowrap;
 }

--- a/src/dotnet/UI.Blazor.App/Components/MarkupRenderContext.cs
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupRenderContext.cs
@@ -1,0 +1,11 @@
+namespace ActualChat.UI.Blazor.App.Components;
+
+/// <summary>
+/// What a message's markup views need that isn't in the markup: currently the trailing marks
+/// (sending status, translation), rendered wherever <see cref="Chat.MarkupSuffix"/> was placed.
+/// </summary>
+/// <remarks>
+/// Cascaded once per message. The alternative - handing the fragment to the last view - meant every
+/// container suppressing it for all but its last child, which cost a CascadingValue per child.
+/// </remarks>
+public sealed record MarkupRenderContext(RenderFragment? Suffix);

--- a/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/Navbar/NavbarItem.razor
@@ -29,7 +29,7 @@
             @ChildContent
         </div>
     }
-    <div class="navbar-item-ending">
+    <div class="navbar-item-ending" data-children="audio-controls">
         @Ending
     </div>
 </div>

--- a/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfo.razor
+++ b/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfo.razor
@@ -25,7 +25,7 @@
 }
 
 <div class="place-info-wrapper headerless-page" data-child="headerless-page">
-<div class="place-info">
+<div class="place-info" data-child="place-info">
     <div class="c-top">
         <div class="pic-wrapper">
             @{

--- a/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfo.razor
+++ b/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfo.razor
@@ -24,7 +24,7 @@
     };
 }
 
-<div class="place-info-wrapper headerless-page">
+<div class="place-info-wrapper headerless-page" data-child="headerless-page">
 <div class="place-info">
     <div class="c-top">
         <div class="pic-wrapper">

--- a/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfoTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Components/PlaceInfo/PlaceInfoTestPage.razor
@@ -7,7 +7,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Place Info Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="place-info-test-content">
         <PlaceInfoWideLeftPanel Data="@m" OnClick="@OnPlaceClick"/>
         <PlaceInfo PlaceId="@m.SelectedPlaceId"/>

--- a/src/dotnet/UI.Blazor.App/Components/PlaceInfo/place-info.css
+++ b/src/dotnet/UI.Blazor.App/Components/PlaceInfo/place-info.css
@@ -1,4 +1,4 @@
-.page-with-header-and-footer .layout-body-wrapper > .c-container:has(.place-info) .layout-footer {
+.page-with-header-and-footer .layout-body-wrapper > .c-container[data-has-place-info] .layout-footer {
     @apply hidden;
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
@@ -24,7 +24,7 @@
             @if (lastTextEntry != null) {
                 <div class="c-last-message">
                     @if (chat.Kind != ChatKind.Peer && !lastTextEntry.IsSystemEntry) {
-                        <span class="c-name">
+                        <span class="c-name" data-children="shrinkable non-shrinkable">
                             <AuthorName
                                 AuthorId="@lastTextEntry.AuthorId"
                                 Class="chat-message-author-name"

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/chat-side-panel.css
@@ -541,10 +541,10 @@ body.hoverable .thread-list-item:hover {
     @apply whitespace-pre;
     @apply text-caption-1 text-pal-blue-30;
 }
-.thread-list-item .c-bottom .c-last-message .c-name:has(.non-shrinkable) {
+.thread-list-item .c-bottom .c-last-message .c-name[data-has-non-shrinkable] {
     @apply flex-none;
 }
-.thread-list-item .c-bottom .c-last-message .c-name:has(.shrinkable) {
+.thread-list-item .c-bottom .c-last-message .c-name[data-has-shrinkable] {
     @apply min-w-16;
 }
 .thread-list-item .c-bottom .c-last-message .c-colon {

--- a/src/dotnet/UI.Blazor.App/Components/SearchPanel/SearchInput.razor
+++ b/src/dotnet/UI.Blazor.App/Components/SearchPanel/SearchInput.razor
@@ -1,7 +1,7 @@
 @namespace ActualChat.UI.Blazor.App.Components
 @inherits ComponentBase<AppUIHub>
 
-<div class="@Class search-input">
+<div class="@Class search-input" data-children="close-btn focused-input">
     <label>
         <TextInput
             @ref="_inputRef"
@@ -12,7 +12,7 @@
         </TextInput>
         <i class="icon-search text-2xl search-icon"></i>
         @if (ShowCloseButton) {
-            <HeaderButton Click="Close" Class="c-close-btn">
+            <HeaderButton Click="Close" Class="c-close-btn" data-child="close-btn">
                 <i class="icon-close text-2xl"></i>
             </HeaderButton>
         }

--- a/src/dotnet/UI.Blazor.App/Components/SearchPanel/SearchPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/SearchPanel/SearchPanel.razor
@@ -10,7 +10,7 @@
         <HeaderButton Click="@SmoothCloseSearchPanel" Class="md:hidden">
             <i class="icon-arrow-left"></i>
         </HeaderButton>
-        <div class="search-input">
+        <div class="search-input" data-children="close-btn focused-input">
             <label>
                 <TextInput
                     @ref="_inputRef"
@@ -21,7 +21,7 @@
                 </TextInput>
                 <i class="icon-search text-2xl search-icon"></i>
                 @if (ShowCloseButton) {
-                    <HeaderButton Click="SmoothCloseSearchPanel" Class="c-close-btn">
+                    <HeaderButton Click="@SmoothCloseSearchPanel" Class="c-close-btn" data-child="close-btn">
                         <i class="icon-close text-2xl"></i>
                     </HeaderButton>
                 }
@@ -34,7 +34,7 @@
 @code {
     private static readonly string JSCreateMethod = $"{BlazorUIAppModule.ImportName}.SearchPanel.create";
 
-    TextInput? _inputRef;
+    private TextInput? _inputRef;
 
     private SearchUI SearchUI => Hub.SearchUI;
 

--- a/src/dotnet/UI.Blazor.App/Components/SearchPanel/search-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/SearchPanel/search-panel.css
@@ -90,7 +90,7 @@
     @apply text-left;
     @apply bg-transparent;
 }
-.search-input:has(.c-close-btn) input {
+.search-input[data-has-close-btn] input {
     @apply pr-10;
 }
 .search-input input:focus {
@@ -106,7 +106,7 @@
 .search-input input:focus::placeholder {
     @apply text-transparent;
 }
-.search-input:has(input:focus) {
+.search-input[data-has-focused-input] {
     box-shadow: inset 0 0 0 1px theme(colors.primary);
 }
 

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/VideoPanel.razor
@@ -57,6 +57,9 @@
     var hiddenCls = m.IsHidden ? "panel-hidden" : "";
     var expandedCls = m.IsExpanded ? "expanded" : "";
     var equalLayoutCls = m.IsEqualLayout && m.IsExpanded ? "layout-equal" : "";
+    // Same source of truth as the classes beside them, so a marker lands on the render its class does
+    var panelNames = $"{(m.IsHidden ? "" : "video-panel-shown")} {(m.IsExpanded ? "video-panel-expanded" : "")} "
+        + $"{(m.IsCollapsed ? "" : "open-video-panel")} {(m.IsCollapsed || m.IsHidden ? "" : "visible-video-panel")}";
     var videoMenuRef = MenuRef.New<VideoPanelMenu>(Chat.Id.Value, ScreenSize.IsNarrow().ToString()).ToString();
     var cameraMenuRef = MenuRef.New<CameraMenu>(CameraMenuRequester, m.SelectedCameraDeviceId ?? "").ToString();
     var layout = m.Layout;
@@ -67,7 +70,7 @@
 }
 
 <OnUIEvent TEvent="@CameraSelectedEvent" Handler="OnCameraSelectedEvent"/>
-<div @ref="Ref" class="@panelCls">
+<div @ref="Ref" class="@panelCls" data-child="@panelNames" data-children="video-panel-chat">
     <div class="c-container">
         <div class="video-panel-toolbar video-panel-header">
             <div class="header-row">
@@ -237,7 +240,7 @@
             </div>
         </div>
         @if (m.IsExpanded && isChatVisible && !ScreenSize.IsNarrow() && m.ChatContext is { } chatContext) {
-            <div class="video-panel-chat upload-drag-drop-host">
+            <div class="video-panel-chat upload-drag-drop-host" data-child="video-panel-chat">
                 <CascadingValue Value="@chatContext">
                     <ChatView @key="@chatContext.Chat.Id.Value" NavigationSlotName="@ChatNavigationSlot"/>
                     <div class="layout-subfooter">

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-panel.css
@@ -170,7 +170,7 @@ body.wide .video-panel.expanded > .c-container {
     @apply rounded-lg;
     @apply overflow-hidden;
 }
-body.wide .video-panel.expanded.has-video-panel-chat > .c-container {
+body.wide .video-panel.expanded[data-has-video-panel-chat] > .c-container {
     @apply justify-start;
 }
 .video-panel .video-panel-content {
@@ -331,7 +331,7 @@ body.device-mobile.narrow .video-panel.expanded .video-panel-content.video-panel
     }
 }
 
-.video-panel.expanded.has-video-panel-chat-shown .video-panel-toolbar {
+.video-panel.expanded[data-has-video-panel-chat] .video-panel-toolbar {
     right: calc(var(--video-panel-chat-width) + 0.5rem);
 }
 .btn-video-panel.btn,
@@ -806,17 +806,17 @@ body:not(.show-fps-overlay) .video-panel.expanded:not(.layout-equal)
 
 /* ── Embedded chat panel (expanded video, wide only) ── */
 
-.video-panel.has-video-panel-chat {
+.video-panel[data-has-video-panel-chat] {
     --video-panel-chat-width: 20rem;
 }
 @media (min-width: 1024px) {
-    .video-panel.has-video-panel-chat { --video-panel-chat-width: 28rem; }
+    .video-panel[data-has-video-panel-chat] { --video-panel-chat-width: 28rem; }
 }
 @media (min-width: 1280px) {
-    .video-panel.has-video-panel-chat { --video-panel-chat-width: 32rem; }
+    .video-panel[data-has-video-panel-chat] { --video-panel-chat-width: 32rem; }
 }
 @media (min-width: 1536px) {
-    .video-panel.has-video-panel-chat { --video-panel-chat-width: 40rem; }
+    .video-panel[data-has-video-panel-chat] { --video-panel-chat-width: 40rem; }
 }
 .video-panel-chat {
     @apply absolute z-tooltip right-0 top-0 bottom-0;
@@ -897,7 +897,7 @@ body:not(.show-fps-overlay) .video-panel.expanded:not(.layout-equal)
 .video-panel.expanded .video-panel-content.video-panel-layout__sidebar {
     @apply gap-2 p-4 pb-20;
 }
-.video-panel.expanded.has-video-panel-chat .video-panel-content {
+.video-panel.expanded[data-has-video-panel-chat] .video-panel-content {
     width: calc(100% - var(--video-panel-chat-width) - 0.5rem);
     /* Trimmed to the left region, so its right edge sits mid-container where the
        container's corner clip can't reach — round the video itself instead (left
@@ -1036,23 +1036,23 @@ body.narrow .video-panel.expanded.layout-equal .c-grid {
    with the chat visible below it, and pausing there freezes one-shot entrance
    animations (`smoothShow`, `showSubHeader`) on their opacity:0 first frame —
    the text keeps its box but never appears. */
-body.narrow.video-panel-expanded .layout-body *,
-body.narrow.video-panel-expanded .layout-body *::before,
-body.narrow.video-panel-expanded .layout-body *::after,
-body.narrow.video-panel-expanded .side-nav *,
-body.narrow.video-panel-expanded .side-nav *::before,
-body.narrow.video-panel-expanded .side-nav *::after,
-body.narrow.video-panel-expanded .layout-subfooter,
-body.narrow.video-panel-expanded .layout-subfooter::before,
-body.narrow.video-panel-expanded .layout-subfooter::after {
+body.narrow[data-has-video-panel-expanded] .layout-body *,
+body.narrow[data-has-video-panel-expanded] .layout-body *::before,
+body.narrow[data-has-video-panel-expanded] .layout-body *::after,
+body.narrow[data-has-video-panel-expanded] .side-nav *,
+body.narrow[data-has-video-panel-expanded] .side-nav *::before,
+body.narrow[data-has-video-panel-expanded] .side-nav *::after,
+body.narrow[data-has-video-panel-expanded] .layout-subfooter,
+body.narrow[data-has-video-panel-expanded] .layout-subfooter::before,
+body.narrow[data-has-video-panel-expanded] .layout-subfooter::after {
     /* !important: `animation` shorthands re-declare play-state `running`;
        deep multi-class ones can out-rank this gate's specificity. */
     animation-play-state: paused !important;
 }
-body.narrow.video-panel-expanded .video-panel,
-body.narrow.video-panel-expanded .video-panel *,
-body.narrow.video-panel-expanded .video-panel *::before,
-body.narrow.video-panel-expanded .video-panel *::after {
+body.narrow[data-has-video-panel-expanded] .video-panel,
+body.narrow[data-has-video-panel-expanded] .video-panel *,
+body.narrow[data-has-video-panel-expanded] .video-panel *::before,
+body.narrow[data-has-video-panel-expanded] .video-panel *::after {
     /* Both gates are !important and tie on specificity — this one wins by
        source order, so it MUST stay below the paused block. */
     animation-play-state: running !important;

--- a/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/MapPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/MapPanel.razor
@@ -7,7 +7,7 @@
 }
 
 <div class="map-panel-host">
-    <div class="map-panel">
+    <div class="map-panel" data-child="map-panel">
         <MapView
             @ref="_mapView"
             Class="c-map"

--- a/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Components/VisualActivityPanel/VisualActivityPanel.razor
@@ -74,7 +74,7 @@
             </CascadingValue>
         }
         @if (!_isClosing && m.Activity.PanelMode == VisualActivityPanelMode.Inline) {
-            <div class="c-drag-handle"><div class="c-bar"></div></div>
+            <div class="c-drag-handle" data-child="drag-handle"><div class="c-bar"></div></div>
         }
     </div>
 }

--- a/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
+++ b/src/dotnet/UI.Blazor.App/Module/BlazorUIAppModule.cs
@@ -155,6 +155,7 @@ public sealed class BlazorUIAppModule(IServiceProvider moduleServices)
             .Add<HeaderMarkup, HeaderMarkupView>()
             .Add<BlockQuoteMarkup, BlockQuoteMarkupView>()
             .Add<TableMarkup, TableMarkupView>()
+            .Add<MarkupSuffix, MarkupSuffixView>()
         );
         // IModalViews
         services.AddTypeMap<IModalView>(map => map

--- a/src/dotnet/UI.Blazor.App/Pages/AdminCopyChatToPlacePage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/AdminCopyChatToPlacePage.razor
@@ -5,7 +5,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Copy chat to place</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <Form Class="h-full" @ref="@_formRef" Model="@_form">
     <FormBlock>
         <DataAnnotationsValidator/>

--- a/src/dotnet/UI.Blazor.App/Pages/AudioBlobDownloadTestPage/AudioBlobDownloadTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/AudioBlobDownloadTestPage/AudioBlobDownloadTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Audio Blob Download Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <Form Model="@_form">
     <DataAnnotationsValidator/>
     <FormBlock>

--- a/src/dotnet/UI.Blazor.App/Pages/DigestTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/DigestTestPage.razor
@@ -5,7 +5,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Digest Test</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <Form Model="@_form">
     <FormBlock>
         <FormSection

--- a/src/dotnet/UI.Blazor.App/Pages/EmojisTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/EmojisTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Emojis Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="emojis-test-page">
     <h2 class="emojis-test-title">Static Emojis (@(Emojis.SvgNames.Count))</h2>
     <div class="emojis-test-grid">

--- a/src/dotnet/UI.Blazor.App/Pages/ExternalContactsTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/ExternalContactsTestPage.razor
@@ -4,7 +4,7 @@
 
 <MainHeader>External Contacts Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <Button Class="btn-primary" Click="@(_ => OnGenerateClick())">
         Generate contacts
     </Button>

--- a/src/dotnet/UI.Blazor.App/Pages/FlowsTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/FlowsTestPage.razor
@@ -9,7 +9,7 @@
 @{
     var details = State.Value.Details;
 }
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="flex-y h-full overflow-y-auto select-text p-2 gap-y-2">
         @if (_stats is not { } stats) {
             <span class="text-gray-500">Loading…</span>

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsCookiesContent.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsCookiesContent.razor
@@ -1,6 +1,6 @@
 @namespace ActualChat.UI.Blazor.Components
 
-<div class="docs-content">
+<div class="docs-content" data-child="docs-content">
     <h1>Cookies</h1>
     <p>Last updated: January 18, 2023</p>
     <h1 id="introduction">Introduction</h1>

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsFaqPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsFaqPage.razor
@@ -3,6 +3,6 @@
 
 <DocsDocument Page="@DocsPage.Faq"/>
 
-<div class="docs-content">
+<div class="docs-content" data-child="docs-content">
     <h1>Terms and Conditions</h1>
 </div>

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsLayout.cs
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsLayout.cs
@@ -1,7 +1,10 @@
 namespace ActualChat.UI.Blazor.App.Pages.Landing.Docs;
 
-public class DocsLayout : DefaultLayout
+public sealed class DocsLayout : DefaultLayout
 {
     public DocsLayout()
-        => MiddlePanelClass = "docs-layout";
+    {
+        MiddlePanelClass = "docs-layout";
+        MiddlePanelChild = "docs-layout";
+    }
 }

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsLeftPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsLeftPanel.razor
@@ -4,9 +4,10 @@
 
 <SideNav
     Side="SideNavSide.Left"
+    Children="docs-left-panel"
     IsOpen="@PanelsUI.Left.IsVisible.Value"
     VisibilityChanged="@(isOpen => PanelsUI.Left.SetIsVisible(isOpen))">
-    <div class="docs-left-panel">
+    <div class="docs-left-panel" data-child="docs-left-panel">
         <div class="c-header">
             <div class="c-title-wrapper">
                 <div class="c-title">

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsPrivacyContent.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsPrivacyContent.razor
@@ -1,7 +1,7 @@
 @namespace ActualChat.UI.Blazor.Components
 @inherits ComponentBase<AppUIHub>
 
-<div class="docs-content">
+<div class="docs-content" data-child="docs-content">
     <h1 id="introduction">Privacy Policy</h1>
     <p>Last updated: January 1, 2023</p>
     <p>

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsRightPanel.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsRightPanel.razor
@@ -3,9 +3,10 @@
 
 <SideNav
     Side="SideNavSide.Right"
+    Children="docs-right-panel"
     IsOpen="@PanelsUI.Right.IsVisible.Value"
     VisibilityChanged="@(isOpen => PanelsUI.Right.SetIsVisible(isOpen))">
-    <div class="docs-right-panel">
+    <div class="docs-right-panel" data-child="docs-right-panel">
         <DocsRightPanelHeader/>
         <div class="flex flex-col overflow-y-auto custom-scrollbar">
             <div class="flex-y gap-y-6 p-4">

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsTermsContent.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/Docs/DocsTermsContent.razor
@@ -1,7 +1,7 @@
 @namespace ActualChat.UI.Blazor.Components
 @inherits ComponentBase<AppUIHub>
 
-<div class="docs-content">
+<div class="docs-content" data-child="docs-content">
     <h1>Terms and Conditions</h1>
     <p>Last updated: January 18, 2023</p>
     <p>Please read these terms and conditions carefully before using Our Service.</p>

--- a/src/dotnet/UI.Blazor.App/Pages/Landing/landing.css
+++ b/src/dotnet/UI.Blazor.App/Pages/Landing/landing.css
@@ -1135,7 +1135,7 @@ body.narrow .docs-layout .layout-header {
 .docs-layout .layout-footer {
     @apply hidden;
 }
-body.narrow .side-nav-left:has(.docs-left-panel) {
+body.narrow .side-nav-left[data-has-docs-left-panel] {
     @apply hidden;
 }
 .docs-left-panel {
@@ -1264,10 +1264,10 @@ body.narrow .docs-subheader {
     @apply border-b-2 border-bg-04;
 }
 
-body.narrow .side-nav.side-nav-right:has(> .docs-right-panel) {
+body.narrow .side-nav.side-nav-right[data-has-docs-right-panel] {
     @apply hidden;
 }
-body.narrow .layout-body:has(> .docs-content) {
+body.narrow .layout-body[data-has-docs-content] {
     @apply px-0;
     @apply bg-01;
 }

--- a/src/dotnet/UI.Blazor.App/Pages/MeshTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/MeshTestPage.razor
@@ -15,7 +15,7 @@
     }
 }
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 @{
     <div class="flex-y h-full">
         <div class="flex-x gap-x-2 mb-3">

--- a/src/dotnet/UI.Blazor.App/Pages/MicPermissionTestPage/MicPermissionTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/MicPermissionTestPage/MicPermissionTestPage.razor
@@ -11,7 +11,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Mic Permission Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="test-page-text">
     <div>
         To call, to text, or

--- a/src/dotnet/UI.Blazor.App/Pages/NotificationsTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/NotificationsTestPage.razor
@@ -11,7 +11,7 @@
     var m = State.Value;
 }
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="flex-y gap-y-4 select-text">
         <h3>@(m.Items.Count) active notification(s)</h3>
         @if (m.Error is { } error) {

--- a/src/dotnet/UI.Blazor.App/Pages/Test/BannerStackTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/BannerStackTestPage.razor
@@ -66,7 +66,7 @@
     }
 </RenderIntoStack>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="banner-stack-test">
         <div class="c-title">Banner stack test</div>
         <div class="c-note">

--- a/src/dotnet/UI.Blazor.App/Pages/Test/BlazorTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/BlazorTestPage.razor
@@ -5,7 +5,7 @@
 
 <MainHeader>Blazor Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <p>Counter: @_counter</p>
 <p>
     <Button Click="@(() => _counter++)">Counter++</Button>

--- a/src/dotnet/UI.Blazor.App/Pages/Test/DateTimeTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/DateTimeTestPage.razor
@@ -4,7 +4,7 @@
 
 <MainHeader>Date &amp; Time Formats</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="dt-test">
         <div class="dt-test-top">
             <div class="dt-test-lang">Current UI language: @Lang</div>

--- a/src/dotnet/UI.Blazor.App/Pages/Test/EmbeddedTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/EmbeddedTestPage.razor
@@ -14,7 +14,7 @@
 
 <MainHeader>Embedded Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="fixed bottom-4 right-4 flex flex-y">
     @if (showChat) {
         <iframe class="min-w-88 min-h-128 rounded-lg drop-shadow-xl"

--- a/src/dotnet/UI.Blazor.App/Pages/Test/LocationPermissionTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/LocationPermissionTestPage.razor
@@ -10,7 +10,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Location Permission Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="test-page-btn-group">
     <Button Class="@cls" Click="@(_ => OnShowModal())">
         Show (auto-detected)

--- a/src/dotnet/UI.Blazor.App/Pages/Test/MauiTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/MauiTestPage.razor
@@ -5,7 +5,7 @@
 
 <MainHeader>MAUI Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <BackendStatusTest />
 <ExternalImageTest />
 

--- a/src/dotnet/UI.Blazor.App/Pages/Test/PhotoPermissionTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/PhotoPermissionTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Photo Permission Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="test-page-btn-group">
     <Button Class="btn-danger" Click="OnShowModal">
         Show Photo Troubleshooter Modal

--- a/src/dotnet/UI.Blazor.App/Pages/Test/ShareInModalTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/ShareInModalTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Incoming Share Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <Button Class="btn-primary" Click="ShowIncomingShareTextModal">
         Show Incoming Share Modal
     </Button>

--- a/src/dotnet/UI.Blazor.App/Pages/Test/TranscodingTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/Test/TranscodingTestPage.razor
@@ -15,7 +15,7 @@
     var error = State.Error;
 }
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 
 @if (error != null) {
     <ErrorToast Class="mb-3">@error.Message</ErrorToast>

--- a/src/dotnet/UI.Blazor.App/Pages/VideoInputTestPage/VideoInputTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/VideoInputTestPage/VideoInputTestPage.razor
@@ -6,7 +6,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Video Input Devices</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="test-page-btn-group" style="margin-bottom: 1rem;">
     <Button Class="btn-primary" Click="@(_ => RefreshDevices())">
         Refresh

--- a/src/dotnet/UI.Blazor.App/Pages/VoiceCallTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/VoiceCallTestPage.razor
@@ -6,7 +6,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Voice Call Test</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 @{
     var m = State.Value;
     var incoming = m.Incoming;

--- a/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
+++ b/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
@@ -1,71 +1,8 @@
-// The app's container:has(descendant) relationships, registered as presence classes - see
-// mutation-processor.ts for why. Every class registered here is written by MutationProcessor
-// and must never be set in markup.
+// Presence names the app declares on elements no component renders. Everything else declares its
+// own, in markup: a container carries data-children, a child carries data-child, and
+// presence-tracker.ts writes data-has-{name} on the container while at least one child is present.
 //
-// Only container subjects belong here. A :has() whose subject is a small element (.toggle,
-// .checkbox, .navbar-item) walks a tiny subtree and costs nothing worth replacing.
+// body is the only such element - the two host pages own its markup - and this runs at import time,
+// so the declaration is in place before MutationProcessor.start() takes its first scan.
 
-import { MutationProcessor } from 'mutation-processor';
-
-const virtualListGroup = '.virtual-list .c-virtual-container .group';
-const virtualListItem = '.virtual-list .c-virtual-container .item';
-
-MutationProcessor.registerPresenceClasses(
-    { container: '.chat-message-editor', match: '.related-chat-entry-panel', className: 'has-related-entry' },
-    { container: '.list-view-layout', match: '.chat-activity-panel.listening', className: 'has-listening-activity' },
-    { container: '.list-view-layout', match: '.audio-panel-header', className: 'has-audio-panel-header' },
-    { container: '.right-panel', match: '.c-header.expanded-header', className: 'has-expanded-header' },
-    { container: '.layout-header', match: '.header-activity-panel-wrapper', className: 'has-activity-panel' },
-    // A page that carries its own heading, so the layout's header would be an empty bar with a
-    // separator under it - see .has-headerless-page in main.css.
-    { container: '.list-view-layout', match: '.headerless-page', className: 'has-headerless-page' },
-
-    // The chat view's live-conversation block. Measured on an iPhone 13 Pro during a
-    // fullscreen video call: 69 `.group` and 44 `.item` subjects, every predicate false,
-    // and `matchHasPseudoClass` 20% of attributable main-thread time - the whole cost was
-    // proving absence over and over.
-    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header', className: 'has-live-block' },
-    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header.unjoined', className: 'has-unjoined-live-block' },
-    { container: virtualListGroup, match: ':scope > .item.expanded > .live-conversation-header.dissolving', className: 'has-live-block-dissolving' },
-    { container: virtualListGroup, match: ':scope > .item > .conversation-message.live.joined', className: 'has-joined-live-card' },
-    { container: virtualListItem, match: ':scope > .conversation-message', className: 'has-conversation-message' },
-    { container: virtualListItem, match: ':scope > .conversation-message.live', className: 'has-live-card' },
-    { container: virtualListItem, match: ':scope > .conversation-message.live:empty', className: 'has-empty-live-card' },
-    { container: virtualListItem, match: ':scope > .live-conversation-footer', className: 'has-live-footer' },
-    { container: virtualListItem, match: '.live-conversation-header', className: 'has-live-header' },
-    { container: virtualListItem, match: '.show-author', className: 'has-show-author' },
-    { container: virtualListItem, match: '.conversation-header', className: 'has-conversation-header' },
-    // Either header makes the item itself position:sticky, which is what the virtual list has to know:
-    // while its rubber band hides scroll from the content, sticky re-clamps against the real scroll
-    // position and the item would otherwise drift away from everything around it. One rule, not two -
-    // toggle(className, force) is absolute, so a second rule writing the same class would switch off
-    // what the first had set whenever its own match was absent.
-    { container: virtualListItem, match: '.conversation-header, .live-conversation-header', className: 'vl-sticky' },
-
-    // The video panel's state, mirrored onto body. `body` is an ancestor of every mutation,
-    // so a `body:has()` is re-proven on all of them - and the `.has-video-panel` compound
-    // that guards these short-circuits everywhere EXCEPT during a call, which is the one
-    // time it matters.
-    { container: 'body', match: '.video-panel:not(.panel-hidden)', className: 'video-panel-shown' },
-    { container: 'body', match: '.video-panel.expanded:not(.panel-hidden)', className: 'video-panel-expanded' },
-    { container: 'body', match: '.video-panel.expanded', className: 'video-panel-expanded-any' },
-    { container: '.layout-header', match: '.video-panel:not(.collapsed)', className: 'has-open-video-panel' },
-    { container: '.layout-header', match: '.video-panel:not(.collapsed):not(.panel-hidden)', className: 'has-visible-video-panel' },
-    { container: '.list-view-layout', match: '.video-panel:not(.collapsed)', className: 'has-open-video-panel' },
-    // Shares a declaration block with the video-panel rules above, so it has to move with
-    // them - left as :has() it would keep the specificity those rules just gave up.
-    { container: '.list-view-layout', match: '.map-panel', className: 'has-map-panel' },
-    { container: '.list-view-layout .layout-header', match: '.map-panel', className: 'has-map-panel' },
-    { container: '.video-panel', match: '.video-panel-chat', className: 'has-video-panel-chat' },
-    { container: '.video-panel', match: '.video-panel-chat:not(.chat-hidden)', className: 'has-video-panel-chat-shown' },
-
-    { container: '.tab-panel-tabs .btn-tab .btn-content', match: '.c-badge', className: 'has-badge' },
-    { container: '.chat-message-markup', match: '.code-block-markup', className: 'has-code-block' },
-    { container: '.chat-list .navbar-item .navbar-item-ending', match: '.chat-audio-controls', className: 'has-audio-controls' },
-    { container: '.chat-list .navbar-item-content .c-last-message', match: '.c-text.two-line', className: 'has-two-line-text' },
-    { container: '.chat-list .navbar-item-content .c-last-message .c-name', match: '.non-shrinkable', className: 'has-non-shrinkable' },
-    { container: '.chat-list .navbar-item-content .c-last-message .c-name', match: '.shrinkable', className: 'has-shrinkable' },
-    { container: '.found-result.navbar-item .c-description', match: '.c-second-line', className: 'has-second-line' },
-    { container: '.found-result.navbar-item .c-description', match: '.c-third-line', className: 'has-third-line' },
-    { container: '.found-result.navbar-item .c-description', match: '.c-name .non-shrinkable', className: 'has-non-shrinkable-name' },
-);
+document.body.setAttribute('data-children', 'video-panel-shown video-panel-expanded');

--- a/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
+++ b/src/dotnet/UI.Blazor.App/Services/app-presence-classes.ts
@@ -5,4 +5,4 @@
 // body is the only such element - the two host pages own its markup - and this runs at import time,
 // so the declaration is in place before MutationProcessor.start() takes its first scan.
 
-document.body.setAttribute('data-children', 'video-panel-shown video-panel-expanded');
+document.body.setAttribute('data-children', 'video-panel-shown video-panel-expanded audio-panel-header');

--- a/src/dotnet/UI.Blazor.App/Testing/VirtualListTestPage.razor
+++ b/src/dotnet/UI.Blazor.App/Testing/VirtualListTestPage.razor
@@ -13,7 +13,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>VirtualList Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <InfiniteList
         @key="@ListKey"
         Style="height: 600px;"

--- a/src/dotnet/UI.Blazor/Components/Avatar/AvatarName.razor
+++ b/src/dotnet/UI.Blazor/Components/Avatar/AvatarName.razor
@@ -20,7 +20,7 @@
 }
 
 <span class="hidden avatar-id">@Avatar?.Id</span><span
-    class="@Class @extraClass @flexClass avatar-name" @onclick="@Click">
+    class="@Class @extraClass @flexClass avatar-name" data-child="@flexClass" @onclick="@Click">
     @name
 </span>
 

--- a/src/dotnet/UI.Blazor/Components/Bubble/BubbleHost.razor
+++ b/src/dotnet/UI.Blazor/Components/Bubble/BubbleHost.razor
@@ -7,12 +7,13 @@
 @attribute [UnconditionalSuppressMessage("Trimming", "IL2110", Justification = "UI types are expected to be untrimmed.")]
 @attribute [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "UI types are expected to be untrimmed.")]
 
-<div class="ac-bubble-host" data-no-inert>
+<div class="ac-bubble-host" data-no-inert data-children="bubble">
     <CascadingValue Value="@this" IsFixed="true">
         @if (_bubble != null) {
             <div id="@_bubble.Id"
                  @key="@_bubble.Id"
-                 class="ac-bubble">
+                 class="ac-bubble"
+                 data-child="bubble">
                 <DynamicComponent Type="@_bubble.Ref.BubbleType" Parameters="@_bubble.Parameters"/>
                 <div class="ac-bubble-arrow"></div>
             </div>

--- a/src/dotnet/UI.Blazor/Components/Bubble/bubble.css
+++ b/src/dotnet/UI.Blazor/Components/Bubble/bubble.css
@@ -2,7 +2,7 @@
     @apply fixed z-bubble overflow-hidden;
     @apply pointer-events-none select-none;
 }
-.ac-bubble-host:has(.ac-bubble) {
+.ac-bubble-host[data-has-bubble] {
     @apply inset-0;
 }
 .ac-bubble {

--- a/src/dotnet/UI.Blazor/Components/Button/Button.razor
+++ b/src/dotnet/UI.Blazor/Components/Button/Button.razor
@@ -10,7 +10,7 @@
     @onclick:stopPropagation="@StopPropagation"
     @onclick:preventDefault="@PreventDefault"
     @onclick="@OnClick">
-    <div class="@ContentClass btn-content" tabindex="-1">
+    <div class="@ContentClass btn-content" data-children="badge" tabindex="-1">
         @if (ChildContent is not null) {
             @ChildContent
         } else {

--- a/src/dotnet/UI.Blazor/Components/Card/CardItem.razor
+++ b/src/dotnet/UI.Blazor/Components/Card/CardItem.razor
@@ -7,7 +7,7 @@
     RenderFragment RenderInner() =>
         @<text>
             @if (Left != null) {
-                <div class="c-left">
+                <div class="c-left" data-child="card-left">
                     @Left
                 </div>
             }
@@ -22,7 +22,7 @@
                 }
             </div>
             @if (Right != null) {
-                <div class="c-right">
+                <div class="c-right" data-child="card-right">
                     @Right
                 </div>
             }
@@ -31,6 +31,7 @@
 
 @if (isClickable) {
     <div class="@rootCls @Class"
+         data-children="card-left card-right"
          role="button"
          tabindex="0"
          @onclick="@Click"
@@ -38,7 +39,7 @@
         @RenderInner()
     </div>
 } else {
-    <div class="@rootCls @Class">
+    <div class="@rootCls @Class" data-children="card-left card-right">
         @RenderInner()
     </div>
 }

--- a/src/dotnet/UI.Blazor/Components/Card/card.css
+++ b/src/dotnet/UI.Blazor/Components/Card/card.css
@@ -14,10 +14,10 @@
     @apply overflow-hidden;
     @apply rounded-xl;
 }
-.card-item:not(:has(> .c-left)) > .c-center {
+.card-item:not([data-has-card-left]) > .c-center {
     @apply pl-1;
 }
-.card-item:not(:has(> .c-right)) > .c-center {
+.card-item:not([data-has-card-right]) > .c-center {
     @apply pr-1;
 }
 body.hoverable .card-item.hovered:hover {

--- a/src/dotnet/UI.Blazor/Components/Clipboard/copy-trigger.ts
+++ b/src/dotnet/UI.Blazor/Components/Clipboard/copy-trigger.ts
@@ -1,7 +1,12 @@
 import { fromEvent, Subject, takeUntil, switchMap, tap, delay } from 'rxjs';
 import { getLogs } from 'logging';
+import { getOrInheritData } from 'dom-helpers';
+import { DocumentEvents } from 'event-handling';
 
 const { errorLog } = getLogs('CopyTrigger');
+
+const CopiedClass = 'copied';
+const CopiedHintDuration = 3000;
 
 export class CopyTrigger {
     private readonly triggerElementRef: HTMLElement;
@@ -81,3 +86,39 @@ export class CopyTrigger {
             errorLog?.log('showAsCopied: failed to dispatch mouseover');
     }
 }
+
+// Delegated copy: any element carrying data-copy-text copies it on click, with no component,
+// wrapper element or JS object of its own. Inline code spans use this rather than a CopyTrigger
+// each - a markup-heavy chat renders hundreds of them, and one CopyTrigger per span costs a
+// wrapper element, a component, an ElementReference and an interop round trip on every render.
+// The tooltip needs nothing here: tooltip-host reads data-tooltip off the nearest ancestor too.
+function onDelegatedCopyClick(event: MouseEvent): void {
+    const [element, copyText] = getOrInheritData(event.target, 'copyText');
+    if (!element || !copyText || element.classList.contains(CopiedClass))
+        return;
+
+    void navigator.clipboard.writeText(copyText)
+        .then(() => showCopied(element))
+        .catch((e: unknown) => errorLog?.log('onDelegatedCopyClick: failed to write to clipboard', e));
+}
+
+function showCopied(element: HTMLElement | SVGElement): void {
+    const tooltip = element.getAttribute('data-tooltip');
+    element.classList.add(CopiedClass);
+    redrawTooltip(element, 'Copied');
+    setTimeout(() => {
+        element.classList.remove(CopiedClass);
+        if (tooltip !== null)
+            redrawTooltip(element, tooltip);
+    }, CopiedHintDuration);
+}
+
+function redrawTooltip(element: HTMLElement | SVGElement, text: string): void {
+    if (!element.hasAttribute('data-tooltip'))
+        return;
+
+    element.setAttribute('data-tooltip', text);
+    element.dispatchEvent(new Event('mouseover', { bubbles: true }));
+}
+
+DocumentEvents.active.click$.subscribe(onDelegatedCopyClick);

--- a/src/dotnet/UI.Blazor/Components/ContentSwap/ContentSwap.razor
+++ b/src/dotnet/UI.Blazor/Components/ContentSwap/ContentSwap.razor
@@ -14,9 +14,12 @@
 }
 
 <div @ref="_ref" class="content-swap @Class @_effectClass"
-     data-swap-hold="@_holdToken" data-swap-name="@_name" data-swap-propagate="@MustPropagateDisplay">
+     data-swap-hold="@_holdToken" data-swap-name="@_name" data-swap-propagate="@MustPropagateDisplay"
+     data-children="@Children.NullIfEmpty()">
     @foreach (var layer in Layers()) {
-        <div @key="@layer" class="c-layer @LayerClass @layer.CssClass" inert="@(layer == _outgoingLayer)">
+        <div @key="@layer" class="c-layer @LayerClass @layer.CssClass"
+             data-children="@LayerChildren.NullIfEmpty()"
+             inert="@(layer == _outgoingLayer)">
             <ContentSwapLayer Context="@layer.Context" Content="@layer.Content"/>
         </div>
     }
@@ -46,6 +49,10 @@
     [Parameter] public RenderFragment? Placeholder { get; set; }
     [Parameter] public string Class { get; set; } = "";
     [Parameter] public string LayerClass { get; set; } = "";
+    // Presence names the host / layer elements declare - see presence-tracker.ts. Passed in rather
+    // than hardcoded so this component keeps no vocabulary from the app that uses it.
+    [Parameter] public string Children { get; set; } = "";
+    [Parameter] public string LayerChildren { get; set; } = "";
     [Parameter] public string Name { get; set; } = "";
     [Parameter] public ContentSwapEffect Effect { get; set; } = ContentSwapEffect.Fade;
     [Parameter] public TimeSpan Duration { get; set; } = TimeSpan.FromSeconds(0.5);

--- a/src/dotnet/UI.Blazor/Components/Menu/MenuHost.razor
+++ b/src/dotnet/UI.Blazor/Components/Menu/MenuHost.razor
@@ -12,7 +12,8 @@
         @<div
              id="@menu.Id"
              @key="@menu.Id"
-             class="@(GetMenuCssClass(menu))">
+             class="@(GetMenuCssClass(menu))"
+             data-child="menu">
             <ul class="ac-menu-list" role="menu">
                 <DynamicComponent Type="@menu.Ref.MenuType" Parameters="@menu.Parameters"/>
             </ul>
@@ -20,7 +21,7 @@
     var menu = _menu;
 }
 
-<div class="ac-menu-host @(GetHostCssClass())" data-no-inert>
+<div class="ac-menu-host @(GetHostCssClass())" data-no-inert data-children="menu">
     <CascadingValue Value="@this" IsFixed="true">
         @if (IsOverlayVisible()) {
             <div class="ac-menu-overlay">

--- a/src/dotnet/UI.Blazor/Components/Menu/menu.css
+++ b/src/dotnet/UI.Blazor/Components/Menu/menu.css
@@ -3,8 +3,7 @@
     @apply fixed z-menu-container overflow-hidden;
     @apply pointer-events-none select-none;
 }
-.ac-menu-host:has(.ac-menu),
-.ac-menu-host:has(.ac-menu-hover) {
+.ac-menu-host[data-has-menu] {
     @apply inset-0;
 }
 .ac-menu-host.has-overlay {

--- a/src/dotnet/UI.Blazor/Components/PageWithHeaderAndFooter.razor
+++ b/src/dotnet/UI.Blazor/Components/PageWithHeaderAndFooter.razor
@@ -1,5 +1,6 @@
 @using ActualChat.UI.Blazor.Services
-<div class="page-with-header-and-footer">
+<div class="page-with-header-and-footer"
+     data-children="left-panel-open right-panel-open right-panel-closed chat-panel-skeleton docs-layout test-page">
     <RegionVisibilityProvider IsRegionVisible="@PanelsUI.Left.IsVisible">
         <ErrorBarrier Name="PageWithHeaderAndFooter-LeftDrawer" Kind="@ErrorBarrierKind.Medium">
             @LeftDrawer
@@ -7,22 +8,23 @@
     </RegionVisibilityProvider>
     <RegionVisibilityProvider ComputeIsRegionVisible="@PanelsUI.Middle.IsVisible">
         <ErrorBarrier Name="PageWithHeaderAndFooter-Content" MustHidePanels="@true">
-            <div class="@Class" data-children="listening-activity audio-panel-header headerless-page map-panel open-video-panel">
-                <div class="layout-header" data-children="activity-panel map-panel open-video-panel visible-video-panel">
+            <div class="@Class" data-child="@Child.NullIfEmpty()"
+                 data-children="listening-activity audio-panel-header headerless-page map-panel open-video-panel participating-activity header-pinned drag-handle">
+                <div class="layout-header" data-children="activity-panel map-panel open-video-panel visible-video-panel selection-header video-streaming">
                     @Header
                 </div>
                 <div class="layout-subheader">
                     @SubHeader
                 </div>
-                <div class="layout-body-wrapper">
-                    <div class="c-container">
+                <div class="layout-body-wrapper" data-children="log-list">
+                    <div class="c-container" data-children="place-info safe-area-bottom">
                         <div class="layout-footer">
                             @Footer
                         </div>
                         <div class="layout-subfooter">
                             @SubFooter
                         </div>
-                        <div class="layout-body @BodyClass">
+                        <div class="layout-body @BodyClass" data-children="chat-panel-skeleton docs-content test-page">
                             <ErrorBarrier Name="PageWithHeaderAndFooter-Body" MustHidePanels="@true">
                                 @Body
                             </ErrorBarrier>
@@ -45,6 +47,9 @@
     [Inject] public PanelsUI PanelsUI { get; init; } = null!;
 
     [Parameter] public string Class { get; set; } = "";
+    // The presence name the middle panel declares for this page - see presence-tracker.ts. Passed in
+    // rather than derived from Class so this component keeps no vocabulary from the app that uses it.
+    [Parameter] public string Child { get; set; } = "";
     [Parameter] public string BodyClass { get; set; } = "";
     [Parameter] public RenderFragment? Header { get; set; }
     [Parameter] public RenderFragment? SubHeader { get; set; }

--- a/src/dotnet/UI.Blazor/Components/PageWithHeaderAndFooter.razor
+++ b/src/dotnet/UI.Blazor/Components/PageWithHeaderAndFooter.razor
@@ -7,8 +7,8 @@
     </RegionVisibilityProvider>
     <RegionVisibilityProvider ComputeIsRegionVisible="@PanelsUI.Middle.IsVisible">
         <ErrorBarrier Name="PageWithHeaderAndFooter-Content" MustHidePanels="@true">
-            <div class="@Class">
-                <div class="layout-header">
+            <div class="@Class" data-children="listening-activity audio-panel-header headerless-page map-panel open-video-panel">
+                <div class="layout-header" data-children="activity-panel map-panel open-video-panel visible-video-panel">
                     @Header
                 </div>
                 <div class="layout-subheader">

--- a/src/dotnet/UI.Blazor/Components/Requirements/RequirementsTestPage.razor
+++ b/src/dotnet/UI.Blazor/Components/Requirements/RequirementsTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Requirements Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <EditForm Model="_form">
     <div class="flex-x">
         <InputCheckbox @bind-Value="_form.ShowNestedRequirementChecker" id="1"/>

--- a/src/dotnet/UI.Blazor/Components/SideNav/SideNav.razor
+++ b/src/dotnet/UI.Blazor/Components/SideNav/SideNav.razor
@@ -3,7 +3,9 @@
 @inherits ComponentBase<UIHub>
 @implements IAsyncDisposable
 
-<div @ref="ElementRef" class="@_class @Class" data-side-nav="@_attribute" inert="@(!IsOpen)">
+<div @ref="ElementRef" class="@_class @Class"
+     data-side-nav="@_attribute" data-child="@_child" data-children="@Children.NullIfEmpty()"
+     inert="@(!IsOpen)">
     @ChildContent
 </div>
 
@@ -15,10 +17,14 @@
 
     private string _class = "";
     private string _attribute = "";
+    private string? _child;
     private bool _wasOpen;
 
     [Parameter] public SideNavSide Side { get; set; } = SideNavSide.Left;
     [Parameter] public string Class { get; set; } = "";
+    // Presence names this element's content declares - see presence-tracker.ts. Passed in rather than
+    // hardcoded so this component keeps no vocabulary from the app that uses it.
+    [Parameter] public string Children { get; set; } = "";
     [Parameter] public bool IsOpen { get; set; }
     [Parameter] public RenderFragment ChildContent { get; set; } = null!;
     [Parameter] public EventCallback<bool> VisibilityChanged { get; set; }
@@ -38,6 +44,14 @@
         _attribute = IsOpen
             ? "open"
             : "closed";
+        // The presence name .page-with-header-and-footer counts, which is how CSS reads this panel's
+        // state without a :has() - see presence-tracker.ts.
+        _child = (Side, IsOpen) switch {
+            (SideNavSide.Left, true) => "left-panel-open",
+            (SideNavSide.Right, true) => "right-panel-open",
+            (SideNavSide.Right, false) => "right-panel-closed",
+            _ => null,
+        };
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender) {

--- a/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
+++ b/src/dotnet/UI.Blazor/Components/SideNav/side-nav.css
@@ -42,7 +42,7 @@ body.device-ios .side-nav {
     @apply flex-none flex-y;
     @apply md:w-96 lg:w-96 xl:w-128;
 }
-.page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="open"]) > .side-nav.side-nav-left {
+.page-with-header-and-footer[data-has-right-panel-open] > .side-nav.side-nav-left {
     @apply md:w-1/2 lg:w-96 xl:w-128;
     @apply md:transition-width md:duration-200 md:ease-[cubic-bezier(0.32,0.54,0.4,0.9)] md:delay-0 lg:transition-none;
 }
@@ -102,7 +102,7 @@ body.narrow .side-nav.side-nav-right {
     @apply w-auto;
     transition: transform var(--side-nav-transition-duration) cubic-bezier(0.32, 0.54, 0.4, 0.9);
 }
-body.narrow .page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="open"]) > .side-nav.side-nav-left {
+body.narrow .page-with-header-and-footer[data-has-right-panel-open] > .side-nav.side-nav-left {
     @apply w-auto;
 }
 body.narrow .side-nav.side-nav-right {

--- a/src/dotnet/UI.Blazor/Components/Skeleton/ChatPanelSkeleton.razor
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/ChatPanelSkeleton.razor
@@ -1,6 +1,6 @@
 @namespace ActualChat.UI.Blazor.Components
 
-<div class="chat-panel-skeleton">
+<div class="chat-panel-skeleton" data-child="chat-panel-skeleton">
     <ChatHeaderSkeleton/>
     <PanelBodySkeleton>
         <chat-view-skeleton class="no-scrollbar" count="20"></chat-view-skeleton>

--- a/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/skeleton.css
@@ -49,7 +49,7 @@ thin-left-panel-skeleton {
     --button-margin-left: 0px;
     --button-margin-right: 0px;
 }
-.page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="open"]) thin-left-panel-skeleton {
+.page-with-header-and-footer[data-has-right-panel-open] thin-left-panel-skeleton {
     @apply md:w-24 lg:w-16 xl:w-24;
 }
 thin-left-panel-skeleton .button {
@@ -108,10 +108,10 @@ body.narrow .wide-left-panel-skeleton:has(.inaccessible-place-request) {
 }
 
 /* Chat Panel Skeleton */
-.layout-body:has(.chat-panel-skeleton) {
+.layout-body[data-has-chat-panel-skeleton] {
     scrollbar-width: none;
 }
-.layout-body:has(.chat-panel-skeleton)::-webkit-scrollbar {
+.layout-body[data-has-chat-panel-skeleton]::-webkit-scrollbar {
     display: none;
 }
 .chat-panel-skeleton {

--- a/src/dotnet/UI.Blazor/Components/Skeleton/splash-page-skeleton.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/splash-page-skeleton.lit.ts
@@ -12,11 +12,11 @@ export class SplashPageSkeleton extends LitElement {
 
     protected render(): unknown {
         // The app restores the stored right panel only on a wide screen - see RightPanel's constructor.
-        // Rendering it as open in narrow mode would also shrink the left panel via the :has() rule in side-nav.css.
+        // Rendering it as open in narrow mode would also shrink the left panel via right-panel-open in side-nav.css.
         const isRightPanelOpen = this.isRightPanelVisible === 'true'
             && !document.body.classList.contains('narrow');
         return html`
-            <div class="page-with-header-and-footer">
+            <div class="page-with-header-and-footer" data-children="right-panel-open chat-panel-skeleton">
 <!--                Left Panel -->
                 <div class="left-panel-skeleton side-nav side-nav-left">
                     <div class='left-panel'>
@@ -39,7 +39,7 @@ export class SplashPageSkeleton extends LitElement {
                     </div>
                 </div>
 <!--                Chat Panel -->
-                <div class="chat-panel-skeleton">
+                <div class="chat-panel-skeleton" data-child="chat-panel-skeleton">
                     <div class="chat-header-skeleton">
                         <div class="c-wrapper">
                             <div class="c-icon">
@@ -59,7 +59,8 @@ export class SplashPageSkeleton extends LitElement {
                 </div>
 <!--                Right Panel - a closed one is off-screen anyway, so it's simply left out -->
                 ${isRightPanelOpen ? html`
-                <div class="right-panel-skeleton side-nav side-nav-right" data-side-nav="open">
+                <div class="right-panel-skeleton side-nav side-nav-right"
+                     data-side-nav="open" data-child="right-panel-open">
                     <chat-side-panel-skeleton></chat-side-panel-skeleton>
                 </div>` : ''}
             </div>

--- a/src/dotnet/UI.Blazor/Components/TabPanel/tab-panel.css
+++ b/src/dotnet/UI.Blazor/Components/TabPanel/tab-panel.css
@@ -143,7 +143,7 @@ body.hoverable .tab-panel-tabs .btn-tab.on:hover {
     @apply gap-x-1;
     @apply py-1 px-2;
 }
-.tab-panel-tabs .btn-tab .btn-content.has-badge {
+.tab-panel-tabs .btn-tab .btn-content[data-has-badge] {
     @apply pr-1.5;
 }
 .tab-panel-tabs .btn-tab .btn-content .message-counter-badge {

--- a/src/dotnet/UI.Blazor/Components/TextInput/text-input.ts
+++ b/src/dotnet/UI.Blazor/Components/TextInput/text-input.ts
@@ -1,4 +1,5 @@
 import { Disposable } from 'disposable';
+import { PresenceTracker } from 'presence-tracker';
 import { fromEvent, Subject, takeUntil, debounceTime, switchMap } from 'rxjs';
 
 interface TextInputOptions {
@@ -6,6 +7,10 @@ interface TextInputOptions {
     debounce: number;
     closeOnBlurSelector?: string;
 }
+
+/** Focus is browser state, so nothing renders this presence name - see presence-tracker.ts. An
+ *  enclosing `data-children="focused-input"` turns `X:has(input:focus)` into `X[data-has-focused-input]`. */
+const FocusedChild = 'focused-input';
 
 export class TextInput implements Disposable {
     private readonly disposed$: Subject<void> = new Subject<void>();
@@ -40,6 +45,14 @@ export class TextInput implements Disposable {
                     this.blazorRef.invokeMethodAsync('OnPaste', e.clipboardData?.getData('Text'))),
             ).subscribe();
 
+        this.setFocusedChild(document.activeElement === this.element);
+        fromEvent(this.element, 'focus')
+            .pipe(takeUntil(this.disposed$))
+            .subscribe(() => this.setFocusedChild(true));
+        fromEvent(this.element, 'blur')
+            .pipe(takeUntil(this.disposed$))
+            .subscribe(() => this.setFocusedChild(false));
+
         const closeOnBlurSelector = this.options.closeOnBlurSelector;
         if (closeOnBlurSelector) {
             const boundary = this.element.closest(closeOnBlurSelector);
@@ -70,6 +83,10 @@ export class TextInput implements Disposable {
 
     public blur(): void {
         this.element.blur();
+    }
+
+    private setFocusedChild(isFocused: boolean): void {
+        PresenceTracker.setChild(this.element, FocusedChild, isFocused);
     }
 
     // Called by Blazor

--- a/src/dotnet/UI.Blazor/Components/VirtualList/FiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/FiniteList.razor
@@ -67,12 +67,13 @@
                 var edgeClass = (data.HasVeryFirstItem && i == 0 ? " c-first" : "")
                     + (data.HasVeryLastItem && i == items.Count - 1 ? " c-last" : "");
                 @if (item.IsGroup) {
-                    <li @key="@item.RenderKey" class="group@(edgeClass)">
+                    <li @key="@item.RenderKey" class="group@(edgeClass)" data-children="@GroupChildren.NullIfEmpty()">
                         @Item(item)
                     </li>
                 } else {
                     <li @key="@item.RenderKey"
                         class="item@(edgeClass)"
+                        data-children="@ItemChildren.NullIfEmpty()"
                         data-key="@item.Key"
                         data-skip="@item.ShouldSkipKey"
                         data-vl-size-source="@(item.HasRegularSize ? "" : null)">

--- a/src/dotnet/UI.Blazor/Components/VirtualList/FiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/FiniteList.razor
@@ -33,6 +33,7 @@
 <div @ref="Ref"
      class="@Class virtual-list finite-list"
      style="@Style"
+     data-child="@Child.NullIfEmpty()"
      data-content-swap-dependency="@IsContentSwapDependency">
 
     <div @key="@VirtualListSpecialKeys.RenderIndex"

--- a/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
@@ -43,6 +43,7 @@
      class="@Class virtual-list infinite-list"
      style="@Style"
      data-identity="@Identity"
+     data-child="@Child.NullIfEmpty()"
      data-content-swap-dependency="@IsContentSwapDependency">
 
     <div @key="@VirtualListSpecialKeys.RenderIndex"

--- a/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/InfiniteList.razor
@@ -88,12 +88,13 @@
                 var edgeClass = (hasVeryFirstItem && i == 0 ? " c-first" : "")
                     + (hasVeryLastItem && i == items.Count - 1 ? " c-last" : "");
                 @if (item.IsGroup) {
-                    <li @key="@item.RenderKey" class="group@(edgeClass)">
+                    <li @key="@item.RenderKey" class="group@(edgeClass)" data-children="@GroupChildren.NullIfEmpty()">
                         @Item(item)
                     </li>
                 } else {
                     <li @key="@item.RenderKey"
                         class="item@(edgeClass)"
+                        data-children="@ItemChildren.NullIfEmpty()"
                         data-key="@item.Key"
                         data-skip="@item.ShouldSkipKey"
                         data-vl-h-transition="@GetHeightTransition(item)"

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -49,6 +49,10 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     // Opt-in: most lists sit in no swap area at all. Set it where the enclosing area should hold
     // until this list has its content placed - see ContentSwap and virtual-list.ts.
     [Parameter] public bool IsContentSwapDependency { get; set; }
+    // Presence names the rendered group / item elements declare - see presence-tracker.ts. Passed in
+    // rather than hardcoded so this component keeps no vocabulary from the app that uses it.
+    [Parameter] public string GroupChildren { get; set; } = "";
+    [Parameter] public string ItemChildren { get; set; } = "";
     // NOTE: Only its value at the first SetParametersAsync matters - set it when a pending navigation
     // will issue the first query anyway, so the pre-render one would be superseded before it's rendered
     [Parameter] public bool SkipPreRenderGetDataCall { get; set; }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -49,8 +49,10 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     // Opt-in: most lists sit in no swap area at all. Set it where the enclosing area should hold
     // until this list has its content placed - see ContentSwap and virtual-list.ts.
     [Parameter] public bool IsContentSwapDependency { get; set; }
-    // Presence names the rendered group / item elements declare - see presence-tracker.ts. Passed in
-    // rather than hardcoded so this component keeps no vocabulary from the app that uses it.
+    // Presence names - see presence-tracker.ts. Child is what the list root declares itself as;
+    // GroupChildren / ItemChildren are what the group / item elements count. Passed in rather than
+    // hardcoded so this component keeps no vocabulary from the app that uses it.
+    [Parameter] public string Child { get; set; } = "";
     [Parameter] public string GroupChildren { get; set; } = "";
     [Parameter] public string ItemChildren { get; set; } = "";
     // NOTE: Only its value at the first SetParametersAsync matters - set it when a pending navigation

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -13,12 +13,6 @@ namespace ActualChat.UI.Blazor.Components;
 public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, VirtualListData<TItem>>, IVirtualListBackend
     where TItem : class, IVirtualListItem
 {
-    // Long enough that a warm first load always uses it (1.5-8ms measured), short enough that a cold one
-    // (1114ms at app start) falls back to skeletons instead of holding the whole list blank
-    // ReSharper disable once StaticMemberInGenericType
-    private static readonly TimeSpan InitialDataTimeout = TimeSpan.FromSeconds(0.3);
-
-    private VirtualListData<TItem>? _initialData;
     private VirtualListDataQuery _pendingQuery = VirtualListDataQuery.None;
 
     private ILogger Log => field ??= Hub.LogFor(GetType());
@@ -55,9 +49,6 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     [Parameter] public string Child { get; set; } = "";
     [Parameter] public string GroupChildren { get; set; } = "";
     [Parameter] public string ItemChildren { get; set; } = "";
-    // NOTE: Only its value at the first SetParametersAsync matters - set it when a pending navigation
-    // will issue the first query anyway, so the pre-render one would be superseded before it's rendered
-    [Parameter] public bool SkipPreRenderGetDataCall { get; set; }
     [Parameter] public double ExpandMultiplier { get; set; } = 2;
     // This event is intentionally Action vs EventCallback, coz normally it shouldn't
     // trigger StateHasChanged on parent component.
@@ -121,32 +112,8 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
     public override async Task SetParametersAsync(ParameterView parameters)
     {
         parameters.SetParameterProperties(this);
-        // NOTE: Hub (and other injected services) aren't available yet in the first SetParametersAsync,
-        // so we can't use Hub.IsPrerendering here. RendererInfo is set before SetParametersAsync and is
-        // per-circuit: IsInteractive is false during prerender SSR, true once the list is interactive.
-        var shouldSetInitialData = RendererInfo.IsInteractive && RenderIndex == 0 && !SkipPreRenderGetDataCall;
-        if (shouldSetInitialData) {
-            ChatSwitchTracer.Mark("VirtualList: initial GetData -> in (BLOCKS FIRST RENDER)", Identity);
-            try {
-                _initialData = await DataSource
-                    .GetData(VirtualListDataQuery.None, VirtualListData<TItem>.None, CancellationToken.None)
-                    .WaitAsync(InitialDataTimeout);
-                ChatSwitchTracer.Mark("VirtualList: initial GetData <- out", Identity);
-            }
-            catch (TimeoutException) {
-                // NOTE: The abandoned call is left running rather than cancelled - it warms exactly what
-                // the follow-up GetData needs, so what it costs from here is the item building, not the
-                // round trips. Rendering skeletons now beats holding the list blank until it lands.
-                _initialData = null;
-                ChatSwitchTracer.Mark("VirtualList: initial GetData TIMED OUT - skeletons", Identity);
-            }
-        }
-        else
-            _initialData = null;
-
-        // Always here rather than left to the base: its init flow calls StateHasChanged before it creates
-        // the State, and the await above puts that call outside any render batch, so the render runs inline
-        // and the next StateHasChanged reaches ShouldRender - which needs the State - with none
+        // Before the base rather than left to it: its init flow calls StateHasChanged before it creates
+        // the State, and that render can reach ShouldRender - which needs the State - with none
         if (ReferenceEquals(State, null)) {
             var (state, stateOptions) = CreateState();
             SetState(state, stateOptions);
@@ -191,11 +158,10 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
 
     protected override ComputedState<VirtualListData<TItem>>.Options GetStateOptions()
     {
-        var initialData = _initialData ?? VirtualListData<TItem>.None;
         return new ComputedState<VirtualListData<TItem>>.Options {
-            InitialValue = initialData,
+            InitialValue = VirtualListData<TItem>.None,
             UpdateDelayer = FixedDelayer.NextTick,
-            TryComputeSynchronously = false, // Intended here, _initialData covers that better
+            TryComputeSynchronously = false, // The list renders its skeletons until the first GetData lands
             Category = GetStateCategory(GetType()),
         };
     }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -74,6 +74,9 @@ const ScreenAnchorStillFrames = 12;
 // What the consumer marks a position:sticky element with, so the list can move its sticky threshold
 // by whatever the rubber band's transform is carrying - see updateStickyItems.
 const StickyItemClass = 'vl-sticky';
+// Presence-tracked items declare stickiness through the attribute; two hand-written elements
+// (the author circle and the empty spacer) still carry the class directly.
+const StickyItemSelector = `.${StickyItemClass}, [data-has-${StickyItemClass}]`;
 // Consecutive frames the position must not move before the list acts on a standing intent - shifting
 // the chain back to the middle, or putting the render direction back. Event-based settle checks can't
 // do this: a fling delivers no events between frames and still passes them, while the position itself
@@ -910,7 +913,8 @@ export class InfiniteList extends VirtualList {
     private findStickyItems(): void {
         const known = new Map(this.stickyRefs.map(x => [x.ref, x]));
         const refs = new Array<StickyItem>();
-        for (const ref of this.containerRef.querySelectorAll<HTMLElement>(`:scope .${StickyItemClass}`)) {
+        for (const ref of this.containerRef.querySelectorAll<HTMLElement>(
+            `:scope .${StickyItemClass}, :scope [data-has-${StickyItemClass}]`)) {
             const sticky = known.get(ref) ?? { ref, top: null, bottom: null, isShifted: false };
             // A render can land in the middle of an excursion, and an element that arrives during one
             // has to be given the shift the others are already carrying.
@@ -1965,7 +1969,7 @@ export class InfiniteList extends VirtualList {
         // edge. A stuck element reports the edge it is stuck to, and no amount of moving the chain
         // changes that - so aiming at its rendered position would move the chain without moving the
         // element, over and over. Its flow position is the thing that follows.
-        const stickyRef = anchorRef.closest<HTMLElement>(`.${StickyItemClass}`);
+        const stickyRef = anchorRef.closest<HTMLElement>(StickyItemSelector);
         const position = anchorRef.style.position;
         const stickyPosition = stickyRef?.style.position ?? '';
         anchorRef.style.position = 'static';

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.css
@@ -51,8 +51,8 @@ body.app-ready .virtual-list {
 body.narrow .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
     @apply min-h-0 h-12;
 }
-body.narrow .list-view-layout.has-listening-activity .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor,
-body.narrow .list-view-layout.has-audio-panel-header .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
+body.narrow .list-view-layout[data-has-listening-activity] .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor,
+body.narrow .list-view-layout[data-has-audio-panel-header] .virtual-list > .c-wrapper > ul.c-virtual-container > .c-end-anchor {
     @apply portrait:min-h-0 h-20;
 }
 
@@ -151,7 +151,7 @@ body.app-ready .virtual-list > .c-wrapper > ul.c-virtual-container {
 .virtual-list > .c-wrapper > ul.c-virtual-container .item:empty {
     @apply min-h-0;
 }
-.virtual-list > .c-wrapper > ul.c-virtual-container .item.has-show-author {
+.virtual-list > .c-wrapper > ul.c-virtual-container .item[data-has-show-author] {
     @apply min-h-14;
 }
 
@@ -181,11 +181,11 @@ body.app-ready .virtual-list > .c-wrapper > ul.c-virtual-container {
     overflow-anchor: none;
 }
 
-/* The same top padding the collapsed form carries (.item.has-conversation-message): expanding or
+/* The same top padding the collapsed form carries (.item[data-has-conversation-message]): expanding or
    collapsing swaps one of these boxes for the other, so a gap on one and not the other moves
    everything above it by that much on every toggle. The inset absorbs the padding, so the header
    still reaches the top edge when pinned instead of hanging 16px below it. */
-.virtual-list > .c-wrapper > ul.c-virtual-container .item.has-conversation-header {
+.virtual-list > .c-wrapper > ul.c-virtual-container .item[data-has-conversation-header] {
     @apply sticky z-20 pt-4;
     top: -17px;
 }

--- a/src/dotnet/UI.Blazor/Layouts/DefaultLayout.razor
+++ b/src/dotnet/UI.Blazor/Layouts/DefaultLayout.razor
@@ -3,7 +3,8 @@
 <IsolateRerender>
     <BaseLayout>
         <Body>
-            <PageWithHeaderAndFooter @key="@Key" Class="@MiddlePanelClass" BodyClass="@BodyClass">
+            <PageWithHeaderAndFooter @key="@Key"
+                Class="@MiddlePanelClass" Child="@MiddlePanelChild" BodyClass="@BodyClass">
                 <LeftDrawer><RenderSlot Name="@LayoutSlots.MainLeftDrawer"/></LeftDrawer>
                 <Header><RenderSlot Name="@LayoutSlots.MainHeader"/></Header>
                 <SubHeader><RenderStack Name="@LayoutSlots.SubHeader"/></SubHeader>
@@ -22,5 +23,6 @@
     private static readonly object Key = new();
 
     public string MiddlePanelClass { get; set; } = "default-layout";
+    public string MiddlePanelChild { get; set; } = "";
     public string BodyClass { get; set; } = "";
 }

--- a/src/dotnet/UI.Blazor/Pages/ButtonsTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/ButtonsTestPage.razor
@@ -208,7 +208,7 @@
         </text>;
 }
 
-<div class="test-page-wrapper flex-y gap-y-6 p-4">
+<div class="test-page-wrapper flex-y gap-y-6 p-4" data-child="test-page">
     <div class="theme-light flex-y gap-y-4 p-6 rounded-2xl bg-01 text-01">
         <h1>theme-light</h1>
         @buttons

--- a/src/dotnet/UI.Blazor/Pages/ColorsTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/ColorsTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Colors</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <details>
     <summary class="flex-x items-center gap-4 bg-03">
         <i class="icon-chevron-up rotate-180"></i>

--- a/src/dotnet/UI.Blazor/Pages/ContentSwapTestPage/ContentSwapTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/ContentSwapTestPage/ContentSwapTestPage.razor
@@ -13,7 +13,7 @@
 
 <UITimer Period="@TimeSpan.FromSeconds(0.2)" Tick="@StateHasChanged"/>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="content-swap-test-page">
         <div class="c-controls">
             <div class="test-page-btn-group">

--- a/src/dotnet/UI.Blazor/Pages/DiveInModalTestPage/DiveInModalTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/DiveInModalTestPage/DiveInModalTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Dive-in Modal Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <Button Class="btn-primary" Click="ShowModal">
         Show Dive-in Modal
     </Button>

--- a/src/dotnet/UI.Blazor/Pages/Emails/EmailTemplatesTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/Emails/EmailTemplatesTestPage.razor
@@ -10,7 +10,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Email templates</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <Form Model="@_form">
     <FormBlock>
         <FormSection

--- a/src/dotnet/UI.Blazor/Pages/ErrorBarrierTestPage/ErrorBarrierTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/ErrorBarrierTestPage/ErrorBarrierTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>ErrorBarrier Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="flex-x justify-start items-center">
     <ErrorBarrier Name="Test-Full" Kind="ErrorBarrierKind.Full" MustAutoReload="false">
         <FailingTestTimer Modulo="1000" Boundary="1000"/>

--- a/src/dotnet/UI.Blazor/Pages/FeaturesTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/FeaturesTestPage.razor
@@ -8,7 +8,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Features Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <p>Server time: @(m.ServerTime)</p>
 <p>Client user: @(m.ClientAccount?.Name ?? "n/a")</p>
 <p>Enable incomplete UI: @(m.EnableIncompleteUI)</p>

--- a/src/dotnet/UI.Blazor/Pages/InfoToastTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/InfoToastTestPage.razor
@@ -6,7 +6,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>Toasts Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="test-page-text">
     <div>
         To call, to text, or

--- a/src/dotnet/UI.Blazor/Pages/LandingBackgroundTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/LandingBackgroundTestPage.razor
@@ -4,7 +4,7 @@
 
 <MainHeader>Landing Background Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="landing-test-page">
         <div class="web-splash">
             <div class="c-wrapper">

--- a/src/dotnet/UI.Blazor/Pages/QrCodeTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/QrCodeTestPage.razor
@@ -4,7 +4,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>QR Code Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
     <div class="m-4 flex flex-col items-start gap-4">
         <qr-code url="https://voxt.ai/u/test"></qr-code>
         <qr-code url="https://voxt.ai/u/test" image="/dist/images/voxt-icon-color.svg"></qr-code>

--- a/src/dotnet/UI.Blazor/Pages/ReconnectOverlayTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/ReconnectOverlayTestPage.razor
@@ -5,7 +5,7 @@
 
 <MainHeader>Reconnect Overlay Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="reconnect-overlay-test-page flex-y gap-y-4 h-full text-lg relative">
     <div>
         To call, to text, or

--- a/src/dotnet/UI.Blazor/Pages/RenderSlotTestPage/RenderSlotTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/RenderSlotTestPage/RenderSlotTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>RenderSlot Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="flex-y">
     <RenderSlot Name="TestHeader"/>
 </div>

--- a/src/dotnet/UI.Blazor/Pages/SkeletonsTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/SkeletonsTestPage.razor
@@ -4,8 +4,8 @@
 
 <MainHeader>Skeletons Test Page</MainHeader>
 
-<div class="test-page-wrapper">
-    <div class="skeleton-page page-with-header-and-footer">
+<div class="test-page-wrapper" data-child="test-page">
+    <div class="skeleton-page page-with-header-and-footer" data-children="chat-panel-skeleton">
         <LeftPanelSkeleton/>
         <ChatPanelSkeleton/>
         <RightPanelSkeleton/>

--- a/src/dotnet/UI.Blazor/Pages/SvgCatsTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/SvgCatsTestPage.razor
@@ -3,7 +3,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>SVG Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-2 items-center justify-items-center m-4">
     <phone-verification-cat-svg/>
     <chat-not-found-svg/>

--- a/src/dotnet/UI.Blazor/Pages/SystemTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/SystemTestPage.razor
@@ -7,7 +7,7 @@
 <RequireAccount MustBeAdmin="true"/>
 <MainHeader>System Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <p>HostId: <b>@(HostId)</b></p>
 <p>App kind: <b>@(HostInfo.HostKind)</b></p>
 <p>Host roles: <b>@(HostInfo.Roles.ToDelimitedString())</b></p>

--- a/src/dotnet/UI.Blazor/Pages/TotpTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/TotpTestPage.razor
@@ -5,7 +5,7 @@
 
 <MainHeader>TOTP Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="flex-y flex-1 items-center justify-center">
     <Form
         Class="m-6 w-80"

--- a/src/dotnet/UI.Blazor/Pages/WebSplashTestPage.razor
+++ b/src/dotnet/UI.Blazor/Pages/WebSplashTestPage.razor
@@ -5,7 +5,7 @@
 
 <MainHeader>Web Splash Test Page</MainHeader>
 
-<div class="test-page-wrapper">
+<div class="test-page-wrapper" data-child="test-page">
 <div class="web-splash no-scrollbar">
     <splash-page-skeleton class="no-scrollbar" isRightPanelVisible="@_isRightPanelVisible"/>
 </div>

--- a/src/nodejs/src/mutation-processor.ts
+++ b/src/nodejs/src/mutation-processor.ts
@@ -23,7 +23,10 @@ const RenderScriptPrefix = 'data-render-script-';
 const renderScripts = new Map<string, RenderScript>();
 // What each element was last run with, so a re-render that rewrites the same value is not a re-run.
 const ranRenderScripts = new WeakMap<Element, Map<string, string>>();
-const baseObservedAttributes = ['class', 'data-side-nav', ...PresenceTracker.observedAttributes];
+// Only what this module dispatches on. 'class' and 'data-side-nav' were observed for the
+// selector-driven presence path and are dead now that markup declares presence - and 'class' in
+// particular is the app's noisiest attribute, so observing it delivered records nothing read.
+const baseObservedAttributes = [...PresenceTracker.observedAttributes];
 let observedAttributes = [...baseObservedAttributes];
 let observer: MutationObserver | null = null;
 let isEnabled = true;

--- a/src/nodejs/src/mutation-processor.ts
+++ b/src/nodejs/src/mutation-processor.ts
@@ -4,19 +4,15 @@
 // batch is applied and before paint - so anything driven from here is both timelier and
 // cheaper than an interval, and sees JS-driven mutations no render hook would.
 //
-// Two consumers today:
-//  - presence classes, which replace `container:has(descendant)`. WebKit has no
-//    descendant-direction :has() bits, so StyleInvalidator re-runs a real match up the
-//    ancestor chain on every mutation - 6-8% of WebContent's main thread during a call.
+// Three consumers today:
+//  - presence tracking, which counts data-child elements per data-children container - see
+//    presence-tracker.ts for why markup declares it rather than CSS deriving it.
+//  - render scripts, run when a data-render-script-<name> attribute appears.
 //  - animation phase sync, which used to sweep the whole document every 200ms.
 
 import { AnimationSync } from 'animation-sync';
+import { PresenceTracker } from 'presence-tracker';
 
-export interface PresenceClassRule {
-    container: string;
-    match: string;
-    className: string;
-}
 
 // Runs when `data-render-script-<name>` appears on an element, or its value changes. The name selects
 // the script, so one element can ask for several; the value is the script's argument.
@@ -24,25 +20,15 @@ export type RenderScript = (element: HTMLElement, value: string) => void;
 
 const RenderScriptPrefix = 'data-render-script-';
 
-const rules = new Array<PresenceClassRule>();
 const renderScripts = new Map<string, RenderScript>();
 // What each element was last run with, so a re-render that rewrites the same value is not a re-run.
 const ranRenderScripts = new WeakMap<Element, Map<string, string>>();
-const baseObservedAttributes = ['class', 'data-side-nav'];
+const baseObservedAttributes = ['class', 'data-side-nav', ...PresenceTracker.observedAttributes];
 let observedAttributes = [...baseObservedAttributes];
-// Class tokens any rule's match selector can turn on. Records touching none of them cannot
-// change any predicate, which is nearly all of them - this app toggles classes constantly
-// for animation and hover state, and a full rescan per toggle is what we're avoiding.
-const matchTokens = new Set<string>();
-let containerSelector = '';
 let observer: MutationObserver | null = null;
 let isEnabled = true;
 
 export const MutationProcessor = {
-    get presenceClassRules(): readonly PresenceClassRule[] {
-        return rules;
-    },
-
     // Runtime toggle so the mechanism can be A/B'd inside one session rather than across builds
     get isEnabled(): boolean {
         return isEnabled;
@@ -54,27 +40,7 @@ export const MutationProcessor = {
 
         isEnabled = value;
         if (value)
-            updatePresenceClasses();
-        else
-            clearPresenceClasses();
-    },
-
-    // Registered at import time by the modules that own the matching CSS: the CSS applies
-    // whenever the markup exists, so registering when a component mounts would leave a
-    // window with the class missing.
-    registerPresenceClasses(...newRules: PresenceClassRule[]): void {
-        rules.push(...newRules);
-        containerSelector = [...new Set(rules.map(r => r.container))].join(',');
-        matchTokens.clear();
-        for (const rule of rules) {
-            for (const token of rule.match.match(/\.[\w-]+/g) ?? [])
-                matchTokens.add(token.slice(1));
-            // A renderer can overwrite our classes without changing any matched tokens.
-            // Watching our classes too lets us restore them on the next observer delivery.
-            matchTokens.add(rule.className);
-        }
-        if (observer)
-            updatePresenceClasses();
+            PresenceTracker.scan(document.body);
     },
 
     // Registered at import time, like presence classes: the attribute can be in the very first render.
@@ -96,7 +62,7 @@ export const MutationProcessor = {
 
         observer = new MutationObserver(onMutated);
         reobserve();
-        updatePresenceClasses();
+        PresenceTracker.scan(document.body);
         runRenderScripts(document.body);
         AnimationSync.syncAll(document);
     },
@@ -106,7 +72,7 @@ export const MutationProcessor = {
         observer = null;
     },
 
-    update: updatePresenceClasses,
+    presence: PresenceTracker,
 };
 
 // Private methods
@@ -124,49 +90,24 @@ function onMutated(records: MutationRecord[]): void {
     const roots = coalesceRoots(added);
     syncAddedAnimations(roots);
 
-    const dirty = new Set<Element>();
-    const visited = new Set<Element>();
     for (const record of records) {
         if (record.type === 'childList') {
             for (const node of record.addedNodes)
-                if (node instanceof Element)
+                if (node instanceof Element) {
                     runRenderScripts(node);
+                    PresenceTracker.scan(node);
+                }
+            for (const node of record.removedNodes)
+                if (node instanceof Element)
+                    PresenceTracker.unscan(node);
         }
+        else if (record.attributeName === 'data-child')
+            PresenceTracker.onChildChanged(record.target as Element);
+        else if (record.attributeName === 'data-children')
+            PresenceTracker.onChildrenChanged(record.target as Element);
         else if (isRenderScriptAttribute(record.attributeName))
             runRenderScriptsOn(record.target as Element);
-        if (affectsPresence(record))
-            collectAncestorContainers(record.target, dirty, visited);
     }
-    if (containerSelector)
-        for (const root of roots) {
-            if (root.matches(containerSelector))
-                dirty.add(root);
-            for (const container of root.querySelectorAll(containerSelector))
-                dirty.add(container);
-        }
-
-    // Render-script side effects must reach the next observer delivery too.
-    // Our forced class toggles settle without producing more writes.
-    if (dirty.size !== 0)
-        updateContainers(dirty);
-}
-
-function collectAncestorContainers(target: Node, dirty: Set<Element>, visited: Set<Element>): void {
-    let element = target instanceof Element ? target : target.parentElement;
-    while (element !== null && !visited.has(element)) {
-        visited.add(element);
-        if (element.matches(containerSelector))
-            dirty.add(element);
-
-        element = element.parentElement;
-    }
-}
-
-function updateContainers(containers: Set<Element>): void {
-    for (const container of containers)
-        for (const rule of rules)
-            if (container.matches(rule.container))
-                container.classList.toggle(rule.className, container.querySelector(rule.match) !== null);
 }
 
 // Phase-aligns whatever arrived, replacing the sweep that used to run every 200ms.
@@ -256,39 +197,4 @@ function runRenderScript(element: Element, name: string): void {
 
     ran.set(name, value);
     renderScripts.get(name)?.(element as HTMLElement, value);
-}
-
-function affectsPresence(record: MutationRecord): boolean {
-    if (!containerSelector)
-        return false;
-
-    if (record.type === 'attributes') {
-        if (isRenderScriptAttribute(record.attributeName))
-            return false;
-        if (record.attributeName !== 'class')
-            return true;
-
-        // A class change matters only if it added or removed a token some rule tests for.
-        const target = record.target as Element;
-        const before = new Set((record.oldValue ?? '').split(/\s+/));
-        for (const token of matchTokens)
-            if (target.classList.contains(token) !== before.has(token))
-                return true;
-
-        return false;
-    }
-
-    return record.type === 'childList';
-}
-
-function updatePresenceClasses(): void {
-    for (const rule of rules)
-        for (const container of document.querySelectorAll(rule.container))
-            container.classList.toggle(rule.className, container.querySelector(rule.match) !== null);
-}
-
-function clearPresenceClasses(): void {
-    for (const rule of rules)
-        for (const container of document.querySelectorAll(rule.container))
-            container.classList.remove(rule.className);
 }

--- a/src/nodejs/src/presence-tracker.ts
+++ b/src/nodejs/src/presence-tracker.ts
@@ -48,6 +48,18 @@ export const PresenceTracker = {
         scanRoot(container);
     },
 
+    // For presence no render owns - browser state such as focus, or a mode only JS knows about.
+    // Edits the token list rather than the attribute, so a second name on the element survives.
+    setChild(element: Element, name: string, isPresent: boolean): void {
+        const names = namesOf(element, ChildAttribute).filter(n => n !== name);
+        if (isPresent)
+            names.push(name);
+        if (names.length === 0)
+            element.removeAttribute(ChildAttribute);
+        else
+            element.setAttribute(ChildAttribute, names.join(' '));
+    },
+
     // The truth, recomputed from the DOM. Counting is state, and state that only ever moves by
     // deltas cannot recover from a delivery it never saw.
     verify(root: Element = document.body): { name: string; container: Element; counted: number; actual: number }[] {

--- a/src/nodejs/src/presence-tracker.ts
+++ b/src/nodejs/src/presence-tracker.ts
@@ -1,0 +1,154 @@
+// Reference-counted presence, the successor to the selector-driven presence classes in
+// mutation-processor.ts. Markup declares participation instead of CSS deriving it:
+//
+//   <div class="group" data-children="live-block">      <- counts the children named here
+//     <li class="item expanded" data-child="live-block"> <- one of them
+//
+// and this writes `data-has-live-block` on the container while at least one child is present.
+// A name binds to every ancestor declaring it, which is what container.querySelector(match) did.
+//
+// Why an attribute rather than a class for the result: Blazor diffs `class` and overwrites what
+// we put there, which is why the selector-driven path has to watch for and restore its own
+// classes. It never touches a data- attribute it did not render.
+//
+// Why counting rather than re-querying: the selector path recomputes every predicate for every
+// dirty container on every delivery, so its cost scales with rules x containers. This scales with
+// what actually changed.
+
+const ChildAttribute = 'data-child';
+const ChildrenAttribute = 'data-children';
+const HasAttributePrefix = 'data-has-';
+const ChildSelector = `[${ChildAttribute}]`;
+
+interface Membership {
+    name: string;
+    // Captured at registration: a removed element is already detached, so its container
+    // can no longer be found by walking up from it.
+    container: Element;
+}
+
+const memberships = new WeakMap<Element, Membership[]>();
+const counts = new WeakMap<Element, Map<string, number>>();
+
+export const PresenceTracker = {
+    observedAttributes: [ChildAttribute, ChildrenAttribute],
+
+    scan: scanRoot,
+    unscan: unscanRoot,
+
+    onChildChanged(element: Element): void {
+        unregister(element);
+        register(element);
+    },
+
+    onChildrenChanged(container: Element): void {
+        // The names this element claims changed, so every child under it may have moved to or from
+        // it - including children of nested containers, which closest() re-resolves on its own.
+        unscanRoot(container);
+        scanRoot(container);
+    },
+
+    // The truth, recomputed from the DOM. Counting is state, and state that only ever moves by
+    // deltas cannot recover from a delivery it never saw.
+    verify(root: Element = document.body): { name: string; container: Element; counted: number; actual: number }[] {
+        const wrong = new Array<{ name: string; container: Element; counted: number; actual: number }>();
+        for (const container of root.querySelectorAll(`[${ChildrenAttribute}]`)) {
+            for (const name of namesOf(container, ChildrenAttribute)) {
+                const counted = counts.get(container)?.get(name) ?? 0;
+                const actual = container.querySelectorAll(childSelectorFor(name)).length;
+                if (counted !== actual)
+                    wrong.push({ name, container, counted, actual });
+            }
+        }
+        return wrong;
+    },
+};
+
+// Private methods
+
+function scanRoot(root: Element): void {
+    if (root.matches(ChildSelector))
+        register(root);
+    for (const element of root.querySelectorAll(ChildSelector))
+        register(element);
+}
+
+function unscanRoot(root: Element): void {
+    if (root.matches(ChildSelector))
+        unregister(root);
+    for (const element of root.querySelectorAll(ChildSelector))
+        unregister(element);
+}
+
+function namesOf(element: Element, attribute: string): string[] {
+    const value = element.getAttribute(attribute);
+    if (!value)
+        return [];
+
+    return value.trim().split(/\s+/).filter(name => name.length !== 0);
+}
+
+// JSON.stringify quotes and escapes the value, which is what an attribute selector needs - CSS.escape
+// escapes identifiers, not strings, and would mangle a quoted value.
+function childSelectorFor(name: string): string {
+    return `[${ChildAttribute}~=${JSON.stringify(name)}]`;
+}
+
+function containerFor(element: Element, name: string): Element | null {
+    return element.closest(`[${ChildrenAttribute}~=${JSON.stringify(name)}]`);
+}
+
+function register(element: Element): void {
+    if (memberships.has(element))
+        return;
+
+    const list = new Array<Membership>();
+    for (const name of namesOf(element, ChildAttribute)) {
+        // Every ancestor claiming the name, not just the nearest: the predicate this replaces was
+        // container.querySelector(match), which any matching container answered for itself, so
+        // nested containers both had the class. Usually one iteration.
+        let container = containerFor(element, name);
+        while (container !== null) {
+            list.push({ name, container });
+            increment(container, name);
+            container = container.parentElement === null ? null : containerFor(container.parentElement, name);
+        }
+    }
+    memberships.set(element, list);
+}
+
+function unregister(element: Element): void {
+    const list = memberships.get(element);
+    if (list === undefined)
+        return;
+
+    memberships.delete(element);
+    for (const membership of list)
+        decrement(membership.container, membership.name);
+}
+
+function increment(container: Element, name: string): void {
+    let byName = counts.get(container);
+    if (byName === undefined)
+        counts.set(container, byName = new Map<string, number>());
+
+    const count = (byName.get(name) ?? 0) + 1;
+    byName.set(name, count);
+    if (count === 1)
+        container.setAttribute(HasAttributePrefix + name, '');
+}
+
+function decrement(container: Element, name: string): void {
+    const byName = counts.get(container);
+    if (byName === undefined)
+        return;
+
+    const count = (byName.get(name) ?? 0) - 1;
+    if (count > 0) {
+        byName.set(name, count);
+        return;
+    }
+
+    byName.delete(name);
+    container.removeAttribute(HasAttributePrefix + name);
+}

--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -133,8 +133,8 @@ body.narrow {
     touch-action: none;
 }
 /* Let fullscreen video panel reach the viewport edges under device cutouts */
-body.video-panel-expanded-any .safe-area-left::after,
-body.video-panel-expanded-any .safe-area-right::after {
+body[data-has-video-panel-expanded] .safe-area-left::after,
+body[data-has-video-panel-expanded] .safe-area-right::after {
     display: none;
 }
 .safe-area-bottom-overlay {
@@ -287,7 +287,7 @@ h1.section:nth-child(1), h2.section:nth-child(1), h3.section:nth-child(1), h4.se
 /* A headerless page - one that carries its own heading - would otherwise get an empty bar with a
    separator under it. The box stays, because it is what reserves the top safe area; it just
    collapses to that inset and drops the separator. */
-.list-view-layout.has-headerless-page > .layout-header {
+.list-view-layout[data-has-headerless-page] > .layout-header {
     @apply border-b-0;
     min-height: var(--safe-area-top);
 }
@@ -366,8 +366,8 @@ body.narrow .layout-header > .c-content.selection-header {
     @apply items-center;
     min-height: calc(3.5rem + var(--safe-area-top));
 }
-.list-view-layout .layout-header.has-activity-panel,
-.list-view-layout.has-listening-activity .layout-header {
+.list-view-layout .layout-header[data-has-activity-panel],
+.list-view-layout[data-has-listening-activity] .layout-header {
     @apply relative;
     @apply bg-transparent;
     @apply border-transparent;
@@ -383,18 +383,18 @@ body.narrow .list-view-layout:has(.chat-activity-panel:not(.not-participating)) 
         var(--transparent) 100%);
 }
 /* Video panel styling — no max-height, just visual treatment */
-.list-view-layout .layout-header.has-open-video-panel,
-.list-view-layout .layout-header.has-map-panel {
+.list-view-layout .layout-header[data-has-open-video-panel],
+.list-view-layout .layout-header[data-has-map-panel] {
     border: none;
 }
 /* Collapsed video panel island uses fixed positioning — no header overflow needed.
    The map panel counts too: its Call/Map switch overhangs the header into the subheader area. */
-.list-view-layout.has-open-video-panel .layout-subheader,
-.list-view-layout.has-map-panel .layout-subheader {
+.list-view-layout[data-has-open-video-panel] .layout-subheader,
+.list-view-layout[data-has-map-panel] .layout-subheader {
     @apply z-40;
 }
 /* Hideable elements (control panel buttons) */
-.list-view-layout .layout-header.has-activity-panel .hideable {
+.list-view-layout .layout-header[data-has-activity-panel] .hideable {
     transition-property: opacity, transform, max-width;
     transition-duration: 0.5s;
     transition-timing-function: ease;
@@ -447,18 +447,18 @@ body.narrow .list-view-layout .layout-header.collapsed .chat-header-title {
     border-top: 1px solid var(--violet-80-20);
 }
 /* Colorized header */
-.list-view-layout.has-listening-activity .layout-subheader {
+.list-view-layout[data-has-listening-activity] .layout-subheader {
     @apply bg-transparent;
 }
 /* Colorized footer */
-.list-view-layout.has-listening-activity .layout-subfooter:before {
+.list-view-layout[data-has-listening-activity] .layout-subfooter:before {
     @apply content-empty;
     @apply absolute z-minus inset-x-0 bottom-0;
     @apply h-40;
     @apply opacity-90;
     background: radial-gradient(100.91% 85.88% at 50% 100%, var(--footer-fog-color-1) 0%, var(--footer-fog-color-2) 100%);
 }
-body.narrow .list-view-layout.has-listening-activity .layout-subfooter:before {
+body.narrow .list-view-layout[data-has-listening-activity] .layout-subfooter:before {
     background: radial-gradient(80.91% 105.88% at 50% 100%, var(--footer-fog-color-1) 0%, var(--footer-fog-color-2) 100%);
 }
 .list-view-layout > .layout-header > .c-content {

--- a/src/nodejs/styles/main.css
+++ b/src/nodejs/styles/main.css
@@ -298,7 +298,7 @@ h1.section:nth-child(1), h2.section:nth-child(1), h3.section:nth-child(1), h4.se
 body.narrow .layout-header > .c-content.selection-header {
     @apply pr-3;
 }
-.layout-header:has(.selection-header) {
+.layout-header[data-has-selection-header] {
     @apply bg-gradient-to-r from-pal-magenta-50-20 to-pal-blue-50-20;
 }
 .layout-header > .c-content.c-selection {
@@ -375,7 +375,7 @@ body.narrow .layout-header > .c-content.selection-header {
 .list-view-layout .layout-header.dragging .hideable {
     transition: none;
 }
-body.narrow .list-view-layout:has(.chat-activity-panel:not(.not-participating)) .layout-header {
+body.narrow .list-view-layout[data-has-participating-activity] .layout-header {
     background: linear-gradient(
         to bottom,
         var(--violet-60-20) 15%,
@@ -588,7 +588,7 @@ body.wide .error-container {
     @apply flex-x;
     @apply h-full w-full;
 }
-.page-with-header-and-footer:has(.docs-layout) {
+.page-with-header-and-footer[data-has-docs-layout] {
     @apply theme-light;
 }
 .page-with-header-and-footer .layout-body-wrapper {
@@ -604,12 +604,12 @@ body.wide .error-container {
 .page-with-header-and-footer .layout-body-wrapper > .c-container > .layout-body {
     @apply h-0 min-h-0; /* grows to max h */
 }
-.page-with-header-and-footer .layout-body-wrapper > .c-container:not(:has(.has-safe-area-bottom)) {
+.page-with-header-and-footer .layout-body-wrapper > .c-container:not([data-has-safe-area-bottom]) {
     padding-bottom: var(--safe-area-bottom);
 }
 
-.page-with-header-and-footer:has(.chat-panel-skeleton) .layout-footer,
-.page-with-header-and-footer:has(.chat-panel-skeleton) .layout-subfooter {
+.page-with-header-and-footer[data-has-chat-panel-skeleton] .layout-footer,
+.page-with-header-and-footer[data-has-chat-panel-skeleton] .layout-subfooter {
     @apply hidden;
 }
 
@@ -620,10 +620,10 @@ body.wide .error-container {
     @apply overflow-y-auto;
     border-radius: 0.75rem;
 }
-.page-with-header-and-footer .layout-body:has(.test-page-wrapper) {
+.page-with-header-and-footer .layout-body[data-has-test-page] {
     @apply p-0;
 }
-body.narrow .page-with-header-and-footer:has(.side-nav-left[data-side-nav="open"]):has(.test-page-wrapper) .layout-header {
+body.narrow .page-with-header-and-footer[data-has-left-panel-open][data-has-test-page] .layout-header {
     @apply hidden;
 }
 .page-with-header-and-footer .layout-body .test-page-text {
@@ -638,11 +638,11 @@ body.narrow .page-with-header-and-footer:has(.side-nav-left[data-side-nav="open"
     @apply min-w-full md:min-w-40;
 }
 @media (min-width: 820px) {
-    .page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="open"]) > .list-view-layout {
+    .page-with-header-and-footer[data-has-right-panel-open] > .list-view-layout {
         @apply opacity-0;
         animation: animated-text-1 400ms ease-in-out forwards;
     }
-    .page-with-header-and-footer:has(.side-nav.side-nav-right[data-side-nav="closed"]) > .list-view-layout {
+    .page-with-header-and-footer[data-has-right-panel-closed] > .list-view-layout {
         @apply opacity-100;
         animation: animated-text-2 400ms ease-in-out forwards;
     }
@@ -701,7 +701,7 @@ body.narrow .page-with-header-and-footer:has(.side-nav-left[data-side-nav="open"
 }
 
 /* Activity panel pinned state */
-.list-view-layout:has(.layout-header.pinned) .header-activity-panel-wrapper .chat-activity-panel {
+.list-view-layout[data-has-header-pinned] .header-activity-panel-wrapper .chat-activity-panel {
     @apply cursor-pointer;
 }
 

--- a/tests/Chat.UI.Blazor.UnitTests/VirtualListRecoveryTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/VirtualListRecoveryTest.cs
@@ -15,8 +15,7 @@ public class VirtualListRecoveryTest
         var recovered = new VirtualListData<TestItem>([new("11")]);
         var source = new TestDataSource(initial, new([]), recovered);
         var cut = context.Render<TestList>(p => p
-            .Add(x => x.DataSource, source)
-            .Add(x => x.SkipPreRenderGetDataCall, true));
+            .Add(x => x.DataSource, source));
         cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
         var query = new VirtualListDataQuery(new("10", "10"), default, new(0, 20));
 
@@ -41,8 +40,7 @@ public class VirtualListRecoveryTest
 
         // act
         var cut = context.Render<TestList>(p => p
-            .Add(x => x.DataSource, source)
-            .Add(x => x.SkipPreRenderGetDataCall, true));
+            .Add(x => x.DataSource, source));
 
         // assert
         cut.WaitForAssertion(() => cut.Instance.CurrentData.Should().BeSameAs(recovered), TimeSpan.FromSeconds(3));
@@ -63,8 +61,7 @@ public class VirtualListRecoveryTest
             : new([]) { HasVeryFirstItem = true, HasVeryLastItem = true };
         var source = new TestDataSource(initial, empty);
         var cut = context.Render<TestList>(p => p
-            .Add(x => x.DataSource, source)
-            .Add(x => x.SkipPreRenderGetDataCall, true));
+            .Add(x => x.DataSource, source));
         cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
 
         // act
@@ -87,8 +84,7 @@ public class VirtualListRecoveryTest
         var recovered = new VirtualListData<TestItem>([new("30")]);
         var source = new TestDataSource(initial, new([]), recovered);
         var cut = context.Render<TestList>(p => p
-            .Add(x => x.DataSource, source)
-            .Add(x => x.SkipPreRenderGetDataCall, true));
+            .Add(x => x.DataSource, source));
         cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
         var oldQuery = new VirtualListDataQuery(new("10", "10"), default, new(0, 20));
         var newQuery = new VirtualListDataQuery(new("30", "30"), default, new(0, 20));

--- a/tests/ts/e2e/mutation-processor.test.ts
+++ b/tests/ts/e2e/mutation-processor.test.ts
@@ -128,71 +128,81 @@ describe('MutationProcessor', () => {
         expect(result).toEqual({ first: 1, second: 0, host: true, tick: '200' });
     });
 
-    it('updates nested containers after removing a match and restores classes overwritten by rendering', async () => {
+
+    it('counts a tagged child toward every declaring ancestor and releases it on removal', async () => {
         const result = await page.evaluate(async () => {
             const processor = TestModules.MutationProcessor;
-            processor.registerPresenceClasses({ container: '.box', match: '.match', className: 'has-match' });
             processor.start();
-            document.body.innerHTML = '<div id="outer" class="box"><div id="inner" class="box">'
-                + '<span class="match"></span></div></div>';
+            document.body.innerHTML = '<div id="outer" data-children="match"><div id="inner" data-children="match">'
+                + '<span data-child="match"></span></div></div>';
             await new Promise(resolve => setTimeout(resolve, 0));
+            const outer = document.getElementById('outer')!;
             const inner = document.getElementById('inner')!;
-            inner.className = 'box';
-            await new Promise(resolve => setTimeout(resolve, 0));
-            const restored = inner.classList.contains('has-match');
+            const both = outer.hasAttribute('data-has-match') && inner.hasAttribute('data-has-match');
             inner.firstElementChild!.remove();
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            return { restored, remaining: document.querySelectorAll('.has-match').length };
+            return { both, remaining: document.querySelectorAll('[data-has-match]').length };
         });
-        expect(result).toEqual({ restored: true, remaining: 0 });
+        expect(result).toEqual({ both: true, remaining: 0 });
     });
 
-    it('updates scoped empty predicates when text is added or removed', async () => {
+    it('keeps the marker while any tagged child remains', async () => {
         const result = await page.evaluate(async () => {
             const processor = TestModules.MutationProcessor;
-            processor.registerPresenceClasses({
-                container: '.box', match: ':scope > .slot:empty', className: 'has-empty-slot',
-            });
             processor.start();
-            document.body.innerHTML = '<div class="box"><div class="slot"></div></div>';
+            document.body.innerHTML = '<div id="box" data-children="match">'
+                + '<span id="a" data-child="match"></span><span id="b" data-child="match"></span></div>';
             await new Promise(resolve => setTimeout(resolve, 0));
-            const box = document.querySelector('.box')!;
-            const slot = document.querySelector('.slot')!;
-            const states = [box.classList.contains('has-empty-slot')];
-            const text = document.createTextNode('content');
-            slot.appendChild(text);
+            const box = document.getElementById('box')!;
+            const states = [box.hasAttribute('data-has-match')];
+            document.getElementById('a')!.remove();
             await new Promise(resolve => setTimeout(resolve, 0));
-            states.push(box.classList.contains('has-empty-slot'));
-            text.remove();
+            states.push(box.hasAttribute('data-has-match'));
+            document.getElementById('b')!.remove();
             await new Promise(resolve => setTimeout(resolve, 0));
-            states.push(box.classList.contains('has-empty-slot'));
+            states.push(box.hasAttribute('data-has-match'));
 
             return states;
         });
-        expect(result).toEqual([true, false, true]);
+        expect(result).toEqual([true, true, false]);
+    });
+
+    it('re-binds a child when its data-child attribute changes', async () => {
+        const result = await page.evaluate(async () => {
+            const processor = TestModules.MutationProcessor;
+            processor.start();
+            document.body.innerHTML = '<div id="box" data-children="one two"><span id="c" data-child="one"></span></div>';
+            await new Promise(resolve => setTimeout(resolve, 0));
+            const box = document.getElementById('box')!;
+            const before = { one: box.hasAttribute('data-has-one'), two: box.hasAttribute('data-has-two') };
+            document.getElementById('c')!.setAttribute('data-child', 'two');
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            return { before, after: { one: box.hasAttribute('data-has-one'), two: box.hasAttribute('data-has-two') } };
+        });
+        expect(result).toEqual({ before: { one: true, two: false }, after: { one: false, two: true } });
     });
 
     it('processes DOM and script attributes created by a render script during presence updates', async () => {
         const result = await page.evaluate(async () => {
             const processor = TestModules.MutationProcessor;
             const calls: string[] = [];
-            processor.registerPresenceClasses({ container: '.box', match: '.match', className: 'has-match' });
             processor.registerRenderScript('first', () => {
                 calls.push('first');
                 const late = document.createElement('div');
-                late.className = 'box';
+                late.setAttribute('data-children', 'match');
                 late.setAttribute('data-render-script-second', '1');
-                late.innerHTML = '<span class="match"></span>';
+                late.innerHTML = '<span data-child="match"></span>';
                 document.body.appendChild(late);
             });
             processor.registerRenderScript('second', () => calls.push('second'));
-            document.body.innerHTML = '<div class="box" id="initial"></div>';
+            document.body.innerHTML = '<div data-children="match" id="initial"></div>';
             processor.start();
-            document.getElementById('initial')!.innerHTML = '<div class="match" data-render-script-first="1"></div>';
+            document.getElementById('initial')!.innerHTML = '<div data-child="match" data-render-script-first="1"></div>';
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            return { calls, containers: document.querySelectorAll('.box.has-match').length };
+            return { calls, containers: document.querySelectorAll('[data-has-match]').length };
         });
         expect(result).toEqual({ calls: ['first', 'second'], containers: 2 });
     });

--- a/tests/ts/e2e/preformatted-text-copy.test.ts
+++ b/tests/ts/e2e/preformatted-text-copy.test.ts
@@ -77,8 +77,8 @@ describe('preformatted text markup copy-on-click', () => {
     it('copies the preformatted text to the clipboard on click', async () => {
         const code = page.locator(`code.preformatted-text-markup:has-text("${preformattedText}")`).first();
         await code.click();
-        // CopyTrigger adds `.copied` to its wrapper for 3s after a successful copy.
-        await page.locator('.copy-trigger.copied').first()
+        // The delegated copy handler adds `.copied` to the clicked element for 3s after a copy.
+        await page.locator('code.preformatted-text-markup.copied').first()
             .waitFor({ state: 'visible', timeout: 5_000 })
             .catch(() => { /* hint may auto-clear before we observe it */ });
 


### PR DESCRIPTION
## Why

A navbar switch (all chats ⇄ a place) stalled the WebKit main thread ~190 ms on iOS, and a chat switch took ~950 ms to show the new chat. Android/Chromium on the same account was instant. Everything below was measured on a physical iPhone 13 Pro against prod data, arms alternated, with the first run of each arm dropped as warm-up.

## Where the time actually went

Time Profiler on `com.apple.WebKit.WebContent`, 29 taps, symbolicated: **63% of main-thread CPU was `Document::resolveStyle`**, and inside it *applying* the cascade (31.2%) cost 3× *matching* selectors (10.8%). The reason it ran so much is DOM churn — a navbar tap creates **1541 brand-new elements**, and a new element gets no `RenderStyle` reuse, so it matches ~6590 rules and builds a fresh `PropertyCascade`.

**Method note, because it invalidated a lot of early work:** measuring a CSS rule's cost by *disabling* it is invalid — the declarations stop applying, the page lays out differently, and the delta is mostly the cheaper render. An early A/B of this kind said live `:has()` rules cost ~1.2 ms each; re-injecting all 52 with an inert declaration costs **5 ms total**. Every number below comes from additive-and-inert probes or from the profiler.

## What each commit does, and what it bought

| commit | measured effect |
|---|---|
| `perf(ui)` presence tracking | MutationProcessor 56.5 → 37.5 ms/tap |
| `perf(ui)` `:has()` → `[data-has-*]` | perf-neutral; removes the WebKit cliff from the hot path |
| `perf(css)` Tailwind defaults → `@property` | **stall 188 → 119 ms mean, 202 → 138 ms median** |
| `perf(virtual-list)` drop blocking initial GetData | **tap → new chat visible ~949 → ~435-516 ms** |
| `perf(markup)` cut the DOM a message renders | 2786 → ~2470 elements, 4154 → 3862 component instances |
| `build(ios)` min 14.2 → 16.4 | aligns the csproj with Info.plist and the share extension |

### The one that mattered most

Tailwind v3 keeps `transform: translate(var(--tw-translate-x), …) rotate(…)` valid when only one utility is used by declaring all 51 composition variables on **every element and pseudo**. WebKit builds a per-element custom-property map for every element it resolves, and a switch creates ~1500 of them.

`@property` alone cannot express Tailwind's defaults — two thirds are the empty space toggle (`--tw-blur: ;`) and `initial-value` cannot be empty. So the pass registers each name `{ syntax: "*"; inherits: false; }` with **no** initial value and rewrites every reference to carry its default as a fallback: `var(--tw-rotate, 0)`, `var(--tw-blur, )`. The fallback does what the declaration did; `inherits: false` does what re-declaring on every element did.

In the profile afterwards: `resolveStyle` 63% → 40%, `applyMatchedProperties` 31% → 8%, custom-property self time 893 → 52 ms, and `applyCustomPropertyImpl` — previously the hottest symbol in the whole profile — leaves the top 30 entirely.

## Verification

- **`@property`**: transform replayed on the live CSSOM of the running app — 4238 elements × 19 properties, **zero** computed-style differences. On WebKit, confirmed the registration takes (a child inherits nothing from a parent's `--tw-blur`), composed declarations stay valid with nothing set, and rendered-effect counts match the baseline exactly.
- **CSS span rule**: replayed on a real bot chat on device (2734 elements, 224 inline code, 204 `<strong>`, 85 headers) — the only computed style that moves is the header container's own `font-weight`, which has no text of its own.
- **Trailing marks**: 0/25 orphaned onto their own line; 26/48 orphan with a preceding space vs 0/48 with padding alone.
- **Presence tracker**: `verify()` clean across 7 interactions including the JS-owned `focused-input`.
- `tsc`, eslint, CSS build, `ActualChat.CI.slnf`, and the 5 `VirtualListRecoveryTest` cases all pass.

## Behaviour changes worth knowing about

- **Every @mention renders at 400.** `.mention-markup` applied `font-medium`, but `.chat-message-markup span` (0,1,1) beat it (0,1,0) and pinned `<span>` mentions to 400 — while chat/place mentions (`<a>`) and unresolvable ones (`<div>`) were never matched and stayed at 500. The same badge came out at two weights depending on its element. All are 400 now, matching the text around them.
- **Messages ending in a code block or table** now show the trailing marks below the block. Before, `CodeBlockMarkupView`/`TableMarkupView` never consumed the cascaded fragment, so the marks were **lost entirely** there.
- **The marks are no longer caught by the translation blur**, which only ever applied to them because they sat inside `.plain-text-markup`.

## Reviewed by pairing

A second model audited the branch and found three things: a component-identity bug (injecting the suffix conditionally re-created the last leaf on a Sending → Default transition, costing `PlayableTextMarkupView` a JS round trip and its playback highlighting), the missing memoization that would have re-rendered the whole spine per render, and the translation marker doubling its gap. All fixed. It also killed a top-ranked risk of its own — cssnano mangling the `@property` output — by evidence: the production bundle keeps all 41 registrations and all 301 empty fallbacks.

## Open

- Whether the chat list shows a skeleton frame on **navbar-driven** place switches, where the swap does not hold. Low blast radius, unconfirmed either way; settled by logging `rs.count` and the swap-hold state on a new `FiniteList`'s first render.
- Not verified visually: messages ending in a code block or table with marks showing.
- `@property` on Firefox < 128 / Safari < 16.4 on the **web** app: the failure mode is inheritance leakage, not invalidation, since the fallbacks work unregistered.
- Nothing checked on Android or desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjXy21zX36zrKBd1KKvtBB
