### PR TITLE
fix(virtual-list): prevent stale jumps and recover stalled renders

### DIFF
--- a/docs/ui/virtual-list.md
+++ b/docs/ui/virtual-list.md
@@ -113,9 +113,10 @@ in a later section looks loaded — most of them are.*
   consecutive animation frames in which `scrollTop` has not changed, no finger is down and no excursion
   is open. Stricter than "no scroll events", which a fling passes while it is still moving. The one
   standing intent that changes the list's coordinates — a re-centre — waits for one.
-- **guard window** — *`lastProgrammaticScrollAt`, `ProgrammaticScrollGuardMs`; `suppressUntil` in the
-  controller.* The interval after a scroll the code wrote itself, during which the resulting scroll
-  event is ignored. The list's window and the controller's are separate and differently sized.
+- **guard window** — *`suppressUntil`, `lastWrittenTop`, `isScrollWriteEcho`, all in the controller.*
+  The 300ms after a scroll the controller wrote itself — a jump, a resize clamp — during which a
+  scroll event standing on the written value is that write's echo. The list has no window of its own:
+  it asks the controller, so a scroll that has moved on since the write is the user's even inside it.
 - **position guard** — *`checkPosition`, `PositionGuardIntervalMs`.* The one correction that does not
   run off an event: a 1s check that the view is inside the band and has content on it, for the state
   where a blank viewport leaves the user nothing to scroll with (§3.6). Nothing to do with a *guard
@@ -487,7 +488,7 @@ overscroll rows are the summary of §3.7.*
 | trigger | transition | what happens | term |
 |---|---|---|---|
 | any `scroll` event | Resting → Free-scrolling | hold the scroll for 200ms and arm the settle timer — this much happens for every scroll event except the list's own follow, which is recognised by where it landed and dropped whole | `scrollTop` |
-| the same event, trusted and outside the guard window | — | additionally: drop any interactive or screen anchor, re-derive the pinned edge, queue a data query | — |
+| the same event, trusted and not the echo of a controller write | — | additionally: drop any pending jump and any interactive or screen anchor, re-derive the pinned edge, queue a data query | — |
 | 200ms with no scroll event, or `scrollend` | Free-scrolling → Resting | release the scroll hold, re-derive the pin, report visibility, query, arm the stranded check | — |
 | a scroll event past a limit, finger down | in-band → following | latch the boundary; seed `over` at the true excursion and the transform at its resisted share; each frame after: `over += Δscroll`, nudge by the resisted share | `transform` |
 | a scroll event past a limit, no finger, ordinary path | in-band → engaged | the same seed, the carry seeded from the fling's speed, then the bounce and the floor per frame | `transform` |
@@ -506,7 +507,7 @@ overscroll rows are the summary of §3.7.*
 | the same, delta past `maxOverscroll` | Pinned → Placing | a re-placement: up to three `setScrollOffset` passes, re-measuring between them because near an edge `container.top` moves with the scroll | `scrollTop` |
 | `repinEdge` called during an excursion | Pinned → awaiting overscroll end | deferred; past a boundary the measured position is not the visible one and the write would snap the bounce | — |
 | `scrollToKey` that is not the newest item | any → Placing | suppress new height animations, wait out the ones in flight, then place the item at `center` or `end` | `container.top` then `scrollTop` |
-| `scrollToKey` that *is* the newest item, end loaded | any → Pinned End | pin and re-pin, which in reverse is a follow of a few pixels or nothing at all — so a message you just posted still animates in | `scrollTop` |
+| `scrollToKey` that *is* the newest item, end loaded | any → Pinned End | drop any jump still waiting, then pin and re-pin, which in reverse is a follow of a few pixels or nothing at all — so a message you just posted still animates in | `scrollTop` |
 | the user scrolls away from the edge | Pinned → Free | `updatePinnedEdge` finds neither edge within `EdgeEpsilon` (4px); on desktop the scroll a wheel away from the edge produced clears the pin outright, even inside the guard window — but only that scroll: a wheel that scrolls nothing (a chat that fits on screen, a scroller nested in a message) leaves the pin alone | — |
 | a `data-vl-hold` control is clicked or tapped | Pinned → Free, interactive anchor set | the clicked item is what the next render holds; `keep-edge` controls leave a pinned list alone; expires after 2s | — |
 | a `data-vl-hold` control marked `data-anchor="below"` | Pinned → Free, key-addressed screen anchor set | the first content item below the control keeps its rendered position; placed only by the render that inserts content directly above that item, however many unrelated renders land first | — |
@@ -525,7 +526,9 @@ for a quiet moment), and height (`ResizeObserver` → settle delay → transitio
 
 **Render.** `MutationObserver` → `onRenderBatch` → `applyRender`. The render index attribute and the
 render-state JSON are written in different Blazor batches, so a render only counts once the JSON's own
-index matches the attribute.
+index matches the attribute — and the JSON element is observed too (child list and character data),
+because it can land in a batch of its own with nothing else in the list changing; without that, a
+render rejected as incomplete waited for an unrelated mutation to be looked at again.
 
 1. snapshot the old keys, offsets, `chainStart` and heights;
 2. `rebuildItems` — observers attached and detached, height tracking updated, dropped keys purged; a
@@ -706,28 +709,41 @@ Two guards:
 
 #### The programmatic-scroll guard
 
-Every write the list makes stamps `lastProgrammaticScrollAt`. For `ProgrammaticScrollGuardMs`
-afterwards — **250ms on mobile, 100ms elsewhere** — `onScroll` ignores what it sees: the scroll a
-re-pin just wrote is not the user moving, and reading it as one would drop the very pin that produced
-it. Scroll events the page dispatched itself (`isTrusted === false`) are dropped outright.
+The scroll a re-pin, a jump or a resize clamp just wrote is not the user moving, and reading it as one
+would drop the very pin that produced it — and, since a user scroll also cancels a jump still waiting
+for animations, the navigation the user just asked for. The list has no timer of its own for this;
+it asks the controller, whose `isScrollWriteEcho` is the one rule for both: `scrollTo` and a viewport
+resize open `suppressUntil = now + 300ms` (`ProgrammaticScrollSuppressMs`), and inside that window a
+scroll event is the write's echo only while `scrollTop` still stands on `lastWrittenTop`, the value the
+synchronous write landed on. A smooth scroll lands over many frames and records no value, so its whole
+window counts. The controller itself uses the same predicate to ignore a boundary crossing of its own
+making; its speed estimate simply pauses for the window. Scroll events the page dispatched itself
+(`isTrusted === false`) are dropped outright.
 
-`ScrollController` keeps its own, separate window: `scrollTo` and a viewport resize set
-`suppressUntil = now + 300ms` (`ProgrammaticScrollSuppressMs`), during which the controller neither
-updates its speed estimate nor treats a boundary crossing as a gesture.
+The read-back is what a time-only guard could not do: the list used to keep a separate
+`lastProgrammaticScrollAt` window (250ms on mobile, 100ms elsewhere), which missed corrections that
+bypassed `setScrollOffset` — the controller's resize clamp erased a pending navigation — and swallowed
+a user scroll that began right after a jump, so the jump it should have cancelled ran anyway. A swipe
+that begins inside the window is recognised the moment it moves the position; it used to trap the
+view at the bottom during live transcription, when a write per settle kept a window open almost
+continuously.
 
-The guard also suppresses `updatePinnedEdge`, so a user swipe that begins inside a guard window does
-not clear the pin. That used to trap the view at the bottom during live transcription, because there
-was a scroll write per settle and therefore a guard window open almost continuously.
-
-The follow writes `scrollTop` again — and deliberately does **not** open that window, because it would
+The follow writes `scrollTop` again — and deliberately does **not** open the window, because it would
 never close. It is recognised the other way instead: `followBy` reports where the write landed, and
 the next scroll event standing on that exact value is dropped whole, while the first event anywhere
-else is the user's. So the guard proper is only open after a genuine jump — opening a chat, a
-`scrollToKey`, a re-centre — where suppressing the handler is what we want. A wheel away from the edge
-remains the escape hatch on desktop: `onWheel` only notes it, and the scroll it produces inside
-`WheelAwayWindowMs` (300ms) drops the pin whatever the guard says. Noting rather than dropping is what
+else is the user's. So the window proper is only open after a genuine jump — opening a chat, a
+`scrollToKey`, a re-centre — or a resize.
+
+A wheel is the user's whatever the read-back says: a precise wheel near a limit is driven by the
+controller through `followBy`, so its scroll lands exactly on `lastWrittenTop` and would read as an
+echo. `onWheel` only notes the wheel and its direction (`lastWheelAt`, `isLastWheelAway`), and the
+scroll it produces inside `WheelWindowMs` (300ms) is treated as the user's; when the wheel was away
+from the pinned edge it also drops the pin outright, since the position it lands on may still read as
+the edge. Any other wheel re-derives the pin as a scroll normally does, so wheeling to the end of an
+unpinned chat pins it on arrival, animations or not. Noting rather than acting in `onWheel` is what
 keeps a wheel that scrolls nothing — a chat that fits on screen, a scroller nested in a message — from
-leaving the list unpinned with nothing to put the pin back until the next render's clamp.
+leaving the list unpinned, or its navigation cancelled, with nothing to put either back until the next
+render's clamp.
 
 #### Stranded recovery
 
@@ -2075,7 +2091,7 @@ controller, no model beyond arithmetic, spacers that cover the unloaded ranges e
 scrollbar, and one `scrollTop` writer.*
 
 **What it shares**, all of it in `virtual-list.ts`: the Blazor round trip (a `MutationObserver` on the
-render index and the container, the render-state JSON parsed only when its index matches the attribute,
+render index, the container and the render-state JSON, the JSON parsed only when its index matches the attribute,
 `RequestData` out, `UpdateItemVisibility` back, the request guard with its 2.5s timeout and 1s retry),
 the DOM handles (wrapper, container, both spacers), and the initial reveal.
 

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualList.cs
@@ -209,6 +209,13 @@ public abstract class VirtualList<TItem> : ComputedStateComponent<UIHub, Virtual
             if (ComputedImpl.GetDependencies(computed).Any(d => d.IsInvalidated()))
                 return renderedData; // Already invalidated - a render of this data would be wasted
 
+            if (!data.IsNone && data.Count == 0 && !data.HasAllItems) {
+                // An unresolved empty window has no keys for the browser to request around.
+                // Keep the previous window and leave its query pending for a timed recompute.
+                computed.Invalidate(TimeSpan.FromSeconds(1));
+                return renderedData;
+            }
+
             isAnswered = true;
             return data;
         }

--- a/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListData.cs
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/VirtualListData.cs
@@ -54,7 +54,8 @@ public sealed class VirtualListData<TItem>
     public bool IsSimilarTo(VirtualListData<TItem> other)
         // A separator moving changes every position after it even when the loaded items are the same
         => ReferenceEquals(this, other) ||
-            (HasVeryFirstItem == other.HasVeryFirstItem
+            (!IsNone && !other.IsNone
+            && HasVeryFirstItem == other.HasVeryFirstItem
             && HasVeryLastItem == other.HasVeryLastItem
             && ScrollToKey == other.ScrollToKey
             && (ReferenceEquals(SeparatorIndexes, other.SeparatorIndexes)

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -29,7 +29,6 @@ const UpdateViewportIntervalMs = 64;
 const UpdateVisibilityIntervalMs = 250;
 const MaxRelayoutPasses = 4;
 const ScrollSettleMs = 200;
-const ProgrammaticScrollGuardMs = DeviceInfo.isMobile ? 250 : 100;
 // How long a wheel away from the pinned edge waits for the scroll it produces before it is forgotten.
 const WheelAwayWindowMs = 300;
 const SmoothScrollMs = 500;
@@ -215,7 +214,6 @@ export class InfiniteList extends VirtualList {
     private readonly isReverse: boolean;
     private pinnedEdge: VirtualListEdge | null = null;
     private endAnchorSize = 0;
-    private lastProgrammaticScrollAt = 0;
     private wheelAwayAt = 0;
     private isWatchingStillness = false;
     private isAwaitingOverscrollEnd = false;
@@ -599,7 +597,6 @@ export class InfiniteList extends VirtualList {
 
     // A jump to an absolute position, and the only thing that writes scrollTop outside a follow.
     private setScrollOffset(scrollOffset: number, isSmooth = false, mustClamp = true, isReanchor = false): void {
-        this.lastProgrammaticScrollAt = performance.now();
         if (isSmooth)
             this.stability.holdScroll(SmoothScrollMs);
         this.scrollController.scrollTo(this.toScrollTop(scrollOffset),
@@ -1009,6 +1006,7 @@ export class InfiniteList extends VirtualList {
         if (scrollToKey != null && this.indexByKey.has(scrollToKey)) {
             this.isInitiallyPlaced = true;
             if (scrollToKey === this.getLastContentKey() && rs.hasVeryLastItem) {
+                this.pendingJump = null;
                 this.handledScrollToKey = scrollToKey;
                 this.setPinnedEdge(VirtualListEdge.End);
                 this.repinEdge('scroll-to-last');
@@ -1783,14 +1781,16 @@ export class InfiniteList extends VirtualList {
         // it produced: a wheel that scrolls nothing - a chat that fits on screen, a scroller nested in a
         // message - has not left the edge, and a pin dropped there had nothing to put it back until the
         // next render's clamp.
-        const isWheelAway = performance.now() - this.wheelAwayAt < WheelAwayWindowMs;
-        // The scroll a re-pin or a re-centre just wrote isn't the user moving, and reading it as one
-        // would drop the very pin that produced it.
+        const isWheelAway = this.wheelAwayAt !== 0
+            && performance.now() - this.wheelAwayAt < WheelAwayWindowMs;
+        // Read back the controller's writes, including resize clamps. A time-only guard would
+        // also swallow user scrolling that immediately follows a correction.
         if (!isWheelAway && !this.scrollController.isTouchActive
-            && performance.now() - this.lastProgrammaticScrollAt < ProgrammaticScrollGuardMs)
+            && this.scrollController.isScrollWriteEcho)
             return;
 
         this.wheelAwayAt = 0;
+        this.pendingJump = null;
         this.interactiveAnchor = null;
         this.releaseScreenAnchor();
         if (isWheelAway)
@@ -1814,17 +1814,16 @@ export class InfiniteList extends VirtualList {
         this.updateVisibilityThrottled();
     };
 
-    // A wheel gesture away from the pinned edge says the user wants to leave it; onScroll acts on that
-    // when the scroll it produces arrives, whether or not that scroll lands inside the guard window.
+    // Includes unpinned navigation waits: controller-driven wheels can otherwise look like own writes.
+    // Act on the resulting scroll, so a wheel consumed by a nested scroller does not cancel navigation.
     private onWheel = (event: WheelEvent): void => {
         // Momentum scrolling on mobile also arrives as wheel events; there onScroll is enough. A
         // ctrl+wheel is a pinch-zoom, which doesn't scroll the list at all.
-        if (DeviceInfo.isMobile || event.ctrlKey || this.pinnedEdge == null)
+        if (DeviceInfo.isMobile || event.ctrlKey)
             return;
 
-        const isAwayFromEdge = this.pinnedEdge === VirtualListEdge.End
-            ? event.deltaY < 0
-            : event.deltaY > 0;
+        const isAwayFromEdge = this.pinnedEdge == null
+            || (this.pinnedEdge === VirtualListEdge.End ? event.deltaY < 0 : event.deltaY > 0);
         if (isAwayFromEdge)
             this.wheelAwayAt = performance.now();
     };

--- a/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/infinite-list.ts
@@ -29,8 +29,8 @@ const UpdateViewportIntervalMs = 64;
 const UpdateVisibilityIntervalMs = 250;
 const MaxRelayoutPasses = 4;
 const ScrollSettleMs = 200;
-// How long a wheel away from the pinned edge waits for the scroll it produces before it is forgotten.
-const WheelAwayWindowMs = 300;
+// How long a wheel waits for the scroll it produces before it is forgotten.
+const WheelWindowMs = 300;
 const SmoothScrollMs = 500;
 const EdgeEpsilon = 4;
 const VisibilityEpsilon = 4;
@@ -214,7 +214,8 @@ export class InfiniteList extends VirtualList {
     private readonly isReverse: boolean;
     private pinnedEdge: VirtualListEdge | null = null;
     private endAnchorSize = 0;
-    private wheelAwayAt = 0;
+    private lastWheelAt = 0;
+    private isLastWheelAway = false;
     private isWatchingStillness = false;
     private isAwaitingOverscrollEnd = false;
     private isNearSkeleton = false;
@@ -1775,21 +1776,20 @@ export class InfiniteList extends VirtualList {
         this.turnOffIsScrollingDebounced();
         if (!event.isTrusted)
             return;
-        // A wheel away from the pinned edge is the user's however its scroll lands - inside the guard
-        // window as often as not, while content is resizing and re-pinning - and it drops the pin
-        // outright, since the position it lands on may still read as the edge. But only on the scroll
-        // it produced: a wheel that scrolls nothing - a chat that fits on screen, a scroller nested in a
-        // message - has not left the edge, and a pin dropped there had nothing to put it back until the
-        // next render's clamp.
-        const isWheelAway = this.wheelAwayAt !== 0
-            && performance.now() - this.wheelAwayAt < WheelAwayWindowMs;
-        // Read back the controller's writes, including resize clamps. A time-only guard would
-        // also swallow user scrolling that immediately follows a correction.
-        if (!isWheelAway && !this.scrollController.isTouchActive
-            && this.scrollController.isScrollWriteEcho)
+        // A wheel is the user's however its scroll lands - on the controller's own write as often as
+        // not, while content is resizing and re-pinning, or when the controller drives the gesture - and
+        // one away from the pinned edge drops the pin outright, since the position it lands on may still
+        // read as the edge. But only on the scroll it produced: a wheel that scrolls nothing - a chat
+        // that fits on screen, a scroller nested in a message - has not left the edge, and a pin dropped
+        // there had nothing to put it back until the next render's clamp. Zero is "no wheel", not a time.
+        const isWheel = this.lastWheelAt !== 0 && performance.now() - this.lastWheelAt < WheelWindowMs;
+        const isWheelAway = isWheel && this.isLastWheelAway;
+        // Every other write of the controller's is read back, resize clamps included: a time-only guard
+        // also swallowed user scrolling that immediately followed a correction.
+        if (!isWheel && !this.scrollController.isTouchActive && this.scrollController.isScrollWriteEcho)
             return;
 
-        this.wheelAwayAt = 0;
+        this.lastWheelAt = 0;
         this.pendingJump = null;
         this.interactiveAnchor = null;
         this.releaseScreenAnchor();
@@ -1814,18 +1814,17 @@ export class InfiniteList extends VirtualList {
         this.updateVisibilityThrottled();
     };
 
-    // Includes unpinned navigation waits: controller-driven wheels can otherwise look like own writes.
-    // Act on the resulting scroll, so a wheel consumed by a nested scroller does not cancel navigation.
+    // Only noted here: onScroll acts on the scroll the wheel produces, if any - a wheel consumed by a
+    // nested scroller must neither drop the pin nor cancel a navigation still waiting to run.
     private onWheel = (event: WheelEvent): void => {
         // Momentum scrolling on mobile also arrives as wheel events; there onScroll is enough. A
         // ctrl+wheel is a pinch-zoom, which doesn't scroll the list at all.
         if (DeviceInfo.isMobile || event.ctrlKey)
             return;
 
-        const isAwayFromEdge = this.pinnedEdge == null
-            || (this.pinnedEdge === VirtualListEdge.End ? event.deltaY < 0 : event.deltaY > 0);
-        if (isAwayFromEdge)
-            this.wheelAwayAt = performance.now();
+        this.lastWheelAt = performance.now();
+        this.isLastWheelAway = this.pinnedEdge != null
+            && (this.pinnedEdge === VirtualListEdge.End ? event.deltaY < 0 : event.deltaY > 0);
     };
 
     private readonly turnOffIsScrollingDebounced = debounce(() => this.turnOffIsScrolling(), ScrollSettleMs);

--- a/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
+++ b/src/dotnet/UI.Blazor/Components/VirtualList/virtual-list.ts
@@ -86,12 +86,12 @@ export abstract class VirtualList implements VirtualListOverlayTarget {
         this.renderIndexRef = ref.querySelector(':scope > .data.render-index')!;
         this.rowGap = parseFloat(window.getComputedStyle(this.containerRef).rowGap) || 0;
 
-        // Both triggers, because Blazor applies a render in several batches and the render-state JSON
-        // is deliberately written in the last one (RenderAtDepth) - the items and the JSON can land in
-        // different batches, and only the JSON's own render index says the render is complete.
+        // Blazor can deliver the final JSON after the index and items. Its own mutation must wake
+        // a render previously rejected as incomplete; the matching indexes still gate completion.
         this.renderObserver = new MutationObserver(this.onRenderBatch);
         this.renderObserver.observe(this.renderIndexRef, { attributes: true });
         this.renderObserver.observe(this.containerRef, { childList: true, subtree: true });
+        this.renderObserver.observe(this.renderStateRef, { childList: true, characterData: true, subtree: true });
     }
 
     // Called by blazor

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -172,6 +172,12 @@ export class ScrollController {
         return this.isTouching;
     }
 
+    public get isScrollWriteEcho(): boolean {
+        return performance.now() < this.suppressUntil
+            && (this.lastWrittenTop == null
+                || Math.abs(this.element.scrollTop - this.lastWrittenTop) <= FixPrecisionPx);
+    }
+
     // The content is carrying a transform: redefining the coordinates now costs a step of up to the
     // whole displacement.
     public get isOverscrollActive(): boolean {
@@ -422,9 +428,7 @@ export class ScrollController {
         // load re-anchoring under that fling re-arms it - measured at 9712px past the limit in 290ms,
         // with getViolatedBoundary answering correctly on every one of the 18 events that were dropped
         // here. Only the echo of this controller's own write is still ignored.
-        const isOwnWrite = this.lastWrittenTop == null
-            || Math.abs(scrollTop - this.lastWrittenTop) <= FixPrecisionPx;
-        if (this.phase === 'engaged' || this.momentumPhase !== 'none' || (now < this.suppressUntil && isOwnWrite))
+        if (this.phase === 'engaged' || this.momentumPhase !== 'none' || this.isScrollWriteEcho)
             return;
 
         const boundary = this.getViolatedBoundary(scrollTop);

--- a/src/nodejs/src/scroll-controller.ts
+++ b/src/nodejs/src/scroll-controller.ts
@@ -172,6 +172,7 @@ export class ScrollController {
         return this.isTouching;
     }
 
+    /** Whether a scroll event now would be the echo of this controller's own last write. */
     public get isScrollWriteEcho(): boolean {
         return performance.now() < this.suppressUntil
             && (this.lastWrittenTop == null

--- a/tests/Chat.UI.Blazor.UnitTests/VirtualListRecoveryTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/VirtualListRecoveryTest.cs
@@ -1,0 +1,154 @@
+using Bunit;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class VirtualListRecoveryTest
+{
+    [Fact]
+    public async Task UnresolvedWindowShouldKeepRenderedItemsAndRetryTheQuery()
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        context.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var initial = new VirtualListData<TestItem>([new("10")]);
+        var recovered = new VirtualListData<TestItem>([new("11")]);
+        var source = new TestDataSource(initial, new([]), recovered);
+        var cut = context.Render<TestList>(p => p
+            .Add(x => x.DataSource, source)
+            .Add(x => x.SkipPreRenderGetDataCall, true));
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
+        var query = new VirtualListDataQuery(new("10", "10"), default, new(0, 20));
+
+        // act
+        await cut.InvokeAsync(() => cut.Instance.RequestAndWait(query));
+
+        // assert
+        cut.Instance.CurrentData.Should().BeSameAs(initial);
+        cut.WaitForAssertion(() => cut.Instance.CurrentData.Should().BeSameAs(recovered), TimeSpan.FromSeconds(3));
+        source.Queries.ToArray().Should().Equal(VirtualListDataQuery.None, query, query);
+        cut.Markup.Should().Be("11");
+    }
+
+    [Fact]
+    public void InitiallyUnresolvedWindowShouldRecoverWithoutBrowserRequests()
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        context.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var recovered = new VirtualListData<TestItem>([new("10")]);
+        var source = new TestDataSource(new([]), recovered);
+
+        // act
+        var cut = context.Render<TestList>(p => p
+            .Add(x => x.DataSource, source)
+            .Add(x => x.SkipPreRenderGetDataCall, true));
+
+        // assert
+        cut.WaitForAssertion(() => cut.Instance.CurrentData.Should().BeSameAs(recovered), TimeSpan.FromSeconds(3));
+        source.Queries.ToArray().Should().Equal(VirtualListDataQuery.None, VirtualListDataQuery.None);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DefinitivelyEmptyWindowShouldRenderWithoutRetrying(bool isNone)
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        context.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var initial = new VirtualListData<TestItem>([new("10")]);
+        var empty = isNone
+            ? VirtualListData<TestItem>.None
+            : new([]) { HasVeryFirstItem = true, HasVeryLastItem = true };
+        var source = new TestDataSource(initial, empty);
+        var cut = context.Render<TestList>(p => p
+            .Add(x => x.DataSource, source)
+            .Add(x => x.SkipPreRenderGetDataCall, true));
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
+
+        // act
+        await cut.InvokeAsync(() => cut.Instance.RequestAndWait(new(default, default, default)));
+
+        // assert
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("empty"));
+        await Task.Delay(TimeSpan.FromSeconds(1.3));
+        cut.Instance.CurrentData.Should().BeSameAs(empty);
+        source.Queries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task NewQueryShouldSupersedeAnUnresolvedQuery()
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        context.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var initial = new VirtualListData<TestItem>([new("10")]);
+        var recovered = new VirtualListData<TestItem>([new("30")]);
+        var source = new TestDataSource(initial, new([]), recovered);
+        var cut = context.Render<TestList>(p => p
+            .Add(x => x.DataSource, source)
+            .Add(x => x.SkipPreRenderGetDataCall, true));
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("10"));
+        var oldQuery = new VirtualListDataQuery(new("10", "10"), default, new(0, 20));
+        var newQuery = new VirtualListDataQuery(new("30", "30"), default, new(0, 20));
+        await cut.InvokeAsync(() => cut.Instance.RequestAndWait(oldQuery));
+
+        // act
+        await cut.InvokeAsync(() => cut.Instance.RequestAndWait(newQuery));
+
+        // assert
+        cut.WaitForAssertion(() => cut.Instance.CurrentData.Should().BeSameAs(recovered));
+        await Task.Delay(TimeSpan.FromSeconds(1.3));
+        source.Queries.ToArray().Should().Equal(VirtualListDataQuery.None, oldQuery, newQuery);
+    }
+
+    // Nested types
+
+    private sealed class TestItem(string key) : IVirtualListItem
+    {
+        public string Key { get; } = key;
+        public bool IsGroup => false;
+        public bool ShouldSkipKey => false;
+    }
+
+    private sealed class TestDataSource(params VirtualListData<TestItem>[] responses) : IVirtualListDataSource<TestItem>
+    {
+        private int _callCount;
+        public ConcurrentQueue<VirtualListDataQuery> Queries { get; } = new();
+
+        public Task<VirtualListData<TestItem>> GetData(
+            VirtualListDataQuery query,
+            VirtualListData<TestItem> renderedData,
+            CancellationToken cancellationToken)
+        {
+            Queries.Enqueue(query);
+            var index = Math.Min(Interlocked.Increment(ref _callCount) - 1, responses.Length - 1);
+            var response = responses[index];
+            return Task.FromResult(response.IsSimilarTo(renderedData) ? renderedData : response);
+        }
+    }
+
+    private sealed class TestList : VirtualList<TestItem>
+    {
+        public VirtualListData<TestItem> CurrentData => Data;
+
+        public async Task RequestAndWait(VirtualListDataQuery query)
+        {
+            var whenUpdated = State.Snapshot.WhenUpdated();
+            await RequestData(query);
+            await whenUpdated.WaitAsync(TimeSpan.FromSeconds(3));
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            RenderedData = Data;
+            RenderIndex++;
+            builder.AddContent(0, Data.FirstItem?.Key ?? "empty");
+        }
+
+        protected override Task OnAfterRenderAsync(bool firstRender) => Task.CompletedTask;
+        protected override bool ShouldRender() => true;
+        protected override ValueTask<IJSObjectReference> CreateJSRef() => throw new NotSupportedException();
+    }
+}

--- a/tests/UI.Blazor.UnitTests/VirtualListDataTest.cs
+++ b/tests/UI.Blazor.UnitTests/VirtualListDataTest.cs
@@ -5,6 +5,22 @@ namespace ActualChat.UI.Blazor.UnitTests;
 public class VirtualListDataTest(ITestOutputHelper @out) : TestBase(@out)
 {
     [Fact]
+    public void UnresolvedEmptyDataShouldNotBeSimilarToNone()
+    {
+        // arrange
+        var data = new VirtualListData<TestItem>([]);
+        var none = VirtualListData<TestItem>.None;
+
+        // act
+        var isSimilarToNone = data.IsSimilarTo(none);
+        var isSimilarToData = none.IsSimilarTo(data);
+
+        // assert
+        isSimilarToNone.Should().BeFalse();
+        isSimilarToData.Should().BeFalse();
+    }
+
+    [Fact]
     public void LastItemShouldResolveGroupLeafWhenGroupIsLast()
     {
         // arrange

--- a/tests/ts/e2e/virtual-list-fixture.ts
+++ b/tests/ts/e2e/virtual-list-fixture.ts
@@ -1,0 +1,70 @@
+import { InfiniteList } from '../../../src/dotnet/UI.Blazor/Components/VirtualList/infinite-list';
+import { VirtualListEdge } from '../../../src/dotnet/UI.Blazor/Components/VirtualList/ts/virtual-list-edge';
+import {
+    VirtualListRenderDirection,
+} from '../../../src/dotnet/UI.Blazor/Components/VirtualList/ts/virtual-list-render-direction';
+import type {
+    VirtualListRenderState,
+} from '../../../src/dotnet/UI.Blazor/Components/VirtualList/ts/virtual-list-render-state';
+import type { DotNet } from '@microsoft/dotnet-js-interop';
+import { Range } from '../../../src/dotnet/UI.Blazor/Components/VirtualList/ts/range';
+
+export function createList() {
+    const root = document.createElement('div');
+    root.className = 'virtual-list infinite-list';
+    root.style.cssText = 'display:flex;height:600px;overflow-y:scroll;overflow-anchor:none;contain:strict;';
+    root.innerHTML = '<div class="data render-index" data-render-index="0" style="display:none"></div>'
+        + '<div class="data render-state" style="display:none"></div>'
+        + '<div class="c-wrapper" style="position:relative;flex:none;width:100%;min-height:100%">'
+        + '<ul class="c-virtual-container" style="position:absolute;display:flex;flex-direction:column;'
+        + 'width:100%;margin:0;padding:0;list-style:none;overflow-anchor:none">'
+        + '<li class="c-spacer-start" style="flex:none"></li>'
+        + '<li class="c-end-anchor" style="height:48px;flex:none"></li>'
+        + '<li class="c-spacer-end" style="flex:none"></li></ul></div>';
+    const container = root.querySelector('.c-virtual-container')!;
+    const end = root.querySelector('.c-end-anchor')!;
+    for (let key = 1; key <= 30; key++) {
+        const item = document.createElement('li');
+        item.className = 'item';
+        item.dataset.key = String(key);
+        item.style.cssText = 'height:120px;flex:none;';
+        item.textContent = String(key);
+        container.insertBefore(item, end);
+    }
+    const initial: VirtualListRenderState = {
+        renderIndex: 0,
+        keyRange: new Range('1', '30'),
+        count: 30,
+        beforeCount: 0,
+        afterCount: 0,
+        estimatedCount: 30,
+        hasVeryFirstItem: true,
+        hasVeryLastItem: true,
+        scrollToKey: '30',
+    };
+    root.querySelector('.render-state')!.textContent = JSON.stringify(initial);
+    document.body.append(root);
+    const calls: { method: string; args: unknown[] }[] = [];
+    const backend = {
+        invokeMethodAsync: (method: string, ...args: unknown[]) => {
+            calls.push({ method, args });
+            return Promise.resolve();
+        },
+    } as unknown as DotNet.DotNetObject;
+    const list = InfiniteList.create(
+        root, backend, 'regression', VirtualListEdge.End, VirtualListRenderDirection.Reverse, false,
+        1500, 2, 5);
+    return {
+        list, root, initial, calls,
+        navigate(key: string) {
+            list['applyRenderIntent']({ ...initial, scrollToKey: key, scrollToKeyInTheMiddle: true });
+        },
+        position(key: string) {
+            return root.querySelector(`[data-key="${key}"]`)!.getBoundingClientRect().top;
+        },
+    };
+}
+
+export async function nextFrame(): Promise<void> {
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}

--- a/tests/ts/e2e/virtual-list.test.ts
+++ b/tests/ts/e2e/virtual-list.test.ts
@@ -5,7 +5,7 @@ import { connectBrowser, type BrowserConnection } from './helpers';
 
 declare const ListTest: typeof import('./virtual-list-fixture');
 
-describe('InfiniteList navigation', () => {
+describe('VirtualList', () => {
     let connection: BrowserConnection;
     let page: Page;
     let bundle: string;
@@ -166,5 +166,40 @@ describe('InfiniteList navigation', () => {
         // assert
         expect(result).toBeGreaterThan(0);
         expect(result).toBeLessThan(600);
+    });
+
+    it.each(['replace', 'text'])('should apply delayed render metadata after a %s update', async update => {
+        // arrange
+        const result = await page.evaluate(async update => {
+            const fixture = ListTest.createList();
+            await ListTest.nextFrame();
+            const indexRef = fixture.root.querySelector<HTMLElement>('.render-index')!;
+            const stateRef = fixture.root.querySelector('.render-state')!;
+            indexRef.dataset.renderIndex = '1';
+            await ListTest.nextFrame();
+            const incompleteIndex = fixture.list['renderState'].renderIndex;
+
+            // act
+            const json = JSON.stringify({ ...fixture.initial, renderIndex: 1, scrollToKey: '4' });
+            if (update === 'replace')
+                stateRef.textContent = json;
+            else
+                stateRef.firstChild!.nodeValue = json;
+            await ListTest.nextFrame();
+            await ListTest.nextFrame();
+            const result = {
+                incompleteIndex,
+                appliedIndex: fixture.list['renderState'].renderIndex,
+                targetTop: fixture.position('4') - fixture.root.getBoundingClientRect().top,
+            };
+            fixture.list.dispose();
+            return result;
+        }, update);
+
+        // assert
+        expect(result.incompleteIndex).toBe(0);
+        expect(result.appliedIndex).toBe(1);
+        expect(result.targetTop).toBeGreaterThanOrEqual(0);
+        expect(result.targetTop).toBeLessThan(600);
     });
 });

--- a/tests/ts/e2e/virtual-list.test.ts
+++ b/tests/ts/e2e/virtual-list.test.ts
@@ -104,6 +104,36 @@ describe('VirtualList', () => {
         expect(Math.abs(after - before)).toBeLessThanOrEqual(1);
     });
 
+    it.each([false, true])('should pin to the end reached by a trackpad while unpinned (%s)', async isAnimating => {
+        // arrange
+        const result = await page.evaluate(async isAnimating => {
+            const fixture = ListTest.createList();
+            fixture.navigate('15');
+            fixture.list['reveal']();
+            await new Promise(resolve => setTimeout(resolve, 500));
+            if (isAnimating)
+                fixture.list['stability'].holdAnimation('delayed-height', 3000);
+            const root = fixture.root;
+            const max = fixture.list['scrollController'].getEffectiveScrollLimits().max;
+
+            // act: a precise wheel step is one wheel event followed by one scroll event
+            while (root.scrollTop < max) {
+                root.dispatchEvent(new WheelEvent('wheel', { deltaY: 60, deltaMode: 0, bubbles: true }));
+                root.scrollTop = Math.min(root.scrollTop + 60, max);
+                await ListTest.nextFrame();
+            }
+            await ListTest.nextFrame();
+            const pinnedOnArrival = fixture.list['pinnedEdge'];
+            await new Promise(resolve => setTimeout(resolve, 500));
+            const pinnedAtSettle = fixture.list['pinnedEdge'];
+            fixture.list.dispose();
+            return { pinnedOnArrival, pinnedAtSettle };
+        }, isAnimating);
+
+        // assert
+        expect(result).toEqual({ pinnedOnArrival: 1, pinnedAtSettle: 1 });
+    });
+
     it('should retain pending navigation across a programmatic scroll correction', async () => {
         // arrange
         const target = await page.evaluate(async () => {

--- a/tests/ts/e2e/virtual-list.test.ts
+++ b/tests/ts/e2e/virtual-list.test.ts
@@ -1,0 +1,170 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { build } from 'esbuild';
+import type { Page } from 'playwright';
+import { connectBrowser, type BrowserConnection } from './helpers';
+
+declare const ListTest: typeof import('./virtual-list-fixture');
+
+describe('InfiniteList navigation', () => {
+    let connection: BrowserConnection;
+    let page: Page;
+    let bundle: string;
+
+    beforeAll(async () => {
+        const result = await build({
+            entryPoints: ['tests/ts/e2e/virtual-list-fixture.ts'],
+            bundle: true,
+            write: false,
+            format: 'iife',
+            globalName: 'ListTest',
+            plugins: [{
+                name: 'test-host',
+                setup(builder) {
+                    builder.onResolve({ filter: /\/browser-info$/ }, () => ({
+                        path: 'browser-info', namespace: 'test-host',
+                    }));
+                    builder.onLoad({ filter: /.*/, namespace: 'test-host' }, () => ({
+                        contents: "export const BrowserInfo = { hostKind: 'Server' };",
+                    }));
+                },
+            }],
+        });
+        bundle = result.outputFiles[0].text;
+        connection = await connectBrowser();
+        page = await connection.context.newPage();
+        page.on('pageerror', error => console.error(error.message));
+        await page.route('http://virtual-list.test/', route => route.fulfill({
+            contentType: 'text/html', body: '<!doctype html><html><body></body></html>',
+        }));
+        return async () => {
+            await page.close();
+            if (connection.ownsBrowser)
+                await connection.browser.close();
+        };
+    }, 30_000);
+
+    beforeEach(async () => {
+        await page.goto('http://virtual-list.test/');
+        await page.addScriptTag({ content: bundle });
+    });
+
+    it('should keep the latest item in place after an older pending navigation settles', async () => {
+        // arrange
+        const result = await page.evaluate(async () => {
+            const fixture = ListTest.createList();
+            await ListTest.nextFrame();
+            const targets: string[] = [];
+            const scrollToItem = fixture.list['scrollToItem'].bind(fixture.list) as
+                (item: HTMLElement, position: ScrollLogicalPosition, isSmooth: boolean) => void;
+            fixture.list['scrollToItem'] = (item, position, isSmooth) => {
+                targets.push(item.dataset.key!);
+                scrollToItem(item, position, isSmooth);
+            };
+            fixture.list['stability'].holdAnimation('delayed-height', 300);
+            fixture.navigate('4');
+            fixture.navigate('30');
+            const positions: number[] = [];
+
+            // act
+            const until = performance.now() + 600;
+            while (performance.now() < until) {
+                await ListTest.nextFrame();
+                positions.push(fixture.position('30'));
+            }
+            fixture.list.dispose();
+            return { positions, targets };
+        });
+
+        // assert
+        expect(result.targets).toEqual([]);
+        expect(result.positions.length).toBeGreaterThan(3);
+        expect(Math.max(...result.positions) - Math.min(...result.positions)).toBeLessThanOrEqual(1);
+    });
+
+    it.each([0, 150])('should cancel pending navigation on user scroll after %d ms', async delayMs => {
+        // arrange
+        await page.mouse.move(200, 300);
+        await page.evaluate(async delayMs => {
+            const fixture = ListTest.createList();
+            fixture.navigate('15');
+            if (delayMs > 0)
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            fixture.list['stability'].holdAnimation('delayed-height', 1000);
+            fixture.navigate('4');
+        }, delayMs);
+
+        // act
+        await page.mouse.wheel(0, 400);
+        await page.waitForTimeout(150);
+        const before = await page.locator('[data-key="15"]').evaluate(e => e.getBoundingClientRect().top);
+        await page.waitForTimeout(1100);
+        const after = await page.locator('[data-key="15"]').evaluate(e => e.getBoundingClientRect().top);
+
+        // assert
+        expect(Math.abs(after - before)).toBeLessThanOrEqual(1);
+    });
+
+    it('should retain pending navigation across a programmatic scroll correction', async () => {
+        // arrange
+        const target = await page.evaluate(async () => {
+            const fixture = ListTest.createList();
+            fixture.navigate('15');
+            await ListTest.nextFrame();
+            fixture.list['stability'].holdAnimation('delayed-height', 300);
+            fixture.navigate('4');
+
+            // act
+            fixture.list['setScrollOffset'](fixture.list['scrollOffset'] + 100);
+            await ListTest.nextFrame();
+            const pending = fixture.list['pendingJump'];
+            fixture.list.dispose();
+            return pending?.target;
+        });
+
+        // assert
+        expect(target).toMatchObject({ kind: 'key', key: '4' });
+    });
+
+    it('should retain pending navigation across a resize clamp', async () => {
+        // arrange
+        const result = await page.evaluate(async () => {
+            const fixture = ListTest.createList();
+            fixture.navigate('1');
+            await new Promise(resolve => setTimeout(resolve, 150));
+            fixture.list['stability'].holdAnimation('delayed-height', 700);
+            fixture.navigate('4');
+            const before = fixture.root.scrollTop;
+
+            // act
+            fixture.root.style.height = '700px';
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const result = { delta: fixture.root.scrollTop - before, target: fixture.list['pendingJump']?.target };
+            fixture.list.dispose();
+            return result;
+        });
+
+        // assert
+        expect(result.delta).toBeGreaterThan(90);
+        expect(result.target).toMatchObject({ kind: 'key', key: '4' });
+    });
+
+    it('should execute a newer navigation that replaces a waiting one', async () => {
+        // arrange
+        const result = await page.evaluate(async () => {
+            const fixture = ListTest.createList();
+            fixture.list['stability'].holdAnimation('delayed-height', 300);
+            fixture.navigate('4');
+
+            // act
+            fixture.navigate('15');
+            await new Promise(resolve => setTimeout(resolve, 450));
+            const top = fixture.position('15') - fixture.root.getBoundingClientRect().top;
+            fixture.list.dispose();
+            return top;
+        });
+
+        // assert
+        expect(result).toBeGreaterThan(0);
+        expect(result).toBeLessThan(600);
+    });
+});


### PR DESCRIPTION
## Summary

Delayed virtual-list navigation can jump back to an obsolete destination after the user moves on. A render whose JSON metadata arrives after its DOM changes can remain unprocessed, and a temporarily empty chat window has no content keys from which the browser can request recovery.

## Fix

The change addresses three defects:

- Supersede pending jumps when a newer end-navigation or user scroll takes over. Reuse ScrollController's own-write tracking so resize corrections preserve navigation and immediate wheel input still cancels it. Distinguish any wheel from a wheel away from a pinned edge, so an unpinned chat pins immediately when trackpad scrolling reaches the end, including during height animation.
- Observe render-state JSON mutations as well as item/index changes. Continue requiring matching render indexes before applying the batch.
- Keep the rendered window while replacement data is unresolved, retry after one second, and preserve the pending query unless a newer request supersedes it. Distinguish unresolved empty data from the `None` sentinel during result reuse; definitive empty results do not retry.

## Testing

- Ten browser regression tests pass in Chrome1, including immediate wheel input, resize clamping, both metadata mutation forms, and trackpad arrival with and without height animation. The failure cases were reproduced before their fixes.
- Five bUnit recovery tests, six VirtualListData tests, and 26 pull-animation tests pass. The initial-load regression also covers the data-reuse optimization used by ChatView.
- `/server-loop` TypeScript and .NET rebuilds pass; targeted ESLint and `git diff --check` pass.
- Before the trackpad follow-up, real Mac Mini Safari passed five targeted checks in both server and WASM modes; that device pass has not been repeated for the follow-up. Newer end-navigation and native-wheel cancellation show zero obsolete displacement; delayed metadata and resize preservation pass.

The two-user live checks used Chrome1 and Chrome2 streaming into the same chat. They sampled no blank frames but did not complete the original unread-then-latest sequence; the WASM run did not deliver navigation intents and reported main-thread stalls. Full live-sequence verification remains open.

The upstream empty ChatView result remains an injected condition. These changes address confirmed failure paths; they do not establish that every blank frame in the original recordings has the same cause.

Remaining review notes: controller-write echoes delayed beyond 300 ms can still cancel a queued jump. Persistent unresolved results can repeatedly warn, and the existing JS render-skipped retry can interleave with C# invalidation (roughly two attempts per second). These are not changed by the trackpad correction. The virtual-list specification now describes the shared guard and metadata observation.

Closes #4432