### PR TITLE
fix(chat): preserve live blocks through leaving and dissolve

### DIFF
--- a/docs/ui/chat-blocks.md
+++ b/docs/ui/chat-blocks.md
@@ -71,9 +71,10 @@ open-ended range it retains the record's actual end instead of copying the senti
 coverage. Cached open-ended metadata remains valid as the live summary grows, so the previous
 `WithLiveRange` refresh workaround is unnecessary. The UI bounds active block coverage by its current
 chat/overlay snapshot before expanding fetch boundaries; no fetch enumerates an open-ended range.
-Grouping an active, unfrozen block separately uses an open-ended range so pending sends at or beyond
-the chat end and the `long.MaxValue` transcription placeholder stay before its footer. Frozen and
-materialized grouping remains bounded. Grouping coverage must not be reused for entry fetching.
+Grouping an active block separately uses an open-ended range so pending sends at or beyond
+the chat end and the `long.MaxValue` transcription placeholder stay before its footer. This includes
+a viewer who left while the session continues: their overlay has no materialized ID and an unbounded
+end. Closed and materialized grouping remains bounded. Grouping coverage must not be reused for entry fetching.
 Active live folding and transcript filtering are not truncated by later completed ranges. Materialized
 block filtering still stops at a later block's start, including when that record is unavailable.
 Navigation expansion, automatic expansion over witnessed messages, and witness filtering use the same
@@ -82,6 +83,24 @@ truncated ranges, so a stale old conversation cannot expand merely because the v
 These are read projections only. Stored IDs, summaries, timestamps, counts, and conversation creation
 or replacement commands are unchanged. In particular, the existing write path can still delete
 overlapping persisted records; revisiting those building rules is separate work.
+
+## Unsummarized close and dissolve
+
+An attended session that closes without a summary has no persisted replacement conversation.
+`LiveBlockUI` retains a `Conversation` descriptor in its existing frozen template before closure,
+bounded to that snapshot's chat end. The short dissolve overlay exposes this descriptor until its
+timer expires. The record is released from the template when the dissolve finishes.
+
+Both `BuildChatBlocks` and the per-tile card builder use the retained descriptor, even if chat
+summarization is disabled. A range alone cannot restore a missing card or header. This also keeps
+the header's dissolve marker available after the server stops returning the live conversation.
+During this interval its participant title remains visible and it offers no Join action.
+
+`ConversationViewState` carries the descriptor in its tile cache key so entering and leaving dissolve
+rebuild the relevant tiles. `NarrowTo` removes it from unrelated tiles. Its reference remains stable
+through the dissolve interval. The tile scope includes the actual preceding message, which may be
+farther back than the adjacent tile when entries were deleted. Author groups split at the descriptor's
+finite end, keeping subsequent messages outside the block even when they come from the same author.
 
 ## Wire compatibility
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -24,7 +24,7 @@
     <chat-activity-panel-icon-svg size="6" isActive="true" mode="audio"/>
     <span class="c-lc-name">@title</span>
     @* Leaving is just "stop listening", so re-joining stays one tap away. *@
-    @if (!s.IsJoined) {
+    @if (!s.IsJoined && !s.IsDissolving) {
         <button type="button" class="c-lc-join btn btn-sm btn-transparent" @onclick="@Join">@L.Call_Join</button>
     }
     @if (s.CanExpand) {
@@ -74,13 +74,14 @@
         var rawLive = await rawLiveTask.ConfigureAwait(false);
         var blockState = await blockStateTask.ConfigureAwait(false);
         var isLive = live != null && live.Id == conversation.Id;
+        var isDissolving = blockState.Overlay?.IsDissolving ?? false;
         // The rest stay conditional: asking them when there is no live session would add dependencies
         // that recompute this header for sessions it doesn't show
         var isJoined = isLive
             && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
         var isVoiceOnly = isLive
             && !await LiveSessionUI.IsTranscriptionOn(chatId, cancellationToken).ConfigureAwait(false);
-        var participantsText = isLive
+        var participantsText = isLive || isDissolving
             ? await ConversationParticipantsFormatter
                 .GetText(Authors, L, Hub.Session, chatId, conversation.AuthorIds, cancellationToken)
                 .ConfigureAwait(false)
@@ -93,7 +94,7 @@
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new LiveConversationHeaderState(
             translated.Title.Text, participantsText, hasFoldedEntries, isJoined,
-            blockState.Overlay != null, blockState.Overlay?.IsDissolving ?? false, canExpand,
+            blockState.Overlay != null, isDissolving, canExpand,
             isAnyoneTalking);
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Blocks.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Blocks.cs
@@ -20,6 +20,10 @@ public partial class ChatUI
         // Keeps the live render ID after materialization, preferring the persisted record. Retains live coverage
         // when stale metadata has clipped the persisted record before that ID.
         var records = conversations.ToList();
+        if (view.DissolvingConversation is { } dissolvingConversation) {
+            records.RemoveAll(c => c.Id == dissolvingConversation.Id);
+            records.Add(dissolvingConversation);
+        }
         if (view.MaterializedBlockId is not { } materializedId || view.LiveBlockConversationId is not { } renderId
             || records.All(c => c.Id != materializedId))
             return records.ToArray();
@@ -77,7 +81,7 @@ public partial class ChatUI
 
         var blockConversation = view.MaterializedBlockId is { } materializedId
             ? byId.GetValueOrDefault(materializedId)
-            : liveConversation;
+            : view.DissolvingConversation ?? liveConversation;
         if (view.LiveBlockConversationId is { } renderId && blockConversation != null && !liveBlockRange.IsEmpty) {
             if (blockConversation.Id != renderId)
                 blockConversation = blockConversation with { Id = renderId };

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -956,7 +956,8 @@ public partial class ChatUI
         var liveBlock = blocks.FirstOrDefault(b => b.Id == liveBlockId);
         // Fetch coverage stays finite; active grouping also owns optimistic sends and the long.MaxValue placeholder.
         // Frozen and materialized blocks must not absorb entries from after their boundary.
-        var liveBlockRange = liveBlock is { IsLive: true } && overlay == null
+        var liveBlockRange = liveBlock is { IsLive: true }
+            && (overlay == null || overlay is { MaterializedId: null, BlockEndLid: long.MaxValue })
             ? new Range<long>(liveBlock.EntryLidRange.Start, long.MaxValue)
             : liveBlock?.EntryLidRange ?? default;
         // Expanded is not the only form that renders rows: a closed block that kept its card hides

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -24,6 +24,8 @@ public sealed record ConversationViewState(
     Range<long> LiveFoldRange,
     ConversationId? MaterializedBlockId)
 {
+    public Conversation? DissolvingConversation { get; init; }
+
     public bool Equals(ConversationViewState? other)
     {
         // Hand-written because this record is a ChatUI.GetTile compute-method argument - it IS the tile
@@ -41,6 +43,7 @@ public sealed record ConversationViewState(
             && LiveBlockConversationId == other.LiveBlockConversationId
             && LiveFoldRange == other.LiveFoldRange
             && MaterializedBlockId == other.MaterializedBlockId
+            && Equals(DissolvingConversation, other.DissolvingConversation)
             && ExpandedConversations.SetEquals(other.ExpandedConversations);
     }
 
@@ -54,12 +57,18 @@ public sealed record ConversationViewState(
             ? default
             : HiddenLiveTailRange;
         var liveFoldRange = LiveFoldRange.IntersectWith(scope).IsEmpty ? default : LiveFoldRange;
-        if (hiddenLiveTailRange == HiddenLiveTailRange && liveFoldRange == LiveFoldRange)
+        var dissolvingConversation = DissolvingConversation is { } conversation
+            && !conversation.EntryLidRange.Overlaps(scope)
+            ? null
+            : DissolvingConversation;
+        if (hiddenLiveTailRange == HiddenLiveTailRange && liveFoldRange == LiveFoldRange
+            && Equals(dissolvingConversation, DissolvingConversation))
             return this;
 
         return this with {
             HiddenLiveTailRange = hiddenLiveTailRange,
             LiveFoldRange = liveFoldRange,
+            DissolvingConversation = dissolvingConversation,
         };
     }
 
@@ -70,6 +79,7 @@ public sealed record ConversationViewState(
             LiveBlockConversationId,
             LiveFoldRange,
             MaterializedBlockId,
+            DissolvingConversation,
             ExpandedConversations.Count);
         foreach (var conversationId in ExpandedConversations)
             hash ^= conversationId.GetHashCode(); // XOR - the set has no order
@@ -429,7 +439,9 @@ public partial class ChatUI
                 .EnsureMonotonic(Comparer<ChatRangeTile>.Create((a, b) => a.LidRange.Start.CompareTo(b.LidRange.Start)))
                 .ToList();
 
-        var showConversations = (chat.IsSummarized ?? false) || liveConversation != null;
+        var dissolvingConversation = overlay?.DissolvingConversation;
+        var showConversations = (chat.IsSummarized ?? false)
+            || liveConversation != null || dissolvingConversation != null;
 
         // Effective expansion = each conversation's IsExpandedByDefault flipped by a local override, so
         // expandedConversations below is the resolved "render expanded" set, not the raw override set.
@@ -624,7 +636,9 @@ public partial class ChatUI
         var metaAt = CpuTimestamp.Now;
         var conversationView = new ConversationViewState(
             showConversations, expandedConversations, hiddenLiveTailRange,
-            liveBlockId, liveBlockFoldRange, materializedBlockId);
+            liveBlockId, liveBlockFoldRange, materializedBlockId) {
+            DissolvingConversation = dissolvingConversation,
+        };
         var blockRange = liveBlockId is { } coverageId
             ? new Range<long>(coverageId.StartEntryLid,
                 Math.Max(coverageId.StartEntryLid + 1,
@@ -702,11 +716,15 @@ public partial class ChatUI
             else if (shownReadyEntryLid >= idTile.End - 1)
                 lastReadEntryLid = long.MaxValue;
             var isLastTile = tileIndex == tailTileIndex;
+            // Deleted-entry gaps can put the preceding message farther back than the adjacent tile.
+            var tileScope = new Range<long>(
+                Math.Min(idTile.Start - EntryIdTiles.TileSize, prevMessage?.Id ?? idTile.Start),
+                idTile.End);
             var tile = await GetTile(
                     chatId,
                     chat.Rules.Author?.Id,
                     idTile,
-                    conversationView.NarrowTo(idTile.MoveStart(-EntryIdTiles.TileSize)),
+                    conversationView.NarrowTo(tileScope),
                     prevMessage,
                     lastReadEntryLid,
                     isLastTile ? chatLidRange.End : null,
@@ -1144,6 +1162,11 @@ public partial class ChatUI
                 // pre-latch group can't swallow the block's tail entries.
                 if (liveBlockId is { } jlId && entry.LocalId >= jlId.StartEntryLid
                     && (prevEntry == null || prevEntry.LocalId < jlId.StartEntryLid))
+                    isBlockStart = true;
+                // An author group must not pull post-close messages into the dissolving block.
+                if (conversationView.DissolvingConversation is { EndEntryLid: var lastDissolvingLid }
+                    && entry.LocalId > lastDissolvingLid
+                    && (prevEntry == null || prevEntry.LocalId <= lastDissolvingLid))
                     isBlockStart = true;
                 // A same-author message that switches kind (transcribed vs not) starts a new block,
                 // so its author header signals the kind change.

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -16,7 +16,10 @@ public sealed record LiveBlockOverlay(
     long BlockEndLid,
     ConversationId? MaterializedId,
     bool IsExpandedByDefault,
-    bool IsDissolving = false);
+    bool IsDissolving = false)
+{
+    public Conversation? DissolvingConversation { get; init; }
+}
 
 /// <summary>
 /// The live block's fold state. <see cref="FoldBoundaryLid"/> is the governed fold end, already
@@ -190,7 +193,9 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 : chatState.DissolveDone
                     ? null
                     : new LiveBlockOverlay(t.LiveRenderId, t.V, FoldRangeOf(t.V, foldBoundaryLid),
-                        new Range<long>(t.TailStart, long.MaxValue), t.TailStart, null, false, IsDissolving: true);
+                        new Range<long>(t.TailStart, long.MaxValue), t.TailStart, null, false, IsDissolving: true) {
+                        DissolvingConversation = t.DissolvingConversation,
+                    };
 
         if (!amInLive)
             // Leave, session still live: the block goes on exactly as it was - same fold, same
@@ -322,17 +327,32 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
     private async Task<FrozenTemplate> BuildTemplate(ChatId chatId, LiveBlockSnapshot raw, CancellationToken cancellationToken)
     {
         Range<long> chatIdRange;
-        using (Computed.BeginIsolation())
-            chatIdRange = await Chats.GetIdRange(Session, chatId, cancellationToken).ConfigureAwait(false);
+        Conversation? conversation;
+        using (Computed.BeginIsolation()) {
+            var rangeTask = Chats.GetIdRange(Session, chatId, cancellationToken);
+            var conversationTask = raw.HasSummary ? null : LiveSessionUI.GetConversation(chatId, cancellationToken);
+            chatIdRange = await rangeTask.ConfigureAwait(false);
+            conversation = conversationTask == null ? null : await conversationTask.ConfigureAwait(false);
+        }
         var v = raw.VisibleStartLid;
+        var renderId = ConversationId.New(chatId, v);
+        // A close may reach the conversation read before its snapshot; keep the descriptor already shown.
+        if (conversation == null && !raw.HasSummary)
+            lock (Lock)
+                if (_chatStates.TryGetValue(chatId, out var state) && state.Template?.LiveRenderId == renderId)
+                    conversation = state.Template.DissolvingConversation;
+
         return new FrozenTemplate(
             v,
             chatIdRange.End,
             raw.EndEntryLid + 1,
-            ConversationId.New(chatId, v),
+            renderId,
             ConversationId.New(chatId, raw.ContextStartLid > 0 ? raw.ContextStartLid : v),
             raw.IsExpandedByDefault,
-            raw.HasSummary);
+            raw.HasSummary,
+            conversation?.Id == renderId
+                ? conversation with { EndEntryLid = Math.Max(v, chatIdRange.End - 1) }
+                : null);
     }
 
     private static long GetRawFoldEndLid(LiveBlockSnapshot? raw)
@@ -438,8 +458,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             if (isTierOneClose) {
                 if (chatState.DissolveEndsAt == default)
                     chatState.DissolveEndsAt = Clocks.ServerClock.Now + DissolveDuration;
-                if (!chatState.DissolveDone && Clocks.ServerClock.Now >= chatState.DissolveEndsAt)
+                if (!chatState.DissolveDone && Clocks.ServerClock.Now >= chatState.DissolveEndsAt) {
                     chatState.DissolveDone = true;
+                    chatState.Template = chatState.Template! with { DissolvingConversation = null };
+                }
                 if (!chatState.DissolveDone)
                     wakeAt = chatState.DissolveEndsAt;
             }
@@ -550,7 +572,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         ConversationId LiveRenderId,
         ConversationId MaterializedId,
         bool IsExpandedByDefault,
-        bool HadSummary);
+        bool HadSummary,
+        Conversation? DissolvingConversation);
 
     protected sealed record GovernorInputs(
         ChatId? ChatId,

--- a/tests/Chat.UI.Blazor.IntegrationTests/ConversationViewStateKeyTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/ConversationViewStateKeyTest.cs
@@ -10,6 +10,29 @@ namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
 public sealed class ConversationViewStateKeyTest
 {
     [Fact]
+    public void DissolvingConversationShouldRekeyOnlyOverlappingTiles()
+    {
+        // arrange
+        var id = ConversationId.New(ChatId.Parse("the-actual-one"), 100);
+        var conversation = new Conversation(id) { EndEntryLid = 119 };
+        var state = new ConversationViewState(true, ImmutableHashSet.Create(id), default, id, default, null);
+        var dissolving = state with { DissolvingConversation = conversation };
+
+        // act
+        var near = dissolving.NarrowTo(new Range<long>(110, 115));
+        var far = dissolving.NarrowTo(new Range<long>(120, 125));
+        var rebuilt = dissolving with { ExpandedConversations = ImmutableHashSet.Create(id) };
+
+        // assert
+        near.Should().NotBe(state, "retaining or releasing the descriptor must invalidate cached cards");
+        near.DissolvingConversation.Should().BeSameAs(conversation);
+        far.Should().Be(state);
+        far.GetHashCode().Should().Be(state.GetHashCode());
+        rebuilt.Should().Be(dissolving);
+        rebuilt.GetHashCode().Should().Be(dissolving.GetHashCode());
+    }
+
+    [Fact]
     public void StructurallyIdenticalStatesMustBeEqual()
     {
         // arrange

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -20,8 +20,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await base.DisposeAsync();
     }
 
-    [Fact]
-    public async Task ExpandedLiveBlockShouldKeepOptimisticTailBeforeItsFooter()
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ExpandedLiveBlockShouldKeepOptimisticTailBeforeItsFooter(bool mustLeave, bool isRecording)
     {
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -39,6 +42,18 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await chatAudioUI.SetListeningState(chat.Id, true);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
         await AwaitJoinedBlockExpansion(chatUI, chat.Id, live.ToConversation());
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        if (mustLeave) {
+            await chatAudioUI.SetListeningState(chat.Id, false);
+            InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
+            await ComputedTest.When(async ct => {
+                var overlay = (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay;
+                overlay.Should().NotBeNull();
+                overlay!.MaterializedId.Should().BeNull();
+                overlay.BlockEndLid.Should().Be(long.MaxValue);
+            }, TimeSpan.FromSeconds(10));
+        }
+
         var sendingMessages = Tester.ScopedAppServices.GetRequiredService<SendingMessages>();
         var pending = sendingMessages.GetSendingMessages(chat.Id).ChatSendingMessages;
         var now = Tester.AppServices.Clocks().SystemClock.Now;
@@ -48,26 +63,37 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
                 $"pending-{i}", HashString.None, null, () => { }));
         var recorder = Tester.ScopedAppServices.GetRequiredService<AudioRecorder>();
         var recorderState = (MutableState<AudioRecorderState>)recorder.State;
-        recorderState.Set(new AudioRecorderState(chat.Id));
+        if (isRecording)
+            recorderState.Set(new AudioRecorderState(chat.Id));
 
         // act
         try {
             var range = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
             var query = new ChatDataQuery(range, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+            var expectedIds = isRecording
+                ? new[] { range.End, range.End + 1, long.MaxValue }
+                : new[] { range.End, range.End + 1 };
             await ComputedTest.When(async ct => {
                 var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+                if (mustLeave) {
+                    var overlay = (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay;
+                    overlay.Should().NotBeNull();
+                    overlay!.MaterializedId.Should().BeNull();
+                    overlay.BlockEndLid.Should().Be(long.MaxValue);
+                }
+
                 var block = items.Items.OfType<ExpandedConversationMessage>()
                     .Single(b => b.Conversation!.Id == live.ConversationId);
                 var tail = items.Items.SelectMany(i => i.GetLeafMessages())
                     .OfType<ChatEntryMessage>().Where(m => m.Entry.SendingTag != null).ToList();
 
                 // assert
-                tail.Select(m => m.Id).Should().Equal(range.End, range.End + 1, long.MaxValue);
+                tail.Select(m => m.Id).Should().Equal(expectedIds);
                 tail.Should().OnlyContain(m => m.Conversation == null,
                     "optimistic items are placed by grouping coverage, not conversation tags");
                 block.Items.SelectMany(i => i.GetLeafMessages()).OfType<ChatEntryMessage>()
                     .Where(m => m.Entry.SendingTag != null).Select(m => m.Id)
-                    .Should().Equal(range.End, range.End + 1, long.MaxValue);
+                    .Should().Equal(expectedIds, Dump(items));
                 block.Items[^1].Should().BeOfType<LiveConversationFooter>();
             }, TimeSpan.FromSeconds(10));
         }

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -5,6 +5,8 @@ using ActualChat.Streaming;
 using ActualChat.Testing.Host;
 using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
+using Bunit;
+using Microsoft.AspNetCore.Components.Rendering;
 
 namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
 
@@ -1276,8 +1278,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             .Should().BeEmpty("a thread start below the loaded range must not be emitted");
     }
 
-    [Fact]
-    public async Task TierOneCloseDissolvesBeforeVanishing()
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task UnsummarizedBlockShouldRemainUntilDissolveEnds(bool isSummarized, bool mustSkipTile)
     {
         // A too-short (never-summarized) session leaves no card behind, but it must not vanish in one
         // frame - the block is held briefly as "dissolving" so it can fade + collapse out.
@@ -1285,6 +1290,12 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // arrange - a joined live session that never gets a summary
         await Tester.SignInAsUniqueBob();
         var chat = await CreateSettledChat("tier1-dissolve-test");
+        await Tester.Commander.Call(new Chats_Change {
+            Session = Tester.Session,
+            ChatId = chat.Id,
+            ExpectedVersion = null,
+            Change = Change.Update(new ChatDiff { IsSummarized = isSummarized }),
+        });
         var author = await Tester.GetOwnAuthor(chat.Id).Require();
         var peerId = AuthorId.New(chat.Id, 777_210);
         var liveBackend = AppHost.Services.GetRequiredService<ILiveSessionsBackend>();
@@ -1298,7 +1309,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var chatAudioUI = Tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
         var chatUI = Tester.ScopedAppServices.GetRequiredService<ChatUI>();
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        liveBlockUI.DissolveDuration = TimeSpan.FromSeconds(10);
+        liveBlockUI.DissolveDuration = TimeSpan.FromSeconds(5);
         await chatAudioUI.SetListeningState(chat.Id, true);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
         chatUI.SelectChatOnNavigation(chat.Id);
@@ -1307,6 +1318,21 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             var s = await liveBlockUI.GetBlockState(chat.Id, ct);
             s.WasAttending.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
+
+        await AwaitJoinedBlockExpansion(chatUI, chat.Id, live!.ToConversation());
+        var range = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(range, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var before = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
+        var beforeBlock = before.Items.OfType<ExpandedConversationMessage>().Single();
+        beforeBlock.Items.OfType<LiveConversationHeader>().Should().ContainSingle();
+        var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+        Tester.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var header = Tester.Render<LiveConversationHeaderView>(p => p
+            .Add(x => x.Header, beforeBlock.Items.OfType<LiveConversationHeader>().Single())
+            .Add(x => x.ChatContext, new ChatContext(
+                Tester.ScopedAppServices.GetRequiredService<AppUIHub>(), chat)));
+        header.WaitForAssertion(() => header.Find(".c-lc-name").TextContent.Should().NotBeNullOrEmpty());
+        var beforeTitle = header.Find(".c-lc-name").TextContent;
 
         // act - tier-1 close (never summarized)
         await liveBackend.SetParticipation(chat.Id, peerId, ParticipationKind.Record, false, CancellationToken.None);
@@ -1318,7 +1344,47 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             var s = await liveBlockUI.GetBlockState(chat.Id, ct);
             s.Overlay.Should().NotBeNull("a tier-1 close dissolves the block before removing it");
             s.Overlay!.IsDissolving.Should().BeTrue();
-        }, TimeSpan.FromSeconds(10));
+            s.Overlay.MaterializedId.Should().BeNull();
+            s.Overlay.BlockEndLid.Should().BeLessThan(long.MaxValue);
+            (await liveSessionUI.GetConversation(chat.Id, ct)).Should().BeNull();
+        }, TimeSpan.FromSeconds(3));
+        if (mustSkipTile)
+            for (var i = 0; i < 2 * ChatUI.EntryIdTiles.TileSize; i++) {
+                var removedEntry = await Tester.CreateTextEntry(chat.Id, $"removed-{i}");
+                await Tester.RemoveTextEntry(removedEntry.Id);
+            }
+        var afterClose = await Tester.CreateTextEntry(chat.Id, "after-close");
+        var expectedLids = LeafEntryLids(before).Append(afterClose.LocalId).ToList();
+        for (var sample = 0; sample < 10; sample++) {
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+            var overlay = (await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None)).Overlay;
+            overlay.Should().NotBeNull();
+            overlay!.IsDissolving.Should().BeTrue();
+            overlay.MaterializedId.Should().BeNull();
+            overlay.BlockEndLid.Should().BeLessThan(long.MaxValue);
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            LeafEntryLids(items).Should().Equal(expectedLids);
+            var block = items.Items.OfType<ExpandedConversationMessage>()
+                .Should().ContainSingle(
+                    $"sample {sample}, overlay {overlay}: the header must remain to dissolve: " + Dump(items))
+                .Subject;
+            ((IVirtualListItem)block).RenderKey.Should().Be(((IVirtualListItem)beforeBlock).RenderKey);
+            block.Items.OfType<LiveConversationHeader>().Should().ContainSingle();
+            block.Items.SelectMany(i => i.GetLeafMessages()).OfType<ChatEntryMessage>()
+                .Should().NotContain(m => m.Id == afterClose.LocalId);
+            header.WaitForAssertion(() => {
+                header.FindAll(".live-conversation-header.dissolving").Should().ContainSingle();
+                header.Find(".c-lc-name").TextContent.Should().Be(beforeTitle);
+                header.FindAll(".c-lc-join").Should().BeEmpty();
+            });
+        }
+        await ComputedTest.When(async ct => {
+            (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay.Should().BeNull();
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct).WaitAsync(TimeSpan.FromSeconds(5));
+            items.Items.OfType<ExpandedConversationMessage>().Should().BeEmpty();
+            LeafEntryLids(items).Should().Equal(expectedLids);
+        }, TimeSpan.FromSeconds(5));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Two live-block lifecycle states lost their intended grouping. Leaving while other participants continued made pending typed sends and the transcription placeholder appear below the live block's footer. Closing a session without a summary removed its header before the dissolve overlay expired, leaving no header to animate.

## Fix

- Keep grouping open-ended for a live leave overlay whose end is still unbounded and which has no materialized ID. Fetch coverage remains finite, and closed/materialized grouping keeps its finite boundary.
- Retain the last bounded conversation descriptor in the existing frozen template through unsummarized dissolve. Use it for both block projection and tile cards, include it in relevant tile cache keys, and release it at expiry. This works when chat summarization is disabled too.
- Split same-author groups at the frozen boundary, including across deleted-entry tile gaps. During dissolve, preserve the header's participant title and suppress Join.

Two commits, one per defect. `docs/ui/chat-blocks.md` documents the lifecycle and cache decisions. The production dissolve duration remains 300 ms; regression tests extend it to inspect intermediate states.

## Testing

- 51 integration tests passed: the full live-conversation display and conversation-view cache suites.
- 36 unit tests passed: block projection, query expansion, and expanded-conversation grouping.
- Regression checks failed before their corresponding fixes, including left-call pending items, missing dissolve headers, same-author sends across deleted IDs, and blank fading-header titles. The rendered header is checked through bUnit.
- Server-loop rebuilt TypeScript and .NET successfully; local application and health endpoints returned HTTP 200.
- An earlier full run hit the 30-second inactivity watchdog in the existing session-restart test after 11 passes. That test passed in isolation in four seconds, and the full rerun passed all 51 tests with the same watchdog. The intermittent hang's cause remains unconfirmed.
- No Chrome/Safari visual pass or real microphone test. The recording placeholder is simulated in application-host tests.

Issue tracking was skipped at the user's request.