### PR TITLE
fix(video): stop the capture-stall watchdog from restarting an idle screencast

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -85,6 +85,7 @@ import {
     type RecorderWorkerCallbacks,
     type WireSafeRecorderConfig,
 } from '../../Services/Video/sender/recorder-worker-contract';
+import { CaptureStallDetector } from '../../Services/Video/sender/capture-stall-detector';
 import { consumeVideoTraceKill, registerVideoTraceKillWorker } from '../../Services/Video/video-trace-kill-control';
 import { getDownscalerMode } from '../../Services/Video/downscaler-mode';
 import { FrameDropStage } from '../../Services/Video/frame-drop-trace';
@@ -591,8 +592,7 @@ export class VideoRecorder {
 
     private recoveryAttempts = 0;
     private recoveryScheduled = false;
-    // Wallclock when foreground capture first flatlined; 0 when capture is live.
-    private captureStallSinceMs = 0;
+    private readonly captureStallDetector = new CaptureStallDetector(CAPTURE_STALL_RECOVERY_MS);
 
     static create(blazorRef: DotNet.DotNetObject, kind: number): VideoRecorder {
         return new VideoRecorder(blazorRef, kind);
@@ -2398,32 +2398,18 @@ export class VideoRecorder {
         }
     }
 
-    // Recovers a reclaimed encoder / wedged source the frame-driven path can't
-    // see: a foreground capture flatline means no frame reaches the dead
-    // encoder to throw, so force a restart. Foreground-gated to avoid churning
-    // a legitimately backgrounded idle encoder into a restart loop.
-    private detectCaptureStall(
-        stats: RecorderStats,
-        previous: RecorderStats | null,
-        nowMs: number,
-    ): void {
+    private detectCaptureStall(stats: RecorderStats, nowMs: number): void {
         const track = this.inputTrack;
-        const sourceShouldRun = this._recordingState === 'recording'
-            && !stats.isTabBackgrounded
-            && track !== null && track.readyState === 'live' && !track.muted;
-        if (!sourceShouldRun || previous === null || this.recoveryScheduled
-            || stats.framesCaptured > previous.framesCaptured) {
-            this.captureStallSinceMs = 0;
-            return;
-        }
-        if (this.captureStallSinceMs === 0) {
-            this.captureStallSinceMs = nowMs;
-            return;
-        }
-        if (nowMs - this.captureStallSinceMs >= CAPTURE_STALL_RECOVERY_MS) {
-            this.captureStallSinceMs = 0;
+        const isStalled = this.captureStallDetector.onSample({
+            isRecording: this._recordingState === 'recording',
+            isScreencast: this.currentMode === 'screen',
+            isTabBackgrounded: stats.isTabBackgrounded,
+            isTrackLive: track !== null && track.readyState === 'live' && !track.muted,
+            isRecoveryScheduled: this.recoveryScheduled,
+            framesCaptured: stats.framesCaptured,
+        }, nowMs);
+        if (isStalled)
             this.scheduleRecovery('foreground capture stalled (no frames reached the encoder)');
-        }
     }
 
     private scheduleRecovery(reason: string): void {
@@ -2771,7 +2757,7 @@ export class VideoRecorder {
         this.windowDownscaleTimeMsMax = -1;
         this.dropPerSec.clear();
         this.lastReportTickMs = 0;
-        this.captureStallSinceMs = 0;
+        this.captureStallDetector.reset();
         this.recorderHealthTimer = window.setInterval(() => {
             void this.reportRecorderStats();
         }, RECORDER_HEALTH_INTERVAL_MS);
@@ -2889,7 +2875,7 @@ export class VideoRecorder {
             }
             this.lastReportTickMs = nowMs;
 
-            this.detectCaptureStall(stats, previous, nowMs);
+            this.detectCaptureStall(stats, nowMs);
 
             // Drop trace deltas → senderFrameDropRatio. Sum only sender
             // stages (1..30). Denominator = bundles attempted = bundles

--- a/src/dotnet/UI.Blazor.App/Services/Video/sender/capture-stall-detector.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/sender/capture-stall-detector.ts
@@ -1,0 +1,54 @@
+export interface CaptureStallSample {
+    isRecording: boolean;
+    isScreencast: boolean;
+    isTabBackgrounded: boolean;
+    isTrackLive: boolean;
+    isRecoveryScheduled: boolean;
+    framesCaptured: number;
+}
+
+const DEFAULT_STALL_AFTER_MS = 3_000;
+
+// Recovers a reclaimed encoder / wedged source the frame-driven path can't
+// see: a foreground capture flatline means no frame reaches the dead encoder
+// to throw, so the recorder must be restarted. Screencast is exempt — a still
+// screen legitimately captures nothing, and its keep-alive keeps feeding the
+// encoder clones, so a dead encoder there does throw on the frame path.
+// Pure: feed it health-monitor samples; deltas only.
+export class CaptureStallDetector {
+    private readonly stallAfterMs: number;
+    private lastFramesCaptured = -1;
+    private stallSinceMs = 0;
+
+    constructor(stallAfterMs?: number) {
+        this.stallAfterMs = stallAfterMs ?? DEFAULT_STALL_AFTER_MS;
+    }
+
+    reset(): void {
+        this.lastFramesCaptured = -1;
+        this.stallSinceMs = 0;
+    }
+
+    onSample(sample: CaptureStallSample, nowMs: number): boolean {
+        const previous = this.lastFramesCaptured;
+        this.lastFramesCaptured = sample.framesCaptured;
+        const sourceShouldRun = sample.isRecording
+            && !sample.isScreencast
+            && !sample.isTabBackgrounded
+            && sample.isTrackLive;
+        if (!sourceShouldRun || previous < 0 || sample.isRecoveryScheduled
+            || sample.framesCaptured > previous) {
+            this.stallSinceMs = 0;
+            return false;
+        }
+        if (this.stallSinceMs === 0) {
+            this.stallSinceMs = nowMs;
+            return false;
+        }
+        if (nowMs - this.stallSinceMs < this.stallAfterMs)
+            return false;
+
+        this.stallSinceMs = 0;
+        return true;
+    }
+}

--- a/tests/ts/unit/sender/capture-stall-detector.test.ts
+++ b/tests/ts/unit/sender/capture-stall-detector.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CaptureStallDetector,
+    type CaptureStallSample,
+} from '../../../../src/dotnet/UI.Blazor.App/Services/Video/sender/capture-stall-detector';
+
+function sample(over: Partial<CaptureStallSample> = {}): CaptureStallSample {
+    return {
+        isRecording: true,
+        isScreencast: false,
+        isTabBackgrounded: false,
+        isTrackLive: true,
+        isRecoveryScheduled: false,
+        framesCaptured: 10,
+        ...over,
+    };
+}
+
+describe('CaptureStallDetector', () => {
+    it('reports a stall once foreground camera capture flatlines for the threshold', () => {
+        const d = new CaptureStallDetector(3_000);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 0)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 1_000)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 2_000)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 4_000)).toBe(true);
+    });
+
+    it('re-arms after a stall so the next flatline is reported again', () => {
+        const d = new CaptureStallDetector(3_000);
+        d.onSample(sample({ framesCaptured: 10 }), 0);
+        d.onSample(sample({ framesCaptured: 10 }), 1_000);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 4_000)).toBe(true);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 5_000)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 10 }), 9_000)).toBe(true);
+    });
+
+    it('resets when frames arrive', () => {
+        const d = new CaptureStallDetector(3_000);
+        d.onSample(sample({ framesCaptured: 10 }), 0);
+        d.onSample(sample({ framesCaptured: 10 }), 1_000);
+        d.onSample(sample({ framesCaptured: 11 }), 2_000);
+        expect(d.onSample(sample({ framesCaptured: 11 }), 4_500)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 11 }), 5_500)).toBe(false);
+        expect(d.onSample(sample({ framesCaptured: 11 }), 7_500)).toBe(true);
+    });
+
+    it('never reports a stall for a screencast, whose idle screen legitimately captures nothing', () => {
+        const d = new CaptureStallDetector(3_000);
+        for (let t = 0; t <= 30_000; t += 1_000)
+            expect(d.onSample(sample({ isScreencast: true, framesCaptured: 1 }), t)).toBe(false);
+    });
+
+    it('ignores backgrounded tabs, dead tracks, pending recovery and non-recording states', () => {
+        const d = new CaptureStallDetector(3_000);
+        d.onSample(sample(), 0);
+        d.onSample(sample(), 1_000);
+        expect(d.onSample(sample({ isTabBackgrounded: true }), 4_000)).toBe(false);
+        expect(d.onSample(sample({ isTrackLive: false }), 8_000)).toBe(false);
+        expect(d.onSample(sample({ isRecoveryScheduled: true }), 12_000)).toBe(false);
+        expect(d.onSample(sample({ isRecording: false }), 16_000)).toBe(false);
+        // Each of those resets the window, so a fresh flatline needs the full threshold again.
+        expect(d.onSample(sample(), 17_000)).toBe(false);
+        expect(d.onSample(sample(), 19_000)).toBe(false);
+        expect(d.onSample(sample(), 20_500)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

During this morning's dev call (2026-09-09, 05:30–05:44 UTC) a screencast was re-published 39 times under new stream ids, roughly every 5 s, so every viewer rebuilt the tile each time — the "blinking" in #4423.

`getDisplayMedia` emits frames only when the shared screen changes. The sender's keep-alive covers that for the wire by re-emitting a clone once per second, but those clones are injected downstream of the capture counter. The foreground capture-stall watchdog in `video-recorder.ts` (added in 11e5535dab to recover a reclaimed encoder) reads that counter, so a still screen looked like a dead encoder: after 3 s it restarted the recorder under a new stream id, the screen was still still, and the loop ran until the share ended. The healthy first 82 s of the same share had a changing screen. Camera + screencast coexistence was not involved.

## Fix

The stall decision moves into a pure `CaptureStallDetector` (`Services/Video/sender/capture-stall-detector.ts`) that receives the mode and exempts screencast. That is sound because the screencast keep-alive already feeds the encoder clones, so a dead encoder there throws on the frame path like everywhere else. Camera behaviour is unchanged: same 3 s threshold, same foreground/track/recovery gates.

Not in this PR: replacing the per-second keep-alive clone with an idle heartbeat, and stopping the recovery-attempt counter from resetting on keep-alive-only bundles. The exemption alone stops the loop.

## Testing

- `npm run build:Verify` (tsc, eslint, build): green.
- `npm run test:unit`: 687 green, including the new `capture-stall-detector.test.ts` (camera stall, re-arm, reset on frames, screencast exemption, gating).
- Not verified live: a real screencast of a static screen with the Voxt tab in the foreground. The server-side tell to check after deploy is that a screencast session no longer emits a `PushStream: VideoRecord … SourceKind = ScreenCast` line every ~5 s.

Closes #4423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqAvjbaa7ywnyuwaDRovTQ
