### PR TITLE
fix(attachments): unstick messages whose failed attachments were removed, refuse empty files

### DIFF
--- a/src/dotnet/Chat.Service/Chats.cs
+++ b/src/dotnet/Chat.Service/Chats.cs
@@ -497,10 +497,13 @@ public partial class Chats(IServiceProvider services) : IChats
             if (repliedEntryLid.IsSome(out var v) && textEntry.RepliedEntryLid != v)
                 throw StandardError.Constraint("Replied entry Id cannot be changed.");
 
+            // A text edit sends no attachments and must keep them, while the upsert completing an upload
+            // sends what got uploaded - there an empty list means every attachment was dropped.
+            var isUploadCompletion = textEntry.HasUploadingAttachments && !command.HasUploadingAttachments;
             var diff = new ChatEntryDiff {
                 Content = text,
                 RepliedEntryLid = repliedEntryLid,
-                Attachments = command.Attachments,
+                Attachments = attachments.Length > 0 || isUploadCompletion ? attachments : null,
             };
 
             if (textEntry.HasAudio) {

--- a/src/dotnet/Chat.Service/ChatsBackend.cs
+++ b/src/dotnet/Chat.Service/ChatsBackend.cs
@@ -1397,7 +1397,9 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
                     Version = VersionGenerator.NextVersion(dbEntry.Version),
                 };
                 entry = await PrepareTextEntryForSave(entry, oldEntry, cancellationToken).ConfigureAwait(false);
-                var hasAttachments = update.Attachments is { Length: > 0 } || dbEntry.HasAttachments;
+                var hasAttachments = update.Attachments is { } newAttachments
+                    ? newAttachments.Length > 0
+                    : dbEntry.HasAttachments;
                 dbEntry.UpdateFrom(entry);
                 dbEntry.HasAttachments = hasAttachments;
                 boundToThreadHasChanged = existingChatEntry.IsThread ^ entry.IsThread
@@ -1457,14 +1459,15 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         ChatEntryAttachment[]? attachmentsProto = null;
         if (change.IsCreate(out var create) && create.Attachments is { Length: > 0 } attachments1)
             attachmentsProto = attachments1;
-        if (change.IsUpdate(out var update1) && update1.Attachments is { Length: > 0 } attachments2)
+        // On update a non-null list replaces the attachments, so an empty one removes them all
+        if (change.IsUpdate(out var update1) && update1.Attachments is { } attachments2)
             attachmentsProto = attachments2;
 
-        if (attachmentsProto is not null) {
-            if (change.Kind is ChangeKind.Update) {
-                var removeAttachmentsCmd = new ChatsBackend_RemoveAttachments(chatEntryId);
-                await Commander.Call(removeAttachmentsCmd, cancellationToken).ConfigureAwait(false);
-            }
+        if (attachmentsProto is not null && change.Kind is ChangeKind.Update) {
+            var removeAttachmentsCmd = new ChatsBackend_RemoveAttachments(chatEntryId);
+            await Commander.Call(removeAttachmentsCmd, cancellationToken).ConfigureAwait(false);
+        }
+        if (attachmentsProto is { Length: > 0 }) {
             var newAttachments = attachmentsProto
                 .Select((x, i) => new ChatEntryAttachment {
                     EntryId = chatEntryId,
@@ -2256,8 +2259,8 @@ public partial class ChatsBackend(IServiceProvider services) : DbServiceBase<Cha
         // Remove: ChatEntry doesn't carry HasAttachments, and oldEntry is loaded without
         // attachments, so we don't know if the entry being removed had any. Schedule
         // defensively — the media flow's delete-by-entryId is a no-op when no rows match.
-        // Update never empties attachments (only replaces with a non-empty list), so the
-        // current entry.Attachments alone is sufficient there.
+        // An update that empties the attachments goes through OnRemoveAttachments, which resumes
+        // the media flow itself, so the current entry.Attachments alone is sufficient there.
         var hasOrHadAttachments = entry.Attachments.Length > 0
             || kind == ChangeKind.Remove;
 

--- a/src/dotnet/Core/Errors/UploadException.cs
+++ b/src/dotnet/Core/Errors/UploadException.cs
@@ -14,6 +14,8 @@ public static partial class StandardError
             => Constraint($"File is too big. Max file size: {FileSizeFormatter.Format(maxSizeBytes)}.");
         public static Exception TooManyFiles(int maxCount)
             => Constraint($"Too many files. Max allowed number is {maxCount}.");
+        public static Exception FileEmpty()
+            => new UploadFileEmptyException("File is empty or no longer available.");
         public static Exception CropExportFailed()
             => Constraint("Failed to export cropped image.");
     }
@@ -50,6 +52,17 @@ public class OffsetConflictException : UploadException
     public OffsetConflictException() : base() { }
     public OffsetConflictException(string? message) : base(message) { }
     public OffsetConflictException(string? message, Exception? innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Exception thrown when the file to upload is empty, so retrying the upload can't help.
+/// </summary>
+[Serializable]
+public class UploadFileEmptyException : UploadException
+{
+    public UploadFileEmptyException() : base() { }
+    public UploadFileEmptyException(string? message) : base(message) { }
+    public UploadFileEmptyException(string? message, Exception? innerException) : base(message, innerException) { }
 }
 
 /// <summary>

--- a/src/dotnet/Localization/Resources/Messages.bg.json
+++ b/src/dotnet/Localization/Resources/Messages.bg.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Изрязаното изображение не можа да бъде експортирано.",
   "Error_FileTooBig_Format": "Файлът е твърде голям. Максимален размер: {size}.",
   "Error_TooManyFiles_Format": "Твърде много файлове. Максималният разрешен брой е {count}.",
+  "Error_FileEmpty": "Файлът е празен или вече не е достъпен.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Линкът за покана вече е използван.",

--- a/src/dotnet/Localization/Resources/Messages.bs.json
+++ b/src/dotnet/Localization/Resources/Messages.bs.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Izrezana slika se nije mogla izvesti.",
   "Error_FileTooBig_Format": "Fajl je prevelik. Najveća veličina fajla: {size}.",
   "Error_TooManyFiles_Format": "Previše fajlova. Najveći dozvoljeni broj je {count}.",
+  "Error_FileEmpty": "Fajl je prazan ili više nije dostupan.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Link pozivnice je već iskorišten.",

--- a/src/dotnet/Localization/Resources/Messages.cnr.json
+++ b/src/dotnet/Localization/Resources/Messages.cnr.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Izrezana slika se nije mogla izvesti.",
   "Error_FileTooBig_Format": "Fajl je prevelik. Najveća veličina fajla: {size}.",
   "Error_TooManyFiles_Format": "Previše fajlova. Najveći dozvoljeni broj je {count}.",
+  "Error_FileEmpty": "Fajl je prazan ili više nije dostupan.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Link pozivnice je već iskorišten.",

--- a/src/dotnet/Localization/Resources/Messages.cs.json
+++ b/src/dotnet/Localization/Resources/Messages.cs.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Nepodařilo se exportovat oříznutý obrázek.",
   "Error_FileTooBig_Format": "Soubor je příliš velký. Maximální velikost: {size}.",
   "Error_TooManyFiles_Format": "Příliš mnoho souborů. Maximální povolený počet je {count}.",
+  "Error_FileEmpty": "Soubor je prázdný nebo už není dostupný.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Odkaz s pozvánkou už byl použit.",

--- a/src/dotnet/Localization/Resources/Messages.de.json
+++ b/src/dotnet/Localization/Resources/Messages.de.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Das zugeschnittene Bild konnte nicht exportiert werden.",
   "Error_FileTooBig_Format": "Die Datei ist zu groß. Maximale Dateigröße: {size}.",
   "Error_TooManyFiles_Format": "Zu viele Dateien. Die maximal zulässige Anzahl ist {count}.",
+  "Error_FileEmpty": "Die Datei ist leer oder nicht mehr verfügbar.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Dieser Einladungslink wurde bereits verwendet.",

--- a/src/dotnet/Localization/Resources/Messages.en.json
+++ b/src/dotnet/Localization/Resources/Messages.en.json
@@ -125,6 +125,7 @@
   "Error_CropExportFailed": "Failed to export cropped image.",
   "Error_FileTooBig_Format": "File is too big. Max file size: {size}.",
   "Error_TooManyFiles_Format": "Too many files. Max allowed number is {count}.",
+  "Error_FileEmpty": "File is empty or no longer available.",
 
   // Invites
   "Error_InviteAlreadyUsed": "The invite link is already used.",

--- a/src/dotnet/Localization/Resources/Messages.es.json
+++ b/src/dotnet/Localization/Resources/Messages.es.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "No se pudo exportar la imagen recortada.",
   "Error_FileTooBig_Format": "El archivo es demasiado grande. Tamaño máximo: {size}.",
   "Error_TooManyFiles_Format": "Demasiados archivos. El número máximo permitido es {count}.",
+  "Error_FileEmpty": "El archivo está vacío o ya no está disponible.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Este enlace de invitación ya se ha usado.",

--- a/src/dotnet/Localization/Resources/Messages.fr.json
+++ b/src/dotnet/Localization/Resources/Messages.fr.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Échec de l'exportation de l'image recadrée.",
   "Error_FileTooBig_Format": "Le fichier est trop volumineux. Taille maximale : {size}.",
   "Error_TooManyFiles_Format": "Trop de fichiers. Le nombre maximal autorisé est {count}.",
+  "Error_FileEmpty": "Le fichier est vide ou n’est plus disponible.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Ce lien d’invitation a déjà été utilisé.",

--- a/src/dotnet/Localization/Resources/Messages.hi.json
+++ b/src/dotnet/Localization/Resources/Messages.hi.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "काटी गई छवि निर्यात नहीं की जा सकी.",
   "Error_FileTooBig_Format": "फ़ाइल बहुत बड़ी है. अधिकतम आकार: {size}.",
   "Error_TooManyFiles_Format": "बहुत सारी फ़ाइलें. अधिकतम अनुमत संख्या {count} है.",
+  "Error_FileEmpty": "फ़ाइल खाली है या अब उपलब्ध नहीं है।",
 
   // Invites
   "Error_InviteAlreadyUsed": "यह आमंत्रण लिंक पहले ही उपयोग हो चुका है।",

--- a/src/dotnet/Localization/Resources/Messages.hr.json
+++ b/src/dotnet/Localization/Resources/Messages.hr.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Izrezana slika se nije mogla izvesti.",
   "Error_FileTooBig_Format": "Datoteka je prevelik. Najveća veličina datoteke: {size}.",
   "Error_TooManyFiles_Format": "Previše datoteka. Najveći dozvoljeni broj je {count}.",
+  "Error_FileEmpty": "Datoteka je prazan ili više nije dostupan.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Link pozivnice je već iskorišten.",

--- a/src/dotnet/Localization/Resources/Messages.id.json
+++ b/src/dotnet/Localization/Resources/Messages.id.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Gagal mengekspor gambar yang dipangkas.",
   "Error_FileTooBig_Format": "File terlalu besar. Ukuran file maksimum: {size}.",
   "Error_TooManyFiles_Format": "Terlalu banyak file. Jumlah maksimum yang diizinkan adalah {count}.",
+  "Error_FileEmpty": "File kosong atau tidak lagi tersedia.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Tautan undangan sudah dipakai.",

--- a/src/dotnet/Localization/Resources/Messages.it.json
+++ b/src/dotnet/Localization/Resources/Messages.it.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Impossibile esportare l'immagine ritagliata.",
   "Error_FileTooBig_Format": "Il file è troppo grande. Dimensione massima: {size}.",
   "Error_TooManyFiles_Format": "Troppi file. Il numero massimo consentito è {count}.",
+  "Error_FileEmpty": "Il file è vuoto o non è più disponibile.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Questo link di invito è già stato usato.",

--- a/src/dotnet/Localization/Resources/Messages.ja.json
+++ b/src/dotnet/Localization/Resources/Messages.ja.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "切り抜いた画像をエクスポートできませんでした。",
   "Error_FileTooBig_Format": "ファイルが大きすぎます。最大サイズ: {size}。",
   "Error_TooManyFiles_Format": "ファイルが多すぎます。許可される最大数は {count} 件です。",
+  "Error_FileEmpty": "ファイルが空か、利用できなくなっています。",
 
   // Invites
   "Error_InviteAlreadyUsed": "この招待リンクはすでに使用されています。",

--- a/src/dotnet/Localization/Resources/Messages.ko.json
+++ b/src/dotnet/Localization/Resources/Messages.ko.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "자른 이미지를 내보내지 못했습니다.",
   "Error_FileTooBig_Format": "파일이 너무 큽니다. 최대 크기: {size}.",
   "Error_TooManyFiles_Format": "파일이 너무 많습니다. 최대 허용 개수는 {count}개입니다.",
+  "Error_FileEmpty": "파일이 비어 있거나 더 이상 사용할 수 없습니다.",
 
   // Invites
   "Error_InviteAlreadyUsed": "이 초대 링크는 이미 사용되었습니다.",

--- a/src/dotnet/Localization/Resources/Messages.max.json
+++ b/src/dotnet/Localization/Resources/Messages.max.json
@@ -125,6 +125,7 @@
   "Error_CropExportFailed": "Изрязаното изображение не можа да бъде експортирано.",
   "Error_FileTooBig_Format": "Файл слишком большой. Максимальный размер: {size}.",
   "Error_TooManyFiles_Format": "Слишком много файлов. Максимально допустимое количество — {count}.",
+  "Error_FileEmpty": "ファイルが空か、利用できなくなっています。",
 
   // Invites
   "Error_InviteAlreadyUsed": "Dieser Einladungslink wurde bereits verwendet.",

--- a/src/dotnet/Localization/Resources/Messages.pl.json
+++ b/src/dotnet/Localization/Resources/Messages.pl.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Nie udało się wyeksportować przyciętego obrazu.",
   "Error_FileTooBig_Format": "Plik jest za duży. Maksymalny rozmiar pliku: {size}.",
   "Error_TooManyFiles_Format": "Za dużo plików. Maksymalna dozwolona liczba to {count}.",
+  "Error_FileEmpty": "Plik jest pusty lub nie jest już dostępny.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Ten link zapraszający został już wykorzystany.",

--- a/src/dotnet/Localization/Resources/Messages.pt.json
+++ b/src/dotnet/Localization/Resources/Messages.pt.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Não foi possível exportar a imagem recortada.",
   "Error_FileTooBig_Format": "O arquivo é muito grande. Tamanho máximo: {size}.",
   "Error_TooManyFiles_Format": "Arquivos demais. O número máximo permitido é {count}.",
+  "Error_FileEmpty": "O arquivo está vazio ou não está mais disponível.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Este link de convite já foi usado.",

--- a/src/dotnet/Localization/Resources/Messages.ru.json
+++ b/src/dotnet/Localization/Resources/Messages.ru.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Не удалось экспортировать обрезанное изображение.",
   "Error_FileTooBig_Format": "Файл слишком большой. Максимальный размер: {size}.",
   "Error_TooManyFiles_Format": "Слишком много файлов. Максимально допустимое количество — {count}.",
+  "Error_FileEmpty": "Файл пуст или больше недоступен.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Эта ссылка-приглашение уже использована.",

--- a/src/dotnet/Localization/Resources/Messages.sr.json
+++ b/src/dotnet/Localization/Resources/Messages.sr.json
@@ -122,6 +122,7 @@
   "Error_CropExportFailed": "Изрезана слика се није могла извести.",
   "Error_FileTooBig_Format": "Фајл је превелик. Највећа величина фајла: {size}.",
   "Error_TooManyFiles_Format": "Превише фајлова. Највећи дозвољени број је {count}.",
+  "Error_FileEmpty": "Фајл је празан или више није доступан.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Линк позивнице је већ искоришћен.",

--- a/src/dotnet/Localization/Resources/Messages.tr.json
+++ b/src/dotnet/Localization/Resources/Messages.tr.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Kırpılan görsel dışa aktarılamadı.",
   "Error_FileTooBig_Format": "Dosya çok büyük. En büyük dosya boyutu: {size}.",
   "Error_TooManyFiles_Format": "Çok fazla dosya. İzin verilen en fazla sayı {count}.",
+  "Error_FileEmpty": "Dosya boş veya artık kullanılamıyor.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Bu davet bağlantısı zaten kullanılmış.",

--- a/src/dotnet/Localization/Resources/Messages.uk.json
+++ b/src/dotnet/Localization/Resources/Messages.uk.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Не вдалося експортувати обрізане зображення.",
   "Error_FileTooBig_Format": "Файл занадто великий. Максимальний розмір: {size}.",
   "Error_TooManyFiles_Format": "Забагато файлів. Максимально дозволена кількість — {count}.",
+  "Error_FileEmpty": "Файл порожній або вже недоступний.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Це посилання-запрошення вже використано.",

--- a/src/dotnet/Localization/Resources/Messages.vi.json
+++ b/src/dotnet/Localization/Resources/Messages.vi.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "Không thể xuất ảnh đã cắt.",
   "Error_FileTooBig_Format": "Tệp quá lớn. Kích thước tối đa: {size}.",
   "Error_TooManyFiles_Format": "Quá nhiều tệp. Số lượng tối đa cho phép là {count}.",
+  "Error_FileEmpty": "Tệp trống hoặc không còn khả dụng.",
 
   // Invites
   "Error_InviteAlreadyUsed": "Liên kết mời này đã được dùng.",

--- a/src/dotnet/Localization/Resources/Messages.zh.json
+++ b/src/dotnet/Localization/Resources/Messages.zh.json
@@ -114,6 +114,7 @@
   "Error_CropExportFailed": "无法导出裁剪后的图片。",
   "Error_FileTooBig_Format": "文件太大。最大文件大小：{size}。",
   "Error_TooManyFiles_Format": "文件过多。最多允许 {count} 个。",
+  "Error_FileEmpty": "文件为空或已不可用。",
 
   // Invites
   "Error_InviteAlreadyUsed": "该邀请链接已被使用。",

--- a/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentProgress.cs
+++ b/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentProgress.cs
@@ -7,6 +7,7 @@ public sealed record AttachmentProgress(double Progress, string Details = "")
     public bool IsInProgress { get; init; }
     public bool IsReady { get; init; }
     public bool IsFailed { get; init; }
+    public bool CanRestart { get; init; }
     public long UploadProgress { get; init; }
     public long UploadSize { get; init; }
 }

--- a/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentsState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/Attachment/AttachmentsState.cs
@@ -69,6 +69,7 @@ public class AttachmentsState(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), ICom
             IsInProgress = !isReady && !isFailed,
             IsReady = isReady,
             IsFailed = isFailed,
+            CanRestart = isFailed && !uploadProgress.IsUnrecoverable,
             UploadProgress = uploadedBytes,
             UploadSize = totalBytes,
         };

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/AttachmentItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/AttachmentItem.razor
@@ -44,7 +44,7 @@
                     <RoundProgress Class="attachment-upload-ring" Fraction="@(percent / 100d)" title="@progress.Details">
                         <span class="c-percent">@percent%</span>
                     </RoundProgress>
-                } else if (progress.IsFailed && !m.NoAccess && RestartClick.HasDelegate) {
+                } else if (progress.CanRestart && !m.NoAccess && RestartClick.HasDelegate) {
                     <span class="spinner-icon-wrapper">
                         <ButtonRound Click="@RestartClick">
                             <i class="icon-sync text-2xl"></i>

--- a/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/FileAttachments.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatMessageEditor/FileAttachments.cs
@@ -71,6 +71,12 @@ public class FileAttachments : UIServiceBase<AppUIHub>
 
     private async Task<bool> TryAddWebFileAttachment(AttachmentList list, int id, string fileName, string fileType, long size)
     {
+        // A browser knows a File's size upfront, and 0 there is what a paste of an image whose
+        // clipboard data is already gone yields; the server can't create an upload for it either.
+        if (size <= 0) {
+            UICommander.ShowError(StandardError.Upload.FileEmpty());
+            return false;
+        }
         if (CheckCanAdd(list, size) is { } e) {
             UICommander.ShowError(e);
             return false;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileUploadAttachment.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/FileUploadAttachment.razor
@@ -57,7 +57,7 @@
         </div>
     </div>
     @if (!progress.IsReady) {
-        @if (progress.IsFailed && !m.NoAccess && RestartClick.HasDelegate) {
+        @if (progress.CanRestart && !m.NoAccess && RestartClick.HasDelegate) {
             <span class="reload-icon-wrapper">
                 <ButtonRound Click="@RestartClick" Class="btn-sm">
                     <i class="icon-sync text-2xl"></i>

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/UploadAttachmentItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Attachment/UploadAttachmentItem.razor
@@ -38,7 +38,7 @@
                         <RoundProgress Class="attachment-upload-ring" Fraction="@(percent / 100d)" title="@progress.Details">
                             <span class="c-percent">@percent%</span>
                         </RoundProgress>
-                    } else if (progress.IsFailed && !m.NoAccess && RestartClick.HasDelegate) {
+                    } else if (progress.CanRestart && !m.NoAccess && RestartClick.HasDelegate) {
                         <span class="reload-icon-wrapper">
                             <ButtonRound Click="@RestartClick" Class="btn-sm">
                                 <i class="icon-sync text-2xl"></i>

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/AttachmentsController.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/AttachmentsController.cs
@@ -42,8 +42,8 @@ public class AttachmentsController(AppUIHub hub) : UIServiceBase<AppUIHub>(hub),
     public async Task RestartUpload(Attachment attachment)
     {
         var progress = await AttachmentsState.GetProgress(attachment.Id, default).ConfigureAwait(false);
-        if (!progress.IsFailed)
-            throw new InvalidOperationException("Can't restart. Upload is not failed");
+        if (!progress.CanRestart)
+            throw new InvalidOperationException("Can't restart. Upload is not failed or can't succeed");
         var previewState = await AttachmentsState.GetPreview(attachment.Id, default).ConfigureAwait(false);
         if (previewState.State is PreviewAccessState.NoFileAccess)
             throw new InvalidOperationException("Can't restart. No access to file");

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadOperations.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadOperations.cs
@@ -44,6 +44,10 @@ public class UploadOperations(AppUIHub hub)
         var snapshot = snapshotAccessor.Get();
         var fileProvider = snapshot.FileProvider;
         await fileProvider.WhenFileStreamReady().WaitAsync(cancellationToken).ConfigureAwait(false);
+        // Only now the length is known everywhere: a native gallery pick reports 0 until the file loads
+        if (source.Metadata.Length <= 0)
+            throw StandardError.Upload.FileEmpty();
+
         await GetOrRegisterUpload(source, snapshotAccessor, cancellationToken).ConfigureAwait(false); // Ensure upload id is registered
         progress ??= new Progress<double>(_ => { });
         var uploadOperation = new FileUploadOperation(StartUpload);

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSession.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSession.cs
@@ -20,6 +20,7 @@ public class UploadSession
 
     public event EventHandler<double>? UploadProgressChanged;
     public event EventHandler<double>? ServerProcessingProgressChanged;
+    public event EventHandler<Exception>? Failed;
 
     private readonly Func<UploadSessionSnapshot, bool, CancellationToken, Task>? _storage;
     private readonly SemaphoreSlim _stateLock = new(1, 1);
@@ -64,6 +65,7 @@ public class UploadSession
     public UploadId? UploadId => _snapshot.UploadId;
     public UploadSessionState CurrentState => _snapshot.CurrentState;
     public bool IsFailed => _snapshot.IsFailed;
+    public bool IsUnrecoverable => _snapshot.IsUnrecoverable;
     public Exception? LastError { get; private set; }
     [MemberNotNullWhen(true, nameof(MediaRef))]
     public bool IsCompleted => CurrentState == UploadSessionState.Completed;
@@ -78,7 +80,7 @@ public class UploadSession
         if (CurrentState == UploadSessionState.Cancelled)
             throw new InvalidOperationException("Upload session is cancelled. Can't resume.");
 
-        if (CurrentState == UploadSessionState.Completed)
+        if (CurrentState == UploadSessionState.Completed || IsUnrecoverable)
             return false;
 
         if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
@@ -241,7 +243,10 @@ public class UploadSession
         Log.LogError(ex, "Upload '{SessionId}' session for file '{FileName}' failed on step '{Step}'",
             SessionId, FileProvider.Metadata.FileName, _snapshot.CurrentState.ToString());
         LastError = ex;
-        await UpdateState(s => s with { IsFailed = true }, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var isUnrecoverable = ex is UploadFileEmptyException;
+        await UpdateState(s => s with { IsFailed = true, IsUnrecoverable = isUnrecoverable },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        Failed?.Invoke(this, ex);
     }
 
     private async Task UpdateState(

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionProgress.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionProgress.cs
@@ -6,6 +6,7 @@ public sealed record UploadSessionProgress(UploadStage Stage, double StageProgre
 
     public bool IsReady => Stage == UploadStage.Completed;
     public bool IsFailed { get; init; }
+    public bool IsUnrecoverable { get; init; }
     public string ErrorMessage { get; init; } = "";
     public long TotalBytes { get; init; }
     public double UploadedFraction

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionSnapshot.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionSnapshot.cs
@@ -22,4 +22,5 @@ public partial record UploadSessionSnapshot
     [DataMember, Key(11)] public double StageProgress { get; set; }
     [DataMember, Key(12)] public string MediaScope { get; set; } = "";
     [DataMember, Key(13)] public FilePath? TranscodedFilePath { get; set; }
+    [DataMember, Key(14)] public bool IsUnrecoverable { get; set; }
 }

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessions.cs
@@ -30,7 +30,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
 
         var now = _uploadOperations.Now();
         var snapshot = UploadSession.NewUploadSnapshot(fileProvider, metadata, now, mediaScope);
-        var session = new UploadSession(snapshot, _uploadOperations, _storage);
+        var session = NewSession(snapshot);
         // Register in memory before persisting, so cleanup never reclaims it before the caller references it.
         _sessions[session.SessionId] = new SessionRef(session);
         await _repo.Save(snapshot).ConfigureAwait(false);
@@ -53,7 +53,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
             return null;
 
         snapshot.FileProvider.Initialize(Hub.Services);
-        var session = new UploadSession(snapshot, _uploadOperations, _storage);
+        var session = NewSession(snapshot);
         _sessions[sessionId] = new SessionRef(session);
         SetProgress(sessionId, GetProgressFromSnapshot(snapshot));
         return session;
@@ -115,6 +115,21 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
         Log.LogDebug("Deleted stale session '{SessionId}' ('{FileName}')", sessionId, fileProvider.Metadata.FileName);
     }
 
+    private UploadSession NewSession(UploadSessionSnapshot snapshot)
+    {
+        var session = new UploadSession(snapshot, _uploadOperations, _storage);
+        session.Failed += OnSessionFailed;
+        return session;
+    }
+
+    private void OnSessionFailed(object? sender, Exception error)
+    {
+        // Other failures leave a restart button on the attachment, so its "Error" is enough;
+        // an empty file has nothing to restart, and without this the user never learns why.
+        if (error is UploadFileEmptyException)
+            UICommander.ShowError(error);
+    }
+
     private void ReleaseSessionInternal(UploadSession session)
     {
         Log.LogDebug("Releasing reference for session '{SessionId}' ('{FileName}')", session.SessionId, session.FileProvider.Metadata.FileName);
@@ -170,6 +185,7 @@ public partial class UploadSessions : UIServiceBase<AppUIHub>
 
         return new UploadSessionProgress(uploadStage, progress) {
             IsFailed = s.IsFailed,
+            IsUnrecoverable = s.IsUnrecoverable,
             TotalBytes = s.FileProvider.Metadata.Length,
         };
     }

--- a/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionsState.cs
+++ b/src/dotnet/UI.Blazor.App/Services/FileUploads/UploadSessionsState.cs
@@ -17,7 +17,7 @@ public class UploadSessionsState(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), I
     public virtual Task<ImmutableArray<string>> GetActiveSessionIds(CancellationToken cancellationToken)
     {
         var ids = _progresses
-            .Where(kv => IsActiveStage(kv.Value.Stage))
+            .Where(kv => IsActive(kv.Value))
             .Select(kv => kv.Key)
             .ToImmutableArray();
         return Task.FromResult(ids);
@@ -25,9 +25,9 @@ public class UploadSessionsState(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), I
 
     public void SetProgress(string sessionId, UploadSessionProgress progress)
     {
-        var wasActive = IsActiveStage(_progresses.GetValueOrDefault(sessionId)?.Stage);
+        var wasActive = IsActive(_progresses.GetValueOrDefault(sessionId));
         _progresses[sessionId] = progress;
-        var isActive = IsActiveStage(progress.Stage);
+        var isActive = IsActive(progress);
         using (Invalidation.Begin()) {
             _ = GetProgress(sessionId, default);
             if (wasActive != isActive)
@@ -37,7 +37,7 @@ public class UploadSessionsState(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), I
 
     public void Remove(string sessionId)
     {
-        var wasActive = IsActiveStage(_progresses.GetValueOrDefault(sessionId)?.Stage);
+        var wasActive = IsActive(_progresses.GetValueOrDefault(sessionId));
         _progresses.TryRemove(sessionId, out _);
         using (Invalidation.Begin()) {
             _ = GetProgress(sessionId, default);
@@ -46,6 +46,7 @@ public class UploadSessionsState(AppUIHub hub) : UIServiceBase<AppUIHub>(hub), I
         }
     }
 
-    private static bool IsActiveStage(UploadStage? stage)
-        => stage is UploadStage.Uploading or UploadStage.ServerProcessing;
+    // A failed session keeps its stage but is waiting for a restart, not uploading
+    private static bool IsActive(UploadSessionProgress? progress)
+        => progress is { IsFailed: false, Stage: UploadStage.Uploading or UploadStage.ServerProcessing };
 }

--- a/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Skeleton/image-skeleton.lit.ts
@@ -21,6 +21,8 @@ export class ImageSkeleton extends LitElement {
     private _imageRef: Ref<HTMLImageElement> = createRef();
     private _imageState: ImageState = 'none';
     private _isRetrying = false;
+    // Retries stop once the element is detached; the <img> won't report that failure again on re-attach.
+    private _isRetryInterrupted = false;
     // The src whose retries were exhausted; tracked by value so a new src retries.
     private _failedSrc: string | null = null;
     // Attempts already spent on the current src, so a decode failure after a
@@ -44,6 +46,10 @@ export class ImageSkeleton extends LitElement {
         if (this._imageState === 'none' && ImageStates.includes(this.initialState))
             this._imageState = this.initialState as ImageState;
         this.applyState();
+        if (this._isRetryInterrupted) {
+            this._isRetryInterrupted = false;
+            this.reloadImage();
+        }
     }
 
     render() {
@@ -146,11 +152,16 @@ export class ImageSkeleton extends LitElement {
         const isOwnContent = this.isOwnContent(this.src);
         try {
             for (; attempt < RetryCount; attempt++) {
-                this._attemptsBySrc.set(this.src, attempt + 1);
                 if (attempt >= 1) {
                     const delay = Math.min(MaxRetryDelay, Math.pow(2, attempt - 1));
                     await delayAsync(delay * 1000);
                 }
+                if (!this.isConnected) {
+                    this._isRetryInterrupted = true;
+                    return;
+                }
+
+                this._attemptsBySrc.set(this.src, attempt + 1);
                 // Blocked/offline/DNS failures reject instead of returning a non-ok
                 // response, which would otherwise skip the backoff and the fallback.
                 const response = await fetch(this.src, { mode: isOwnContent ? undefined : 'cors' })

--- a/tests/Chat.IntegrationTests/PostChatMessageTest.cs
+++ b/tests/Chat.IntegrationTests/PostChatMessageTest.cs
@@ -217,6 +217,82 @@ public class PostChatMessageTest(ChatCollection.AppHostFixture fixture, ITestOut
     }
 
     [Fact]
+    public async Task EditShouldKeepAttachments()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        _ = await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var (chatId, _) = await tester.CreateChat(true);
+        var mediaId = await SaveTextFile(tester, chatId, "file.txt");
+        var chatEntry = await tester.Commander.Call(new Chats_UpsertEntry {
+            Session = session,
+            ChatId = chatId,
+            LocalId = null,
+            Text = "Message with an attachment",
+            Attachments = [new ChatEntryAttachment { MediaId = mediaId }],
+        });
+
+        // act
+        await tester.Commander.Call(new Chats_UpsertEntry {
+            Session = session,
+            ChatId = chatId,
+            LocalId = chatEntry.LocalId,
+            Text = "Edited message with an attachment",
+        });
+
+        // assert
+        var editedEntry = await chats.GetEntry(session, chatEntry.Id);
+        editedEntry.Should().NotBeNull();
+        editedEntry.Content.Should().Be("Edited message with an attachment");
+        editedEntry.Attachments.Select(a => a.MediaId).Should().Equal(mediaId);
+    }
+
+    [Fact]
+    public async Task FinalUpsertWithNoAttachmentsLeftShouldRemoveUploadingAttachments()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        _ = await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var chats = tester.AppServices.GetRequiredService<IChats>();
+        var (chatId, _) = await tester.CreateChat(true);
+        var reservedMediaId = await tester.Commander.Call(new Media_ReserveMedia {
+            Session = session,
+            Scope = chatId.Value,
+        });
+        var chatEntry = await tester.Commander.Call(new Chats_UpsertEntry {
+            Session = session,
+            ChatId = chatId,
+            LocalId = null,
+            Text = "Message whose upload failed",
+            Attachments = [new ChatEntryAttachment { MediaId = reservedMediaId }],
+            HasUploadingAttachments = true,
+        });
+        var uploadingEntry = await chats.GetEntry(session, chatEntry.Id);
+        uploadingEntry.Should().NotBeNull();
+        uploadingEntry.HasUploadingAttachments.Should().BeTrue();
+
+        // act
+        await tester.Commander.Call(new Chats_UpsertEntry {
+            Session = session,
+            ChatId = chatId,
+            LocalId = chatEntry.LocalId,
+            Text = chatEntry.Content,
+            Attachments = [],
+            HasUploadingAttachments = false,
+        });
+
+        // assert
+        var finalEntry = await chats.GetEntry(session, chatEntry.Id);
+        finalEntry.Should().NotBeNull();
+        finalEntry.Content.Should().Be("Message whose upload failed");
+        finalEntry.Attachments.Should().BeEmpty("the only attachment was removed before its upload");
+        finalEntry.HasUploadingAttachments.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task PostWhileCaughtUpAdvancesReadPosition()
     {
         // arrange

--- a/tests/Chat.IntegrationTests/UploadSessionFlowTest.cs
+++ b/tests/Chat.IntegrationTests/UploadSessionFlowTest.cs
@@ -64,6 +64,33 @@ public class UploadSessionFlowTest(ChatCollection.AppHostFixture fixture, ITestO
     }
 
     [Fact]
+    public async Task EmptyFileShouldFailWithoutCreatingUpload()
+    {
+        // arrange
+        await using var tester = AppHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob();
+        var hub = tester.ScopedAppServices.AppUIHub();
+        var fileProvider = new DataFileProvider([], "empty.txt", "text/plain");
+        var uploadOperations = new UploadOperations(hub);
+        var snapshot = UploadSession.NewUploadSnapshot(
+            fileProvider, new MetadataBag(), uploadOperations.Now(), "empty-test");
+        var uploadSession = new UploadSession(snapshot, uploadOperations, storage: null);
+
+        // act
+        uploadSession.Resume();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (!uploadSession.IsCompleted && !uploadSession.IsFailed)
+            await Task.Delay(100, cts.Token);
+
+        // assert
+        uploadSession.IsFailed.Should().BeTrue();
+        uploadSession.LastError.Should().BeOfType<UploadFileEmptyException>();
+        uploadSession.IsUnrecoverable.Should().BeTrue();
+        uploadSession.UploadId.Should().BeNull("an upload of 0 bytes must not reach the server");
+        uploadSession.Resume().Should().BeFalse("restarting can't make the file any longer");
+    }
+
+    [Fact]
     public async Task ShouldRestoreUploadSessionFromRepo()
     {
         await using var appHost = await NewAppHost("restore-session", options => options with {


### PR DESCRIPTION
## Summary

A message whose attachment failed to upload and was then removed with × kept showing "uploading attachments" forever - to the sender and to every other participant.

The entry is created with attachments whose media is reserved but not yet uploaded, and `HasUploadingAttachments` is derived from them (`DbChatEntry.ToModel`). When every attachment was removed but text remained, `CompleteAttachmentUploads` sent the final `Chats_UpsertEntry` with `Attachments = []`, and `ChatsBackend` reads an empty list on update as "keep the attachments" (a plain text edit sends the same empty list). The dangling attachment stayed, so the flag stayed.

The trigger in the reported case was a pasted image whose clipboard data was already gone: Chrome hands over a 0-byte `File`, and `Uploads_Create` on Google Storage rejects a 0-length upload with "A content length of 0 cannot be enforced". The same session also showed the preview's retry loop running for minutes after the attachment was gone, and a failed session still counting as an active upload.

## Fix

- **Server** (`fix(chat)`): `Chats.OnUpsertEntry` passes `null` ("keep") for a plain text edit and the list as is - even empty - for the upsert that completes an upload (the entry has uploading attachments and the command doesn't). `ChatsBackend` treats a non-null list on update as a full replacement, so an empty one removes them all. Invariant: an update diff with `Attachments = []` now **clears** attachments - `Chats.OnUpsertEntry` and `ChatThreads` are the only producers and both pass `null` when nothing should change.
- **`image-skeleton`** (`fix(ui)`): the retry loop checks `isConnected` after each backoff delay, stops once detached and resumes on re-attach. The `blob:` skip itself already landed in dev with 613530a7e3.
- **Empty files** (`fix(attachments)`): the web editor refuses a 0-byte file upfront with "File is empty or no longer available." (new `Error_FileEmpty` in every catalog). Native pickers report length 0 until the file loads, so the upload also checks the length once the file is ready and fails with `UploadFileEmptyException` before `Uploads_Create`; such a session is marked unrecoverable (new `UploadSessionSnapshot` key 14), `Resume()` refuses it, the restart button is hidden, and the user gets the toast.
- **Activity set** (`fix(uploads)`): a failed session no longer counts as an active upload (it kept the Android/iOS upload notification up).

## Testing

- New integration tests: `PostChatMessageTest.FinalUpsertWithNoAttachmentsLeftShouldRemoveUploadingAttachments` (failed before the server fix), `PostChatMessageTest.EditShouldKeepAttachments`, `UploadSessionFlowTest.EmptyFileShouldFailWithoutCreatingUpload` (confirmed red with the check disabled).
- On the rebased branch (.NET 11 RC 1): `PostChatMessageTest`, `UploadSessionFlowTest`, `ChatContentIndexingTest`, `ChatThreadOperationsTest` - 29/29; serialization, upload activity and localization unit tests - 36/36; `npm run build:Verify` clean.
- **Not verified yet:** no manual run in a browser or on a device - the toast, the hidden restart button, the "uploading attachments" placeholder going away, and the empty-file path on Android/iOS are covered by tests only. The full `ActualChat.sln` (MAUI) was not built; affected projects were built through the test projects.
- Already stuck messages are not healed by this change.

Closes #4460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A8Zx8qcFGV5jDVLh5f54V
