### PR TITLE
fix(translation): keep the original when the model answers in another script

### DIFF
--- a/src/dotnet/Chat.Service/Translation/AlphabetLanguageDetector.cs
+++ b/src/dotnet/Chat.Service/Translation/AlphabetLanguageDetector.cs
@@ -20,7 +20,31 @@ public static class AlphabetLanguageDetector
         return found.Count == 0 ? [] : [..found];
     }
 
+    // A translation that shares no script with its target can't be one: the model answered in
+    // another language instead of NO_TRANSLATION_NEEDED. Same-script pairs, e.g. English to
+    // Spanish, can't be told apart here and stay with the prompt.
+    public static bool IsScriptMismatch(string source, string translation, Language target)
+    {
+        if (GetScript(target) is not { } script)
+            return false;
+        if (Detect(source).Count == 0)
+            return false;
+
+        var scripts = Detect(translation);
+        return scripts.Count > 0 && !scripts.Contains(script);
+    }
+
     // Private methods
+
+    // The script a translation into the language must contain, or null when it can't be told:
+    // a script Classify doesn't know, or the CJK ideographs Chinese and Japanese share.
+    private static Language? GetScript(Language language)
+    {
+        var scripts = Detect(language.NativeName);
+        return scripts is [var script] && script != Languages.Chinese && script != Languages.Japanese
+            ? script
+            : null;
+    }
 
     private static Language? Classify(char c)
     {

--- a/src/dotnet/Chat.Service/Translation/Translator.cs
+++ b/src/dotnet/Chat.Service/Translation/Translator.cs
@@ -200,38 +200,46 @@ public class Translator(IServiceProvider services, [ServiceKey] string serviceKe
         chatHistory.AddSystemMessage(systemMessage);
 
         // Chat-style few-shot examples would prime UI-text translations toward conversational register
-        if (context.Length == 0 && ServiceKey != Constants.Translation.UITextServiceKey) {
+        if (ServiceKey != Constants.Translation.UITextServiceKey) {
             // Provide translation examples to improve the quality of the translation
+            if (context.Length == 0) {
+                if (targetLanguage.IsAnyEnglish) {
+                    chatHistory.AddUserMessage("Хорошо.");
+                    chatHistory.AddAssistantMessage("Alright.");
+                    chatHistory.AddUserMessage("Да");
+                    chatHistory.AddAssistantMessage("Yes");
+                    chatHistory.AddUserMessage("Bien");
+                    chatHistory.AddAssistantMessage("Right");
+                }
+                if (targetLanguage.IsAnySpanish) {
+                    chatHistory.AddUserMessage("Good.");
+                    chatHistory.AddAssistantMessage("Bueno.");
+                    chatHistory.AddUserMessage("Yep");
+                    chatHistory.AddAssistantMessage("Sí");
+                    chatHistory.AddUserMessage("Right");
+                    chatHistory.AddAssistantMessage("Bien");
+                }
+                if (targetLanguage == Languages.Russian) {
+                    chatHistory.AddUserMessage("Alright.");
+                    chatHistory.AddAssistantMessage("Хорошо.");
+                    chatHistory.AddUserMessage("Yes");
+                    chatHistory.AddAssistantMessage("Да");
+                    chatHistory.AddUserMessage("Bien");
+                    chatHistory.AddAssistantMessage("Хорошо");
+                }
+            }
+            // The already-in-target-language example stays even with context: a chat full of
+            // translation pairs pulls the model into translating same-language input too, and the
+            // prompt's rule alone doesn't hold against that
             if (targetLanguage.IsAnyEnglish) {
-                chatHistory.AddUserMessage("Хорошо.");
-                chatHistory.AddAssistantMessage("Alright.");
-                chatHistory.AddUserMessage("Да");
-                chatHistory.AddAssistantMessage("Yes");
-                chatHistory.AddUserMessage("Bien");
-                chatHistory.AddAssistantMessage("Right");
-                // Example showing no translation needed when text is already in target language
                 chatHistory.AddUserMessage("Hello, how are you?");
                 chatHistory.AddAssistantMessage(Constants.Translation.NoTranslationNeededText);
             }
             if (targetLanguage.IsAnySpanish) {
-                chatHistory.AddUserMessage("Good.");
-                chatHistory.AddAssistantMessage("Bueno.");
-                chatHistory.AddUserMessage("Yep");
-                chatHistory.AddAssistantMessage("Sí");
-                chatHistory.AddUserMessage("Right");
-                chatHistory.AddAssistantMessage("Bien");
-                // Example showing no translation needed when text is already in target language
                 chatHistory.AddUserMessage("Hola, ¿cómo estás?");
                 chatHistory.AddAssistantMessage(Constants.Translation.NoTranslationNeededText);
             }
             if (targetLanguage == Languages.Russian) {
-                chatHistory.AddUserMessage("Alright.");
-                chatHistory.AddAssistantMessage("Хорошо.");
-                chatHistory.AddUserMessage("Yes");
-                chatHistory.AddAssistantMessage("Да");
-                chatHistory.AddUserMessage("Bien");
-                chatHistory.AddAssistantMessage("Хорошо");
-                // Example showing no translation needed when text is already in target language
                 chatHistory.AddUserMessage("Привет, как дела?");
                 chatHistory.AddAssistantMessage(Constants.Translation.NoTranslationNeededText);
             }

--- a/src/dotnet/Chat.Service/TranslationsBackend.cs
+++ b/src/dotnet/Chat.Service/TranslationsBackend.cs
@@ -214,6 +214,7 @@ public class TranslationsBackend(IServiceProvider services) : DbServiceBase<Chat
                 context,
                 GetTranslationContextHint(id.Kind),
                 cancellationToken).ConfigureAwait(false);
+            translatedText = KeepOriginalOnScriptMismatch(id, translationSource.Content, translatedText);
 
             var contentHash = translationSource.ContentHash.IsNone
                 ? ChatEntryHashExt.GetContentHashString(translationSource.Content)
@@ -273,7 +274,7 @@ public class TranslationsBackend(IServiceProvider services) : DbServiceBase<Chat
                     : translationSource.ContentHash;
                 var finalizeChange = Change.Update(new TranslationDiff {
                     StreamId = null,
-                    Content = translatedTranscript.Text,
+                    Content = KeepOriginalOnScriptMismatch(id, translationSource.Content, translatedTranscript.Text),
                     SourceContentHash = contentHash,
                 });
                 var finalizeCmd = new TranslationsBackend_Change(
@@ -569,8 +570,8 @@ public class TranslationsBackend(IServiceProvider services) : DbServiceBase<Chat
                                 lastText = text;
                             }
                         }
-                        var content = lastTranslatedTranscript.Text;
                         var sourceContent = lastTranscript.Text;
+                        var content = KeepOriginalOnScriptMismatch(translationId, sourceContent, lastTranslatedTranscript.Text);
                         var finalizeRealtime = new TranslationsBackend_Change(translationId,
                             newTranslationVersion, // Will overwrite the first version only
                             Change.Update(new TranslationDiff {
@@ -694,6 +695,15 @@ public class TranslationsBackend(IServiceProvider services) : DbServiceBase<Chat
     // The translation rules live in the UI-text prompt file; the hint only names the kind
     private static string GetUITextTranslationHint(UITextKind kind)
         => "The input is a user-facing error or status message.";
+
+    private string KeepOriginalOnScriptMismatch(TranslationId id, string source, string translated)
+    {
+        if (!AlphabetLanguageDetector.IsScriptMismatch(source, translated, id.Language))
+            return translated;
+
+        Log.LogWarning("Translation #{Id} came back in another script, keeping the original", id);
+        return source;
+    }
 
     private async ValueTask<(ChatEntry e, Translation?)> SelectTranslationAsync(ChatEntry e, Language language, CancellationToken cancellationToken)
         => (e, await GetInternal(TranslationId.New(ChatEntryId.New(e.ChatId, e.LocalId), language), cancellationToken).ConfigureAwait(false));

--- a/src/dotnet/Transcription.Service/Transcribers/DeepgramTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/DeepgramTranscriber.cs
@@ -223,11 +223,10 @@ public sealed partial class DeepgramTranscriber : ITranscriber
         var isStreamFinalized = result.FromFinalize ?? false;
         var alternative = result.Channel?.Alternatives?.FirstOrDefault();
         var suffix = alternative?.Transcript ?? "";
-        // NOTE: as for now deepgram does not support language detection in streaming mode,
-        // so we use language from options
-        var detectedLanguages = alternative?.Languages?.Select(DeepgramLanguage.FromDeepgram)
+        // Only what Deepgram detected: the configured language is a hint, and stamping it on a
+        // transcript would hide a foreign message from translation
+        var languages = alternative?.Languages?.Select(DeepgramLanguage.FromDeepgram)
             .Distinct().ToArray() ?? [];
-        var languages = detectedLanguages.Length > 0 ? detectedLanguages : [options.Language];
         var endTime = (float?)result.Duration ?? 0;
         if (isFinal) {
             if (TryParseFinal(state, result, out suffix, out var map))

--- a/src/dotnet/Transcription.Service/Transcribers/GoogleTranscriber.cs
+++ b/src/dotnet/Transcription.Service/Transcribers/GoogleTranscriber.cs
@@ -368,11 +368,10 @@ public sealed partial class GoogleTranscriber : ITranscriber
                 return;
             }
 
+        // Only what Google detected - see DeepgramTranscriber
         var languages = Language.TryParse(result.LanguageCode, out var language)
             ? new [] {language}
             : [];
-        if (languages.Length == 0)
-            languages = [options.Language];
         state.Append(suffix, endTime, languages, mustAppendToUnstable).MakeStable(isFinal);
     }
 

--- a/tests/Chat.IntegrationTests/RetranscribeTranslationFlowTest.cs
+++ b/tests/Chat.IntegrationTests/RetranscribeTranslationFlowTest.cs
@@ -154,40 +154,6 @@ public sealed class RetranscribeTranslationCollection : ICollectionFixture<Retra
             });
 }
 
-// Deterministic translator: prefixes the source so the stored translation reveals which
-// transcript (realtime vs refined) it was derived from.
-sealed file class FakeTranslator(IServiceProvider services, string serviceKey = Constants.Translation.ServiceKey)
-    : Translator(services, serviceKey)
-{
-    public const string Prefix = "T:";
-    public static bool MustFailRealtime { get; set; }
-    private bool IsRealtime { get; } = serviceKey == Constants.Translation.RealtimeServiceKey;
-
-    public static void Reset()
-        => MustFailRealtime = false;
-
-    public override Task<string> Translate(
-        string textToTranslate,
-        Language targetLanguage,
-        TranslationResult[] context,
-        string? contextHint = null,
-        CancellationToken cancellationToken = default)
-        => MustFailRealtime && IsRealtime
-            ? Task.FromException<string>(StandardError.External("Realtime translation failed."))
-            : Task.FromResult(Prefix + textToTranslate);
-
-    public override async IAsyncEnumerable<StringDiff> Stream(
-        string textToTranslate,
-        Language targetLanguage,
-        TranslationResult[] context,
-        string? contextHint = null,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        await Task.CompletedTask.ConfigureAwait(false);
-        yield return StringDiff.New(Prefix + textToTranslate, "");
-    }
-}
-
 sealed file class FakeOfflineTranscriber : IOfflineTranscriber
 {
     public TranscriberInfo Info { get; } = new() {

--- a/tests/Chat.IntegrationTests/SameLanguageTranslationTest.cs
+++ b/tests/Chat.IntegrationTests/SameLanguageTranslationTest.cs
@@ -1,0 +1,137 @@
+using ActualChat.Chat.Module;
+using ActualChat.Module;
+using ActualChat.Testing.Host;
+
+namespace ActualChat.Chat.IntegrationTests;
+
+// Same-language text goes to the translator with no detection first (that would double the LLM
+// calls), so the prompt's NO_TRANSLATION_NEEDED rule is what keeps it - and the model sometimes
+// answers in English instead. The stored translation is checked by script to catch that.
+[Collection(nameof(SameLanguageTranslationCollection))]
+public class SameLanguageTranslationTest(
+    SameLanguageTranslationCollection.AppHostFixture fixture,
+    ITestOutputHelper @out)
+    : SharedAppHostTestBase<SameLanguageTranslationCollection.AppHostFixture>(fixture, @out)
+{
+    private const string ShortRussianText = "Привет! Как дела?";
+    private const string LongRussianText =
+        "Привет! Как дела? Это сообщение достаточно длинное, чтобы перевод пошёл потоком, а не одним ответом.";
+
+    private WebClientTester Tester => field ??= AppHost.NewWebClientTester(Out);
+    private ITranslations Translations => Tester.Translations;
+    private FakeTranslator Translator => field ??= (FakeTranslator)Tester.AppServices.GetRequiredService<Translator>();
+
+    [Fact]
+    public async Task AnswerInAnotherScriptShouldKeepTheOriginal()
+    {
+        // arrange
+        Translator.Respond = static (_, _) => "Hi! How are you?";
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(false);
+        var entry = await Tester.CreateTextEntry(chatId, ShortRussianText);
+
+        // act
+        var translation = await WhenTranslated(entry.Id, Languages.Russian);
+
+        // assert
+        translation.Content.Should().Be(ShortRussianText);
+        translation.SourceContentHash.Should().Be(entry.ContentHash);
+    }
+
+    [Fact]
+    public async Task StreamedAnswerInAnotherScriptShouldKeepTheOriginal()
+    {
+        // arrange
+        Translator.Respond = static (_, _) => "Hi! How are you? This message is long enough to be translated as a stream.";
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(false);
+        var entry = await Tester.CreateTextEntry(chatId, LongRussianText);
+
+        // act
+        var translation = await WhenTranslated(entry.Id, Languages.Russian);
+
+        // assert
+        translation.Content.Should().Be(LongRussianText);
+        translation.SourceContentHash.Should().Be(entry.ContentHash);
+    }
+
+    // Fixed-language voice entries used to be stored with no languages, which the client reads as
+    // foreign, so they take the same route as typed text
+    [Fact]
+    public async Task VoiceEntryAnswerInAnotherScriptShouldKeepTheOriginal()
+    {
+        // arrange
+        Translator.Respond = static (_, _) => "Hi! How are you?";
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(false);
+        var streamingEntry = await Tester.CreateStreamingEntry(chatId, Languages.Russian);
+        await Tester.UpdateEntryLanguage(streamingEntry.EntryLanguage with { Languages = [] });
+        var entry = await FinalizeEntry(streamingEntry.ChatEntrySlim, ShortRussianText);
+
+        // act
+        var translation = await WhenTranslated(entry.Id, Languages.Russian);
+
+        // assert
+        translation.Content.Should().Be(ShortRussianText);
+        translation.SourceContentHash.Should().Be(entry.ContentHash);
+    }
+
+    [Fact]
+    public async Task TextInAnotherLanguageShouldBeTranslated()
+    {
+        // arrange
+        Translator.Respond = FakeTranslator.Translated;
+        await Tester.SignInAsUniqueAlice();
+        var (chatId, _) = await Tester.CreateChat(false);
+        const string text = "Hi! How are you?";
+        var entry = await Tester.CreateTextEntry(chatId, text);
+
+        // act
+        var translation = await WhenTranslated(entry.Id, Languages.Russian);
+
+        // assert
+        translation.Content.Should().Be(FakeTranslator.Translated(text, Languages.Russian));
+        translation.SourceContentHash.Should().Be(entry.ContentHash);
+    }
+
+    // Private methods
+
+    // Unlike FinalizeStreamingEntry, leaves the entry language as the audio pipeline does:
+    // under the hash of the still-empty streaming entry.
+    private Task<ChatEntry> FinalizeEntry(ChatEntry streamingEntry, string text)
+        => Tester.Commander.Call(new ChatsBackend_ChangeEntry(
+            streamingEntry.Id,
+            streamingEntry.Version,
+            Change.Update(new ChatEntryDiff {
+                Content = text,
+                ContentStreamId = "",
+                Audio = new ChatEntryAudio { MediaId = MediaId.Parse("fake:mediaid") },
+                EndsAt = Tester.AppServices.Clocks().SystemClock.Now,
+            })));
+
+    private Task<Translation> WhenTranslated(ChatEntryId id, Language language)
+        => ComputedTest.When(async ct => {
+                var translation = await Translations.Get(Tester.Session, TranslationId.New(id, language), true, ct).Require();
+                translation.IsStreaming.Should().BeFalse();
+                return translation;
+            },
+            TimeSpan.FromSeconds(10));
+}
+
+[CollectionDefinition(nameof(SameLanguageTranslationCollection))]
+public sealed class SameLanguageTranslationCollection : ICollectionFixture<SameLanguageTranslationCollection.AppHostFixture>
+{
+    public sealed class AppHostFixture(IMessageSink messageSink)
+        : ActualChat.Testing.Host.AppHostFixture(
+            "same-language-translation",
+            messageSink,
+            TestAppHostOptions.Default with {
+                ConfigureHost = (_, cfg) => {
+                    cfg.AddInMemory<ChatSettings>((x => x.IsTranslationEnabled, "true"));
+                    cfg.AddInMemory<CoreServerSettings>((x => x.OpenAIKey, "test-key"));
+                },
+                ConfigureServices = (_, services) => {
+                    services.AddSingleton<Translator>(c => new FakeTranslator(c));
+                },
+            });
+}

--- a/tests/Chat.UnitTests/AlphabetLanguageDetectorTest.cs
+++ b/tests/Chat.UnitTests/AlphabetLanguageDetectorTest.cs
@@ -23,6 +23,25 @@ public class AlphabetLanguageDetectorTest(ITestOutputHelper @out) : TestBase(@ou
     }
 
     [Theory]
+    [InlineData("Привет", "Hello", "ru-RU", true)]
+    [InlineData("Привет", "Привет!", "ru-RU", false)]
+    [InlineData("Hello", "Привет, **Bob**!", "ru-RU", false)]
+    [InlineData("Hello", "Привет", "en-US", true)]
+    [InlineData("Hola", "Hello", "en-US", false)]
+    [InlineData("Hello", "こんにちは", "ja-JP", false)]
+    [InlineData("Hello", "Hello", "ja-JP", false)]
+    [InlineData("123", "Hello", "ru-RU", false)]
+    [InlineData("Привет", "", "ru-RU", false)]
+    public void ShouldDetectScriptMismatch(string source, string translation, string targetId, bool expected)
+    {
+        // act
+        var isMismatch = AlphabetLanguageDetector.IsScriptMismatch(source, translation, Language.Parse(targetId));
+
+        // assert
+        isMismatch.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("Hello, Привет!", "en-US", "ru-RU")]
     [InlineData("привет hello", "en-US", "ru-RU")]
     [InlineData("Hello こんにちは 你好", "en-US", "ja-JP", "zh-CN")]

--- a/tests/Testing.Host/FakeTranslator.cs
+++ b/tests/Testing.Host/FakeTranslator.cs
@@ -1,0 +1,45 @@
+using ActualChat.Chat;
+using ActualChat.Transcription;
+
+namespace ActualChat.Testing.Host;
+
+/// <summary>
+/// Deterministic translator. By default it answers in the target's own script and keeps the
+/// source, so a stored translation reveals which text it was given; a test can swap the answer
+/// on its own host's instance.
+/// </summary>
+public sealed class FakeTranslator(IServiceProvider services, string serviceKey = Constants.Translation.ServiceKey)
+    : Translator(services, serviceKey)
+{
+    // Static: the retranscribe flow has to fail the keyed realtime instance it never resolves
+    public static bool MustFailRealtime { get; set; }
+    public Func<string, Language, string> Respond { get; set; } = Translated;
+    private bool IsRealtime { get; } = serviceKey == Constants.Translation.RealtimeServiceKey;
+
+    public static string Translated(string text, Language targetLanguage)
+        => $"{targetLanguage.NativeName}: {text}";
+
+    public static void Reset()
+        => MustFailRealtime = false;
+
+    public override Task<string> Translate(
+        string textToTranslate,
+        Language targetLanguage,
+        TranslationResult[] context,
+        string? contextHint = null,
+        CancellationToken cancellationToken = default)
+        => MustFailRealtime && IsRealtime
+            ? Task.FromException<string>(StandardError.External("Realtime translation failed."))
+            : Task.FromResult(Respond(textToTranslate, targetLanguage));
+
+    public override async IAsyncEnumerable<StringDiff> Stream(
+        string textToTranslate,
+        Language targetLanguage,
+        TranslationResult[] context,
+        string? contextHint = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield return StringDiff.New(Respond(textToTranslate, targetLanguage), "");
+    }
+}


### PR DESCRIPTION
Closes #4384

## Symptom

In Bugs (Mobile) under a Russian target, typed entry 9626 came back as a Russian-to-Russian paraphrase and voice entry 9629 came back in English.

## Causes

**Typed text.** Same-language text is sent to the translator without detecting its language first (that would double the LLM calls), so the prompt's `NO_TRANSLATION_NEEDED` rule is the only guard, and the model sometimes paraphrases or answers in English instead. #3449 was the same slip in the other direction. The same-language few-shot example was also dropped as soon as context existed, which in a live chat is always.

**Voice.** Soniox and ElevenLabs only report token languages in detect mode, so a voice entry recorded with a fixed chat language is stored with no languages, which the client reads as "foreign" and asks to translate - the Russian transcript then took the same route as typed text. Deepgram and Google went the other way: they stamped the configured language onto such entries, which hides a genuinely foreign recording from translation (an English recording in a Russian chat was stored as `["ru-RU"]` and never offered a translation).

## Changes

- `AlphabetLanguageDetector.IsScriptMismatch`: an answer that shares no script with the target language is stored as the original. Applied in the plain, streaming and realtime finalizers. Same-script pairs (e.g. English to Spanish) can't be told apart this way and still rely on the prompt.
- `Translator.BuildRequest` keeps the already-in-target-language example even when context is present.
- Deepgram and Google no longer fall back to `options.Language`: all four transcribers store only the languages the provider detected. An empty list means the single translation request decides.
- `FakeTranslator` moved to Testing.Host and shared; its answer hook is per instance.

No pre-translation language detection was added: one LLM request per translation stays the contract.

## Tests

- `SameLanguageTranslationTest`: short, streamed and voice wrong-script answers keep the original; a foreign text is translated. Red without the check, green with it.
- `AlphabetLanguageDetectorTest`: 9 mismatch cases.
- Existing `RetranscribeTranslationFlowTest`, `StreamingEntryNetworkLossTest`, `StreamingEntryFixupTest` and the Transcription unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
