### PR TITLE
fix(video): recover a viewer's tile when its worker's RPC peer dies after a reconnect

### DIFF
--- a/docs/api-index-ts.md
+++ b/docs/api-index-ts.md
@@ -148,7 +148,7 @@ See also: [C# Full API Index](api-index-full.md), [Condensed API Index](api-inde
 - `SessionTokenProvider` (type) - Function providing session tokens.
 - `ApiConnectivityUI` (interface) - Connectivity status from .NET side.
 - `ApiInitOptions` (interface) - Initialization options for API.
-- `ApiReconnectDelayer` (class) - Manages API reconnection backoff.
+- `ApiReconnectDelayer` (class) - Reconnect backoff; parks while no scope requires a connection, slows to a probe while the .NET-connectivity hint says offline.
 - `SystemPropertiesDef` (const) - RPC service definition for system properties.
 - `ServerApiInfoDto` (interface) - DTO for server API information.
 - `SystemPropertiesClient` (interface) - Client for system properties RPC.

--- a/docs/live-video/07-receiver.md
+++ b/docs/live-video/07-receiver.md
@@ -196,6 +196,16 @@ The MSTG render backend on the main thread runs a watchdog that retries
 `<video>.play()` on stalls and falls back to canvas if `<video>` is stuck
 for a configurable period (`render-backend-mstg.ts`).
 
+`video-player.ts` also polls the worker's own RPC peer on every liveness
+tick (`getConnectionState`, 2 s) and re-pushes main-thread connectivity to
+it, since the worker gates its reconnect loop on that signal. A peer that
+stays down for 15 s while the main-thread peer is connected is treated as
+dead — the state a parked or stopped worker reconnect loop leaves behind,
+where every pull restart waits on a connection that never comes — and the
+whole worker is rebuilt with a fresh peer (`DeadPeerDetector`,
+`recreatePlayerWorker`). The rebuilt tile loses its background blur: the
+bg canvas was transferred to the old worker and cannot be transferred again.
+
 ### Rotation-aware presentation
 
 The sender stamps a quantized device-orientation rotation on each wire frame

--- a/docs/live-video/07-receiver.md
+++ b/docs/live-video/07-receiver.md
@@ -196,15 +196,20 @@ The MSTG render backend on the main thread runs a watchdog that retries
 `<video>.play()` on stalls and falls back to canvas if `<video>` is stuck
 for a configurable period (`render-backend-mstg.ts`).
 
-`video-player.ts` also polls the worker's own RPC peer on every liveness
-tick (`getConnectionState`, 2 s) and re-pushes main-thread connectivity to
-it, since the worker gates its reconnect loop on that signal. A peer that
-stays down for 15 s while the main-thread peer is connected is treated as
-dead — the state a parked or stopped worker reconnect loop leaves behind,
-where every pull restart waits on a connection that never comes — and the
-whole worker is rebuilt with a fresh peer (`DeadPeerDetector`,
-`recreatePlayerWorker`). The rebuilt tile loses its background blur: the
-bg canvas was transferred to the old worker and cannot be transferred again.
+The worker's own RPC peer reconnects on its own evidence. Main-thread
+connectivity reaches it through `ConnectivityUI.publishTo` — on every change
+and every 5 s regardless, so a push lost across the worker boundary is
+corrected by the next one — but the worker's `ApiReconnectDelayer` treats
+that signal as a hint: while it says offline, reconnect attempts are spaced
+to a 15 s probe rather than stopped. Only "no scope requires a connection"
+parks the loop.
+
+`video-player.ts` still polls the worker's peer on every liveness tick
+(`getConnectionState`, 2 s). A peer that stays down for 15 s while the
+main-thread peer is connected is treated as dead and the whole worker is
+rebuilt with a fresh peer (`DeadPeerDetector`, `recreatePlayerWorker`). The
+rebuilt tile loses its background blur: the bg canvas was transferred to the
+old worker and cannot be transferred again.
 
 ### Rotation-aware presentation
 

--- a/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/AudioRecorder/opus-media-recorder.ts
@@ -7,7 +7,7 @@ import { catchErrors, delayAsync, delayAsyncWith, PromiseSource, ResolvedPromise
 import { rpcClient, rpcClientServer, RpcNoWait, rpcNoWait } from 'rpc';
 import { BrowserInit } from '../../../UI.Blazor/Services/BrowserInit/browser-init';
 import { BrowserInfo } from '../../../UI.Blazor/Services/BrowserInfo/browser-info';
-import { ConnectivityUI } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
+import { ConnectivityUI, type ConnectivityPublisher } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
 import { DebugUI } from '../../../UI.Blazor/Services/DebugUI/debug-ui';
 import { Api, WorkerKind } from 'api';
 import { audioContextSource, recordingAudioContextSource, AppAudioContext, AudioContextRef, AudioContextAction } from '../../Services/audio-context-source';
@@ -213,6 +213,7 @@ export class OpusMediaRecorder implements RecorderStateServer {
     public stream: MediaStream | null = null;
     private heartbeatTimerId: ReturnType<typeof setInterval> | undefined;
     private heartbeatSuspendedUntil = 0;
+    private connectivityPublisher: ConnectivityPublisher | null = null;
 
     private get isRecording(): boolean {
         return !!(this.stream && this.state === 'recording');
@@ -369,18 +370,10 @@ export class OpusMediaRecorder implements RecorderStateServer {
 
         SharedSettingsWorkerSync.register(this.encoderWorker);
 
-        const updateWorkerConnectivityUI = () => {
-            void this.encoderWorker?.onConnectivityUpdate(
-                ConnectivityUI.isOnline,
-                ConnectivityUI.isConnected,
-                ConnectivityUI.isBlazorServer,
-                rpcNoWait)
-        }
-        ConnectivityUI.isOnlineChanged.add(updateWorkerConnectivityUI);
-        ConnectivityUI.isConnectedChanged.add(updateWorkerConnectivityUI);
+        this.connectivityPublisher?.dispose();
+        this.connectivityPublisher = ConnectivityUI.publishTo((isOnline, isConnected, isBlazorServer) =>
+            this.encoderWorker?.onConnectivityUpdate(isOnline, isConnected, isBlazorServer, rpcNoWait));
         await ConnectivityUI.whenReady;
-        void this.encoderWorker.onConnectivityUpdate(
-            ConnectivityUI.isOnline, ConnectivityUI.isConnected, ConnectivityUI.isBlazorServer, rpcNoWait);
 
         await this.vadWorker.create(
             AC,
@@ -498,6 +491,8 @@ export class OpusMediaRecorder implements RecorderStateServer {
 
     public async terminate(): Promise<void> {
         this.stopHeartbeat();
+        this.connectivityPublisher?.dispose();
+        this.connectivityPublisher = null;
         await this.encoderWorker?.stop();
         await this.vadWorker?.reset();
         this.recordingAction?.dispose();

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -37,7 +37,7 @@ import { pickRenderBackendKind } from './render-backend-selection';
 import type { BgBlurMode } from '../../Services/Video/playback/bg-blur-tap';
 import { readBgBlurOverride } from '../../Services/Video/playback/bg-blur-override';
 import { BrowserInit } from '../../../UI.Blazor/Services/BrowserInit/browser-init';
-import { ConnectivityUI } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
+import { ConnectivityUI, type ConnectivityPublisher } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
 import { AC, VIDEO } from 'app-constants';
 import { RunningEMA } from 'math';
 
@@ -197,8 +197,7 @@ export class VideoPlayer {
      *  callback. Used so `stop()` can issue `worker.stop(streamId)`
      *  without races. */
     private workerStreamActive = false;
-    private connectivityHandlerOnline: { dispose(): void } | null = null;
-    private connectivityHandlerConnected: { dispose(): void } | null = null;
+    private connectivityPublisher: ConnectivityPublisher | null = null;
     private traceKillRegistration: Disposable | null = null;
     private sharedSettingsRegistration: Disposable | null = null;
     private readonly sourceCodec: string;
@@ -478,7 +477,6 @@ export class VideoPlayer {
         if (!this.playerWorker || !this.isPlaying)
             return;
 
-        this.pushConnectivityToWorker();
         if (await this.recreateWorkerIfPeerDead())
             return;
 
@@ -518,20 +516,6 @@ export class VideoPlayer {
         this.lastWedgeDiagnosis = `${diag.kind}: frozen ${(diag.frozenMs / 1000).toFixed(1)}s; ${diag.detail}`;
         this.lastWedgeAtMs = now;
         this.onWedgeDetected(diag);
-    }
-
-    // Mirrors main-thread ConnectivityUI into the worker, which gates its own
-    // reconnect loop on it. Re-sent from every liveness poll too: a missed
-    // update would otherwise park that loop for the life of the worker.
-    private pushConnectivityToWorker(): void {
-        if (!this.playerWorker)
-            return;
-
-        void this.playerWorker.onConnectivityUpdate(
-            ConnectivityUI.isOnline,
-            ConnectivityUI.isConnected,
-            ConnectivityUI.isBlazorServer,
-            rpcNoWait);
     }
 
     // The worker's peer can stay down after a reconnect while the main peer is
@@ -582,13 +566,9 @@ export class VideoPlayer {
     }
 
     private disposePlayerWorker(): void {
-        if (this.connectivityHandlerOnline) {
-            this.connectivityHandlerOnline.dispose();
-            this.connectivityHandlerOnline = null;
-        }
-        if (this.connectivityHandlerConnected) {
-            this.connectivityHandlerConnected.dispose();
-            this.connectivityHandlerConnected = null;
+        if (this.connectivityPublisher) {
+            this.connectivityPublisher.dispose();
+            this.connectivityPublisher = null;
         }
         if (this.traceKillRegistration) {
             this.traceKillRegistration.dispose();
@@ -779,10 +759,8 @@ export class VideoPlayer {
                 warnLog?.log('Player worker init failed:', e);
             });
 
-            const pushConnectivity = (): void => this.pushConnectivityToWorker();
-            this.connectivityHandlerOnline = ConnectivityUI.isOnlineChanged.add(pushConnectivity);
-            this.connectivityHandlerConnected = ConnectivityUI.isConnectedChanged.add(pushConnectivity);
-            void ConnectivityUI.whenReady.then(pushConnectivity);
+            this.connectivityPublisher = ConnectivityUI.publishTo((isOnline, isConnected, isBlazorServer) =>
+                this.playerWorker?.onConnectivityUpdate(isOnline, isConnected, isBlazorServer, rpcNoWait));
 
             // Wire focused-state changes on the mstg backend. The worker no
             // longer paints the bg canvas, so the focused hook becomes a no-op

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-player.ts
@@ -13,12 +13,14 @@ import { type Subscription } from 'rxjs';
 import { chooseFit, isPrimaryTile, updateCollapsedIslandAspect } from '../../Services/Video/services/tile-fit';
 import type {
     PlayerWorker,
+    PlayerWorkerConnectionState,
     LatencySample,
 } from '../../Services/Video/playback/player-worker-contract';
 import { getAudioLatency, isSkipToAudioEnabled } from '../../Services/Video/audio-latency-registry';
 import type { RenderBackendKind } from '../../Services/Video/playback/render-backends';
 import type { PlayerStats } from '../../Services/Video/frame-envelopes';
 import { WedgeDetector, type WedgeDiagnosis } from '../../Services/Video/playback/wedge-detector';
+import { DeadPeerDetector } from '../../Services/Video/playback/dead-peer-detector';
 import {
     getCodecCandidates,
     selectDecoderCodec,
@@ -199,6 +201,12 @@ export class VideoPlayer {
     private connectivityHandlerConnected: { dispose(): void } | null = null;
     private traceKillRegistration: Disposable | null = null;
     private sharedSettingsRegistration: Disposable | null = null;
+    private readonly sourceCodec: string;
+    private readonly sourceWidth: number;
+    private readonly sourceHeight: number;
+    private readonly sourceCodecSettings: string;
+    private readonly deadPeerDetector = new DeadPeerDetector();
+    private workerRecreateInFlight = false;
 
     private currentAttempt: {
         readonly attemptId: number;
@@ -330,6 +338,10 @@ export class VideoPlayer {
         this.streamId = streamId;
         this.authorId = authorId;
         this.startedAtMs = startedAtMs;
+        this.sourceCodec = codec;
+        this.sourceWidth = width;
+        this.sourceHeight = height;
+        this.sourceCodecSettings = codecSettings;
         this.canvas = canvas;
         this.videoEl = videoEl;
         this.bgCanvasEl = bgCanvasEl;
@@ -465,6 +477,11 @@ export class VideoPlayer {
     private async checkLiveness(): Promise<void> {
         if (!this.playerWorker || !this.isPlaying)
             return;
+
+        this.pushConnectivityToWorker();
+        if (await this.recreateWorkerIfPeerDead())
+            return;
+
         // A paused tile's stats don't move; sampling it would just bank an
         // artificial freeze gap toward the wedge threshold once it resumes.
         if (this.getExpectedPaused()) {
@@ -501,6 +518,94 @@ export class VideoPlayer {
         this.lastWedgeDiagnosis = `${diag.kind}: frozen ${(diag.frozenMs / 1000).toFixed(1)}s; ${diag.detail}`;
         this.lastWedgeAtMs = now;
         this.onWedgeDetected(diag);
+    }
+
+    // Mirrors main-thread ConnectivityUI into the worker, which gates its own
+    // reconnect loop on it. Re-sent from every liveness poll too: a missed
+    // update would otherwise park that loop for the life of the worker.
+    private pushConnectivityToWorker(): void {
+        if (!this.playerWorker)
+            return;
+
+        void this.playerWorker.onConnectivityUpdate(
+            ConnectivityUI.isOnline,
+            ConnectivityUI.isConnected,
+            ConnectivityUI.isBlazorServer,
+            rpcNoWait);
+    }
+
+    // The worker's peer can stay down after a reconnect while the main peer is
+    // fine; every pull restart then waits on it forever and nothing surfaces
+    // an error. A fresh worker (and so a fresh peer) is the only recovery.
+    private async recreateWorkerIfPeerDead(): Promise<boolean> {
+        if (!this.playerWorker || this.workerRecreateInFlight)
+            return false;
+
+        let state: PlayerWorkerConnectionState;
+        try {
+            state = await this.playerWorker.getConnectionState();
+        } catch {
+            return false;
+        }
+        const isDead = this.deadPeerDetector.onSample({
+            isPullActive: this.workerStreamActive || this.restartLoopRunning,
+            isWorkerConnected: state.isConnected,
+            isMainConnected: ConnectivityUI.isConnected,
+        }, Date.now());
+        if (!isDead)
+            return false;
+
+        await this.recreatePlayerWorker(`worker rpc peer dead (canConnect=${state.canConnect})`);
+        return true;
+    }
+
+    private async recreatePlayerWorker(reason: string): Promise<void> {
+        this.workerRecreateInFlight = true;
+        this.pushBreadcrumb(`worker recreate: ${reason}`);
+        warnLog?.log(`[${this.streamId}] recreating player worker: ${reason}`);
+        void this.blazorRef.invokeMethodAsync('OnPlaybackStalled', `dead-peer: ${reason}`)
+            .catch((e: unknown) => warnLog?.log('OnPlaybackStalled error:', e));
+        try {
+            // The old worker owns the transferred bg canvas and it cannot be
+            // transferred twice, so the rebuilt tile plays without the blur.
+            this.workerStreamActive = false;
+            this.disposePlayerWorker();
+            this.wedgeDetector.reset();
+            this.deadPeerDetector.reset();
+            this.playerReady = this.initPlayerWorker(
+                this.sourceCodec, this.sourceWidth, this.sourceHeight, this.sourceCodecSettings);
+            await this.playerReady;
+            this.settleCurrentAttempt({ kind: 'error', error: new Error(reason) });
+        } finally {
+            this.workerRecreateInFlight = false;
+        }
+    }
+
+    private disposePlayerWorker(): void {
+        if (this.connectivityHandlerOnline) {
+            this.connectivityHandlerOnline.dispose();
+            this.connectivityHandlerOnline = null;
+        }
+        if (this.connectivityHandlerConnected) {
+            this.connectivityHandlerConnected.dispose();
+            this.connectivityHandlerConnected = null;
+        }
+        if (this.traceKillRegistration) {
+            this.traceKillRegistration.dispose();
+            this.traceKillRegistration = null;
+        }
+        if (this.sharedSettingsRegistration) {
+            this.sharedSettingsRegistration.dispose();
+            this.sharedSettingsRegistration = null;
+        }
+        if (this.playerWorker) {
+            this.playerWorker.dispose();
+            this.playerWorker = null;
+        }
+        if (this.playerWorkerInstance) {
+            this.playerWorkerInstance.terminate();
+            this.playerWorkerInstance = null;
+        }
     }
 
     // Escalation ladder (rationale: a sender republish cured the incident
@@ -674,15 +779,7 @@ export class VideoPlayer {
                 warnLog?.log('Player worker init failed:', e);
             });
 
-            // Mirror main-thread ConnectivityUI → worker connectivity.
-            const pushConnectivity = (): void => {
-                if (!this.playerWorker) return;
-                void this.playerWorker.onConnectivityUpdate(
-                    ConnectivityUI.isOnline,
-                    ConnectivityUI.isConnected,
-                    ConnectivityUI.isBlazorServer,
-                    rpcNoWait);
-            };
+            const pushConnectivity = (): void => this.pushConnectivityToWorker();
             this.connectivityHandlerOnline = ConnectivityUI.isOnlineChanged.add(pushConnectivity);
             this.connectivityHandlerConnected = ConnectivityUI.isConnectedChanged.add(pushConnectivity);
             void ConnectivityUI.whenReady.then(pushConnectivity);
@@ -1560,33 +1657,7 @@ export class VideoPlayer {
             this.workerStreamActive = false;
         }
 
-        if (this.connectivityHandlerOnline) {
-            this.connectivityHandlerOnline.dispose();
-            this.connectivityHandlerOnline = null;
-        }
-        if (this.connectivityHandlerConnected) {
-            this.connectivityHandlerConnected.dispose();
-            this.connectivityHandlerConnected = null;
-        }
-        if (this.traceKillRegistration) {
-            this.traceKillRegistration.dispose();
-            this.traceKillRegistration = null;
-        }
-        if (this.sharedSettingsRegistration) {
-            this.sharedSettingsRegistration.dispose();
-            this.sharedSettingsRegistration = null;
-        }
-
-        // Tear the worker down.
-        if (this.playerWorker) {
-            this.playerWorker.dispose();
-            this.playerWorker = null;
-        }
-        if (this.playerWorkerInstance) {
-            this.playerWorkerInstance.terminate();
-            this.playerWorkerInstance = null;
-        }
-
+        this.disposePlayerWorker();
         this.renderBackend.dispose();
 
         debugLog?.log(`VideoPlayer stopped for stream ${this.streamId}`);

--- a/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
+++ b/src/dotnet/UI.Blazor.App/Components/VideoPanel/video-recorder.ts
@@ -44,7 +44,7 @@ import { DeviceInfo } from 'device-info';
 import { ScreenOrientation } from 'orientation';
 import { BrowserInit } from '../../../UI.Blazor/Services/BrowserInit/browser-init';
 import { BrowserInfo } from '../../../UI.Blazor/Services/BrowserInfo/browser-info';
-import { ConnectivityUI } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
+import { ConnectivityUI, type ConnectivityPublisher } from '../../../UI.Blazor/Services/ConnectivityUI/connectivity-ui';
 import { SharedSettings } from 'shared-settings';
 import { SharedSettingsWorkerSync } from 'shared-settings-worker';
 import { EncodeDeficitTicker } from '../../Services/Video/throughput-deficit-ticker';
@@ -577,7 +577,7 @@ export class VideoRecorder {
 
     // Connectivity / disconnect-api wiring (kept identical to legacy).
     private _disconnectApiHandler: (() => void) | null = null;
-    private _connectivityHandler: (() => void) | null = null;
+    private _connectivityPublisher: ConnectivityPublisher | null = null;
     private _sharedSettingsRegistration: Disposable | null = null;
     private _traceKillRegistration: Disposable | null = null;
     private recorderHealthTimer: number | null = null;
@@ -602,21 +602,10 @@ export class VideoRecorder {
         this.blazorRef = blazorRef;
         this.register(kind);
 
-        // Subscribe to connectivity changes once per VideoRecorder
-        // lifetime — handlers reference `this.worker` lazily so a
-        // worker recycle (stop+start) doesn't need re-subscription.
-        // Same leak shape as the legacy `VideoPipeline` (which never
-        // removed these), but since the active-recorder registry is
-        // bounded the leak is bounded too.
-        this._connectivityHandler = (): void => {
-            void this.worker?.onConnectivityUpdate(
-                ConnectivityUI.isOnline,
-                ConnectivityUI.isConnected,
-                ConnectivityUI.isBlazorServer);
-        };
-        ConnectivityUI.isOnlineChanged.add(this._connectivityHandler);
-        ConnectivityUI.isConnectedChanged.add(this._connectivityHandler);
-        void ConnectivityUI.whenReady.then(this._connectivityHandler);
+        // One publisher per VideoRecorder lifetime; it reads `this.worker`
+        // lazily, so a worker recycle (stop+start) needs no re-subscription.
+        this._connectivityPublisher = ConnectivityUI.publishTo((isOnline, isConnected, isBlazorServer) =>
+            this.worker?.onConnectivityUpdate(isOnline, isConnected, isBlazorServer));
     }
 
     // ---- Public methods called from Blazor (preserved surface) -----------
@@ -1989,15 +1978,8 @@ export class VideoRecorder {
             this.tearDownWorker();
         }
 
-        // The connectivity handler stays subscribed past dispose
-        // (the legacy `VideoPipeline` doesn't unsubscribe either —
-        // `EventHandlerSet.remove(...)` takes the `EventHandler<T>`
-        // wrapper returned from `.add(...)`, and we discard it). It
-        // becomes a dead-letter no-op once `this.worker` is null,
-        // and the bounded active-recorder lifecycle keeps the leak
-        // bounded. TODO(phase 7+): tighten this once the registry
-        // grows churn pressure.
-        this._connectivityHandler = null;
+        this._connectivityPublisher?.dispose();
+        this._connectivityPublisher = null;
 
         this.resetDemandState();
         this.isSpeaking = false;
@@ -2061,10 +2043,7 @@ export class VideoRecorder {
         );
         this._traceKillRegistration = registerVideoTraceKillWorker('recording', this.worker);
 
-        // Push current connectivity to the freshly-created worker
-        // (the long-lived listeners installed in the constructor only
-        // fire on transitions, so we need a one-shot push here).
-        this._connectivityHandler?.();
+        this._connectivityPublisher?.publish();
 
         this._disconnectApiHandler = () => void this.worker?.disconnectApi();
         Api.onDisconnectRequested(WorkerKind.VideoCapture).add(this._disconnectApiHandler);

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/dead-peer-detector.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/dead-peer-detector.ts
@@ -1,0 +1,40 @@
+export interface DeadPeerSample {
+    isPullActive: boolean;
+    isWorkerConnected: boolean;
+    isMainConnected: boolean;
+}
+
+const DEFAULT_DEAD_AFTER_MS = 15_000;
+
+// Detects a player worker whose RPC peer stays down while the main-thread
+// peer is up — the state a parked or stopped worker reconnect loop leaves
+// behind, where every pull restart waits on a connection that never comes and
+// nothing surfaces an error. Pure: feed it liveness-poll samples.
+export class DeadPeerDetector {
+    private readonly deadAfterMs: number;
+    private deadSinceMs = -1;
+
+    constructor(deadAfterMs?: number) {
+        this.deadAfterMs = deadAfterMs ?? DEFAULT_DEAD_AFTER_MS;
+    }
+
+    reset(): void {
+        this.deadSinceMs = -1;
+    }
+
+    onSample(sample: DeadPeerSample, nowMs: number): boolean {
+        if (!sample.isPullActive || !sample.isMainConnected || sample.isWorkerConnected) {
+            this.deadSinceMs = -1;
+            return false;
+        }
+        if (this.deadSinceMs < 0) {
+            this.deadSinceMs = nowMs;
+            return false;
+        }
+        if (nowMs - this.deadSinceMs < this.deadAfterMs)
+            return false;
+
+        this.deadSinceMs = -1;
+        return true;
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker-contract.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker-contract.ts
@@ -115,7 +115,17 @@ export interface PlayerWorker extends SharedSettingsWorker {
 
     getStats(streamId: string): Promise<PlayerStats>;
 
+    getConnectionState(): Promise<PlayerWorkerConnectionState>;
+
     stop(streamId?: string): Promise<void>;
+}
+
+// State of the worker's own RPC peer (the one carrying the pulls). Reported
+// as connected until the pull API is initialized, so a cold worker never
+// reads as a dead peer.
+export interface PlayerWorkerConnectionState {
+    isConnected: boolean;
+    canConnect: boolean;
 }
 
 // Main-thread-side RPC surface. The worker calls these to notify the

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker-host.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker-host.ts
@@ -16,6 +16,7 @@ import {
 } from './player-worker';
 import type {
     PlayerWorkerCallbacks,
+    PlayerWorkerConnectionState,
     PlayerWorkerOptions,
 } from './player-worker-contract';
 import type { DecoderLike } from '../operators/decode';
@@ -61,6 +62,13 @@ function ensurePullApi(): void {
     Api.requireConnection('VideoPlayer');
     pullApiInitialized = true;
     infoLog?.log(`ensurePullApi: Api initialized for ${pullApiUrl}`);
+}
+
+function getConnectionState(): PlayerWorkerConnectionState {
+    if (!pullApiInitialized)
+        return { isConnected: true, canConnect: true };
+
+    return { isConnected: Api.peer.isConnected, canConnect: Api.canConnect };
 }
 
 async function getStream(streamId: string): Promise<AsyncIterable<VideoFrameDto>> {
@@ -173,6 +181,7 @@ const callbacks = rpcClientServer<PlayerWorkerCallbacks>(
 
 __setPlayerWorkerHooks({
     getStream,
+    getConnectionState,
     createDecoder,
     buildBackend,
     onTrackReady: (streamId, kind, track) => callbacks.onTrackReady(streamId, kind, track),

--- a/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
+++ b/src/dotnet/UI.Blazor.App/Services/Video/playback/player-worker.ts
@@ -13,6 +13,7 @@ import { BgBlurController, bgBlurTap, type BgBlurMode } from './bg-blur-tap';
 import { sharedSettingsWorker } from 'shared-settings-worker';
 import type {
     PlayerWorker,
+    PlayerWorkerConnectionState,
     PlayerWorkerOptions,
 } from './player-worker-contract';
 
@@ -65,6 +66,7 @@ interface PlayerWorkerHooks {
     reportCodecProven?: (streamId: string, codec: string) => void;
     reportTraceKillInjected?: () => void;
     prewarmRpc?: (apiUrl: string) => void;
+    getConnectionState?: () => PlayerWorkerConnectionState;
 }
 
 let hooks: PlayerWorkerHooks | null = null;
@@ -301,6 +303,10 @@ export const playerWorkerImpl: PlayerWorker = {
             return Promise.resolve(createEmptyPlayerStats());
 
         return Promise.resolve(player.snapshotStats());
+    },
+
+    getConnectionState(): Promise<PlayerWorkerConnectionState> {
+        return Promise.resolve(hooks?.getConnectionState?.() ?? { isConnected: true, canConnect: true });
     },
 
     async stop(streamId?: string): Promise<void> {

--- a/src/dotnet/UI.Blazor/Services/ConnectivityUI/connectivity-ui.ts
+++ b/src/dotnet/UI.Blazor/Services/ConnectivityUI/connectivity-ui.ts
@@ -1,5 +1,6 @@
 import { EventHandlerSet } from 'event-handling';
 import { delayAsync, PromiseSource, PromiseSourceWithTimeout } from 'actuallab-core';
+import { Disposable } from 'disposable';
 import { getLogs } from 'logging';
 
 const { infoLog, warnLog, errorLog } = getLogs('ConnectivityUI');
@@ -10,6 +11,14 @@ const ReadyRetryIntervalMs = 1000;
 // A plain GET is rejected by RpcWebSocketServer with 400 - or 503 once ApplicationStopping fires,
 // since that check runs first, so a node on its way out can't pass for a live one.
 const ReadyProbeUrl = '/rpc/ws';
+const PublishPeriodMs = 5000;
+
+export type ConnectivityPublishTarget =
+    (isOnline: boolean, isConnected: boolean, isBlazorServer: boolean) => Promise<void> | void;
+
+export interface ConnectivityPublisher extends Disposable {
+    publish(): void;
+}
 
 export class ConnectivityUI {
     private static _isOnline = true;
@@ -129,6 +138,38 @@ export class ConnectivityUI {
         finally {
             handler.dispose();
         }
+    }
+
+    /** Mirrors the state into another realm (a worker): on every change, once
+     *  ready, and every `periodMs` regardless. The periodic push is the point:
+     *  a change push is fire-and-forget across a worker boundary, and a copy
+     *  that misses one stays wrong until the next change, which may never come. */
+    public static publishTo(target: ConnectivityPublishTarget, periodMs = PublishPeriodMs): ConnectivityPublisher {
+        let isDisposed = false;
+        const publish = (): void => {
+            if (isDisposed)
+                return;
+
+            try {
+                void Promise.resolve(target(this._isOnline, this._isConnected, this._isBlazorServer))
+                    .catch((e: unknown) => warnLog?.log('publishTo: push failed', e));
+            } catch (e) {
+                warnLog?.log('publishTo: push failed', e);
+            }
+        };
+        const onlineHandler = this.isOnlineChanged.add(publish);
+        const connectedHandler = this.isConnectedChanged.add(publish);
+        const timer = setInterval(publish, periodMs);
+        void this.whenReady.then(publish);
+        return {
+            publish,
+            dispose(): void {
+                isDisposed = true;
+                onlineHandler.dispose();
+                connectedHandler.dispose();
+                clearInterval(timer);
+            },
+        };
     }
 
     public static async whenReadyToReload(reason: string): Promise<boolean> {

--- a/src/nodejs/src/actuallab-core/retry-delayer.ts
+++ b/src/nodejs/src/actuallab-core/retry-delayer.ts
@@ -34,8 +34,9 @@ export class RetryDelayer {
         if (this.limit !== undefined && tryIndex >= this.limit)
             return RetryDelayLimitExceeded;
 
-        const delayMs = this.delays.getDelay(tryIndex);
-        if (tryIndex === 0 || delayMs <= 0) return RetryDelayNone;
+        const delayMs = this.getDelayMs(tryIndex);
+        if (tryIndex === 0 || delayMs <= 0)
+            return RetryDelayNone;
 
         const actualDelayMs = Math.max(1, delayMs);
         const endsAt = Date.now() + actualDelayMs;
@@ -60,5 +61,11 @@ export class RetryDelayer {
         this._cancelController = new AbortController();
         old.abort();
         this.cancelDelaysChanged.trigger();
+    }
+
+    // Protected/internal methods
+
+    protected getDelayMs(tryIndex: number): number {
+        return this.delays.getDelay(tryIndex);
     }
 }

--- a/src/nodejs/src/actuallab-rpc/rpc-stream-sender.ts
+++ b/src/nodejs/src/actuallab-rpc/rpc-stream-sender.ts
@@ -247,7 +247,7 @@ export class RpcStreamSender<T> implements IRpcObject {
     // Tells the consumer this shared stream is gone, then disposes it —
     // mirrors RpcSharedStream.SendDisconnect (RpcSharedStream.cs:284-289).
     private _sendDisconnect(): void {
-        const conn = this.peer.connection;
+        const conn = this.wireConnection;
         if (conn)
             this.peer.hub.systemCallSender.disconnect(conn, this.peer.serializationFormat, [this.id.localId]);
 
@@ -257,6 +257,15 @@ export class RpcStreamSender<T> implements IRpcObject {
     /** Called by system call handler when $sys.AckEnd is received from the client. */
     onAckEnd(_hostId: string): void {
         this.disconnect();
+    }
+
+    // Gated on `isConnected`, not just `connection`: during connect and
+    // handshake `connection` is already set, and an item written then hits
+    // the wire before $sys.Handshake and kills the connection (same hazard
+    // as RpcStream._sendAck). A held item is resent from the replay buffer
+    // after the reset ack.
+    private get wireConnection(): RpcPeer['connection'] {
+        return this.peer.isConnected ? this.peer.connection : undefined;
     }
 
     /**
@@ -270,7 +279,7 @@ export class RpcStreamSender<T> implements IRpcObject {
      */
     sendItem(item: T): void {
         if (this._ended) return;
-        const conn = this.peer.connection;
+        const conn = this.wireConnection;
         if (conn) {
             this.peer.hub.systemCallSender.item(
                 conn, this.peer.serializationFormat, this.id.localId, this._nextIndex, item,
@@ -285,7 +294,7 @@ export class RpcStreamSender<T> implements IRpcObject {
     /** Send a batch of items to the client. See {@link sendItem} for disconnect semantics. */
     sendBatch(items: T[]): void {
         if (this._ended || items.length === 0) return;
-        const conn = this.peer.connection;
+        const conn = this.wireConnection;
         if (conn) {
             this.peer.hub.systemCallSender.batch(
                 conn, this.peer.serializationFormat, this.id.localId, this._nextIndex, items,
@@ -298,7 +307,7 @@ export class RpcStreamSender<T> implements IRpcObject {
     sendEnd(error?: Error | null): void {
         if (this._ended) return;
         this._ended = true;
-        const conn = this.peer.connection;
+        const conn = this.wireConnection;
         if (!conn) return;
         // .NET ExceptionInfo is a non-nullable value type, so we must always
         // emit a valid map shape (empty TypeRef+Message for the "no error" case).

--- a/src/nodejs/src/api/api-reconnect-delayer.ts
+++ b/src/nodejs/src/api/api-reconnect-delayer.ts
@@ -1,58 +1,90 @@
-// Api's reconnect delayer — gates peer connection attempts on an app-level
-// `allowed` flag (derived from `Api.canConnect = requiresConnection &&
-// isDotNetRpcConnected`). When not allowed, `getDelay` returns a promise that
-// only resolves on `cancelDelays()`, so the run loop parks without opening
-// any WebSockets. When the flag flips to `true`, `Api.setAllowed(true)`
-// calls `cancelDelays()` to unblock the loop immediately.
+// Api's reconnect delayer. Two inputs with different weight:
 //
-// Mirrors .NET `AppRpcClientPeerReconnectDelayer` which returns an infinite
-// `RpcClientPeerReconnectDelay` while offline.
+// - `isRequired` (= `Api.requiresConnection`) is a hard gate: with no scope
+//   holding the connection, `getDelay` parks the peer's run loop until a
+//   scope appears, so no WebSocket is opened for nobody.
+// - `isOnline` (= `Api.isDotNetRpcConnected`) is a hint. In a worker it is a
+//   copy of main-thread state pushed across realms, and a copy can go stale.
+//   So it never blocks: while it says offline, every retry waits at least
+//   `offlineProbeDelayMs` instead of the usual backoff, and a flip back to
+//   online wakes the loop at once. A peer that reaches the server proves the
+//   hint wrong on its own.
+//
+// .NET's `AppRpcClientPeerReconnectDelayer` parks fully while offline; there
+// the signal is in-process and authoritative, here it is not.
 
 import { RpcClientPeerReconnectDelayer } from '../actuallab-rpc/index.js';
 import type { RetryDelay } from '../actuallab-core/index.js';
 
-export class ApiReconnectDelayer extends RpcClientPeerReconnectDelayer {
-    private _allowed = false;
+const DEFAULT_OFFLINE_PROBE_DELAY_MS = 15_000;
 
-    get allowed(): boolean {
-        return this._allowed;
+export class ApiReconnectDelayer extends RpcClientPeerReconnectDelayer {
+    private _isRequired = false;
+    private _isOnline = true;
+
+    offlineProbeDelayMs = DEFAULT_OFFLINE_PROBE_DELAY_MS;
+
+    get isRequired(): boolean {
+        return this._isRequired;
     }
 
-    /** Toggle whether the peer is allowed to attempt connections. Flipping
-     *  to `true` wakes any parked run loop; flipping to `false` does not
-     *  tear down an open connection — it only affects the next attempt. */
-    setAllowed(value: boolean): void {
-        if (this._allowed === value) return;
-        this._allowed = value;
-        this.cancelDelays(); // wake any currently-waiting run loop
+    get isOnline(): boolean {
+        return this._isOnline;
+    }
+
+    setIsRequired(value: boolean): void {
+        if (this._isRequired === value)
+            return;
+
+        this._isRequired = value;
+        if (value)
+            this.cancelDelays();
+    }
+
+    setIsOnline(value: boolean): void {
+        if (this._isOnline === value)
+            return;
+
+        this._isOnline = value;
+        if (value)
+            this.cancelDelays();
     }
 
     override getDelay(tryIndex: number, cancellationSignal?: AbortSignal): RetryDelay {
-        if (this._allowed)
-            return super.getDelay(tryIndex, cancellationSignal);
-        return this._parkUntilAllowed(cancellationSignal);
+        if (!this._isRequired)
+            return this._parkUntilRequired(cancellationSignal);
+
+        return super.getDelay(tryIndex, cancellationSignal);
     }
 
-    /** Returns a `RetryDelay` whose promise resolves (not rejects) when
-     *  `cancelDelays()` fires — typically because `setAllowed(true)` was
-     *  called. External cancellation (via `cancellationSignal`) rejects,
-     *  matching the base class's semantics. */
-    private _parkUntilAllowed(cancellationSignal?: AbortSignal): RetryDelay {
-        // Await a fresh cancellation round. `cancelDelaysChanged` fires every
-        // time `cancelDelays()` runs, whether from `setAllowed` or any other
-        // caller. Using `whenNext()` registers a one-shot listener.
-        const waiter = this.cancelDelaysChanged.whenNext();
+    // Protected/internal methods
+
+    protected override getDelayMs(tryIndex: number): number {
+        const delayMs = super.getDelayMs(tryIndex);
+        return this._isOnline ? delayMs : Math.max(delayMs, this.offlineProbeDelayMs);
+    }
+
+    // Private methods
+
+    // Resolves only once `isRequired` is true: `cancelDelays()` also fires for
+    // an online flip, and that alone must not send an unwanted peer connecting.
+    private _parkUntilRequired(cancellationSignal?: AbortSignal): RetryDelay {
         const promise = new Promise<void>((resolve, reject) => {
-            let aborted = false;
-            const onAbort = (): void => {
-                aborted = true;
-                reject(new Error('Retry delay aborted.'));
-            };
+            const onAbort = (): void => reject(new Error('Retry delay aborted.'));
             cancellationSignal?.addEventListener('abort', onAbort, { once: true });
-            void waiter.then(() => {
-                cancellationSignal?.removeEventListener('abort', onAbort);
-                if (!aborted) resolve();
-            });
+            const waitForNextRound = (): void => {
+                if (cancellationSignal?.aborted)
+                    return;
+
+                if (this._isRequired) {
+                    cancellationSignal?.removeEventListener('abort', onAbort);
+                    resolve();
+                    return;
+                }
+
+                void this.cancelDelaysChanged.whenNext().then(waitForNextRound);
+            };
+            waitForNextRound();
         });
         return { promise, endsAt: 0, isLimitExceeded: false };
     }

--- a/src/nodejs/src/api/api.ts
+++ b/src/nodejs/src/api/api.ts
@@ -20,15 +20,18 @@
 //     `register(hub)` — including modules listed via `deps`.
 //
 // Connectivity gating:
-//   The peer is allowed to attempt a connection only when `canConnect` is
-//   true, derived from two signals:
+//   Two signals feed the peer's reconnect delayer (`ApiReconnectDelayer`):
 //     - `requiresConnection` — at least one scope has been requested via
 //       `requireConnection(scope)` and not yet released. Workers typically
 //       have a single scope; the main thread refcounts multiple VideoPlayers.
+//       While false, the peer's run loop parks and opens no WebSocket.
 //     - `isDotNetRpcConnected` — the .NET-side rpc is connected (pushed in
 //       from ConnectivityUI on the main thread, from WorkerConnectivityUI
-//       on workers). If .NET can't reach the server, neither can we.
-//   The three states are exposed as getters plus matching
+//       on workers). A hint only: while false, reconnect attempts are spaced
+//       out to a slow probe rather than stopped, so a stale copy of the
+//       main-thread state can't strand a worker's peer.
+//   `canConnect` = `requiresConnection && isDotNetRpcConnected` is exposed
+//   for diagnostics. All three are getters plus matching
 //   `*Changed: EventHandlerSet<boolean>` events.
 
 import { EventHandlerSet } from 'actuallab-core';
@@ -177,7 +180,7 @@ export class Api {
     /** Fires when `isDotNetRpcConnected` flips. */
     static readonly isDotNetRpcConnectedChanged = new EventHandlerSet<boolean>();
     /** Fires when `canConnect` (= `requiresConnection && isDotNetRpcConnected`)
-     *  flips. Drives the internal reconnect-delayer gate. */
+     *  flips. */
     static readonly canConnectChanged = new EventHandlerSet<boolean>();
 
     /** Initialize or extend the shared RpcHub. Later calls may add modules and
@@ -250,13 +253,15 @@ export class Api {
             return;
 
         Api._isDotNetRpcConnected = value;
+        Api._delayer.setIsOnline(value);
         Api.isDotNetRpcConnectedChanged.trigger(value);
         Api._recomputeCanConnect();
     }
 
-    /** Derived: `requiresConnection && isDotNetRpcConnected`. While false, the
-     *  peer's run loop parks on the reconnect delayer and does not open a
-     *  WebSocket. Already-open connections are NOT torn down by this flag. */
+    /** Derived: `requiresConnection && isDotNetRpcConnected` — whether the
+     *  peer is expected to be connected right now. Diagnostics only; the
+     *  reconnect delayer takes the two inputs separately (see the module
+     *  header). Already-open connections are NOT torn down by this flag. */
     static get canConnect(): boolean {
         return Api._canConnect;
     }
@@ -297,6 +302,7 @@ export class Api {
         const wasEmpty = Api._scopes.size === 0;
         Api._scopes.add(scope);
         if (wasEmpty) {
+            Api._delayer.setIsRequired(true);
             Api.requiresConnectionChanged.trigger(true);
             Api._recomputeCanConnect();
         }
@@ -309,6 +315,7 @@ export class Api {
             return;
 
         if (Api._scopes.size === 0) {
+            Api._delayer.setIsRequired(false);
             Api.requiresConnectionChanged.trigger(false);
             Api._recomputeCanConnect();
         }
@@ -383,6 +390,5 @@ export class Api {
 
         Api._canConnect = value;
         Api.canConnectChanged.trigger(value);
-        Api._delayer.setAllowed(value);
     }
 }

--- a/tests/ts/unit/api-reconnect-delayer.test.ts
+++ b/tests/ts/unit/api-reconnect-delayer.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiReconnectDelayer } from '../../../src/nodejs/src/api/api-reconnect-delayer';
+
+// The delayer is what a worker's RPC peer waits on between reconnect attempts.
+// `isRequired` may park it for good; `isOnline` is a cross-realm copy of the
+// main thread's state and must only slow it down.
+
+function createDelayer(): ApiReconnectDelayer {
+    const delayer = new ApiReconnectDelayer();
+    delayer.offlineProbeDelayMs = 15_000;
+    return delayer;
+}
+
+// A delay resolves through a short promise chain, so drain the microtask queue before looking.
+async function settled(promise: Promise<void>): Promise<'resolved' | 'rejected' | 'pending'> {
+    let outcome: 'resolved' | 'rejected' | 'pending' = 'pending';
+    void promise.then(() => { outcome = 'resolved'; }, () => { outcome = 'rejected'; });
+    for (let i = 0; i < 10; i++)
+        await Promise.resolve();
+
+    return outcome;
+}
+
+describe('ApiReconnectDelayer', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('parks while no scope requires a connection and wakes when one does', async () => {
+        const delayer = createDelayer();
+        const delay = delayer.getDelay(0);
+        vi.advanceTimersByTime(600_000);
+        expect(await settled(delay.promise)).toBe('pending');
+
+        delayer.setIsRequired(true);
+        expect(await settled(delay.promise)).toBe('resolved');
+    });
+
+    it('stays parked through an online flip when still not required', async () => {
+        const delayer = createDelayer();
+        const delay = delayer.getDelay(0);
+        delayer.setIsOnline(false);
+        delayer.setIsOnline(true);
+        await Promise.resolve();
+        expect(await settled(delay.promise)).toBe('pending');
+
+        delayer.setIsRequired(true);
+        expect(await settled(delay.promise)).toBe('resolved');
+    });
+
+    it('rejects a parked delay when the peer stops', async () => {
+        const delayer = createDelayer();
+        const stop = new AbortController();
+        const delay = delayer.getDelay(0, stop.signal);
+        stop.abort();
+        expect(await settled(delay.promise)).toBe('rejected');
+    });
+
+    it('uses the base backoff while required and online', async () => {
+        const delayer = createDelayer();
+        delayer.setIsRequired(true);
+        expect(delayer.getDelay(0).endsAt).toBe(0);
+
+        const delay = delayer.getDelay(1);
+        expect(delay.endsAt - Date.now()).toBeLessThan(15_000);
+        vi.advanceTimersByTime(delay.endsAt - Date.now());
+        expect(await settled(delay.promise)).toBe('resolved');
+    });
+
+    it('stretches retries to the probe delay while offline instead of parking', async () => {
+        const delayer = createDelayer();
+        delayer.setIsRequired(true);
+        delayer.setIsOnline(false);
+        const delay = delayer.getDelay(1);
+        expect(delay.endsAt - Date.now()).toBe(15_000);
+
+        vi.advanceTimersByTime(14_999);
+        expect(await settled(delay.promise)).toBe('pending');
+        vi.advanceTimersByTime(1);
+        expect(await settled(delay.promise)).toBe('resolved');
+    });
+
+    it('keeps the first attempt immediate even while offline', () => {
+        const delayer = createDelayer();
+        delayer.setIsRequired(true);
+        delayer.setIsOnline(false);
+        expect(delayer.getDelay(0).endsAt).toBe(0);
+    });
+
+    it('wakes an offline probe delay as soon as the hint flips online', async () => {
+        const delayer = createDelayer();
+        delayer.setIsRequired(true);
+        delayer.setIsOnline(false);
+        const delay = delayer.getDelay(1);
+        vi.advanceTimersByTime(1000);
+        expect(await settled(delay.promise)).toBe('pending');
+
+        delayer.setIsOnline(true);
+        expect(await settled(delay.promise)).toBe('resolved');
+    });
+
+    it('does not wake a running backoff on a flip to offline', async () => {
+        const delayer = createDelayer();
+        delayer.setIsRequired(true);
+        const delay = delayer.getDelay(3);
+        delayer.setIsOnline(false);
+        await Promise.resolve();
+        expect(await settled(delay.promise)).toBe('pending');
+    });
+});

--- a/tests/ts/unit/connectivity-publisher.test.ts
+++ b/tests/ts/unit/connectivity-publisher.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectivityUI } from '../../../src/dotnet/UI.Blazor/Services/ConnectivityUI/connectivity-ui';
+
+type Push = [isOnline: boolean, isConnected: boolean, isBlazorServer: boolean];
+
+describe('ConnectivityUI.publishTo', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        ConnectivityUI.init(null, false);
+        ConnectivityUI.setOnline(true);
+        ConnectivityUI.setConnected(true);
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('pushes once ready, on every change, and periodically in between', async () => {
+        const pushes: Push[] = [];
+        const publisher = ConnectivityUI.publishTo((...args) => { pushes.push(args); }, 1000);
+        await Promise.resolve();
+        expect(pushes).toEqual([[true, true, false]]);
+
+        ConnectivityUI.setConnected(false);
+        expect(pushes).toHaveLength(2);
+        expect(pushes[1]).toEqual([true, false, false]);
+
+        vi.advanceTimersByTime(2000);
+        expect(pushes).toHaveLength(4);
+        expect(pushes[3]).toEqual([true, false, false]);
+
+        publisher.dispose();
+        ConnectivityUI.setConnected(true);
+        vi.advanceTimersByTime(5000);
+        expect(pushes).toHaveLength(4);
+    });
+
+    it('publishes on demand and survives a rejecting target', async () => {
+        let calls = 0;
+        const publisher = ConnectivityUI.publishTo(() => {
+            calls++;
+            return Promise.reject(new Error('worker gone'));
+        }, 1000);
+        await Promise.resolve();
+        publisher.publish();
+        expect(calls).toBe(2);
+
+        vi.advanceTimersByTime(1000);
+        expect(calls).toBe(3);
+        publisher.dispose();
+    });
+});

--- a/tests/ts/unit/playback/dead-peer-detector.test.ts
+++ b/tests/ts/unit/playback/dead-peer-detector.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DeadPeerDetector,
+    type DeadPeerSample,
+} from '../../../../src/dotnet/UI.Blazor.App/Services/Video/playback/dead-peer-detector';
+
+function sample(over: Partial<DeadPeerSample> = {}): DeadPeerSample {
+    return { isPullActive: true, isWorkerConnected: false, isMainConnected: true, ...over };
+}
+
+describe('DeadPeerDetector', () => {
+    it('reports a dead peer once the worker stays disconnected while the main peer is connected', () => {
+        const d = new DeadPeerDetector(15_000);
+        expect(d.onSample(sample(), 0)).toBe(false);
+        expect(d.onSample(sample(), 10_000)).toBe(false);
+        expect(d.onSample(sample(), 15_000)).toBe(true);
+    });
+
+    it('re-arms after reporting so a worker that dies again is reported again', () => {
+        const d = new DeadPeerDetector(15_000);
+        d.onSample(sample(), 0);
+        expect(d.onSample(sample(), 15_000)).toBe(true);
+        expect(d.onSample(sample(), 20_000)).toBe(false);
+        expect(d.onSample(sample(), 35_000)).toBe(true);
+    });
+
+    it('resets when the worker reconnects on its own', () => {
+        const d = new DeadPeerDetector(15_000);
+        d.onSample(sample(), 0);
+        d.onSample(sample({ isWorkerConnected: true }), 10_000);
+        expect(d.onSample(sample(), 20_000)).toBe(false);
+        expect(d.onSample(sample(), 34_000)).toBe(false);
+        expect(d.onSample(sample(), 35_000)).toBe(true);
+    });
+
+    it('does not count time while the main peer is down or no pull is active', () => {
+        const d = new DeadPeerDetector(15_000);
+        d.onSample(sample({ isMainConnected: false }), 0);
+        d.onSample(sample({ isMainConnected: false }), 20_000);
+        expect(d.onSample(sample(), 21_000)).toBe(false);
+        d.onSample(sample({ isPullActive: false }), 30_000);
+        expect(d.onSample(sample(), 40_000)).toBe(false);
+        expect(d.onSample(sample(), 55_000)).toBe(true);
+    });
+});

--- a/tests/ts/unit/rpc-stream-sender-handshake-gate.test.ts
+++ b/tests/ts/unit/rpc-stream-sender-handshake-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { RpcStreamSender } from '../../../src/nodejs/src/actuallab-rpc/rpc-stream-sender';
+import type { RpcPeer } from '../../../src/nodejs/src/actuallab-rpc/rpc-peer';
+
+// A reconnecting peer has `connection` set from the moment the socket opens,
+// but the server accepts nothing but $sys.Handshake until the handshake
+// completes: an item written in that window kills the connection
+// ("Handshake failed: expected $sys.Handshake, got $sys.I").
+
+function createSender(isConnected: boolean) {
+    const sent: string[] = [];
+    const peerStub = {
+        hub: {
+            hubId: 'test-host',
+            systemCallSender: {
+                item: () => { sent.push('item'); },
+                batch: () => { sent.push('batch'); },
+                end: () => { sent.push('end'); },
+                disconnect: () => { sent.push('disconnect'); },
+            },
+        },
+        sharedObjects: {
+            nextId: () => 1,
+            unregister: () => undefined,
+        },
+        connection: {},
+        isConnected,
+        serializationFormat: null,
+    };
+    const sender = new RpcStreamSender<number>(
+        peerStub as unknown as RpcPeer, 4, 8, true, true, () => true, false, 16);
+    return { sender, sent };
+}
+
+describe('RpcStreamSender handshake gate', () => {
+    it('writes nothing to the wire while the peer is connected but not yet handshaken', () => {
+        const { sender, sent } = createSender(false);
+        sender.sendItem(1);
+        sender.sendBatch([2, 3]);
+        sender.sendEnd();
+        expect(sent).toEqual([]);
+    });
+
+    it('writes items, batches and the end marker once the handshake is done', () => {
+        const { sender, sent } = createSender(true);
+        sender.sendItem(1);
+        sender.sendBatch([2, 3]);
+        sender.sendEnd();
+        expect(sent).toEqual(['item', 'batch', 'end']);
+    });
+
+    it('keeps advancing the index for held items so the replay buffer resends them after the reset ack', () => {
+        const { sender } = createSender(false);
+        sender.sendItem(1);
+        sender.sendItem(2);
+        expect(sender.nextIndex).toBe(2);
+    });
+});

--- a/tests/ts/unit/rpc-stream-sender-window.test.ts
+++ b/tests/ts/unit/rpc-stream-sender-window.test.ts
@@ -61,6 +61,7 @@ async function runPublishSim(options: SimOptions): Promise<SimResult> {
             unregister: () => undefined,
         },
         connection: {},
+        isConnected: true,
         serializationFormat: null,
     };
     sender = new RpcStreamSender<TestFrame>(


### PR DESCRIPTION
## Summary

In the 2026-09-09 ~17:10 UTC dev call a viewer on a phone lost two of three remote tiles for 3m15s after a ~1 s network blip (#4453). Server logs show the mechanism: each `VideoPlayer` owns a worker with its own RPC peer; the two affected player peers reconnected with an unchanged server peer, the server saw their sockets "closed prematurely" 50–70 ms after the handshake, the client never reconnected, and the server reaped them 180 s later. Meanwhile the client's recorder peer was rejected twice with "Handshake failed: expected $sys.Handshake, got $sys.I" — a stream item written before the handshake.

"Closed prematurely" is `WebSocketError.ConnectionClosedPrematurely`: TCP dropped with no close frame, so the sockets died at the network/proxy level, not from client code. The bug is that the peers never came back. A worker peer's reconnect loop parked in `ApiReconnectDelayer` whenever `Api.canConnect` was false, and in a worker half of that flag is a copy of main-thread `ConnectivityUI` pushed across the realm boundary on change only, fire-and-forget. A lost or late push left the peer in `Connecting` with no WebSocket for the life of the worker: every pull restart waited on it, nothing surfaced an error, and the server reaped the peer.

## Fix

- `api-reconnect-delayer.ts`: the two inputs are separated. `isRequired` (the scope refcount) still parks the loop, and a park now resolves only when a scope appears, not on any `cancelDelays()`. `isOnline` (the .NET-connectivity hint) only stretches retries to a 15 s probe; a flip back online wakes the loop at once. `RetryDelayer` gets a `getDelayMs` hook for this.
- `connectivity-ui.ts`: `ConnectivityUI.publishTo` mirrors the state into a worker on change, once ready, and every 5 s regardless. `video-player.ts`, `video-recorder.ts` and `opus-media-recorder.ts` use it instead of their own change-only handlers; the two recorders now dispose the subscription.
- `rpc-stream-sender.ts`: item, batch, end and disconnect writes are gated on `peer.isConnected` (handshake done) instead of `peer.connection` (socket open) — the guard `RpcStream._sendAck` already had. Held items keep advancing the index and are resent from the replay buffer after the reset ack.
- `video-player.ts`: the liveness tick polls the worker's own peer through `PlayerWorker.getConnectionState()`. A pure `DeadPeerDetector` flags a peer that stays down for 15 s while the main peer is connected; the player then disposes and recreates the worker (fresh peer), beacons `OnPlaybackStalled('dead-peer: …')`, and fails the current attempt so the restart loop re-pulls on the new worker. Kept as defense in depth.

Invariants for reviewers: `workerStreamActive` is cleared before the old worker is disposed so the attempt's `finally` does not call `stop` on the new worker; the rebuilt tile plays without background blur because the bg `OffscreenCanvas` was transferred to the old worker and cannot be transferred twice (documented in `07-receiver.md`).

## Testing

- `npm run build:Verify` (tsc, eslint, build): green.
- `npm run test:unit`: 699 green, including the new `api-reconnect-delayer.test.ts`, `connectivity-publisher.test.ts`, `rpc-stream-sender-handshake-gate.test.ts` and `dead-peer-detector.test.ts`.
- Not verified on a device or against a real reconnect. After deploy, a worker peer that lost its socket should be back within one probe interval; an `OnPlaybackStalled` beacon with `dead-peer:` in the reason now means the RPC-layer recovery did not happen and is worth a client log.

Closes #4453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeM8r4G6Lg97wYveckV4CZ
