### PR TITLE
fix(search): find system chats by their localized title #4362

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -354,10 +354,16 @@ against the chat `Chats.Get` returned, so an unchanged (localized) title produce
 The keys are `SystemChat_Notes`, `SystemChat_Announcements_Format` (`{0}` is the
 product name) and `SystemChat_Welcome`; the onboarding groups reuse their
 `Onboarding_Chat*` labels, since the label offers exactly the chat that gets created.
-The search index still holds the stored English title, so searching for a system chat
-by its localized name is not yet supported (#4362). A forwarded message's "Forwarded
-from" header shows the `ChatEntryForwarded.ChatTitle` snapshot, taken from the
-forwarder's `Chats.Get` - so it reads in the forwarder's language, not the reader's.
+The search index holds the stored English title and knows no reader, so a system chat
+is found by its localized name on the client instead: `SearchUI` serves the reader's own
+groups - inside a place too - from `LocalSearchUI`, whose candidates come from the contact
+list and thus carry the `Chats.Get` title (#4362). Two consequences are deliberate: an
+English query no longer matches an own system chat once the UI is in another language,
+and Welcome chats of places the reader is not a member of are not searchable by their
+localized name, since a list of identically named chats tells them nothing. A forwarded
+message's "Forwarded from" header shows the `ChatEntryForwarded.ChatTitle` snapshot,
+taken from the forwarder's `Chats.Get` - so it reads in the forwarder's language, not
+the reader's.
 That is deliberate: the header names someone else's chat, and localizing it would need
 the system tag on the wire and in the entry row for a small surface.
 

--- a/src/dotnet/UI.Blazor.App/Services/LocalSearchUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LocalSearchUI.cs
@@ -60,15 +60,19 @@ public class LocalSearchUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
 
     public async Task<IReadOnlyList<FoundContact>> FindContacts(
         SearchScope scope,
+        PlaceId? placeId,
         string criteria,
         int limit,
         CancellationToken cancellationToken)
     {
+        // People are place-independent here: a place-scoped people search stays on the server
         if (limit <= 0)
             return [];
 
         var candidates = scope switch {
             SearchScope.People => await ListUserContactCandidates(cancellationToken).ConfigureAwait(false),
+            SearchScope.Groups when placeId is { } id
+                => await ListPlaceChatContactCandidates(id, cancellationToken).ConfigureAwait(false),
             SearchScope.Groups => await ListChatContactCandidates(cancellationToken).ConfigureAwait(false),
             _ => [],
         };
@@ -296,6 +300,23 @@ public class LocalSearchUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
 
             var title = chat.Title;
             result.Add(new ContactCandidate(ContactId.NewChat(ownerId, groupChatId), title, new SearchDocument(title)));
+        }
+        return result.ToApiArray();
+    }
+
+    [ComputeMethod]
+    public virtual async Task<ApiArray<ContactCandidate>> ListPlaceChatContactCandidates(
+        PlaceId placeId, CancellationToken cancellationToken)
+    {
+        var ownUserId = await GetOwnUserId(cancellationToken).ConfigureAwait(false);
+        if (ownUserId is not { } ownerId)
+            return [];
+
+        var chats = await ListPlaceChats(placeId, cancellationToken).ConfigureAwait(false);
+        var result = new List<ContactCandidate>(chats.Count);
+        foreach (var chat in chats) {
+            var title = chat.Title;
+            result.Add(new ContactCandidate(ContactId.NewAny(ownerId, chat.Id), title, new SearchDocument(title)));
         }
         return result.ToApiArray();
     }

--- a/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.StateSync.cs
+++ b/src/dotnet/UI.Blazor.App/Services/Search/SearchUI.StateSync.cs
@@ -149,12 +149,20 @@ public partial class SearchUI
             .ToDictionary(x => x.First, x => x.Second.Value);
 
         async Task<IReadOnlyList<IHasSearchMatch>> FindSubgroup(SubgroupKey key) {
-            // Own people & groups are served from fast in-memory local search; global results,
-            // place-scoped results, places and messages stay on the server.
-            if (key is { Own: true, Scope: SearchScope.People or SearchScope.Groups } && criteria.PlaceId is null)
+            // Own people & groups are served from fast in-memory local search - own groups inside a place
+            // too, so a system chat is found under the name the reader sees, which only the client has.
+            // Global results, place-scoped people, places and messages stay on the server.
+            var isLocal = key.Own && key.Scope switch {
+                SearchScope.People => criteria.PlaceId is null,
+                SearchScope.Groups => true,
+                _ => false,
+            };
+            if (isLocal) {
+                var limit = criteria.DisplayLimit(key.Scope) + 1;
                 return await LocalSearch
-                    .FindContacts(key.Scope, criteria.Text, criteria.DisplayLimit(key.Scope) + 1, cancellationToken)
+                    .FindContacts(key.Scope, criteria.PlaceId, criteria.Text, limit, cancellationToken)
                     .ConfigureAwait(false);
+            }
 
             // TODO: reuse cached data for scope
             switch (key.Scope) {

--- a/tests/Chat.UI.Blazor.IntegrationTests/LocalSearchUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LocalSearchUITest.cs
@@ -1,0 +1,77 @@
+using ActualChat.Search;
+using ActualChat.Testing.Host;
+using ActualChat.UI.Blazor.App.Services;
+using ActualChat.Users;
+
+namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
+
+[Collection(nameof(ChatUICollection))]
+public class LocalSearchUITest(ChatAppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<ChatAppHostFixture>(fixture, @out)
+{
+    private BlazorTester Tester => field ??= AppHost.NewBlazorTester(Out);
+
+    protected override async Task DisposeAsync()
+    {
+        await Tester.DisposeSilentlyAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ShouldFindSystemChatsByLocalizedTitle()
+    {
+        // arrange
+        var bob = await Tester.SignInAsUniqueBob();
+        await Tester.AppServices.UserSettingsUI(Tester.Session)
+            .UserLanguageSettings()
+            .Set(new UserLanguageSettings { UILanguage = Languages.Russian });
+        var notesChat = await CreateSystemChat(Constants.Chat.System.Notes, null);
+        var place = await Tester.CreatePlace(false, "local-search-place");
+        var welcomeChat = await CreateSystemChat(Constants.Chat.System.Welcome, place.Id);
+        notesChat.Title.Should().Be("Заметки", "Chats.Get names a system chat in the reader's language");
+
+        // act, assert
+        var found = await Find(SearchScope.Groups, null, "Заметки", 1);
+        found[0].ContactId.Should().Be(ContactId.NewAny(bob.Id, notesChat.Id));
+        found[0].Match.Text.Should().Be("Заметки");
+
+        found = await Find(SearchScope.Groups, place.Id, "Добро", 1);
+        found[0].ContactId.Should().Be(ContactId.NewAny(bob.Id, welcomeChat.Id));
+        found[0].Match.Text.Should().Be("Добро пожаловать");
+
+        found = await Find(SearchScope.Groups, null, "Notes", 0);
+        found.Should().BeEmpty("the local candidates carry the localized title only, by design");
+    }
+
+    private async Task<Chat> CreateSystemChat(Constants.Chat.SystemChat systemChat, PlaceId? placeId)
+    {
+        var chat = await Tester.Commander.Call(new Chats_Change {
+            Session = Tester.Session,
+            ChatId = default,
+            ExpectedVersion = null,
+            Change = new() {
+                Create = new ChatDiff {
+                    Title = systemChat.DefaultTitle,
+                    Kind = placeId is null ? ChatKind.Group : null,
+                    IsPublic = placeId is not null,
+                    PlaceId = placeId,
+                    SystemTag = systemChat.Tag,
+                },
+            },
+        }).Require();
+        return await Tester.Chats.Get(Tester.Session, chat.Id, CancellationToken.None).Require();
+    }
+
+    // The contact behind a new chat lands through queued events, so the candidate list fills in after creation
+    private Task<IReadOnlyList<FoundContact>> Find(
+        SearchScope scope,
+        PlaceId? placeId,
+        string criteria,
+        int expectedCount)
+        => TestsExt.When(async () => {
+            var localSearch = Tester.ScopedAppServices.GetRequiredService<LocalSearchUI>();
+            var found = await localSearch.FindContacts(scope, placeId, criteria, 10, CancellationToken.None);
+            found.Should().HaveCount(expectedCount);
+            return found;
+        }, TimeSpan.FromSeconds(20));
+}

--- a/tests/ts/e2e/system-chat-localized-search.test.ts
+++ b/tests/ts/e2e/system-chat-localized-search.test.ts
@@ -1,0 +1,130 @@
+/**
+ * E2E test: the left search panel finds a system chat by its localized name (#4362).
+ * With the UI in Russian, "Заметки" must find the Notes chat and "Анонсы" the announcements
+ * chat, and each result must be shown under the Russian name - own groups are served from
+ * LocalSearchUI, whose candidates carry the Chats.Get title.
+ *
+ * Run:
+ *   ./node_modules/.bin/vitest run tests/ts/e2e/system-chat-localized-search.test.ts --config vitest.config.e2e.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Page } from 'playwright';
+import {
+    BASE_URL, connectBrowser, ensureSignedIn, screenshot, setUILanguage,
+    skipOnboarding, waitForAppReady, type BrowserConnection,
+} from './helpers';
+
+const RUSSIAN = 'ru-RU';
+const shot = (name: string) => screenshot('system-chat-search', name);
+
+async function clearSearch(page: Page) {
+    const input = page.locator('.left-chat-search-input input[type="text"]').first();
+    if (!await input.isVisible({ timeout: 1000 }).catch(() => false))
+        return;
+
+    await input.click({ force: true }).catch(() => { /* ignore */ });
+    // fill('') alone doesn't fire Blazor's debounced input listener - use a real keystroke.
+    await input.click({ clickCount: 3, force: true }).catch(() => { /* ignore */ });
+    await page.keyboard.press('Backspace').catch(() => { /* ignore */ });
+    await input.fill('').catch(() => { /* ignore */ });
+    await page.waitForTimeout(800);
+}
+
+// LeftChatSearchInput resets the location filter to the current chat every time the panel
+// opens. The location badge renders first, and its text is localized, so it's picked by position.
+async function setLocationAnywhere(page: Page) {
+    const badge = page.locator('.left-chat-search-input .search-filter-badge').first();
+    if (await badge.isVisible({ timeout: 1500 }).catch(() => false)) {
+        await badge.click({ force: true });
+        await badge.waitFor({ state: 'hidden', timeout: 3_000 }).catch(() => { /* ignore */ });
+    }
+}
+
+async function searchFor(page: Page, query: string) {
+    await skipOnboarding(page);
+    await clearSearch(page);
+    const input = page.locator('.left-chat-search-input input[type="text"]').first();
+    await input.waitFor({ state: 'visible', timeout: 10_000 });
+    await input.click({ force: true });
+    await page.waitForTimeout(200);
+    await setLocationAnywhere(page);
+    // pressSequentially: TextInput's input listener is debounced 800ms; fill() can land before it attaches.
+    await input.pressSequentially(query, { delay: 60 });
+    await page.waitForTimeout(2_500);
+}
+
+async function foundGroupTitles(page: Page): Promise<string[]> {
+    await page.locator('.found-result.chat').first()
+        .waitFor({ state: 'visible', timeout: 10_000 })
+        .catch(() => { /* asserted by the caller */ });
+    const titles = page.locator('.found-result.chat .c-title');
+    const count = await titles.count();
+    const result: string[] = [];
+    for (let i = 0; i < count; i++)
+        result.push(((await titles.nth(i).textContent({ timeout: 1000 }).catch(() => '')) ?? '').trim());
+    return result;
+}
+
+describe('system chat localized search', () => {
+    let conn: BrowserConnection;
+    let page: Page;
+    // '' is a real value here - the "Auto" option - so null is what marks "never switched".
+    let originalLanguage: string | null = null;
+
+    beforeAll(async () => {
+        conn = await connectBrowser();
+        page = await conn.context.newPage();
+        await ensureSignedIn(page);
+        originalLanguage = await setUILanguage(page, RUSSIAN);
+
+        // The reload leaves the settings modal open; come back on a clean route.
+        await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+        await waitForAppReady(page);
+        await skipOnboarding(page);
+        await page.locator('.left-chat-search-input input[type="text"]').first()
+            .waitFor({ state: 'visible', timeout: 20_000 });
+        await page.screenshot({ path: shot('00-ready-ru') });
+    }, 120_000);
+
+    afterAll(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- page may be unset if beforeAll fails
+        if (page) {
+            await clearSearch(page);
+            await page.keyboard.press('Escape').catch(() => { /* ignore */ });
+            if (originalLanguage !== null) {
+                try {
+                    await setUILanguage(page, originalLanguage);
+                } catch (e) {
+                    console.log('Failed to restore UI language:', e instanceof Error ? e.message : String(e));
+                }
+            }
+            await page.close();
+        }
+        if (conn.ownsBrowser) {
+            await conn.context.close();
+            await conn.browser.close();
+        }
+    });
+
+    it.each([
+        { query: 'Заметки', title: 'Заметки', name: 'notes' },
+        { query: 'Анонсы', title: 'Анонсы Voxt', name: 'announcements' },
+    ])('finds "$title" when searching for "$query"', async ({ query, title, name }) => {
+        await searchFor(page, query);
+        const titles = await foundGroupTitles(page);
+        await page.screenshot({ path: shot(`01-${name}`) });
+
+        expect(titles, `group results for "${query}"`).toContain(title);
+    }, 45_000);
+
+    it('does not match an own system chat by its English title', async () => {
+        await searchFor(page, 'Notes');
+        const titles = await foundGroupTitles(page);
+        await page.screenshot({ path: shot('02-english-query') });
+
+        // Deliberate: the local candidates carry the localized title only (docs/i18n.md).
+        expect(titles).not.toContain('Заметки');
+        expect(titles).not.toContain('Notes');
+    }, 45_000);
+});


### PR DESCRIPTION
Closes #4362

## Summary

With the UI in a non-English language, a system chat (Notes, the announcements chat, an onboarding group, a place's Welcome chat) is shown under a localized name, but global search only matched the stored English title.

The reader's own groups are already served from `LocalSearchUI`, whose candidates come from the frontend `Chats.Get` and so carry the localized title: "Заметки" finds Notes with no place selected. What was missing is the place-scoped case, where own groups still went to the server index and the local candidate list skipped place chats, so a place's Welcome chat was only findable as "Welcome".

- `SearchUI` now routes own groups to local search inside a place too; own people in a place stay on the server.
- `LocalSearchUI.FindContacts` takes a place id, with a new candidate list built from the place's chat list.
- docs/i18n.md describes the behavior and the deliberate gaps: an English query no longer matches an own system chat in a non-English UI, and Welcome chats of places the reader has not joined are not searchable by localized name.

An index-side fix (localized titles in the group index, index v6, flow restart on version bump) was tried first and dropped in favor of this after discussion; the branch is squashed to one commit.

## Testing

- New `LocalSearchUITest`: Russian UI, a Notes chat and a place Welcome chat; "Заметки" and "Добро" find them with Russian result text, "Notes" finds nothing.
- `ChatMentionSearchTest` still green (shares `LocalSearchUI`).
- New e2e spec `system-chat-localized-search`: Russian UI, "Заметки" and "Анонсы" find their chats, "Notes" finds nothing; it restores the account's language afterwards.
- Headless check against the worktree server with a Russian UI confirmed the no-place case already worked before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

