### PR TITLE
feat(macos): show the chat icon in local notification banners

### DIFF
--- a/src/dotnet/App.Maui/MauiProgram.MacOS.cs
+++ b/src/dotnet/App.Maui/MauiProgram.MacOS.cs
@@ -18,7 +18,7 @@ public static partial class MauiProgram
         services.AddTransient<IDeviceTokenRetriever>(_ => new MacDeviceTokenRetriever());
         services.AddScoped<IRecordingPermissionRequester>(_ => new WebRecordingPermissionRequester());
         services.AddScoped<INotificationsPermission>(c => new MacOSNotificationsPermission(c.AppUIHub()));
-        services.AddScoped<IDeviceNotifications>(_ => new MacOSDeviceNotifications());
+        services.AddScoped<IDeviceNotifications>(c => new MacOSDeviceNotifications(c));
         services.AddTransient<IAppIconBadge>(_ => new MacOSAppIconBadge());
         services.AddScoped<IFileSaver>(c => new MacOSFileSaver(c.UIHub()));
     }

--- a/src/dotnet/App.Maui/Platforms/MacOS/MacOSDeviceNotifications.cs
+++ b/src/dotnet/App.Maui/Platforms/MacOS/MacOSDeviceNotifications.cs
@@ -1,5 +1,12 @@
+using ActualChat.Maui.Services;
 using ActualChat.UI.Blazor.App.Services;
+using ActualLab.Generators;
+using ActualLab.IO;
+using CoreGraphics;
 using Foundation;
+using ImageIO;
+using Microsoft.Maui.Storage;
+using UniformTypeIdentifiers;
 using UserNotifications;
 
 namespace ActualChat.App.Maui;
@@ -8,8 +15,17 @@ namespace ActualChat.App.Maui;
 // "create" IS delivery here: NotificationReconciler pulls the active set over the app's own
 // RPC and every newly-active notification becomes a local UNNotificationRequest - which also
 // means notifications appear only while the app is running, by design.
-public class MacOSDeviceNotifications : IDeviceNotifications
+// The chat icon rides along as an image attachment, which macOS renders as the banner's
+// thumbnail. A communication notification (INSendMessageIntent, the iOS route to an avatar
+// in place of the app icon) was tried first: the update succeeds, but macOS 15.1+ draws the
+// app icon regardless - Messages and WhatsApp lost their sender pictures the same way.
+public class MacOSDeviceNotifications(IServiceProvider services) : IDeviceNotifications
 {
+    // A banner that lands seconds late is worse than an iconless one, and these are 128px
+    // avatars: a slow fetch means the network is gone anyway.
+    private static readonly TimeSpan IconFetchTimeout = TimeSpan.FromSeconds(5);
+    private static readonly FilePath CircleIconCacheDir
+        = new FilePath(FileSystem.CacheDirectory) | "notification-icons";
     private static readonly ILogger Log = StaticLog.For<MacOSDeviceNotifications>();
 
     private readonly SemaphoreSlim _reconcileLock = new(1, 1);
@@ -19,6 +35,8 @@ public class MacOSDeviceNotifications : IDeviceNotifications
     private readonly Dictionary<string, (string Title, string Text)> _lastContentByTag = new();
 
     private static UNUserNotificationCenter NotificationCenter => UNUserNotificationCenter.Current;
+
+    private IconUI IconUI => field ??= services.GetRequiredService<IconUI>();
 
     public async Task Reconcile(
         IReadOnlyList<ActiveNotificationInfo> active,
@@ -68,30 +86,118 @@ public class MacOSDeviceNotifications : IDeviceNotifications
             if (!isNew && !isChanged)
                 continue;
 
-            await Post(info).ConfigureAwait(false);
-            Log.LogDebug("Reconcile: {Action} notification for tag {Tag}", isChanged ? "replaced" : "created", info.Tag);
+            var hasIcon = await Post(info).ConfigureAwait(false);
+            Log.LogDebug("Reconcile: {Action} notification for tag {Tag}, icon: {HasIcon}",
+                isChanged ? "replaced" : "created", info.Tag, hasIcon);
         }
 
         foreach (var staleTag in _lastContentByTag.Keys.Where(t => !activeTags.Contains(t)).ToList())
             _lastContentByTag.Remove(staleTag);
+    }
 
-        return;
+    private async Task<bool> Post(ActiveNotificationInfo info)
+    {
+        using var content = new UNMutableNotificationContent {
+            Title = info.Title,
+            Body = info.Text,
+            ThreadIdentifier = info.Tag,
+            // Unlike the other platforms, this is delivery rather than healing a dropped
+            // push, so it alerts.
+            Sound = UNNotificationSound.Default,
+            UserInfo = NSDictionary.FromObjectAndKey(
+                new NSString(info.Url),
+                new NSString(Constants.Notification.MessageDataKeys.Link)),
+        };
+        using var icon = await GetIconAttachment(info).ConfigureAwait(false);
+        if (icon is not null)
+            content.Attachments = [icon];
 
-        static async Task Post(ActiveNotificationInfo info) {
-            using var content = new UNMutableNotificationContent {
-                Title = info.Title,
-                Body = info.Text,
-                ThreadIdentifier = info.Tag,
-                // Unlike the other platforms, this is delivery rather than healing a dropped
-                // push, so it alerts.
-                Sound = UNNotificationSound.Default,
-                UserInfo = NSDictionary.FromObjectAndKey(
-                    new NSString(info.Url),
-                    new NSString(Constants.Notification.MessageDataKeys.Link)),
-            };
-            // The tag doubles as the identifier, so a re-posted tag replaces its predecessor
-            var request = UNNotificationRequest.FromIdentifier(info.Tag, content, null);
-            await NotificationCenter.AddNotificationRequestAsync(request).ConfigureAwait(false);
+        // The tag doubles as the identifier, so a re-posted tag replaces its predecessor
+        var request = UNNotificationRequest.FromIdentifier(info.Tag, content, null);
+        await NotificationCenter.AddNotificationRequestAsync(request).ConfigureAwait(false);
+        return icon is not null;
+    }
+
+    private async Task<UNNotificationAttachment?> GetIconAttachment(ActiveNotificationInfo info)
+    {
+        // Null means "post the plain banner": no icon, or anything failing on the way to one.
+        if (info.IconUrl.IsNullOrEmpty())
+            return null;
+
+        var iconPath = await FetchIcon(info.IconUrl).ConfigureAwait(false);
+        if (iconPath.IsEmpty)
+            return null;
+
+        // The circle is rendered once per icon; every post hands over a fresh copy, since the
+        // system moves the attached file into its own store.
+        var attachmentPath = new FilePath(Path.GetTempPath()) & $"icon-{RandomStringGenerator.Default.Next()}.png";
+        try {
+            var circlePath = CircleIconCacheDir | (iconPath.FileNameWithoutExtension + ".png");
+            if (!File.Exists(circlePath)) {
+                Directory.CreateDirectory(CircleIconCacheDir);
+                if (!WriteCircularPng(iconPath, circlePath)) {
+                    Log.LogWarning("Icon isn't a decodable image: {IconUrl}", info.IconUrl);
+                    return null;
+                }
+            }
+            File.Copy(circlePath, attachmentPath);
+
+            var options = new UNNotificationAttachmentOptions { TypeHint = UTTypes.Png.Identifier };
+            var attachment = UNNotificationAttachment.FromIdentifier(
+                "icon", NSUrl.CreateFileUrl(attachmentPath), options, out var error);
+            if (attachment is not null && error is null)
+                return attachment;
+
+            Log.LogWarning("Icon attachment failed for {IconUrl}: {Error}",
+                info.IconUrl, error?.LocalizedDescription);
+            attachment?.Dispose();
         }
+        catch (Exception e) {
+            Log.LogWarning(e, "Icon attachment failed for {IconUrl}", info.IconUrl);
+        }
+        File.Delete(attachmentPath);
+        return null;
+    }
+
+    private async Task<FilePath> FetchIcon(string iconUrl)
+    {
+        using var timeoutCts = new CancellationTokenSource(IconFetchTimeout);
+        try {
+            return await IconUI.FetchImage(iconUrl, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) {
+            Log.LogWarning("Icon fetch timed out: {IconUrl}", iconUrl);
+            return FilePath.Empty;
+        }
+    }
+
+    // The thumbnail slot is a rounded square, so the circle comes from the image itself:
+    // the centered square of the source clipped to an ellipse over transparent corners.
+    // TODO(#4442): drop this once the server serves round icons - attach the cached file as is.
+    private static bool WriteCircularPng(FilePath sourcePath, FilePath targetPath)
+    {
+        using var source = CGImageSource.FromUrl(NSUrl.CreateFileUrl(sourcePath));
+        using var image = source?.CreateImage(0, null);
+        if (image is null)
+            return false;
+
+        var size = (int)Math.Min(image.Width, image.Height);
+        using var colorSpace = CGColorSpace.CreateDeviceRGB();
+        using var context = new CGBitmapContext(
+            null, size, size, 8, size * 4, colorSpace, CGImageAlphaInfo.PremultipliedLast);
+        context.AddEllipseInRect(new CGRect(0, 0, size, size));
+        context.Clip();
+        var origin = new CGPoint((size - (int)image.Width) / 2, (size - (int)image.Height) / 2);
+        context.DrawImage(new CGRect(origin, new CGSize(image.Width, image.Height)), image);
+        using var circle = context.ToImage();
+        if (circle is null)
+            return false;
+
+        using var destination = CGImageDestination.Create(NSUrl.CreateFileUrl(targetPath), UTTypes.Png.Identifier, 1);
+        if (destination is null)
+            return false;
+
+        destination.AddImage(circle, (CGImageDestinationOptions?)null);
+        return destination.Close();
     }
 }

--- a/src/dotnet/Maui/Module/MauiModule.cs
+++ b/src/dotnet/Maui/Module/MauiModule.cs
@@ -61,6 +61,10 @@ public sealed class MauiModule(IServiceProvider moduleServices)
         var fusion = services.AddFusion();
         fusion.AddService<IconUI>(ServiceLifetime.Scoped);
         fusion.AddService<IncomingShareSuggestions, AndroidIncomingShareSuggestions>(ServiceLifetime.Scoped);
+#elif MACOS
+        // No share suggestions on the desktop; the icons feed the notification banners
+        var fusion = services.AddFusion();
+        fusion.AddService<IconUI>(ServiceLifetime.Scoped);
 #endif
 
         // Video transcoding

--- a/src/dotnet/Maui/Services/Icons/IconUI.cs
+++ b/src/dotnet/Maui/Services/Icons/IconUI.cs
@@ -20,15 +20,7 @@ public class IconUI(IServiceProvider services) : ProcessorBase, IComputeService
         return filePath.IsEmpty ? null : new LoadedImage(filePath, kind);
     }
 
-    private (string Url, AvatarKind? Kind) GetIconUrl(IconQuery query)
-    {
-        var pictureUrl = UrlMapper.PicturePreview128Url(query.Picture);
-        return pictureUrl.IsNullOrEmpty()
-            ? (UrlMapper.AvatarUrl(query.AvatarQuery), query.AvatarQuery.Kind)
-            : (pictureUrl, null);
-    }
-
-    private Task<FilePath> FetchImage(string url, CancellationToken cancellationToken)
+    public Task<FilePath> FetchImage(string url, CancellationToken cancellationToken)
     {
         if (url.IsNullOrEmpty())
             return Task.FromResult(FilePath.Empty);
@@ -36,6 +28,16 @@ public class IconUI(IServiceProvider services) : ProcessorBase, IComputeService
         var ext = Path.GetExtension(url);
         var filePath = GetCacheFilePath(url, ext);
         return FetchToCache(url, filePath, cancellationToken);
+    }
+
+    // Private methods
+
+    private (string Url, AvatarKind? Kind) GetIconUrl(IconQuery query)
+    {
+        var pictureUrl = UrlMapper.PicturePreview128Url(query.Picture);
+        return pictureUrl.IsNullOrEmpty()
+            ? (UrlMapper.AvatarUrl(query.AvatarQuery), query.AvatarQuery.Kind)
+            : (pictureUrl, null);
     }
 
     private async Task<FilePath> FetchToCache(string url, FilePath filePath, CancellationToken cancellationToken)

--- a/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
+++ b/src/dotnet/UI.Blazor.App/Services/NotificationReconciler.cs
@@ -56,6 +56,7 @@ public sealed class NotificationReconciler(AppUIHub hub) : UIWorkerBase<AppUIHub
                 : [];
             _lastActiveTags = currentTags;
             _isInitialized = true;
+            Log.LogDebug("Active set changed: {ActiveCount} active, {CreateCount} new", infos.Count, createTags.Count);
             await deviceNotifications.Reconcile(infos, createTags, cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
## Summary

Banners posted by the macOS AppKit build carried the app icon alone. `MacOSDeviceNotifications` built each `UNNotificationRequest` from title, body, thread id, sound and link, and never used the `IconUrl` the reconciler already hands it, so the chat avatar visible on every other platform was missing on the Mac.

The obvious route, a communication notification (`INSendMessageIntent` applied through `UNNotificationContent.Update`, which is how the iOS notification service extension replaces the app icon), was implemented first. The update succeeds with the entitlement in place, but macOS 15.1 and later draws the app icon regardless, even with a known-good bundled PNG; Messages and WhatsApp lost their sender pictures the same way. The attachment thumbnail is the only banner rendering on current macOS that shows the chat icon.

## Fix

- The icon is fetched through `IconUI`'s file cache, clipped to a circle over transparent corners with CoreGraphics (the thumbnail slot itself is a rounded square with no circular option), written as a PNG and attached to the request. Any failure on that path falls back to the plain banner with a warning.
- A fresh PNG is written per banner on purpose: the system moves the attached file into its own store, so the shared cache file must stay put.
- `IconUI.FetchImage` is public now and `IconUI` is registered on the macOS target; `NotificationReconciler` logs each active-set change at debug level.
- The round shape being produced client-side is tracked as #4442.

## Testing

- `net11.0-macos` build clean.
- Device-verified on macOS 26: a bot message produced a live banner with the circular chat avatar as the thumbnail. The dev cluster had one pod that delivered no active-set invalidations during testing, so verification was repeated on the healthy pod.
- No automated tests cover the AppKit notification path.

Closes #4434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
