### PR TITLE
fix(ios-ptt): keep a failed vibration from aborting the recording start

### DIFF
--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleTuneUI.cs
@@ -1,4 +1,5 @@
 using ActualChat.App.Maui.Services;
+using ActualChat.Maui.Services;
 using ActualChat.Pooling;
 using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.Services;
@@ -62,9 +63,14 @@ public sealed class AppleTuneUI(UIHub hub) : MauiTuneUI(hub)
         => Haptics.IsSupported;
 
     protected override Task Vibrate(Tune tune, TuneInfo info)
-        => info.Vibration.Length == 0
-            ? Task.CompletedTask
-            : BackgroundTask.Run(() => Haptics.Vibrate(tune, info.Vibration), Log, $"Failed to vibrate '{tune}'");
+    {
+        // CoreHaptics is foreground-only: in the background every engine creation fails, and a
+        // PTT reply from the lock screen would pay for that with an aborted recording start.
+        if (info.Vibration.Length == 0 || MauiBackgroundState.IsBackground.Value)
+            return Task.CompletedTask;
+
+        return BackgroundTask.Run(() => Haptics.Vibrate(tune, info.Vibration));
+    }
 #endif
 
     // Private methods

--- a/src/dotnet/App.Maui/Platforms/iOS/Audio/Haptics.cs
+++ b/src/dotnet/App.Maui/Platforms/iOS/Audio/Haptics.cs
@@ -93,7 +93,7 @@ public class Haptics(AppUIHub hub) : IDisposable
                 return engine;
             }
             catch (Exception e) {
-                Log.LogError(e, "Failed to create haptic engine");
+                Log.LogWarning(e, "Failed to create haptic engine");
                 throw;
             }
     }

--- a/src/dotnet/App.Maui/Services/MauiTuneUI.cs
+++ b/src/dotnet/App.Maui/Services/MauiTuneUI.cs
@@ -47,9 +47,21 @@ public class MauiTuneUI : TuneUI
         if (GetTuneInfo(tune) is not { } info)
             return;
 
-        var vibrateTask = Vibrate(tune, info);
+        var vibrateTask = VibrateSafely(tune, info);
         var playSoundTask = PlaySound(info.Sound);
         await Task.WhenAll(vibrateTask, playSoundTask).ConfigureAwait(false);
+    }
+
+    private async Task VibrateSafely(Tune tune, TuneInfo info)
+    {
+        // The recorder start awaits its begin tune, so a vibration that fails - CoreHaptics can't
+        // run in the background - must not take the recording down with it.
+        try {
+            await Vibrate(tune, info).ConfigureAwait(false);
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Failed to vibrate '{Tune}'", tune);
+        }
     }
 
     // Protected methods


### PR DESCRIPTION
## Summary

A Talk press on the iOS system PTT button played the begin tune, then at once the end tune, and only recorded after a 0.5 s restart. Sentry breadcrumbs from the TestFlight build (2.20.35) show the chain on every press: CoreHaptics cannot create its engine while the app is in the background (the lock-screen case), that failure faulted the tune's vibrate task (`BackgroundTask.Run` with a logger logs *and* rethrows), `PlayAndWait(BeginRecording)` threw inside `RecordChat`, and the recorder died before capturing anything. `PushRecordingState` restarted it without a begin tune, which is what recorded. Speech survived through the pre-roll, but the recorder came up ~2.5 s after the press and the tunes read as "started, then stopped".

## Fix

- `MauiTuneUI.PlayAndWaitInternal` awaits the vibration under a catch (`VibrateSafely`): a tune's sound still plays, and nothing that awaits a tune, the recorder start above all, depends on the vibration motor any more. Invariant: a tune must never fault its awaiter.
- `AppleTuneUI.Vibrate` skips haptics while `MauiBackgroundState.IsBackground` is set, where every CoreHaptics engine creation fails.
- `Haptics.CreateHapticEngine` logs the failure at Warning instead of Error (it was one Sentry error per background tune).

## Testing

- `net11.0-ios` compiles. Not device-verified: needs the next dev TestFlight build; expected result is one begin tune at the press, the recorder starting on the first attempt, one end tune on release, and no `PushRecordingState … restarting` line in the breadcrumbs.
- Android target not compiled: the local SDK resolved to `11.0.100-rc.1` without the `wasm-tools` workload (unrelated); the shared `MauiTuneUI` change is a try/catch around an existing await.

Part of #4414 (tracking issue, intentionally not closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHgmKfBmQVUKYoUmnJ7HoX
