### PR TITLE
fix(mac): make the traffic lights clickable and hide the window on close

### DIFF
--- a/docs/macos-appkit.md
+++ b/docs/macos-appkit.md
@@ -58,7 +58,8 @@ members. WebKit accepts extra URL scheme handlers only before the WKWebView exis
 |---|---|
 | [MacOSCustomBlazorWebViewHandler.CreatePlatformView](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/MacOS/MacOSCustomBlazorWebViewHandler.cs) replays the base handler's three config lines (`webwindowinterop` message handler, Blazor init script, `app://` scheme handler) and adds `content://`, autoplay and `__useWebAudio` | the labs handler raises `BlazorWebViewInitializing`; the config then moves back to `MauiWebView.MaciOS.OnInitializing` |
 | [LabsBlazorWebViewHandlerExt](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/MacOS/LabsBlazorWebViewHandlerExt.cs) reaches the private `BlazorInitScript`, `WebViewScriptMessageHandler`, `SchemeHandler` and `MessageReceived` by reflection, failing fast on a rename | same as above |
-| `LayoutInvalidatingWKWebView` in the same file sets `Superview.NeedsLayout` on attach, because the labs `ContentPageHandler` adds content without invalidating layout and a late-attached WebView keeps a zero frame | the labs page handler invalidates layout |
+| `PatchedWKWebView` in the same file sets `Superview.NeedsLayout` on attach, because the labs `ContentPageHandler` adds content without invalidating layout and a late-attached WebView keeps a zero frame | the labs page handler invalidates layout |
+| The same subclass calls [WindowConfigurator.KeepTitlebarAboveContent](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/MacOS/WindowConfigurator.cs) once it has a window: the labs handler installs a titlebar-wide drag overlay above the titlebar itself, so clicks on the traffic lights started a window drag until the first full-screen round trip put the titlebar back on top | `TitlebarDragOverlayView.HitTest` skips the standard window buttons |
 | The `#if MACOS` branch in [MauiWebView.cs](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/WebView/MauiWebView.cs) builds the view without event subscriptions | `MacOSBlazorWebView` gets the three events |
 | [MauiWebView.MacOS.cs](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/WebView/MauiWebView.MacOS.cs) attaches its own `WKNavigationDelegate` and `WKUIDelegate` as the stand-in for `UrlLoading` | same |
 
@@ -99,9 +100,10 @@ flowchart LR
 - The statics patch runs twice (from `Main` and from `AddMacOSEssentials`), and each run calls
   `VersionTracking.Track()` on a fresh instance, so `IsFirstLaunchForCurrentVersion` reads
   false even on a genuine first launch. Voxt does not use `VersionTracking`.
-- Closing the window logs a burst of `InvalidOperationException: VirtualView cannot be null here`
-  from the labs `WindowHandler.OnWindowClosed`: the handler is already disconnected when
-  `WillClose` fires. First-chance only, the app still exits cleanly.
+- A real window close (the red button only hides the window, see below) logs a burst of
+  `InvalidOperationException: VirtualView cannot be null here` from the labs
+  `WindowHandler.OnWindowClosed`: the handler is already disconnected when `WillClose` fires.
+  First-chance only, the app still exits cleanly.
 :::
 
 ### The dispatcher factory answers only on the main thread
@@ -145,6 +147,13 @@ markers:
 
 ## Behaviour worth knowing
 
+- **The red button and Cmd+W hide the window; the app keeps running.** Same policy as the
+  Windows app: while `App.MustMinimizeOnQuit` holds, [WindowConfigurator](https://github.com/Actual-Chat/actual-chat/blob/main/src/dotnet/App.Maui/Platforms/MacOS/WindowConfigurator.cs)
+  answers `windowShouldClose` with an `orderOut`, and a Dock click brings the same window back
+  through `applicationShouldHandleReopen`. The labs backend has neither: its window closes for
+  good and nothing reopens it, which left a windowless process in the Dock. The background
+  state follows focus and window visibility, so a hidden or minimized window stops auto-reading
+  chats. Cmd+Q quits as usual.
 - **Sign-in** uses the Windows-style flow: the default browser plus a `voxt-dev://` callback
   registered in `Info.plist` (a prod-flavour build needs `voxt` there). `ASWebAuthenticationSession` was tried and dropped, its
   handoff stalls in Chromium browsers and its ephemeral session forces a separate Google login.

--- a/src/dotnet/App.Maui/MauiProgram.MacOS.cs
+++ b/src/dotnet/App.Maui/MauiProgram.MacOS.cs
@@ -1,7 +1,6 @@
 using ActualChat.App.Maui.Services;
 using ActualChat.UI.Blazor;
 using ActualChat.UI.Blazor.Services;
-using ActualChat.Maui.Services;
 using ActualChat.UI.Blazor.App;
 using ActualChat.UI.Blazor.App.Services;
 using Microsoft.Maui.LifecycleEvents;
@@ -24,10 +23,8 @@ public static partial class MauiProgram
     }
 
     private static partial void ConfigurePlatformLifecycleEvents(ILifecycleBuilder events)
-        // Focus is the desktop's "is the user looking" signal: without it the app counts as
-        // foreground forever, so an open chat keeps auto-reading incoming messages - which
-        // also suppresses their notifications (the server hides read ones).
         => events.AddMacOS(macOS => macOS
-            .DidBecomeActive(_ => MauiBackgroundState.Set(false))
-            .DidResignActive(_ => MauiBackgroundState.Set(true)));
+            .DidFinishLaunching(_ => WindowConfigurator.Configure())
+            .DidBecomeActive(_ => WindowConfigurator.UpdateBackgroundState())
+            .DidResignActive(_ => WindowConfigurator.UpdateBackgroundState()));
 }

--- a/src/dotnet/App.Maui/Platforms/MacOS/AppDelegate.cs
+++ b/src/dotnet/App.Maui/Platforms/MacOS/AppDelegate.cs
@@ -21,6 +21,9 @@ public class AppDelegate : MacOSMauiApplication
         UNUserNotificationCenter.Current.Delegate = MacOSNotificationDelegate.Instance;
     }
 
+    public override bool ApplicationShouldHandleReopen(NSApplication sender, bool hasVisibleWindows)
+        => hasVisibleWindows || !WindowConfigurator.TryShowWindow();
+
     public override void OpenUrls(NSApplication application, NSUrl[] urls)
     {
         foreach (var url in urls)

--- a/src/dotnet/App.Maui/Platforms/MacOS/MacOSCustomBlazorWebViewHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/MacOS/MacOSCustomBlazorWebViewHandler.cs
@@ -1,3 +1,4 @@
+using CoreFoundation;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Platforms.MacOS.Handlers;
@@ -62,7 +63,7 @@ public sealed class MacOSCustomBlazorWebViewHandler : BlazorWebViewHandler
         // no sound even though the pipeline runs.
         config.MediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypes.None;
 
-        var webView = new LayoutInvalidatingWKWebView(CGRect.Empty, config);
+        var webView = new PatchedWKWebView(CGRect.Empty, config);
         config.Preferences.SetValueForKey(NSObject.FromObject(true), new NSString("developerExtrasEnabled"));
         webView.SetValueForKey(NSObject.FromObject(false), new NSString("drawsBackground"));
         if (OperatingSystem.IsMacOSVersionAtLeast(13, 3))
@@ -78,7 +79,7 @@ public sealed class MacOSCustomBlazorWebViewHandler : BlazorWebViewHandler
 
     // Nested types
 
-    private sealed class LayoutInvalidatingWKWebView(CGRect frame, WKWebViewConfiguration configuration)
+    private sealed class PatchedWKWebView(CGRect frame, WKWebViewConfiguration configuration)
         : WKWebView(frame, configuration)
     {
         public override void ViewDidMoveToSuperview()
@@ -88,9 +89,19 @@ public sealed class MacOSCustomBlazorWebViewHandler : BlazorWebViewHandler
             // The labs ContentPageHandler adds page content without invalidating layout, so a
             // WebView attached after the first layout pass keeps a zero frame forever - our
             // MainPage attaches it only once BlazorWebViewApp is ready, long past that pass.
-            // TODO(maui-labs): delete this subclass once the labs ContentPageHandler invalidates layout.
+            // TODO(maui-labs): delete this override once the labs ContentPageHandler invalidates layout.
             if (Superview is { } superview)
                 superview.NeedsLayout = true;
+        }
+
+        public override void ViewDidMoveToWindow()
+        {
+            base.ViewDidMoveToWindow();
+
+            // The labs handler installs its titlebar drag overlay from a KVO observer of this very
+            // window change, so the reorder must run after the current pass.
+            if (Window is { } window)
+                DispatchQueue.MainQueue.DispatchAsync(() => WindowConfigurator.KeepTitlebarAboveContent(window));
         }
     }
 }

--- a/src/dotnet/App.Maui/Platforms/MacOS/WindowConfigurator.cs
+++ b/src/dotnet/App.Maui/Platforms/MacOS/WindowConfigurator.cs
@@ -1,0 +1,95 @@
+using ActualChat.Maui.Services;
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+
+namespace ActualChat.App.Maui;
+
+/// <summary>
+/// Desktop window policy of the AppKit app, the twin of the Windows <c>WindowConfigurator</c>:
+/// the red button hides the window instead of closing it while <see cref="App.MustMinimizeOnQuit"/>
+/// holds, a Dock click brings it back, and the background state follows window visibility.
+/// </summary>
+internal static class WindowConfigurator
+{
+    private static NSWindow? _window;
+    private static WindowDelegate? _windowDelegate;
+
+    public static void Configure()
+    {
+        if (App.Current.Windows.FirstOrDefault()?.Handler?.PlatformView is not NSWindow window)
+            return;
+
+        _window = window;
+        _windowDelegate = new WindowDelegate(window.Delegate as NSWindowDelegate);
+        window.Delegate = _windowDelegate;
+        // The labs menu bar has no File menu, so Cmd+W lives in the Window menu
+        if (NSApplication.SharedApplication.WindowsMenu is { } windowsMenu) {
+            windowsMenu.InsertItem(NSMenuItem.SeparatorItem, 0);
+            windowsMenu.InsertItem(new NSMenuItem("Close Window", new Selector("performClose:"), "w"), 0);
+        }
+        UpdateBackgroundState();
+    }
+
+    // Returns false when there is no window to show, i.e. AppKit's default reopen handling applies
+    public static bool TryShowWindow()
+    {
+        if (_window is not { } window)
+            return false;
+
+        if (window.IsMiniaturized)
+            window.Deminiaturize(null);
+        else
+            window.MakeKeyAndOrderFront(null);
+        UpdateBackgroundState();
+        return true;
+    }
+
+    public static void UpdateBackgroundState()
+    {
+        // Focus and visibility are the desktop's "is the user looking" signal: without them the app
+        // counts as foreground forever, so an open chat keeps auto-reading incoming messages - which
+        // also suppresses their notifications (the server hides read ones).
+        var isVisible = _window is null or { IsVisible: true };
+        MauiBackgroundState.Set(!NSApplication.SharedApplication.Active || !isVisible);
+    }
+
+    public static void KeepTitlebarAboveContent(NSWindow window)
+    {
+        // The labs BlazorWebViewHandler adds a titlebar-wide drag overlay above every other frame
+        // view, traffic lights included, so their clicks start a window drag instead. AppKit itself
+        // puts the titlebar back on top after any full-screen round trip; this does it right away.
+        // TODO(maui-labs): delete once TitlebarDragOverlayView.HitTest skips the standard window buttons.
+        var themeFrame = window.ContentView?.Superview;
+        var subviews = themeFrame?.Subviews ?? [];
+        var titlebar = subviews.FirstOrDefault(v => v.Class.Name == "NSTitlebarContainerView");
+        if (titlebar == null || titlebar.Handle == subviews[^1].Handle)
+            return;
+
+        themeFrame!.AddSubview(titlebar, NSWindowOrderingMode.Above, null);
+    }
+
+    // Nested types
+
+    private sealed class WindowDelegate(NSWindowDelegate? inner) : NSWindowDelegate
+    {
+        public override bool WindowShouldClose(NSObject sender)
+        {
+            if (!App.MustMinimizeOnQuit)
+                return inner?.WindowShouldClose(sender) ?? true;
+
+            (sender as NSWindow)?.OrderOut(null);
+            UpdateBackgroundState();
+            return false;
+        }
+
+        public override void WillClose(NSNotification notification)
+            => inner?.WillClose(notification);
+
+        public override void DidMiniaturize(NSNotification notification)
+            => UpdateBackgroundState();
+
+        public override void DidDeminiaturize(NSNotification notification)
+            => UpdateBackgroundState();
+    }
+}


### PR DESCRIPTION
## Summary

On the AppKit Mac app the traffic lights did not react to clicks, and the red button left a windowless process in the Dock.

- The labs `BlazorWebViewHandler` installs a titlebar-wide drag overlay above the titlebar container once the WebView joins the window. Its hit test only carves out toolbar items, so a click on close, minimize or zoom started a window drag. AppKit puts the titlebar back on top after a full-screen round trip, which is why the buttons "sometimes" worked.
- Closing followed the labs default: the window was destroyed, nothing reopened it, and the app had no `applicationShouldHandleReopen`, so a Dock click did nothing until Cmd+Q and a relaunch.

## Fix

- `PatchedWKWebView` (was `LayoutInvalidatingWKWebView`) re-orders the titlebar container above the overlay right after it gets a window, via `WindowConfigurator.KeepTitlebarAboveContent`. The overlay stays, so dragging the titlebar area still works.
- New `Platforms/MacOS/WindowConfigurator`, the twin of the Windows one, wraps the labs window delegate. While `App.MustMinimizeOnQuit` holds, `windowShouldClose` orders the window out instead of closing it; the AppDelegate's reopen override brings the same window back on a Dock click. A real close still forwards to the labs delegate, so quit teardown is unchanged.
- "Close Window" (Cmd+W) is added to the Window menu, since the labs menu bar has no File menu.
- `MauiBackgroundState` now follows focus and window visibility (hidden or minimized counts as background), fed from the lifecycle events and the delegate's miniaturize callbacks.
- Docs ledger updated with the workaround and the close policy.

Invariants for reviewers: the reorder must run after the labs KVO install (hence the dispatch), and only `MustMinimizeOnQuit == false` may let a close through.

## Testing

Debug AppKit build on macOS 26 with Stage Manager on, driven by real CGEvent mouse clicks (Accessibility presses bypass hit-testing and hide the bug): yellow minimizes, red hides with the process alive and a Dock click restores, Cmd+W behaves like red, green enters and leaves full screen. Not covered: a Release/sandboxed run, and the 33 px blank strip in full screen, which is the labs content inset and is tracked separately in #4461.

Closes #4433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
