### PR TITLE
fix(avatar): show progress while the crop modal saves the picture

### DIFF
--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -881,6 +881,8 @@ public static class LocalizedStringsLocalizerExt
         public string PicCrop_Apply => l["PicCrop_Apply"].Value;
         public string PicCrop_RotateLeft => l["PicCrop_RotateLeft"].Value;
         public string PicCrop_RotateRight => l["PicCrop_RotateRight"].Value;
+        public string PicCrop_Uploading_Format(object arg0) => l["PicCrop_Uploading_Format", arg0].Value;
+        public string PicCrop_Processing => l["PicCrop_Processing"].Value;
         public string PeerContact_Title => l["PeerContact_Title"].Value;
         public string PeerContact_DisplayName => l["PeerContact_DisplayName"].Value;
         public string PeerContact_BlockUser => l["PeerContact_BlockUser"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Приложете",
   "PicCrop_RotateLeft": "Завъртете наляво",
   "PicCrop_RotateRight": "Завъртете надясно",
+  "PicCrop_Uploading_Format": "Качване... {0}%",
+  "PicCrop_Processing": "Обработка...",
   "PeerContact_Title": "Редактирайте контакта",
   "PeerContact_DisplayName": "Показвано име",
   "PeerContact_BlockUser": "Блокирайте потребителя",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Primijenite",
   "PicCrop_RotateLeft": "Rotirajte lijevo",
   "PicCrop_RotateRight": "Rotirajte desno",
+  "PicCrop_Uploading_Format": "Otpremanje... {0}%",
+  "PicCrop_Processing": "Obrada...",
   "PeerContact_Title": "Uredite kontakt",
   "PeerContact_DisplayName": "Prikazano ime",
   "PeerContact_BlockUser": "Blokirajte korisnika",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Primijenite",
   "PicCrop_RotateLeft": "Rotirajte lijevo",
   "PicCrop_RotateRight": "Rotirajte desno",
+  "PicCrop_Uploading_Format": "Otpremanje... {0}%",
+  "PicCrop_Processing": "Obrada...",
   "PeerContact_Title": "Uredite kontakt",
   "PeerContact_DisplayName": "Prikazano ime",
   "PeerContact_BlockUser": "Blokirajte korisnika",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Použít",
   "PicCrop_RotateLeft": "Otočit doleva",
   "PicCrop_RotateRight": "Otočit doprava",
+  "PicCrop_Uploading_Format": "Nahrávání... {0}%",
+  "PicCrop_Processing": "Zpracování...",
   "PeerContact_Title": "Upravit kontakt",
   "PeerContact_DisplayName": "Zobrazované jméno",
   "PeerContact_BlockUser": "Zablokovat uživatele",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Übernehmen",
   "PicCrop_RotateLeft": "Nach links drehen",
   "PicCrop_RotateRight": "Nach rechts drehen",
+  "PicCrop_Uploading_Format": "Wird hochgeladen... {0}%",
+  "PicCrop_Processing": "Wird verarbeitet...",
   "PeerContact_Title": "Kontakt bearbeiten",
   "PeerContact_DisplayName": "Anzeigename",
   "PeerContact_BlockUser": "Nutzer blockieren",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -997,6 +997,8 @@
   "PicCrop_Apply": "Apply",
   "PicCrop_RotateLeft": "Rotate left",
   "PicCrop_RotateRight": "Rotate right",
+  "PicCrop_Uploading_Format": "Uploading... {0}%",
+  "PicCrop_Processing": "Processing...",
   "PeerContact_Title": "Edit contact",
   "PeerContact_DisplayName": "Display Name",
   "PeerContact_BlockUser": "Block user",

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Aplicar",
   "PicCrop_RotateLeft": "Girar a la izquierda",
   "PicCrop_RotateRight": "Girar a la derecha",
+  "PicCrop_Uploading_Format": "Subiendo... {0}%",
+  "PicCrop_Processing": "Procesando...",
   "PeerContact_Title": "Editar contacto",
   "PeerContact_DisplayName": "Nombre visible",
   "PeerContact_BlockUser": "Bloquear usuario",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Appliquer",
   "PicCrop_RotateLeft": "Pivoter à gauche",
   "PicCrop_RotateRight": "Pivoter à droite",
+  "PicCrop_Uploading_Format": "Envoi en cours... {0}%",
+  "PicCrop_Processing": "Traitement...",
   "PeerContact_Title": "Modifier le contact",
   "PeerContact_DisplayName": "Nom affiché",
   "PeerContact_BlockUser": "Bloquer l'utilisateur",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "लागू करें",
   "PicCrop_RotateLeft": "बाएँ घुमाएँ",
   "PicCrop_RotateRight": "दाएँ घुमाएँ",
+  "PicCrop_Uploading_Format": "अपलोड हो रहा है... {0}%",
+  "PicCrop_Processing": "प्रोसेस हो रहा है...",
   "PeerContact_Title": "संपर्क संपादित करें",
   "PeerContact_DisplayName": "प्रदर्शित नाम",
   "PeerContact_BlockUser": "उपयोगकर्ता को ब्लॉक करें",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Primijenite",
   "PicCrop_RotateLeft": "Rotirajte lijevo",
   "PicCrop_RotateRight": "Rotirajte desno",
+  "PicCrop_Uploading_Format": "Prijenos... {0}%",
+  "PicCrop_Processing": "Obrada...",
   "PeerContact_Title": "Uredite kontakt",
   "PeerContact_DisplayName": "Prikazano ime",
   "PeerContact_BlockUser": "Blokirajte korisnika",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Terapkan",
   "PicCrop_RotateLeft": "Putar ke kiri",
   "PicCrop_RotateRight": "Putar ke kanan",
+  "PicCrop_Uploading_Format": "Mengunggah... {0}%",
+  "PicCrop_Processing": "Memproses...",
   "PeerContact_Title": "Edit kontak",
   "PeerContact_DisplayName": "Nama tampilan",
   "PeerContact_BlockUser": "Blokir pengguna",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Applica",
   "PicCrop_RotateLeft": "Ruota a sinistra",
   "PicCrop_RotateRight": "Ruota a destra",
+  "PicCrop_Uploading_Format": "Caricamento... {0}%",
+  "PicCrop_Processing": "Elaborazione...",
   "PeerContact_Title": "Modifica contatto",
   "PeerContact_DisplayName": "Nome visualizzato",
   "PeerContact_BlockUser": "Blocca utente",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "適用",
   "PicCrop_RotateLeft": "左に回転",
   "PicCrop_RotateRight": "右に回転",
+  "PicCrop_Uploading_Format": "アップロード中... {0}%",
+  "PicCrop_Processing": "処理中...",
   "PeerContact_Title": "連絡先を編集",
   "PeerContact_DisplayName": "表示名",
   "PeerContact_BlockUser": "ユーザーをブロック",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "적용",
   "PicCrop_RotateLeft": "왼쪽으로 회전",
   "PicCrop_RotateRight": "오른쪽으로 회전",
+  "PicCrop_Uploading_Format": "업로드 중... {0}%",
+  "PicCrop_Processing": "처리 중...",
   "PeerContact_Title": "연락처 편집",
   "PeerContact_DisplayName": "표시 이름",
   "PeerContact_BlockUser": "사용자 차단",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -997,6 +997,8 @@
   "PicCrop_Apply": "Übernehmen",
   "PicCrop_RotateLeft": "Повернути ліворуч",
   "PicCrop_RotateRight": "Повернути праворуч",
+  "PicCrop_Uploading_Format": "Wird hochgeladen... {0}%",
+  "PicCrop_Processing": "प्रोसेस हो रहा है...",
   "PeerContact_Title": "Редактирайте контакта",
   "PeerContact_DisplayName": "Отображаемое имя",
   "PeerContact_BlockUser": "Заблокировать пользователя",

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Zastosuj",
   "PicCrop_RotateLeft": "Obróć w lewo",
   "PicCrop_RotateRight": "Obróć w prawo",
+  "PicCrop_Uploading_Format": "Przesyłanie... {0}%",
+  "PicCrop_Processing": "Przetwarzanie...",
   "PeerContact_Title": "Edytuj kontakt",
   "PeerContact_DisplayName": "Wyświetlana nazwa",
   "PeerContact_BlockUser": "Zablokuj użytkownika",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Aplicar",
   "PicCrop_RotateLeft": "Girar à esquerda",
   "PicCrop_RotateRight": "Girar à direita",
+  "PicCrop_Uploading_Format": "Enviando... {0}%",
+  "PicCrop_Processing": "Processando...",
   "PeerContact_Title": "Editar contato",
   "PeerContact_DisplayName": "Nome de exibição",
   "PeerContact_BlockUser": "Bloquear usuário",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Применить",
   "PicCrop_RotateLeft": "Повернуть влево",
   "PicCrop_RotateRight": "Повернуть вправо",
+  "PicCrop_Uploading_Format": "Загрузка... {0}%",
+  "PicCrop_Processing": "Обработка...",
   "PeerContact_Title": "Изменить контакт",
   "PeerContact_DisplayName": "Отображаемое имя",
   "PeerContact_BlockUser": "Заблокировать пользователя",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Примените",
   "PicCrop_RotateLeft": "Ротирајте лијево",
   "PicCrop_RotateRight": "Ротирајте десно",
+  "PicCrop_Uploading_Format": "Отпремање... {0}%",
+  "PicCrop_Processing": "Обрада...",
   "PeerContact_Title": "Уредите контакт",
   "PeerContact_DisplayName": "Приказано име",
   "PeerContact_BlockUser": "Блокирајте корисника",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Uygulayın",
   "PicCrop_RotateLeft": "Sola döndürün",
   "PicCrop_RotateRight": "Sağa döndürün",
+  "PicCrop_Uploading_Format": "Yükleniyor... %{0}",
+  "PicCrop_Processing": "İşleniyor...",
   "PeerContact_Title": "Kişiyi düzenleyin",
   "PeerContact_DisplayName": "Görünen ad",
   "PeerContact_BlockUser": "Kullanıcıyı engelleyin",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Застосувати",
   "PicCrop_RotateLeft": "Повернути ліворуч",
   "PicCrop_RotateRight": "Повернути праворуч",
+  "PicCrop_Uploading_Format": "Завантаження... {0}%",
+  "PicCrop_Processing": "Обробка...",
   "PeerContact_Title": "Редагувати контакт",
   "PeerContact_DisplayName": "Відображуване ім'я",
   "PeerContact_BlockUser": "Заблокувати користувача",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "Áp dụng",
   "PicCrop_RotateLeft": "Xoay trái",
   "PicCrop_RotateRight": "Xoay phải",
+  "PicCrop_Uploading_Format": "Đang tải lên... {0}%",
+  "PicCrop_Processing": "Đang xử lý...",
   "PeerContact_Title": "Chỉnh sửa liên hệ",
   "PeerContact_DisplayName": "Tên hiển thị",
   "PeerContact_BlockUser": "Chặn người dùng",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -842,6 +842,8 @@
   "PicCrop_Apply": "应用",
   "PicCrop_RotateLeft": "向左旋转",
   "PicCrop_RotateRight": "向右旋转",
+  "PicCrop_Uploading_Format": "正在上传... {0}%",
+  "PicCrop_Processing": "正在处理...",
   "PeerContact_Title": "编辑联系人",
   "PeerContact_DisplayName": "显示名称",
   "PeerContact_BlockUser": "屏蔽用户",

--- a/src/dotnet/UI.Blazor.App/Components/PicCropModal/PicCropModal.razor
+++ b/src/dotnet/UI.Blazor.App/Components/PicCropModal/PicCropModal.razor
@@ -6,7 +6,10 @@
 @implements IAsyncDisposable
 
 <DialogFrame
-    Class="@("pic-crop-modal" + (ModalModel.IsSquare ? " square" : "") + (ModalModel.HasBlur ? " has-blur" : ""))"
+    Class="@("pic-crop-modal"
+        + (ModalModel.IsSquare ? " square" : "")
+        + (ModalModel.HasBlur ? " has-blur" : "")
+        + (_isSaving ? " saving" : ""))"
     Title="@(ModalModel.HasBlur
         ? L.PicCrop_WallpaperTitle
         : ModalModel.IsSquare ? L.PicCrop_PlaceAvatarTitle : L.PicCrop_AvatarTitle)"
@@ -25,7 +28,9 @@
                 </div>
                 @if (ModalModel.ViewportAspectRatio > 0) {
                     <div class="c-preview">
-                        <canvas @ref="_previewRef" width="120" height="@((int)(120 / ModalModel.ViewportAspectRatio))"></canvas>
+                        <canvas @ref="_previewRef"
+                                width="120"
+                                height="@((int)(120 / ModalModel.ViewportAspectRatio))"></canvas>
                         <span class="c-preview-label">@L.PicCrop_Preview</span>
                     </div>
                 } else {
@@ -44,25 +49,33 @@
                 }
                 <div class="c-buttons-row">
                     <div class="c-group">
-                        <ButtonRound Class="btn-zoom-out" Tooltip="@L.PicCrop_ZoomOut">
+                        <ButtonRound Class="btn-zoom-out" Tooltip="@L.PicCrop_ZoomOut" IsDisabled="@_isSaving">
                             <i class="icon-minus-circle text-2xl"></i>
                         </ButtonRound>
-                        <ButtonRound Class="btn-zoom-in" Tooltip="@L.PicCrop_ZoomIn">
+                        <ButtonRound Class="btn-zoom-in" Tooltip="@L.PicCrop_ZoomIn" IsDisabled="@_isSaving">
                             <i class="icon-plus-circle text-2xl"></i>
                         </ButtonRound>
                     </div>
-                    <ButtonRound Class="btn-confirm" Click="@OnConfirm" Tooltip="@L.PicCrop_Apply">
-                        <i class="icon-checkmark-simple text-2xl"></i>
+                    <ButtonRound Class="btn-confirm"
+                                 Click="@OnConfirm"
+                                 Tooltip="@L.PicCrop_Apply"
+                                 IsDisabled="@_isSaving">
+                        @if (_isSaving) {
+                            <Spinner/>
+                        } else {
+                            <i class="icon-checkmark-simple text-2xl"></i>
+                        }
                     </ButtonRound>
                     <div class="c-group">
-                        <ButtonRound Class="btn-rotate-ccw" Tooltip="@L.PicCrop_RotateLeft">
+                        <ButtonRound Class="btn-rotate-ccw" Tooltip="@L.PicCrop_RotateLeft" IsDisabled="@_isSaving">
                             <i class="icon-refresh text-2xl c-flip"></i>
                         </ButtonRound>
-                        <ButtonRound Class="btn-rotate-cw" Tooltip="@L.PicCrop_RotateRight">
+                        <ButtonRound Class="btn-rotate-cw" Tooltip="@L.PicCrop_RotateRight" IsDisabled="@_isSaving">
                             <i class="icon-refresh text-2xl"></i>
                         </ButtonRound>
                     </div>
                 </div>
+                <div class="c-status">@_saveStatus</div>
             </div>
         }
     </Body>
@@ -77,7 +90,10 @@
     private ElementReference _previewRef;
     private IJSObjectReference? _jsRef;
     private DotNetObjectReference<PicCropModal>? _blazorRef;
+    private CancellationTokenSource? _saveCts;
     private bool _hasError;
+    private bool _isSaving;
+    private string _saveStatus = "";
 
     [CascadingParameter] public Modal Modal { get; set; } = null!;
     [Parameter] public Model ModalModel { get; set; } = null!;
@@ -99,6 +115,8 @@
     }
 
     public async ValueTask DisposeAsync() {
+        _saveCts.CancelAndDisposeSilently();
+        _saveCts = null;
         if (_jsRef is { } jsRef) {
             _jsRef = null;
             await jsRef.DisposeSilentlyAsync("dispose");
@@ -114,8 +132,15 @@
     }
 
     private async Task OnConfirm() {
+        if (_isSaving)
+            return;
+
+        _isSaving = true;
+        _saveCts = new CancellationTokenSource();
+        var cancellationToken = _saveCts.Token;
         try {
-            var exported = await _jsRef!.InvokeAsync<bool>("exportCrop").ConfigureAwait(true);
+            SetSaveStatus(L.PicCrop_Uploading_Format(0));
+            var exported = await _jsRef!.InvokeAsync<bool>("exportCrop", cancellationToken).ConfigureAwait(true);
             if (!exported) {
                 UICommander.ShowError(StandardError.Upload.CropExportFailed());
                 return;
@@ -123,35 +148,55 @@
 
             // Upload the cropped blob via the standard pipeline
             var scope = ModalModel.Scope;
-            var mediaId = await UICommander.Call(new Media_ReserveMedia { Session = Session, Scope = scope });
+            var mediaId = await UICommander.Call(
+                new Media_ReserveMedia { Session = Session, Scope = scope },
+                cancellationToken);
 
             var tag = $"FileUpload/v1/{scope}";
             var metadata = new MetadataBag()
                 .Set("FileName", "avatar-crop.png")
                 .Set("ContentType", "image/png");
-            var blobSize = await _jsRef!.InvokeAsync<long>("getCroppedBlobSize").ConfigureAwait(true);
+            var blobSize = await _jsRef!
+                .InvokeAsync<long>("getCroppedBlobSize", cancellationToken)
+                .ConfigureAwait(true);
             var uploadId = await UICommander.Call(new Uploads_Create {
                 Session = Session,
                 Length = blobSize,
                 Tag = tag,
                 Metadata = metadata,
-            });
+            }, cancellationToken);
 
             var streamSource = new WebUploadStreamSource(_jsRef!);
-            await FileUploader.Upload(streamSource, uploadId, null, CancellationToken.None);
+            var progress = new Progress<double>(p => SetSaveStatus(L.PicCrop_Uploading_Format((int)p)));
+            await FileUploader.Upload(streamSource, uploadId, progress, cancellationToken);
 
+            SetSaveStatus(L.PicCrop_Processing);
             var mediaRef = await UICommander.Call(new Media_ProcessUpload {
                 Session = Session,
                 MediaId = mediaId,
                 UploadId = uploadId,
-            });
+            }, cancellationToken);
 
             ModalModel.OnCropped?.Invoke(mediaRef);
             Modal.Close();
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            // The modal was closed while saving
+        }
         catch (Exception e) {
             UICommander.ShowError(e);
         }
+        finally {
+            _isSaving = false;
+            _saveStatus = "";
+            _saveCts.DisposeSilently();
+            _saveCts = null;
+        }
+    }
+
+    private void SetSaveStatus(string status) {
+        _saveStatus = status;
+        _ = InvokeAsync(StateHasChanged);
     }
 
     // Nested types

--- a/src/dotnet/UI.Blazor.App/Components/PicCropModal/pic-crop-modal.css
+++ b/src/dotnet/UI.Blazor.App/Components/PicCropModal/pic-crop-modal.css
@@ -32,6 +32,9 @@
 .pic-crop-modal .c-canvas-container > canvas:active {
     @apply cursor-grabbing;
 }
+.pic-crop-modal.saving .c-canvas-container {
+    @apply pointer-events-none;
+}
 
 /* ── Preview ── */
 
@@ -133,6 +136,13 @@
 .pic-crop-modal .c-controls .btn-round.btn-confirm {
     @apply bg-primary;
     @apply text-white;
+}
+.pic-crop-modal .c-controls .btn-round.btn-confirm .spinner {
+    @apply w-5 h-5;
+}
+.pic-crop-modal .c-controls .c-status {
+    @apply h-5;
+    @apply text-sm text-03;
 }
 .pic-crop-modal .c-controls .c-flip {
     @apply -scale-x-100;

--- a/tests/ts/e2e/svg-avatar-upload.test.ts
+++ b/tests/ts/e2e/svg-avatar-upload.test.ts
@@ -136,6 +136,11 @@ describe('SVG avatar upload', () => {
         const confirmBtn = cropModal.locator('.btn-confirm').first();
         await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 });
         await confirmBtn.click();
+
+        // Apply switches the modal into its saving state (spinner on the button,
+        // upload/processing status) until the server returns the converted media.
+        await cropModal.locator('.btn-confirm .spinner').waitFor({ state: 'visible', timeout: 5_000 });
+        await page.screenshot({ path: screenshot('e2e', 'svg-avatar-crop-saving') });
         await cropModal.waitFor({ state: 'hidden', timeout: 15_000 });
         await page.screenshot({ path: screenshot('e2e', 'svg-avatar-uploaded') });
 


### PR DESCRIPTION
## Summary

Apply in `PicCropModal` ran the whole save pipeline — crop export, `Media_ReserveMedia`, `Uploads_Create`, `FileUploader.Upload`, `Media_ProcessUpload` — with nothing changing on screen. The button stayed enabled, so a second click started a second upload, and nothing told the user the save was in flight (#4445).

## Fix

- A saving state in the modal: `Spinner` replaces the checkmark on Apply, all five control buttons are disabled, and a `saving` class makes the canvas inert.
- A status line under the buttons shows the upload percentage — `FileUploader.Upload` already reported it through `IProgress<double>`, the modal just passed `null` — and then a processing message while the server converts the image.
- Re-entry guard on Apply; a `CancellationTokenSource` cancels the pipeline when the modal is disposed mid-save.
- Two new catalog keys (`PicCrop_Uploading_Format`, `PicCrop_Processing`) across all hand-written languages; BCMS and Max catalogs regenerated with the derive scripts.

## Testing

- Server-loop rebuild green (npm + dotnet), server up.
- `AppLocalizationTest` 16/16 green; `derive-bcms --check` / `derive-max --check` pass.
- Not browser-verified yet — the chrome-devtools MCPs were down in the session. Owed: open the avatar editor, pick an image, Apply, and watch the spinner and status line.

Closes #4445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
