### PR TITLE
fix(win): drop Windows ML's app-local onnxruntime.dll from the MSIX payload

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -190,6 +190,7 @@
     <PackageVersion Include="Microsoft.JSInterop" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AI.DirectML" Version="1.15.4" />
+    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.1.74" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.26.0" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.24.4" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.26.0" />

--- a/src/dotnet/App.Maui/App.Maui.csproj
+++ b/src/dotnet/App.Maui/App.Maui.csproj
@@ -218,9 +218,13 @@
 <!--      <ExcludeAssets>runtime</ExcludeAssets>-->
 <!--    </PackageReference>-->
     <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" />
-    <!-- Exclude DirectML.dll from this package - it's already in MsixContent via Windows App SDK.
-         Must block build/buildTransitive because the package uses custom targets, not runtimes/ layout. -->
+    <!-- Neither DirectML.dll nor Windows ML's onnxruntime.dll may be app-local: the ONNX DirectML runtime
+         above already ships onnxruntime.dll, and a second copy fails MSIX packaging (APPX1101). Both packages
+         are transitive; a direct reference is how NuGet lets us drop their native assets. Build assets go
+         too: Microsoft.AI.DirectML copies via custom targets rather than the runtimes/ layout, and the
+         Windows ML targets are validation-only and reject TargetPlatformMinVersion 17763. -->
     <PackageReference Include="Microsoft.AI.DirectML" ExcludeAssets="build;buildTransitive;native" />
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" ExcludeAssets="build;buildTransitive;native" />
     <PackageReference Include="NAudio" />
     <PackageReference Include="OpusSharp.Core" />
     <PackageReference Include="OpusSharp.Natives" />


### PR DESCRIPTION
## Summary

The Windows package job on `dev` fails since the .NET 11 RC 1 bump (e23592e0a0) with
APPX1101: the MSIX payload has two `onnxruntime.dll` files
([failed job](https://github.com/Actual-Chat/actual-chat/actions/runs/34440602926/job/102757569793)).

MAUI 11 RC 1 moves Windows App SDK from 1.8 to 2.3.1. That version depends on
Microsoft.WindowsAppSDK.ML, which pulls in Microsoft.Windows.AI.MachineLearning 2.1.74.
The 1.8 ML package kept its binaries under a non-standard `runtimes-framework/` folder that
NuGet ignores; the new package uses the standard `runtimes/win-x64/native/` layout, so NuGet
now copies its `onnxruntime.dll`, `DirectML.dll` and `Microsoft.Windows.AI.MachineLearning.dll`
app-local. App.Maui already ships `onnxruntime.dll` via Microsoft.ML.OnnxRuntime.DirectML.

The ML package's own `_SuppressWindowsMLNativeCopyLocal` target does not prevent this: it prunes
`ReferenceCopyLocalPaths`, while the MSIX payload is built from the publish item list.

## Fix

A direct reference to Microsoft.Windows.AI.MachineLearning with
`ExcludeAssets="build;buildTransitive;native"` in the Windows item group of App.Maui.csproj,
plus the version pin in Directory.Packages.props. This is the same pattern already used for
Microsoft.AI.DirectML two lines above. NuGet's include-flag rules let a direct reference override
the flags a package gets transitively.

Invariants for reviewers:
- The last good MSIX (2.20.65.0) carried neither `DirectML.dll` nor any Windows ML binary
  app-local; it depends on the WindowsAppRuntime framework package. This change restores exactly
  that payload.
- Build assets are excluded too: the package's targets are validation-only and error for
  `TargetPlatformMinVersion` below 18362 (ours is 17763) when imported directly.
- The pinned 2.1.74 must stay inside the range WindowsAppSDK.ML requires (`[2.1.74, 3.0.0)`);
  a future MAUI bump may need to move it, same as Microsoft.AI.DirectML.

## Testing

- Not run: `pack-win` itself. It needs a Windows machine with the pinned RC 1 SDK, which I do
  not have. Package jobs do not run for fix branches on push, so I dispatched the workflow
  for this branch with package building on and tests skipped; its Windows job is the real check:
  https://github.com/Actual-Chat/actual-chat/actions/runs/34447309653
- Verified the NuGet-level effect with a scratch `net11.0-windows10.0.22621.0` / `win-x64`
  project restored on Linux against WindowsAppSDK 2.3.1: without the change the package's
  `native` group lists the three DLLs, with it the group is the `_._` placeholder.
- A regular project (`Core`) still restores with the edited Directory.Packages.props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeM8r4G6Lg97wYveckV4CZ
