### PR TITLE
fix(chat): retire the optimistic copy once its own entry is loaded

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -1219,7 +1219,11 @@ public partial class ChatUI
 
         if (rangeEnd.HasValue) {
             // processing last tile
-            chatSendingMessages.ProcessLoadedEntriesRange(rangeEnd.Value);
+            var loadedClientIds = entries
+                .Where(e => !e.ClientId.IsNullOrEmpty())
+                .Select(e => e.ClientId)
+                .ToHashSet();
+            chatSendingMessages.ProcessLoadedEntriesRange(rangeEnd.Value, loadedClientIds);
             var newMessages = await chatSendingMessages.GetNewMessages(currentAuthorId!, rangeEnd.Value).ConfigureAwait(false);
             entries.AddRange(newMessages);
 

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessages.cs
@@ -74,13 +74,17 @@ public class ChatSendingMessages
             _ = _triggers.IsSending(sendingMessage);
     }
 
-    public void ProcessLoadedEntriesRange(long rangeEnd)
+    public void ProcessLoadedEntriesRange(long rangeEnd, IReadOnlySet<string> loadedClientIds)
     {
+        // PostedChatEntry lands only when the post command returns, and the entry can reach the range
+        // first - the copy then outlives it. The stored entry carries its ClientId, so that's enough.
         lock (_lock) {
             if (_newMessages.Count == 0)
                 return;
 
-            foreach (var sendingMessage in _newMessages.Where(m => m.PostedChatEntry is not null && m.PostedChatEntry.LocalId < rangeEnd)) {
+            foreach (var sendingMessage in _newMessages.Where(m
+                => (m.PostedChatEntry is not null && m.PostedChatEntry.LocalId < rangeEnd)
+                    || (!m.ClientId.IsNullOrEmpty() && loadedClientIds.Contains(m.ClientId)))) {
                 if (sendingMessage.IsCompleted)
                     sendingMessage.MarkToRemove();
                 else

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessagesAccessor.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/ChatSendingMessagesAccessor.cs
@@ -78,8 +78,8 @@ public class ChatSendingMessagesAccessor(ChatSendingMessages chatSendingMessages
         return entries.ToArray();
     }
 
-    public void ProcessLoadedEntriesRange(long rangeEnd)
-        => ChatSendingMessages.ProcessLoadedEntriesRange(rangeEnd);
+    public void ProcessLoadedEntriesRange(long rangeEnd, IReadOnlySet<string> loadedClientIds)
+        => ChatSendingMessages.ProcessLoadedEntriesRange(rangeEnd, loadedClientIds);
 
     public Task<bool> IsSending(SendingMessage sendingMessage)
         => ChatSendingMessages.IsSending(sendingMessage);

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessage.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessage.cs
@@ -4,6 +4,9 @@ namespace ActualChat.UI.Blazor.App.Services;
 
 public record SendingMessage(
     string Uuid,
+    // Travels with the post command and comes back on the entry the server stored, which is how a
+    // loaded entry is matched back to its send. Empty for edits - they address an entry by LocalId.
+    string ClientId,
     ChatId ChatId,
     long? LocalId,
     Moment BeginsAt,

--- a/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.Messages.cs
+++ b/src/dotnet/UI.Blazor.App/Services/SendingMessages/SendingMessages.Messages.cs
@@ -54,6 +54,7 @@ partial class SendingMessages
         // NOTE(DF): we need to set the content hash to trigger ChatEntryMessageInternalView re-rendering for edited messages.
         var textHash = isNewMessage ? HashString.None : request.Text.Hash().Blake2b().ToBase64HashString(HashAlgorithm.Blake2b);
         var sendingMessage = new SendingMessage(request.Uuid,
+            request.ClientId,
             request.ChatId,
             request.LocalId,
             request.Now,

--- a/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/SendingMessagesDisplayTest.cs
@@ -39,6 +39,7 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
         var accessor = sendingMessages.GetSendingMessages(chat.Id);
         var sendingMessage = new SendingMessage(
             Guid.NewGuid().ToString(),
+            "",
             chat.Id,
             null,
             now,
@@ -77,6 +78,7 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
         var accessor = sendingMessages.GetSendingMessages(chat.Id);
         var sendingMessage = new SendingMessage(
             Guid.NewGuid().ToString(),
+            "",
             chat.Id,
             null,
             now,
@@ -98,6 +100,51 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
         await ComputedTest.When(async ct => {
             var sending = await GetSendingContents(chatUI, chat.Id, ct);
             sending.Should().BeEmpty();
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    // Same race as above, seen from the other side: confirmation may never have happened yet when the
+    // entry lands. The entry carries the send's ClientId, so its presence in the loaded range is enough
+    // to retire the optimistic copy - otherwise the copy is re-emitted at the next free lid, where it
+    // grows in and is dropped a render later.
+    [Fact]
+    public async Task ShouldDropSendingMessageWhoseEntryLoadedBeforeConfirmation()
+    {
+        // arrange: the entry is posted with a client id, and its send is never confirmed
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(false, "sending-client-id-test");
+        var clientId = Guid.NewGuid().ToString();
+        await Tester.Commander.Call(new Chats_UpsertEntry {
+            Session = Tester.Session,
+            ChatId = chat.Id,
+            LocalId = null,
+            Text = "CLIENT_ID_RACE",
+            ClientId = clientId,
+        });
+
+        var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        var sendingMessages = Tester.ScopedAppServices.GetRequiredService<SendingMessages>();
+        var now = Tester.AppServices.Clocks().SystemClock.Now;
+
+        var accessor = sendingMessages.GetSendingMessages(chat.Id);
+        var sendingMessage = new SendingMessage(
+            Guid.NewGuid().ToString(),
+            clientId,
+            chat.Id,
+            null,
+            now,
+            "CLIENT_ID_RACE",
+            HashString.None,
+            null,
+            () => { });
+        accessor.ChatSendingMessages.AddSendingMessage(sendingMessage);
+
+        // act + assert: loading the tail retires the copy, though ConfirmMessageWasSent never ran and
+        // PostedChatEntry is still null - the entry's ClientId is what retires it
+        await ComputedTest.When(async ct => {
+            await GetSendingContents(chatUI, chat.Id, ct);
+            sendingMessage.PostedChatEntry.Should().BeNull();
+            sendingMessage.LoadedForDisplay.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
     }
 
@@ -141,6 +188,7 @@ public class SendingMessagesDisplayTest(ChatAppHostFixture fixture, ITestOutputH
         var accessor = sendingMessages.GetSendingMessages(chat.Id);
         accessor.ChatSendingMessages.AddSendingMessage(new SendingMessage(
             Guid.NewGuid().ToString(),
+            "",
             chat.Id,
             null,
             now,


### PR DESCRIPTION
## Summary

Third and last of the causes behind a sent message arriving unevenly, after #4406 and
#4410.

A send puts an optimistic copy at the chat tail. `ProcessLoadedEntriesRange` drops that
copy only once `PostedChatEntry` is set, and that happens when the post command returns.
The entry the command created can reach the loaded range first — the post result and the
entry's invalidation travel different paths — and the copy then outlives its own entry:
`GetNewMessages` re-emits it at the next free lid, where it grows in from zero height and
is dropped a render later.

What that looks like: an extra, empty-looking row appears at the tail for a moment and
vanishes, shifting everything above it by its own height. In frame captures it is the
residual 12–24px step the two earlier fixes left behind.

## Fix

The entry the server stored already carries the send's `ClientId` — it travels as
`Chats_UpsertEntry.ClientId`, is persisted on `DbChatEntry`, and comes back on
`ChatEntry.ClientId`. The resend guard in `TryFindPreviouslySentEntry` matches on it
today, so this is not a new trust assumption. The copy is now retired as soon as an entry
with its `ClientId` is in the loaded range, whether or not the command has answered.

The set of client ids is built from the `entries` list the tile already has, one line
above the call — no extra queries.

Invariants a reviewer should hold onto:

- **The empty-`ClientId` guard must stay.** Edits address an entry by `LocalId` and carry
  an empty `ClientId`; without the guard every edit would match every other one.
- The test is one-sided and additive, like `Covers` in #4410: a match means the real entry
  is already in the list, so a false "loaded" is impossible; a miss just falls back to
  today's `PostedChatEntry` path.

## Testing

`dotnet build ActualChat.CI.slnf` green and `SendingMessagesDisplayTest` 4/4 on the
current `dev` base.

`ShouldDropSendingMessageWhoseEntryLoadedBeforeConfirmation` is new. It asserts on the
mechanism — `PostedChatEntry` still null while `LoadedForDisplay` is already set — rather
than on rendered text, because the first version asserted absence without first
establishing presence and passed for the wrong reason. Red-green verified both ways on
freshly built binaries.

Browser checks on a local WASM build, frame by frame:

- With confirmation artificially delayed by 3s, the phantom row lives 3015ms without the
  fix and does not appear at all with it; the copy dies in the frame its real entry
  appears, and the entry is born at its own height, so the swap costs no movement.
- Editing a message: no row born or dropped during the whole operation, no duplicate
  render keys.
- Sending with an attachment, on a fast link and with the network throttled: attachment
  lands, no phantom row, no duplicate keys.

**Not verified:** anything on a real device — the browser cannot cover touch scrolling,
WebView/WKWebView, or a phone's own timing. `ChatEntry.ClientId` is marked
`// Soon obsolete`; this puts one more responsibility on it, and if the field goes away
the match has to move to the command's `Uuid`, which the server does not store on the
entry today.

Closes #4440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01292JknuHUfxNF2LXgcNkM3
