### PR TITLE
fix(macos): open a file panel for <input type=file> in the AppKit WebView

### DIFF
--- a/src/dotnet/App.Maui/WebView/MauiWebView.MacOS.cs
+++ b/src/dotnet/App.Maui/WebView/MauiWebView.MacOS.cs
@@ -1,5 +1,6 @@
 using ActualChat.App.Maui.Services;
 using ActualChat.Module;
+using AppKit;
 using AVFoundation;
 using Foundation;
 using WebKit;
@@ -151,6 +152,25 @@ public partial class MauiWebView
                 _ = HandleWebNavigation(mauiWebView, uri);
             }
             return null;
+        }
+
+        public override void RunOpenPanel(
+            WKWebView webView,
+            WKOpenPanelParameters parameters,
+            WKFrameInfo frame,
+            Action<NSUrl[]> completionHandler)
+        {
+            // Unlike iOS, WebKit on macOS shows nothing for <input type=file> unless the delegate
+            // runs the panel itself; a null result is how the completion handler reports a cancel.
+            var panel = new NSOpenPanel {
+                CanChooseFiles = true,
+                CanChooseDirectories = parameters.AllowsDirectories,
+                AllowsMultipleSelection = parameters.AllowsMultipleSelection,
+            };
+            if (webView.Window is { } window)
+                panel.BeginSheet(window, result => completionHandler.Invoke(result == 1 ? panel.Urls : null!));
+            else
+                completionHandler.Invoke(panel.RunModal() == 1 ? panel.Urls : null!);
         }
 
         public override void RequestMediaCapturePermission(


### PR DESCRIPTION
## Summary

Changing a chat avatar in the AppKit Mac app did nothing: the label click reached the `<input type=file>` behind `PicUpload`, but no file chooser appeared. WebKit on macOS only opens one when the `WKUIDelegate` implements `runOpenPanelWithParameters:`; iOS and Mac Catalyst run their own document picker, so only the AppKit twin of the delegate (`MauiWebView.MacOS.cs`) was missing it. Every other file input in the app was dead the same way.

## Fix

`RunOpenPanel` override in the macOS `UIDelegate`: an `NSOpenPanel` shown as a sheet on the WebView's window (`RunModal` fallback when there is none), honouring WebKit's `AllowsDirectories` / `AllowsMultipleSelection` parameters.

Invariants for reviewers:
- The completion handler gets `null` on cancel. An empty array is a zero-file selection, not a cancel, and WebKit treats them differently.
- `WKOpenPanelParameters` exposes no public `accept` list, so the panel has no file-type filter; `FileUpload` still enforces size and the server enforces content type.
- The sandboxed Release build already carries `com.apple.security.files.user-selected.read-write`, so the panel works through the powerbox unchanged.

## Testing

- `net11.0-macos` builds clean.
- Verified on the Mac (Debug, AppKit): open panel appears as a sheet, picking an image changes the chat avatar.
- Not run: Release/sandboxed build of this branch; other platforms untouched (file lives in the macOS-only partial).

Closes #4435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
