### PR TITLE
fix(chat): fold the expanded live block, make collapse the card alone

### DIFF
--- a/docs/plans/chat-view-list-issues.md
+++ b/docs/plans/chat-view-list-issues.md
@@ -452,7 +452,14 @@ lastContentKey` in every sample.
 ### F — expansion follows the block, not the viewer's call state
 
 `hiddenLiveTailRange` and the card's tail preview both follow the block's rendered
-expansion now, so collapsing works for a viewer in the call. `IsExpandedByDefault`
+expansion now, so collapsing works for a viewer in the call: a collapsed block is the
+card alone — title, description, the preview of the latest spoken rows — exactly what a
+viewer who never joined sees, with nothing to reveal. The expanded block is the
+auto-swallow mode: the governed fold (rows that scrolled above the viewport) applies
+there, behind the card's "show more". The first cut had the fold and "show more" on the
+*collapsed* block and none of it on the expanded one, so a participant saw the whole
+session unfolded and their collapse offered a "show more" that had nothing to show
+(2026-09-09, #4424). `IsExpandedByDefault`
 is latched write-once (`_knownConversationDefaultExpanded.TryAdd`), so a summary
 landing can no longer invert anyone's effective state. And the join is watched where
 the data is built: on the transition into the call the current block is expanded if
@@ -475,8 +482,9 @@ the toggle, so only a stable id can hold it.
 ### H — a collapsed live block ends where it starts
 
 `GroupExpandedConversations` takes entries into the live block only while it is
-expanded. Collapsed, the block is the header, the card and its footer, and nothing
-else; everything below is placed by the ordinary rules, with transcribed entries
-filtered and typed ones rendered as usual. The card's tail preview is restricted to
-what is actually hidden — spoken entries — so a typed message is never previewed in
-the card *and* rendered below it.
+expanded, and even then the governed fold keeps the rows above the viewport behind the
+card. Collapsed, the block is the header, the card and its footer, and nothing else;
+everything below is placed by the ordinary rules, with transcribed entries filtered and
+typed ones rendered as usual. The card's tail preview is restricted to what is
+actually hidden — spoken entries — so a typed message is never previewed in the card
+*and* rendered below it.

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -13,7 +13,6 @@ public sealed record ConversationLiveState(
     bool IsVoiceOnly,
     string ParticipantsText = "",
     bool HasFoldedEntries = false,
-    bool IsExpanded = false,
     IReadOnlyList<PreviewEntry>? TailPreview = null,
     bool HasSummary = false,
     int SwallowedCount = 0,

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessage.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessage.cs
@@ -15,6 +15,9 @@ public sealed class ConversationMessage : ChatMessage
     // Set when this card is the live block's card: the block appends its own trailing ConversationFooter,
     // so the card must not render its own - otherwise a materialized block shows the footer twice.
     public bool HasSplitFooter { get; init; }
+    // Decided by the tile builder - the same build that places (or folds) the conversation's rows - so
+    // the card's collapsed/expanded form can never disagree with what renders around it.
+    public bool IsExpanded { get; init; }
 
     public override bool Equals(ChatMessage? other)
     {
@@ -32,7 +35,8 @@ public sealed class ConversationMessage : ChatMessage
             && Date == other.Date
             && Flags == other.Flags
             && HasSplitHeader == otherConversationMessage.HasSplitHeader
-            && HasSplitFooter == otherConversationMessage.HasSplitFooter;
+            && HasSplitFooter == otherConversationMessage.HasSplitFooter
+            && IsExpanded == otherConversationMessage.IsExpanded;
     }
 
     public override int GetHashCode()
@@ -41,5 +45,6 @@ public sealed class ConversationMessage : ChatMessage
             Date,
             Flags,
             HasSplitHeader,
-            HasSplitFooter);
+            HasSplitFooter,
+            IsExpanded);
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -205,12 +205,12 @@
         var conversation = Message.Conversation!;
         var chatEntryId = ChatEntryId.New(conversation.Id.ChatId, conversation.Id.StartEntryLid);
         _fakeEntry = new TextEntry(chatEntryId);
-        // The preview and the swallowed count follow the model's expansion, which arrives as a parameter,
-        // not through a dependency the state could observe.
-        var mustRecompute = _lastMessage != null && _lastMessage.IsExpanded != Message.IsExpanded;
+        // Invalidated synchronously, so the render this parameter set triggers cannot pair the new flag
+        // with the old preview and swallowed count; the base recomputes on the parameter change.
+        var hasExpansionFlipped = _lastMessage != null && _lastMessage.IsExpanded != Message.IsExpanded;
         _lastMessage = Message;
-        if (mustRecompute)
-            _ = State.Recompute();
+        if (hasExpansionFlipped)
+            State.Invalidate(immediately: true);
     }
 
     protected override async Task<ConversationLiveState> ComputeState(CancellationToken cancellationToken) {
@@ -261,7 +261,7 @@
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new ConversationLiveState(
             translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries,
-            isExpanded, tailPreview, hasSummary, swallowedCount, revealBatch, isAnyoneTalking,
+            tailPreview, hasSummary, swallowedCount, revealBatch, isAnyoneTalking,
             blockState.Overlay != null);
     }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -22,9 +22,9 @@
     // The split-out header carries the title; when expanded the description + meta-row drop out, so an
     // otherwise-empty card would render as a 1rem-padded gap between the header and the first message.
     var showLiveCard = (!Message.HasSplitHeader && hasLiveTitle)
-        || (hasDescription && !state.IsExpanded)
-        || (state.HasSummary && !state.IsExpanded)
-        || (state.IsExpanded && state.SwallowedCount > 0)
+        || (hasDescription && !Message.IsExpanded)
+        || (state.HasSummary && !Message.IsExpanded)
+        || (Message.IsExpanded && state.SwallowedCount > 0)
         || state.TailPreview is { Count: > 0 };
     // The wrapper below carries the block's tint, border and context menu, so emitting it around an
     // omitted card leaves an empty tinted bar in the chat. A live block with nothing to show renders an
@@ -52,15 +52,15 @@
                     <HeaderButton
                         Class="c-lc-expand"
                         data-vl-hold="always"
-                        data-collapse-arm="@(state.IsExpanded ? conversation.Id.Value : null)"
+                        data-collapse-arm="@(Message.IsExpanded ? conversation.Id.Value : null)"
                         Click="@ToggleShowMessage">
-                        <i class="@(state.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
+                        <i class="@(Message.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
                     </HeaderButton>
                 </div>
             }
             @* Gated on the text, not hasSummary: a fold can outlive an empty description. Also collapsed-only:
                expanded reads as a plain conversation, so the description box drops out once expanded. *@
-            @if (hasDescription && !state.IsExpanded) {
+            @if (hasDescription && !Message.IsExpanded) {
                 <div class="c-lc-summary-box">
                     <div class="c-lc-summary">
                         <CascadingValue Value="@_fakeEntry" IsFixed="true">
@@ -69,7 +69,7 @@
                     </div>
                 </div>
             }
-            @if (state.HasSummary && !state.IsExpanded) {
+            @if (state.HasSummary && !Message.IsExpanded) {
                 <div class="c-lc-meta-row">
                     <AuthorCircleGroup
                         Class="c-lc-authors"
@@ -91,7 +91,7 @@
                 <Divider/>
                 <LastEntriesPreview Entries="@tailPreview" Faded="true" MustSuppressMenu="true"/>
             }
-            @if (state.IsExpanded && state.SwallowedCount > 0) {
+            @if (Message.IsExpanded && state.SwallowedCount > 0) {
                 <button
                     type="button"
                     class="c-lc-showmore"
@@ -205,7 +205,12 @@
         var conversation = Message.Conversation!;
         var chatEntryId = ChatEntryId.New(conversation.Id.ChatId, conversation.Id.StartEntryLid);
         _fakeEntry = new TextEntry(chatEntryId);
+        // The preview and the swallowed count follow the model's expansion, which arrives as a parameter,
+        // not through a dependency the state could observe.
+        var mustRecompute = _lastMessage != null && _lastMessage.IsExpanded != Message.IsExpanded;
         _lastMessage = Message;
+        if (mustRecompute)
+            _ = State.Recompute();
     }
 
     protected override async Task<ConversationLiveState> ComputeState(CancellationToken cancellationToken) {
@@ -236,12 +241,7 @@
         var hasFoldedEntries = isLive && !isVoiceOnly
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
-        // Awaited for the dependency; the values themselves are read through IsConversationExpanded below.
-        await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
-        await ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
-        // Via ChatUI so this reads the same latched default the data layer does - the record's own
-        // flag flips when a summary lands, and the two would then disagree for the session.
-        var isExpanded = ChatUI.IsConversationExpanded(conversation);
+        var isExpanded = Message.IsExpanded;
         var tailPreview = isLive && !isVoiceOnly && !isExpanded
             ? await GetTailPreview(chatId, rawLive?.EffectiveVisibleStartLid ?? 0, cancellationToken)
                 .ConfigureAwait(false)

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -252,7 +252,7 @@
         // spoken rows (exactly what a viewer who never joined sees), with nothing to reveal.
         var swallowedCount = 0;
         var revealBatch = 0;
-        if (isExpanded) {
+        if (isLive && !isVoiceOnly && isExpanded) {
             swallowedCount = await LiveBlockUI.GetSwallowedCount(chatId, cancellationToken).ConfigureAwait(false);
             if (swallowedCount > 0)
                 revealBatch = Math.Min(LiveFoldMath.RevealBatchSize, swallowedCount);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -24,7 +24,7 @@
     var showLiveCard = (!Message.HasSplitHeader && hasLiveTitle)
         || (hasDescription && !state.IsExpanded)
         || (state.HasSummary && !state.IsExpanded)
-        || (!state.IsExpanded && state.SwallowedCount > 0)
+        || (state.IsExpanded && state.SwallowedCount > 0)
         || state.TailPreview is { Count: > 0 };
     // The wrapper below carries the block's tint, border and context menu, so emitting it around an
     // omitted card leaves an empty tinted bar in the chat. A live block with nothing to show renders an
@@ -91,7 +91,7 @@
                 <Divider/>
                 <LastEntriesPreview Entries="@tailPreview" Faded="true" MustSuppressMenu="true"/>
             }
-            @if (!state.IsExpanded && state.SwallowedCount > 0) {
+            @if (state.IsExpanded && state.SwallowedCount > 0) {
                 <button
                     type="button"
                     class="c-lc-showmore"
@@ -247,9 +247,12 @@
                 .ConfigureAwait(false)
             : null;
         var hasSummary = !translated.Title.Text.IsNullOrEmpty();
+        // Expanded is the auto-swallow mode - rows that scrolled above the viewport fold behind the card,
+        // and "show more" is the way back to them. Collapsed is the card alone, previewing the latest
+        // spoken rows (exactly what a viewer who never joined sees), with nothing to reveal.
         var swallowedCount = 0;
         var revealBatch = 0;
-        if (isJoined && !isExpanded) {
+        if (isExpanded) {
             swallowedCount = await LiveBlockUI.GetSwallowedCount(chatId, cancellationToken).ConfigureAwait(false);
             if (swallowedCount > 0)
                 revealBatch = Math.Min(LiveFoldMath.RevealBatchSize, swallowedCount);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeader.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeader.cs
@@ -8,12 +8,17 @@ public sealed class LiveConversationHeader : ChatMessage
         ShouldSkipKey = true;
     }
 
+    // Decided by the tile builder - the same build that places (or folds) the block's rows - so the
+    // header can never show one state while the rows show another.
+    public bool IsExpanded { get; init; }
+
     public override bool Equals(ChatMessage? other)
         => ReferenceEquals(this, other)
             || (other is LiveConversationHeader o
                 && Conversation!.VersionEquals(o.Conversation)
-                && Kind == o.Kind && Date == o.Date && Flags == o.Flags);
+                && Kind == o.Kind && Date == o.Date && Flags == o.Flags
+                && IsExpanded == o.IsExpanded);
 
     public override int GetHashCode()
-        => HashCode.Combine(Conversation, Kind, Date, Flags);
+        => HashCode.Combine(Conversation, Kind, Date, Flags, IsExpanded);
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
@@ -4,7 +4,6 @@ public sealed record LiveConversationHeaderState(
     string Title,
     string ParticipantsText,
     bool HasFoldedEntries,
-    bool IsExpanded,
     bool IsJoined = false,
     bool HasOverlay = false,
     bool IsDissolving = false,

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -25,9 +25,9 @@
         <HeaderButton
             Class="c-lc-expand"
             data-vl-hold="always"
-            data-collapse-arm="@(s.IsExpanded ? Header.Conversation!.Id.Value : null)"
+            data-collapse-arm="@(Header.IsExpanded ? Header.Conversation!.Id.Value : null)"
             Click="@Toggle">
-            <i class="@(s.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
+            <i class="@(Header.IsExpanded ? "icon-collapse" : "icon-expand")"></i>
         </HeaderButton>
     }
 </div>
@@ -83,12 +83,7 @@
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
         var canExpand = isLive && !isVoiceOnly && rawLive is { SessionStartedAt: not null };
-        // Awaited for the dependency; the values themselves are read through IsConversationExpanded below.
-        await ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
-        await ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
-        // Via ChatUI so this reads the same latched default the data layer does - the record's own
-        // flag flips when a summary lands, and the two would then disagree for the session.
-        var isExpanded = ChatUI.IsConversationExpanded(conversation);
+        var isExpanded = Header.IsExpanded;
         var isAnyoneTalking = isLive
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new LiveConversationHeaderState(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -49,7 +49,7 @@
             t => new ComputedState<LiveConversationHeaderState>.Options() {
                 // IsJoined defaults true in the placeholder so the clickable Join button doesn't flash
                 // before the first ComputeState resolves the real join state.
-                InitialValue = new LiveConversationHeaderState(conversation.Title, "", false, false, true),
+                InitialValue = new LiveConversationHeaderState(conversation.Title, "", false, true),
                 Category = GetStateCategory(t),
             });
     }
@@ -83,11 +83,10 @@
             && rawLive is { SessionStartedAt: not null }
             && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
         var canExpand = isLive && !isVoiceOnly && rawLive is { SessionStartedAt: not null };
-        var isExpanded = Header.IsExpanded;
         var isAnyoneTalking = isLive
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new LiveConversationHeaderState(
-            translated.Title.Text, participantsText, hasFoldedEntries, isExpanded, isJoined,
+            translated.Title.Text, participantsText, hasFoldedEntries, isJoined,
             blockState.Overlay != null, blockState.Overlay?.IsDissolving ?? false, canExpand,
             isAnyoneTalking);
     }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -1444,11 +1444,13 @@ public partial class ChatUI
             // closes (materializedBlockId set), the block stays frozen but renders as a completed
             // conversation: the card falls back to its own regular header instead.
             var hasSplitHeader = conversation.Id == liveBlockId && materializedBlockId == null;
+            var isExpanded = expandedConversations.Contains(conversation.Id);
             if (hasSplitHeader) {
                 var header = new LiveConversationHeader(conversation) {
                     Kind = ChatMessageKind.LiveConversationHeader,
                     Date = date,
                     PreviousMessage = prevMessage,
+                    IsExpanded = isExpanded,
                 };
                 if (prevMessage != null)
                     prevMessage.NextMessage = header;
@@ -1461,6 +1463,7 @@ public partial class ChatUI
                 PreviousMessage = prevMessage,
                 HasSplitHeader = hasSplitHeader,
                 HasSplitFooter = conversation.Id == liveBlockId,
+                IsExpanded = isExpanded,
             };
             // Can't skip adding a conversation message even if it's the same as previous message
             // Note: the same conversation can be returned by different id tiles as it spans across multiple tiles

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -969,18 +969,20 @@ public partial class ChatUI
                 .EnsureMonotonic();
 
             // A collapsed conversation excludes its whole range (a single id-tile then renders its card).
-            // The live block is the exception: its governed fold range can be narrower than its raw
-            // range (lag/viewport hold entries back), so only the governed range is excluded here too -
-            // otherwise the id tiles past the fold would never load, and the still-visible tail would
-            // have nothing to render. Once closed, the persisted conversation's range starts at
+            // The live block is the exception: it excludes its governed fold range, expanded or not -
+            // that range can be narrower than its raw range (lag/viewport hold entries back), and
+            // excluding more would leave the id tiles past the fold unloaded, so the still-visible tail
+            // would have nothing to render. Once closed, the persisted conversation's range starts at
             // ContextStartLid (its materialized id), not V (the live-era render id) - both identities
             // must resolve to the same governed range, or a session with pre-latch context would lose
             // its frozen tail's id-tiles after close.
             var excludedRanges = conversationIdRanges
-                .Where(r => !expandedConversations.Contains(ConversationId.New(chatId, r.Start)))
                 .Select(r => {
                     var rangeId = ConversationId.New(chatId, r.Start);
-                    return rangeId == liveBlockId || rangeId == materializedBlockId ? liveBlockFoldRange : r;
+                    if (rangeId == liveBlockId || rangeId == materializedBlockId)
+                        return liveBlockFoldRange;
+
+                    return expandedConversations.Contains(rangeId) ? default : r;
                 })
                 .Where(r => !r.IsEmpty)
                 .ToList();
@@ -1168,10 +1170,12 @@ public partial class ChatUI
                         .Where(c => c.Id == liveSpanId || c.EntryLidRange.IntersectWith(liveSpan).IsEmpty)
                         .ToArray();
             }
+            // The live block folds its governed range whether expanded or not - never the whole
+            // EntryLidRange, so entry V and the un-summarized tail stay loadable. Expanded is the
+            // auto-swallow mode: rows that scrolled above the viewport sit behind the card's "show more".
+            // Collapsed hides the tail too (hiddenLiveTailRange), so the card stands in for it all.
             idRangesToSkip = conversations
-                .Where(c => !expandedConversations.Contains(c.Id))
-                // The joined live block folds only its summarized range (empty pre-summary), never the whole
-                // EntryLidRange - so entry V and the un-summarized tail stay visible.
+                .Where(c => c.Id == liveBlockId || !expandedConversations.Contains(c.Id))
                 .Select(c => c.Id == liveBlockId ? liveFoldRange : c.EntryLidRange)
                 .Where(r => !r.IsEmpty)
                 .ToArray();
@@ -1180,7 +1184,7 @@ public partial class ChatUI
             // un-summarised rows (§4) - this tile then carries no matching Conversation to substitute
             // above, and the fold would never apply. Add it explicitly so folding is never limited by
             // how far the persisted conversation record itself currently reaches.
-            if (liveBlockId is { } liveBlockConversationId && !expandedConversations.Contains(liveBlockConversationId)
+            if (liveBlockId is { } liveBlockConversationId
                 && !liveFoldRange.IsEmpty && conversations.All(c => c.Id != liveBlockConversationId))
                 idRangesToSkip = [..idRangesToSkip, liveFoldRange];
         }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -450,6 +450,11 @@ public partial class ChatUI
             // has no override - an auto-collapse nobody asked for.
             foreach (var c in conversationTiles.SelectMany(t => t))
                 _knownConversationDefaultExpanded.TryAdd(c.Id, c.IsExpandedByDefault);
+            // Latched before the snapshot below, which the join branch's override decision reads: seeded
+            // elsewhere in between (the fold governor reads the same latch), the decision and the next
+            // build's resolution would disagree, and the block would collapse itself one build later.
+            if (amInLiveConversation && liveConversation is { } joinedLiveConversation)
+                _knownConversationDefaultExpanded.TryAdd(joinedLiveConversation.Id, false);
             defaultExpanded = _knownConversationDefaultExpanded
                 .Where(kv => kv.Value)
                 .Select(kv => kv.Key)
@@ -976,11 +981,15 @@ public partial class ChatUI
             // ContextStartLid (its materialized id), not V (the live-era render id) - both identities
             // must resolve to the same governed range, or a session with pre-latch context would lose
             // its frozen tail's id-tiles after close.
+            // Once closed, an expanded block excludes nothing: its card has no "show more" any more, so a
+            // fold it kept would hide rows the reader has no way back to.
+            var isClosedExpandedBlock = materializedBlockId != null
+                && liveBlockId is { } closedBlockId && expandedConversations.Contains(closedBlockId);
             var excludedRanges = conversationIdRanges
                 .Select(r => {
                     var rangeId = ConversationId.New(chatId, r.Start);
                     if (rangeId == liveBlockId || rangeId == materializedBlockId)
-                        return liveBlockFoldRange;
+                        return isClosedExpandedBlock ? default : liveBlockFoldRange;
 
                     return expandedConversations.Contains(rangeId) ? default : r;
                 })
@@ -1173,9 +1182,12 @@ public partial class ChatUI
             // The live block folds its governed range whether expanded or not - never the whole
             // EntryLidRange, so entry V and the un-summarized tail stay loadable. Expanded is the
             // auto-swallow mode: rows that scrolled above the viewport sit behind the card's "show more".
-            // Collapsed hides the tail too (hiddenLiveTailRange), so the card stands in for it all.
+            // Collapsed hides the tail too (hiddenLiveTailRange), so the card stands in for it all. Once
+            // closed, an expanded block folds nothing: its card has no "show more" any more.
+            var isFoldingLiveBlock = liveBlockId is { } foldingBlockId
+                && (materializedBlockId == null || !expandedConversations.Contains(foldingBlockId));
             idRangesToSkip = conversations
-                .Where(c => c.Id == liveBlockId || !expandedConversations.Contains(c.Id))
+                .Where(c => (c.Id == liveBlockId && isFoldingLiveBlock) || !expandedConversations.Contains(c.Id))
                 .Select(c => c.Id == liveBlockId ? liveFoldRange : c.EntryLidRange)
                 .Where(r => !r.IsEmpty)
                 .ToArray();
@@ -1184,7 +1196,7 @@ public partial class ChatUI
             // un-summarised rows (§4) - this tile then carries no matching Conversation to substitute
             // above, and the fold would never apply. Add it explicitly so folding is never limited by
             // how far the persisted conversation record itself currently reaches.
-            if (liveBlockId is { } liveBlockConversationId
+            if (liveBlockId is { } liveBlockConversationId && isFoldingLiveBlock
                 && !liveFoldRange.IsEmpty && conversations.All(c => c.Id != liveBlockConversationId))
                 idRangesToSkip = [..idRangesToSkip, liveFoldRange];
         }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -520,16 +520,16 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     }
 
     public bool IsConversationExpanded(Conversation conversation)
+        => IsConversationExpanded(conversation.Id, conversation.IsExpandedByDefault);
+
+    public bool IsConversationExpanded(ConversationId conversationId, bool isExpandedByDefault)
     {
         // Read the latched default, never the record's: IsExpandedByDefault flips when a summary lands,
         // and a consumer still reading the record would disagree with everything keyed off the cache for
         // the rest of the session. Seeds it too, so whichever consumer sees the conversation first wins.
-        var isExpandedByDefault = _knownConversationDefaultExpanded.GetOrAdd(
-            conversation.Id,
-            static (_, c) => c.IsExpandedByDefault,
-            conversation);
-        return (isExpandedByDefault ^ _conversationExpansionOverrides.Value.Contains(conversation.Id))
-            || _autoExpandedConversations.Value.Contains(conversation.Id);
+        var latched = _knownConversationDefaultExpanded.GetOrAdd(conversationId, isExpandedByDefault);
+        return (latched ^ _conversationExpansionOverrides.Value.Contains(conversationId))
+            || _autoExpandedConversations.Value.Contains(conversationId);
     }
 
     // Other helpers

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -89,14 +89,14 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         if (effectiveBoundary <= v)
             return 0;
 
+        // Bounded to the fold itself: read from the chat end, this would re-walk the whole live tail and
+        // depend on every tile of it, for every participant, on every new entry.
         var count = 0;
-        await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
-            if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
-                continue;
-            if (entry.LocalId < v)
-                break;
-            count++;
-        }
+        var reader = Chats.NewEntryReader(Session, chatId);
+        var foldRange = new Range<long>(v, effectiveBoundary);
+        await foreach (var entry in reader.ReadReverse(foldRange, cancellationToken).ConfigureAwait(false))
+            if (!entry.IsSystemEntry)
+                count++;
         return count;
     }
 
@@ -119,11 +119,12 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var revealed = v;
         using (Computed.BeginIsolation()) {
             var taken = 0;
-            await foreach (var entry in Chats.ReadReverse(Session, chatId, cancellationToken).ConfigureAwait(false)) {
-                if (entry.LocalId >= effectiveBoundary || entry.IsSystemEntry)
+            var reader = Chats.NewEntryReader(Session, chatId);
+            var foldRange = new Range<long>(v, effectiveBoundary);
+            await foreach (var entry in reader.ReadReverse(foldRange, cancellationToken).ConfigureAwait(false)) {
+                if (entry.IsSystemEntry)
                     continue;
-                if (entry.LocalId < v)
-                    break;
+
                 revealed = entry.LocalId;
                 if (++taken >= LiveFoldMath.RevealBatchSize)
                     break;
@@ -229,13 +230,15 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var tailFloorLid = raw is { IsLatched: true }
             ? await GetTailFloorLid(chatId, raw.VisibleStartLid, cancellationToken).ConfigureAwait(false)
             : long.MaxValue;
-        // Read the way the header and the card read it, so the three cannot disagree on what "collapsed" is.
+        // Resolved from the same latch and states the tile builder resolves expansion from, so the governor
+        // and the render cannot disagree on what "collapsed" is. The snapshot already carries the id and the
+        // default; the conversation record would only add a churnier dependency.
         var isBlockExpanded = false;
         if (raw is { IsLatched: true }) {
-            var conversation = await LiveSessionUI.GetConversation(chatId, cancellationToken).ConfigureAwait(false);
             await Hub.ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
             await Hub.ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
-            isBlockExpanded = conversation != null && Hub.ChatUI.IsConversationExpanded(conversation);
+            isBlockExpanded = Hub.ChatUI.IsConversationExpanded(
+                ConversationId.New(chatId, raw.VisibleStartLid), raw.IsExpandedByDefault);
         }
         return new GovernorInputs(
             chatId, raw, visibility, isJoined, isBlockExpanded, streamingTail.FloorLid, tailFloorLid);
@@ -289,8 +292,9 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
             // Seed the template alongside the attending latch: a join immediately followed by a leave
             // (before the governor's first iteration) must still freeze, so WasAttending never outruns
-            // the template GetBlockState needs to derive the overlay.
-            if (raw is { IsLatched: true } && isJoined)
+            // the template GetBlockState needs to derive the overlay. Built for a viewer who never joined
+            // too - RevealMore reads V from it, and their expanded block folds like anyone's.
+            if (raw is { IsLatched: true })
                 template = await BuildTemplate(chatId, raw, cancellationToken).ConfigureAwait(false);
             // The seed is the one fold end no advance produced, so the floors have to bound it here
             // instead: the governed value only ever grows, and a seed above them could never be
@@ -378,11 +382,11 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var (_, raw, visibility, isJoined, isBlockExpanded, rawStreamingFloorLid, tailFloorLid) = inputs;
         var chatState = await GetOrCreateChatState(chatId, cancellationToken).ConfigureAwait(false);
 
-        // While the viewer is attending a live session, keep a frozen template ready - the exact
-        // descriptor GetBlockState needs to freeze the block the instant it closes. Leaving doesn't
-        // stop the refresh: the block goes on exactly as it was, so the descriptor has to go on
-        // tracking it, and only the close (raw == null) freezes what it holds.
-        var template = raw is { IsLatched: true } && (isJoined || chatState.WasAttending)
+        // While the session is live, keep a frozen template ready - the exact descriptor GetBlockState
+        // needs to freeze the block the instant it closes, and the V that RevealMore walks back from.
+        // Leaving doesn't stop the refresh: the block goes on exactly as it was, so the descriptor has
+        // to go on tracking it, and only the close (raw == null) freezes what it holds.
+        var template = raw is { IsLatched: true }
             ? await BuildTemplate(chatId, raw, cancellationToken).ConfigureAwait(false)
             : null;
         var streamingFloorLid = StreamingFloorOf(raw, rawStreamingFloorLid);
@@ -471,7 +475,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 if (chatState.RevealedBoundaryLid != long.MaxValue && minVisibleLid != 0) {
                     if (minVisibleLid < oldBoundary && !visibility.IsPinnedToEnd)
                         chatState.RevealScrolledInto = true;
-                    else if (chatState.RevealScrolledInto) {
+                    else if (chatState.RevealScrolledInto && minVisibleLid >= oldBoundary) {
                         chatState.RevealedBoundaryLid = long.MaxValue;
                         chatState.RevealScrolledInto = false;
                         clearedReveal = true;

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -229,7 +229,16 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var tailFloorLid = raw is { IsLatched: true }
             ? await GetTailFloorLid(chatId, raw.VisibleStartLid, cancellationToken).ConfigureAwait(false)
             : long.MaxValue;
-        return new GovernorInputs(chatId, raw, visibility, isJoined, streamingTail.FloorLid, tailFloorLid);
+        // Read the way the header and the card read it, so the three cannot disagree on what "collapsed" is.
+        var isBlockExpanded = false;
+        if (raw is { IsLatched: true }) {
+            var conversation = await LiveSessionUI.GetConversation(chatId, cancellationToken).ConfigureAwait(false);
+            await Hub.ChatUI.ConversationExpansionOverrides.Use(cancellationToken).ConfigureAwait(false);
+            await Hub.ChatUI.AutoExpandedConversations.Use(cancellationToken).ConfigureAwait(false);
+            isBlockExpanded = conversation != null && Hub.ChatUI.IsConversationExpanded(conversation);
+        }
+        return new GovernorInputs(
+            chatId, raw, visibility, isJoined, isBlockExpanded, streamingTail.FloorLid, tailFloorLid);
     }
 
     [ComputeMethod(ConsolidationDelay = 1)]
@@ -366,7 +375,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
     private async Task<Moment?> ProcessChat(ChatId chatId, GovernorInputs inputs, CancellationToken cancellationToken)
     {
-        var (_, raw, visibility, isJoined, rawStreamingFloorLid, tailFloorLid) = inputs;
+        var (_, raw, visibility, isJoined, isBlockExpanded, rawStreamingFloorLid, tailFloorLid) = inputs;
         var chatState = await GetOrCreateChatState(chatId, cancellationToken).ConfigureAwait(false);
 
         // While the viewer is attending a live session, keep a frozen template ready - the exact
@@ -398,6 +407,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 chatState.IsClosed = false;
                 chatState.DissolveEndsAt = default;
                 chatState.DissolveDone = false;
+                chatState.WasBlockExpanded = false;
+                chatState.StaleVisibility = null;
                 // The fold boundary only ever advances, so the one the last session left behind would
                 // fold the restart's first entries into the card the moment they arrive.
                 chatState.State.Value = LiveBlockState.None;
@@ -433,7 +444,19 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             if (raw is { IsLatched: true }) {
                 var v = raw.VisibleStartLid;
                 // 0 means no part of the block is visible, which holds the fold where LiveFoldMath left it.
-                var minVisibleLid = visibility.ChatId == chatId && !visibility.IsEmpty
+                // Collapsed counts as invisible: the card stands in for the rows, so the typed rows showing
+                // below it say nothing about what the reader scrolled past - fed to the fold, they would
+                // swallow every spoken row by the time the block is expanded again. The report in hand at
+                // the moment of expansion is that same collapsed-render report, so it is held until the
+                // expanded render replaces it.
+                if (isBlockExpanded && !chatState.WasBlockExpanded)
+                    chatState.StaleVisibility = visibility;
+                chatState.WasBlockExpanded = isBlockExpanded;
+                var isVisibilityUsable = isBlockExpanded
+                    && !ReferenceEquals(visibility, chatState.StaleVisibility)
+                    && visibility.ChatId == chatId
+                    && !visibility.IsEmpty;
+                var minVisibleLid = isVisibilityUsable
                     ? visibility.VisibleMessageLids.Where(lid => lid >= v).DefaultIfEmpty(0).Min()
                     : 0;
                 var oldBoundary = state.FoldBoundaryLid;
@@ -509,6 +532,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         public FrozenTemplate? Template;
         public long RevealedBoundaryLid = long.MaxValue;
         public bool RevealScrolledInto;
+        public bool WasBlockExpanded;
+        public ChatViewItemVisibility? StaleVisibility;
     }
 
     private sealed record FrozenTemplate(
@@ -525,9 +550,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         LiveBlockSnapshot? Raw,
         ChatViewItemVisibility Visibility,
         bool IsJoined,
+        bool IsBlockExpanded,
         long StreamingFloorLid = long.MaxValue,
         long TailFloorLid = long.MaxValue)
     {
-        public static readonly GovernorInputs None = new(null, null, ChatViewItemVisibility.Empty, false);
+        public static readonly GovernorInputs None = new(null, null, ChatViewItemVisibility.Empty, false, false);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -462,11 +462,14 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 var oldBoundary = state.FoldBoundaryLid;
                 var boundaryLid = LiveFoldMath.Advance(
                     oldBoundary, minVisibleLid, streamingFloorLid, tailFloorLid);
-                // A reveal is a temporary peek. Latch that the viewport entered the revealed region (above
-                // the governed boundary); once the reader scrolls back down so every revealed row is above
+                // A reveal is a temporary peek. Latch that the reader scrolled up into the revealed region
+                // (above the governed boundary); once they scroll back down so every revealed row is above
                 // the viewport again, re-swallow them - the block re-compacts on return to the live tail.
+                // Pinned to the end, the revealed rows are on screen only until the next message pushes
+                // them up, and that is not the reader scrolling in - counting it would re-swallow a reveal
+                // made at the live tail within seconds, with the pill back as if nothing had been shown.
                 if (chatState.RevealedBoundaryLid != long.MaxValue && minVisibleLid != 0) {
-                    if (minVisibleLid < oldBoundary)
+                    if (minVisibleLid < oldBoundary && !visibility.IsPinnedToEnd)
                         chatState.RevealScrolledInto = true;
                     else if (chatState.RevealScrolledInto) {
                         chatState.RevealedBoundaryLid = long.MaxValue;

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -741,9 +741,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             },
             false,
             false));
-        await CollapseJoinedLiveBlock(chatUI, chat.Id, live.ToConversation());
-        // Baseline taken once collapsed, so act 1 is compared against the state it actually acts on -
-        // and v+3/v+4 being here at all is the guard already holding the fold at the viewport top.
+        // Baseline first, so act 1 is compared against the state it actually acts on - and v+3/v+4
+        // being here at all is the guard already holding the fold at the viewport top.
         List<long> beforeLids = null!;
         await ComputedTest.When(async ct => {
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
@@ -1419,10 +1418,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task CollapsedBlockFoldsUnsummarizedRowsAboveViewport()
+    public async Task ExpandedBlockFoldsUnsummarizedRowsAboveViewport()
     {
-        // §4: the collapsed live block swallows everything above the viewport, even rows no summary
-        // has ever covered - the boundary tracks the viewport top directly, with no summary gate.
+        // §4: the expanded live block - the auto-swallow mode - swallows everything above the viewport,
+        // even rows no summary has ever covered: the boundary tracks the viewport top directly, with no
+        // summary gate.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -1449,7 +1449,6 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);   // Bob is a recorder => joined
         chatUI.SelectChatOnNavigation(chat.Id);
-        await CollapseJoinedLiveBlock(chatUI, chat.Id, live.ToConversation());
 
         // act - viewport top sits at the 6th entry: everything above it (incl. un-summarised rows) must fold
         var viewportTop = lids[5];
@@ -1650,7 +1649,6 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             var s = await liveBlockUI.GetBlockState(chat.Id, ct);
             s.FoldBoundaryLid.Should().Be(streamingLid, "the streaming entry is what stops the fold");
         }, TimeSpan.FromSeconds(15));
-        await CollapseJoinedLiveBlock(chatUI, chat.Id, live.ToConversation());
 
         // act - the reader scrolls back up onto the streaming entry, and that render is the baseline
         SetViewportTop(streamingLid);
@@ -1902,7 +1900,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task CollapsedJoinedBlockReportsSwallowedCount()
+    public async Task JoinedBlockReportsSwallowedCount()
     {
         // §7: SwallowedCount is the true message count folded in [V, effectiveBoundary) - not a lid
         // span (lids have gaps) - and it must drop to 0 once RevealMore walks the whole backlog back
@@ -2286,6 +2284,120 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             : $"renderId={overlay.RenderId}, cardLid={overlay.CardLid}, hiddenTail={overlay.HiddenTailRange}, "
                 + $"foldRange={overlay.FoldRange}, blockEnd={overlay.BlockEndLid}, "
                 + $"materialized={overlay.MaterializedId}, wasAttending={state!.WasAttending}";
+    }
+
+    [Fact]
+    public async Task ExpandedBlockAutoSwallowsAndCollapseIsTheCardOnly()
+    {
+        // The expanded live block is the auto-swallow mode: rows that scrolled above the viewport fold
+        // into the card behind "show more", the rest of the tail stays visible. A manual collapse is
+        // the card alone - title, description and the preview of the latest spoken rows - exactly what
+        // a viewer who never joined sees, with nothing to reveal. Un-collapsing is the swallow mode
+        // again, fold intact.
+
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var chat = await CreateSettledChat("swallow-vs-collapse-test");
+        var author = await Tester.GetOwnAuthor(chat.Id).Require();
+        var peerId = AuthorId.New(chat.Id, 777_500);
+        var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, true, CancellationToken.None);
+        var live = await liveBackend.GetState(chat.Id, CancellationToken.None);
+        var v = live!.EffectiveVisibleStartLid;
+        var spoken = new List<long>();
+        for (var i = 0; i < 3; i++)
+            spoken.Add((await CreateSpokenEntry(chat.Id, $"spoken-{i}")).LocalId);
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = spoken[^1], MessageCount = 3,
+        }, CancellationToken.None);
+        // Enough spoken rows past the summary for a full MinTailEntryCount tail below the viewport top,
+        // or the tail floor - not the viewport - would be what holds the fold back.
+        for (var i = 3; i < 3 + LiveFoldMath.MinTailEntryCount + 5; i++)
+            spoken.Add((await CreateSpokenEntry(chat.Id, $"spoken-{i}")).LocalId);
+        var typed = (await Tester.CreateTextEntry(chat.Id, "typed-0")).LocalId;
+
+        var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        await chatAudioUI.SetRecordingChatId(chat.Id);   // Bob is a recorder => joined
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var liveConversation = (await liveBackend.GetState(chat.Id, CancellationToken.None))!.ToConversation();
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            chatUI.IsConversationExpanded(liveConversation).Should().BeTrue("joining expands the block");
+            var lids = LeafEntryLids(items);
+            lids.Should().NotContain(spoken.Take(3), "the summary-covered rows fold from the start");
+            lids.Should().Contain(spoken.Skip(3), "nothing else has scrolled above the viewport yet");
+        }, TimeSpan.FromSeconds(15));
+
+        // act - the reader scrolls to the live tail. The viewport top is the 10th real row from the
+        // chat end (the typed row counts), which is exactly where the tail floor sits, so the viewport
+        // is what sets the fold.
+        var viewportTop = spoken[^9];
+        chatUI.ReportItemVisibility(new ChatViewItemVisibility(
+            chat.Id,
+            spoken.TakeLast(9).Select(l => ChatMessageKey.New(ChatMessageKind.None, l)).ToHashSet(),
+            true,
+            true));
+
+        // assert - expanded auto-swallows: the rows above the viewport fold, the tail stays, inside the block
+        var folded = spoken.Where(l => l < viewportTop).ToList();
+        var tail = spoken.Where(l => l >= viewportTop).ToList();
+        await ComputedTest.When(async ct => {
+            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
+            blockState.FoldBoundaryLid.Should().Be(viewportTop, "the fold tracks the viewport top");
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            var lids = LeafEntryLids(items);
+            lids.Should().NotContain(folded, "the expanded block swallows what scrolled above the viewport");
+            lids.Should().Contain(tail, "the swallow mode keeps the live tail on screen");
+            lids.Should().Contain(typed);
+            var block = items.Items.OfType<ExpandedConversationMessage>().Should().ContainSingle().Subject;
+            block.GetLeafMessages().OfType<ChatEntryMessage>().Select(m => m.Id)
+                .Should().Contain(tail, "the visible tail renders inside the block, under its card");
+        }, TimeSpan.FromSeconds(15));
+        (await liveBlockUI.GetSwallowedCount(chat.Id)).Should().Be(folded.Count, "that is what \"show more\" offers");
+
+        // act - a manual collapse
+        chatUI.ToggleExpandConversation(liveConversation.Id);
+
+        // assert - the card alone: every spoken row is behind it, the typed one renders below, and the
+        // preview is the latest spoken rows of all participants
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            chatUI.IsConversationExpanded(liveConversation).Should().BeFalse();
+            var lids = LeafEntryLids(items);
+            lids.Should().NotContain(spoken,
+                "collapsed is the card only - the same render a viewer who never joined gets");
+            lids.Should().Contain(typed, "typed messages are never hidden");
+            var preview = await chatUI.GetThreadPreviewEntries(chat.Id, 5, v, true, ct);
+            preview.Select(e => e.LocalId)
+                .Should().Equal(spoken.TakeLast(5), "the card previews the latest spoken rows");
+        }, TimeSpan.FromSeconds(15));
+
+        // act - un-collapse
+        chatUI.ToggleExpandConversation(liveConversation.Id);
+
+        // assert - the swallow mode again, with the same fold and the tail back on screen
+        await ComputedTest.When(async ct => {
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+            chatUI.IsConversationExpanded(liveConversation).Should().BeTrue();
+            var lids = LeafEntryLids(items);
+            lids.Should().NotContain(folded, "un-collapsing does not un-swallow what was above the viewport");
+            lids.Should().Contain(tail);
+        }, TimeSpan.FromSeconds(15));
+
+        // act - "show more" walks the folded rows back into view
+        await liveBlockUI.RevealMore(chat.Id);
+
+        // assert
+        await ComputedTest.When(async ct => {
+            var lids = LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, ct));
+            lids.Should().Contain(folded, "a reveal must actually show the rows it walked back");
+            lids.Should().Contain(tail);
+        }, TimeSpan.FromSeconds(15));
     }
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -731,6 +731,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         await chatAudioUI.SetListeningState(chat.Id, true);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
         var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
         chatUI.ReportItemVisibility(new ChatViewItemVisibility(
@@ -1449,6 +1450,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);   // Bob is a recorder => joined
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         // act - viewport top sits at the 6th entry: everything above it (incl. un-summarised rows) must fold
         var viewportTop = lids[5];
@@ -1566,6 +1568,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         // act - the viewport top sits at the last entry, so the governor would otherwise fold everything above it
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
@@ -1633,6 +1636,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetListeningState(chat.Id, true);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         void SetViewportTop(long lid)
             => chatUI.ReportItemVisibility(new ChatViewItemVisibility(
@@ -1716,6 +1720,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         // act - viewport top sits at the last entry, so a large range folds
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
@@ -1785,6 +1790,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         void SetViewportTop(long lid)
             => chatUI.ReportItemVisibility(new ChatViewItemVisibility(
@@ -1859,6 +1865,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetListeningState(chat.Id, true);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         // act - viewport top sits at the last entry, so a large range folds
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
@@ -1946,6 +1953,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetRecordingChatId(chat.Id);
         chatUI.SelectChatOnNavigation(chat.Id);
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
 
         // act - viewport top sits at the 6th real entry, folding the 5 real rows above it (plus the
         // interleaved system entry, which must not count towards SwallowedCount)
@@ -2325,6 +2333,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveConversation = (await liveBackend.GetState(chat.Id, CancellationToken.None))!.ToConversation();
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
         var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        // Typed rows below the block, counted by the tail floor like any real entry: with a full
+        // MinTailEntryCount of them the floor sits past every spoken row and only the viewport governs.
+        var typedTail = new List<long> { typed };
+        for (var i = 1; i < LiveFoldMath.MinTailEntryCount; i++)
+            typedTail.Add((await Tester.CreateTextEntry(chat.Id, $"typed-{i}")).LocalId);
         await ComputedTest.When(async ct => {
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
             chatUI.IsConversationExpanded(liveConversation).Should().BeTrue("joining expands the block");
@@ -2333,9 +2346,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             lids.Should().Contain(spoken.Skip(3), "nothing else has scrolled above the viewport yet");
         }, TimeSpan.FromSeconds(15));
 
-        // act - the reader scrolls to the live tail. The viewport top is the 10th real row from the
-        // chat end (the typed row counts), which is exactly where the tail floor sits, so the viewport
-        // is what sets the fold.
+        // act - the reader scrolls to the live tail
         var viewportTop = spoken[^9];
         chatUI.ReportItemVisibility(new ChatViewItemVisibility(
             chat.Id,
@@ -2376,6 +2387,19 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             preview.Select(e => e.LocalId)
                 .Should().Equal(spoken.TakeLast(5), "the card previews the latest spoken rows");
         }, TimeSpan.FromSeconds(15));
+
+        // act - while collapsed, the only rows on screen at or past V are the typed ones below the card
+        chatUI.ReportItemVisibility(new ChatViewItemVisibility(
+            chat.Id,
+            typedTail.Select(l => ChatMessageKey.New(ChatMessageKind.None, l)).ToHashSet(),
+            true,
+            true));
+        await Task.Delay(700);
+
+        // assert - the card stands in for the rows, so what shows below it says nothing about what the
+        // reader scrolled past: the fold holds where the collapse found it
+        (await liveBlockUI.GetBlockState(chat.Id)).FoldBoundaryLid.Should().Be(viewportTop,
+            "a collapsed block must not feed its viewport to the fold");
 
         // act - un-collapse
         chatUI.ToggleExpandConversation(liveConversation.Id);
@@ -2484,9 +2508,10 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         return sb.ToString();
     }
 
-    // Joining now expands the live block, so a test about its collapsed form has to put it back - and
-    // only once the expand has landed, since a toggle that races it is undone by the expand it preceded.
-    private async Task CollapseJoinedLiveBlock(ChatUI chatUI, ChatId chatId, Conversation conversation)
+    // Joining expands the live block in the first data build, and the fold governor tracks the viewport
+    // only for an expanded block - so a test that reports visibility has to let that build land first,
+    // the way the chat view's own render always precedes its first visibility report.
+    private async Task AwaitJoinedBlockExpansion(ChatUI chatUI, ChatId chatId, Conversation conversation)
     {
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chatId, CancellationToken.None);
         var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
@@ -2494,6 +2519,15 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             await chatUI.GetChatItems(chatId, query, 0, ct);
             chatUI.IsConversationExpanded(conversation).Should().BeTrue();
         }, TimeSpan.FromSeconds(15));
+    }
+
+    // A test about the block's collapsed form has to put it back - and only once the expand has landed,
+    // since a toggle that races it is undone by the expand it preceded.
+    private async Task CollapseJoinedLiveBlock(ChatUI chatUI, ChatId chatId, Conversation conversation)
+    {
+        await AwaitJoinedBlockExpansion(chatUI, chatId, conversation);
+        var idRange = await Tester.Chats.GetIdRange(Tester.Session, chatId, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
         chatUI.ToggleExpandConversation(conversation.Id);
         await ComputedTest.When(async ct => {
             await chatUI.GetChatItems(chatId, query, 0, ct);

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -2422,6 +2422,24 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             lids.Should().Contain(folded, "a reveal must actually show the rows it walked back");
             lids.Should().Contain(tail);
         }, TimeSpan.FromSeconds(15));
+        var revealedBoundaryLid = (await liveBlockUI.GetBlockState(chat.Id)).RevealedBoundaryLid;
+
+        // act - pinned to the live tail: the revealed rows are on screen for a moment, then the stream
+        // pushes them above the viewport
+        ChatViewItemVisibility PinnedAt(IEnumerable<long> lids)
+            => new(chat.Id, lids.Select(l => ChatMessageKey.New(ChatMessageKind.None, l)).ToHashSet(), true, true);
+        chatUI.ReportItemVisibility(PinnedAt([..folded.TakeLast(3), ..tail]));
+        await Task.Delay(700);
+        for (var i = 0; i < 3; i++)
+            spoken.Add((await CreateSpokenEntry(chat.Id, $"spoken-late-{i}")).LocalId);
+        chatUI.ReportItemVisibility(PinnedAt(spoken.TakeLast(9)));
+        await Task.Delay(700);
+
+        // assert - the stream moving is not the reader returning to the tail, so the reveal holds
+        (await liveBlockUI.GetBlockState(chat.Id)).RevealedBoundaryLid.Should().Be(revealedBoundaryLid,
+            "a reveal made at the pinned tail must not be re-swallowed by the next messages");
+        LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None))
+            .Should().Contain(folded, "the revealed rows stay revealed while the reader is pinned");
     }
 
     private static void InvalidateAmIInLiveConversation(ChatAudioUI chatAudioUI, ChatId chatId)


### PR DESCRIPTION
## Summary

Reported by Alexey after today's dev meeting (#4424): a participant who manually collapsed the live conversation block saw no recent messages, only the un-joined card with a "Show more" that revealed nothing; later in testing, header, card and rows disagreed with each other (a collapsed card with a pill, an expanded header with no rows), and a collapse or a reveal didn't stick.

Three defects, one per commit:

1. **The governed fold and its "Show more" were wired to the *collapsed* block, while the *expanded* block folded nothing.** Joining auto-expands the block, so a participant saw the whole session unfolded, and their collapse produced the un-joined card plus a swallowed count with nothing behind it.
2. **The fold kept advancing while the block was collapsed.** With the card standing in for the spoken rows, the only visible rows past the block start were the typed ones below it; the governor read them as the viewport top and swallowed every spoken row, and the report still in hand at expansion was that same collapsed-render report - so un-collapsing showed a block with nothing under its card.
3. **The header and the card recomputed "is this block expanded" in their own state, separately from the tile builder that places the rows.** Under a live transcript the data layer rebuilds 10-18 times a second; measured in the browser, the rows switched within 0.3 s of a toggle while the header icon, the pill and the preview trailed by up to 5 s. Every frame in that window was a block that cannot exist.

## Fix

- The live block folds its governed range whether expanded or not (`GetTile`, `TryGetIdTilesToLoad`). **Expanded is the auto-swallow mode**: rows above the viewport fold behind the card's "Show more", the tail stays inside the block. **Collapsed is the card alone** - title, description, faded preview of the latest spoken rows - exactly the un-joined render, with no swallowed count and no pill. Alex's collapsed ⟺ tail-hidden rule is untouched.
- `LiveBlockUI`: a collapsed block counts as invisible to the fold governor, and the visibility report that predates an expansion is ignored until the expanded render replaces it. Expansion is read the way the header and card read it.
- The tile builder stamps `IsExpanded` on the `LiveConversationHeader` and `ConversationMessage` models it emits; the components render icon, pill, description and preview from that stamp, and the card recomputes its preview / swallowed count when the stamp flips (a parameter, not a dependency its state could observe).
- A reveal made while pinned to the live tail no longer re-swallows the instant the next message pushes the revealed rows off-screen: the re-swallow latch needs the reader to have scrolled up into the revealed region themselves (`!IsPinnedToEnd`).

Reviewer notes: a never-joined viewer who expands the block now gets the auto-swallow mode too (one rule for the expanded state). The frozen overlay's `FoldRange` also applies to an attended block after close - consistent with the freeze's intent that nothing already swallowed pops back out under the reader. A stopped-and-restarted session is a new block and still auto-expands on join, by design.

### Review follow-ups (Copilot + /code-review, commits 80e12e41f6 and 241d85f59d)

- Swallowed count and "Show more" only for a live, transcribed block; regression for the pinned-tail reveal (fails without the guard).
- RevealMore works for a viewer who never joined (template built for every latched block); an expanded block folds nothing once closed (its card has no "Show more"); the re-swallow branch also requires every revealed row to be above the viewport.
- `GetSwallowedCount` / `RevealMore` read the fold range itself instead of walking the whole tail; the card invalidates instead of double-computing on a toggle; the governor resolves expansion from the snapshot via `IsConversationExpanded(id, default)`; the joined default is latched before the build's snapshot; the dead `IsExpanded` state mirrors are gone.
- Noted, not changed: the stale-visibility hold is keyed on report identity (a stamped report would be stronger); a typed row that scrolled past while expanded is folded and, once collapsed, reachable only by expanding again.

## Testing

- New `ExpandedBlockAutoSwallowsAndCollapseIsTheCardOnly` covers the cycle: joined + expanded folds above the viewport and keeps the tail inside the block; manual collapse hides every spoken row, keeps typed ones, preview = last five spoken rows; visibility reported while collapsed must not move the fold; un-collapse restores the same fold; reveal walks folded rows back.
- Fold tests retitled from "collapsed" to "expanded"; tests that report visibility for a joined block now wait for the join's auto-expand to land first (the chat view's render always precedes its first report).
- `Chat.UI.Blazor.IntegrationTests` 113 passed / 2 skipped (pre-existing); `Chat.UI.Blazor.UnitTests` 840 passed.
- Browser, two Chromes on the local server-loop build, both users recording: collapse and un-collapse switch header, card and rows in one render (296 ms / 266 ms); the collapsed card streams in-progress phrases; "Show 9 of 9" cleared in 257 ms and stayed cleared for 30 s with the tail pinned and growing.
- Not verified: reveal smoothness (scroll position during the reveal, VirtualList side untouched); one unreproduced observation of a pill not refreshing while the card sat above the viewport; a live two-device pass on dev.

Closes #4424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9XbxHNNXy2L6n2LpyX9QG
