### PR TITLE
refactor(chat): model live block lifecycle explicitly

### DIFF
--- a/docs/architecture/offline-render-path.md
+++ b/docs/architecture/offline-render-path.md
@@ -195,7 +195,7 @@ whole build, and with it every scroll request until the peer reconnects.
 | `IChats.GetChatRangeTile(session, chatId, metaTileStart)` × meta tiles covering the load zone ± `LoadLimit` | cached | Every build. `UseRangeTileOrLastKnown` stands in only after a first successful read. | T (around the tail), D |
 | `IConversations.GetTile(session, chatId, metaTileRange)` × meta tiles | cached | Every build, unconditionally | T |
 | `IChats.GetTile(session, chatId, idTileRange)` × id tiles (+1 preceding) | cached | Every tile in the zone, plus a speculative second copy for the adjacent zone | T (last 100 entries only) |
-| `ILiveSessions.GetState(session, chatId)` via `LiveSessionUI.GetConversation`, `LiveSessionUI.GetBlockSnapshot` and `LiveBlockUI.GetBlockState` | **no-cache** | Every build. `UseConversationOrLastKnown` / `UseSnapshotOrLastKnown` **await the first read** - a chat opened for the first time in this process never renders offline. | n/a |
+| `ILiveSessions.GetState(session, chatId)` via `LiveSessionUI.GetConversation`, `LiveSessionUI.GetBlockState` and `LiveBlockUI.GetBlock` | **no-cache** | Every build. `UseConversationOrLastKnown` / `UseBlockStateOrLastKnown` **await the first read** - a chat opened for the first time in this process never renders offline. | n/a |
 | `IChats.GetIdRange` + `IChats.GetTile` scan (`ChatUI.IsEmpty`) | cached | Only when a build yields no items | T |
 
 ### Chat view: per rendered message

--- a/docs/ui/chat-blocks.md
+++ b/docs/ui/chat-blocks.md
@@ -1,9 +1,15 @@
 # Chat block coverage
 
 `ChatUI` projects completed conversations and live blocks into `ChatBlock`, a UI view of an existing
-`Conversation`. It carries the render identity, full entry-ID coverage, effective expansion state,
-live/completed kind, and a compatibility `CollapsedAt` value. This is client-side presentation data,
+`Conversation`. It carries the render identity, full entry-ID coverage, and a nullable `CollapsedAt`.
+`IsExpanded` derives from `CollapsedAt == null`. This is client-side presentation data,
 not another persisted conversation entity or a new RPC contract.
+
+`ChatBlock` does not carry a lifecycle flag. Open/closed state belongs to `LiveBlock`; the view's
+materialized identity already distinguishes retained live coverage from persisted coverage for fetching.
+Expanded blocks have no cutoff. For collapsed blocks, the builder sets `CollapsedAt` just after the last
+message for completed/materialized blocks, or to the start for open/dissolving blocks. These compatibility
+cutoffs preserve which entries currently show; they are not recorded collapse-action timestamps.
 
 ## Coverage and visibility
 
@@ -15,7 +21,7 @@ Coverage does not mean every entry must render. The existing live fold governor,
 filter, and thread/text rules still determine which loaded entries are visible. A fully collapsed
 completed conversation contributes one representative card ID; its hidden interior is not fetched
 as individual entry tiles by the selector.
-An expanded active live block still excludes its governed fold, matching the auto-swallow behavior.
+An expanded open live block still excludes its governed fold, matching the auto-swallow behavior.
 An expanded materialized block excludes nothing. Neither receives collapsed-boundary expansion.
 
 The distinction matters for a long-running live block: its full current coverage can include many
@@ -33,8 +39,8 @@ that are unavailable do not become fabricated cards.
 
 `BuildChatBlocks` uses metadata coverage for completed conversations and the finite current block
 coverage for a live block. The latter can extend beyond the persisted conversation's last summarized
-entry. An active block ends at the current chat snapshot; a frozen block is also bounded by its
-overlay end. A block with no entries can still cover its own card ID.
+entry. An open block ends at the current chat snapshot; a closed block is also bounded by its
+`ClosedLiveBlock.EndLid`. A block with no entries can still cover its own card ID.
 
 The live block's render ID survives materialization. Its persisted conversation can have a different
 ID because it includes earlier context. The projection resolves that alias before assigning coverage.
@@ -49,7 +55,7 @@ start and never resumes. For example, `[50, 500)` followed by `[100, 120)` becom
 
 An open-ended range (`End == long.MaxValue`) always owns the remaining tail. Its start and end remain
 unchanged, and it is the last range in the normalized sequence. Thus `[50, 300), [100, max), [200, 250)`
-becomes `[50, 100), [100, max)`. A later completed conversation cannot truncate an active live block.
+becomes `[50, 100), [100, max)`. A later completed conversation cannot truncate an open live block.
 An already materialized block is finite and follows the ordinary later-start rule.
 When a live block starts inside an older completed conversation, the older prefix remains a conversation
 card with its own collapsed/expanded state; its rows are no longer forced to render as plain messages.
@@ -58,7 +64,7 @@ card with its own collapsed/expanded state; its rows are no longer forced to ren
 Callers use Core's `RangeExt.TruncateOverlaps(mustKeepOpenEnded: true)` directly. It normalizes finite
 overlaps and stops at the first open-ended range, leaving its boundaries unchanged.
 Duplicate starts retain the largest end. If stale input contains several open-ended candidates, the
-first one in start order remains unchanged; normal backend input has only one active live range.
+first one in start order remains unchanged; normal backend input has only one open live range.
 The live/materialized identity is resolved before UI normalization so it represents one block.
 
 `ConversationsBackend.GetConversationRangeTile` normalizes intersecting ranges together with the nearest previous
@@ -69,13 +75,13 @@ truncates an earlier finite block even when that next block begins outside the c
 `ConversationRangeTile.ApplyTo` applies finite effective ends to fetched conversation copies. For an
 open-ended range it retains the record's actual end instead of copying the sentinel into message
 coverage. Cached open-ended metadata remains valid as the live summary grows, so the previous
-`WithLiveRange` refresh workaround is unnecessary. The UI bounds active block coverage by its current
-chat/overlay snapshot before expanding fetch boundaries; no fetch enumerates an open-ended range.
-Grouping an active block separately uses an open-ended range so pending sends at or beyond
+`WithLiveRange` refresh workaround is unnecessary. The UI bounds open block coverage by its current
+chat snapshot or closed block end before expanding fetch boundaries; no fetch enumerates an open-ended range.
+Grouping an open block separately uses an open-ended range so pending sends at or beyond
 the chat end and the `long.MaxValue` transcription placeholder stay before its footer. This includes
-a viewer who left while the session continues: their overlay has no materialized ID and an unbounded
-end. Closed and materialized grouping remains bounded. Grouping coverage must not be reused for entry fetching.
-Active live folding and transcript filtering are not truncated by later completed ranges. Materialized
+a viewer who left while the session continues: their block remains an `OpenLiveBlock`.
+Closed grouping remains bounded. Grouping coverage must not be reused for entry fetching.
+Open live folding and transcript filtering are not truncated by later completed ranges. Materialized
 block filtering still stops at a later block's start, including when that record is unavailable.
 Navigation expansion, automatic expansion over witnessed messages, and witness filtering use the same
 truncated ranges, so a stale old conversation cannot expand merely because the viewer saw newer live rows.
@@ -84,11 +90,51 @@ These are read projections only. Stored IDs, summaries, timestamps, counts, and 
 or replacement commands are unchanged. In particular, the existing write path can still delete
 overlapping persisted records; revisiting those building rules is separate work.
 
+## Viewer-local live block lifecycle
+
+`LiveSessionUI.GetBlockState` projects the seven session fields needed for block rendering into the
+value-equality `LiveBlockState`. Participant and activity updates that leave those fields unchanged
+do not invalidate this projection's consumers. `LiveBlockUI.GetBlock` combines it with the viewer's
+attendance and fold state, returning one of these results:
+
+| Result | Meaning | Lifetime |
+| --- | --- | --- |
+| `OpenLiveBlock` | A latched session still exists, whether the viewer is joined or has left. | Until the session closes. |
+| `ClosedLiveBlock` with `MaterializedId` | An attended session closed with a summary. | Until dismissed, another chat is selected, or the session restarts. |
+| `ClosedLiveBlock` without `MaterializedId` | An attended session closed without a persisted replacement. | The 300 ms dissolve interval. |
+| `null` | No latched session or retained block for this viewer. | Until a block becomes available. |
+
+Open/closed describe session lifetime; expanded/collapsed describe presentation. `HasAttended` includes
+current attendance and remains true after leaving. Closed blocks always represent an attended session.
+`ConversationId` retains the live render identity even when the materialized conversation has another ID.
+`ClosedLiveBlock.EndLid` is exclusive, unlike `Conversation.EndEntryLid`.
+
+The public `FoldEndLid` is the effective minimum of the governed boundary and any reveal boundary.
+`FoldRange` derives from it and the conversation start. The governor and reveal bookkeeping remain
+private; consumers cannot accidentally ignore an active reveal. A private `LiveBlockTemplate` captures
+both chat and summary ends because an unsummarized dissolve retains the chat tail, while materialization
+uses the summarized end.
+
+Attendance and its retained descriptor are latched together before publishing an attended block,
+including when a previously created viewer context joins and immediately leaves. Session and attendance
+dependencies update `GetBlock` directly. Private changes that alter its result explicitly invalidate it
+outside the state lock: reveal/reset, governor transitions, dissolve expiry, and closed-block dismissal.
+The governor publishes its new fold only after completing private state changes. A changed fold's
+reactive notification covers those changes; with an unchanged fold, it compares the projected result
+and explicitly invalidates if needed. Reveal resets therefore still notify without a fold advance,
+and fold advances do not also trigger an explicit invalidation.
+
+Conversation and block-state projections consolidate independently. When the block state has no latch,
+`GetBlock` also consults the conversation projection through its last-known helper. If no retained block
+exists, an available conversation supplies the open block's identity; the private effective fold and
+attendance (including current membership) still apply. Consumers use this result directly. Latched
+block-state reads avoid the extra conversation dependency, preserving their resistance to transcript churn.
+
 ## Unsummarized close and dissolve
 
 An attended session that closes without a summary has no persisted replacement conversation.
-`LiveBlockUI` retains a `Conversation` descriptor in its existing frozen template before closure,
-bounded to that snapshot's chat end. The short dissolve overlay exposes this descriptor until its
+`LiveBlockUI` retains a `Conversation` descriptor in its private template before closure,
+bounded to that snapshot's chat end. The dissolving `ClosedLiveBlock` exposes this descriptor until its
 timer expires. The record is released from the template when the dissolve finishes.
 
 Both `BuildChatBlocks` and the per-tile card builder use the retained descriptor, even if chat
@@ -144,11 +190,13 @@ The live block's coverage is never replaced by the unbounded hidden-tail sentine
 
 ## CollapsedAt compatibility defaults
 
-`CollapsedAt` is introduced as metadata only. No visibility predicate reads it, collapse clicks do not
-update it, and it is not persisted or synchronized between viewers.
+`CollapsedAt == null` means expanded; `ChatBlock.IsExpanded` is derived rather than stored separately.
+A non-null cutoff means collapsed, but its timestamp remains a compatibility default: entry filtering
+does not yet compare message times against it. It is not persisted or synchronized between viewers.
 
-- Live block: `Conversation.StartsAt`, at or before the first message represented by the block.
-- Completed conversation: `Conversation.EndsAt` plus one tick, saturating at `Moment.MaxValue`.
+- Expanded block: `null`.
+- Collapsed open or dissolving block: `Conversation.StartsAt`, at or before its first message.
+- Collapsed completed or materialized block: `Conversation.EndsAt` plus one tick, saturating at `Moment.MaxValue`.
 
 These defaults express today's intended text behavior without enabling a collapse-time feature.
 Implementing real per-viewer collapse cutoffs later requires explicit state and lifecycle semantics;

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationLiveState.cs
@@ -1,23 +1,20 @@
+using ActualChat.Live;
 using ActualChat.UI.Blazor.App.Services;
 
 namespace ActualChat.UI.Blazor.App.Components;
 
 /// <summary>
-/// Render state for a conversation block: the translated text plus whether it is a live
-/// (in-progress) conversation and whether the current user has joined it.
+/// Render state for a conversation card, including its preview and reveal affordance.
 /// </summary>
 public sealed record ConversationLiveState(
     TranslatedConversation Conversation,
     bool IsLive,
-    bool IsJoined,
     bool IsVoiceOnly,
-    string ParticipantsText = "",
-    bool HasFoldedEntries = false,
     IReadOnlyList<PreviewEntry>? TailPreview = null,
-    bool HasSummary = false,
     int SwallowedCount = 0,
-    int RevealBatch = 0,
     bool IsAnyoneTalking = false,
-    // True once the viewer has attended this block, and it stays true after they stop listening:
-    // leaving is an audio decision, and the block keeps the colour that says they were there.
-    bool HasOverlay = false);
+    bool HasAttended = false)
+{
+    public bool HasSummary => !Conversation.Title.Text.IsNullOrEmpty();
+    public int RevealBatch => Math.Min(LiveFoldMath.RevealBatchSize, SwallowedCount);
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/ConversationMessageView.razor
@@ -1,5 +1,4 @@
 @namespace ActualChat.UI.Blazor.App.Components
-@using ActualChat.Live
 @inherits ComputedStateComponent<AppUIHub, ConversationLiveState>
 @{
     var state = State.Value;
@@ -12,10 +11,10 @@
         CallOutcome.Ended, CallCardFormat.IsCaller(conversation, ChatContext), L);
     var openClass = _isOpen ? "open-details" : "closed-details";
     var detailsCls = _isOpen ? "show" : "";
-    var liveClass = state.IsLive ? (state.IsJoined || state.HasOverlay ? "live joined" : "live") : "";
+    var liveClass = state.IsLive ? (state.HasAttended ? "live joined" : "live") : "";
     var cls = $"conversation-message message-wrapper {openClass} {liveClass}";
     var childNames = state.IsLive
-        ? state.IsJoined || state.HasOverlay
+        ? state.HasAttended
             ? "conversation-message live-card joined-live-card"
             : "conversation-message live-card"
         : "conversation-message";
@@ -55,7 +54,6 @@
             ? L.Conversation_VoiceOnly
             : L.Chat_Messages(messageCount, messageCount);
         var startedAt = L.Conversation_StartedAt_Format(startsAt.ToString("t", DateFormatter));
-        var hasFoldedEntries = state.HasFoldedEntries;
         <div class="@(state.IsAnyoneTalking ? "c-live-card" : "c-live-card quiet")">
             @if (!Message.HasSplitHeader && hasLiveTitle) {
                 <div class="c-lc-title">
@@ -134,7 +132,8 @@
                     <div class="c-short">
                         <MarkupView Markup="@m.Description.Markup"/>
                         @if (!_isOpen && hasSummaryText) {
-                            <span class="show-more-btn" data-vl-hold="always" @onclick="@ToggleDetails">@L.ChatView_ShowDetails</span>
+                            <span class="show-more-btn" data-vl-hold="always"
+                                @onclick="@ToggleDetails">@L.ChatView_ShowDetails</span>
                         }
                     </div>
                 }
@@ -186,7 +185,6 @@
     private ChatEntry _fakeEntry = null!;
 
     private ChatUI ChatUI => Hub.ChatUI;
-    private IAuthors Authors => Hub.Authors;
     private LiveSessionUI LiveSessionUI => Hub.LiveSessionUI;
     private LiveStreamUI LiveStreamUI => Hub.LiveStreamUI;
     private LiveBlockUI LiveBlockUI => Hub.LiveBlockUI;
@@ -211,7 +209,7 @@
             TranslatedMarkup.From(summaryMarkup));
         return ComputedStateComponent.GetStateOptions(GetType(),
             t => new ComputedState<ConversationLiveState>.Options() {
-                InitialValue = new ConversationLiveState(translated, false, false, false),
+                InitialValue = new ConversationLiveState(translated, false, false),
                 Category = GetStateCategory(t),
             });
     }
@@ -238,49 +236,32 @@
 
         var translatedTask = ConversationUI.GetTranslatedConversation(conversation, cancellationToken);
         var liveTask = LiveSessionUI.GetConversation(chatId, cancellationToken);
-        var rawLiveTask = LiveSessionUI.GetState(chatId, cancellationToken);
-        var blockStateTask = LiveBlockUI.GetBlockState(chatId, cancellationToken);
+        var blockTask = LiveBlockUI.GetBlock(chatId, cancellationToken);
         var translated = await translatedTask.ConfigureAwait(false);
         var live = await liveTask.ConfigureAwait(false);
-        var rawLive = await rawLiveTask.ConfigureAwait(false);
-        var blockState = await blockStateTask.ConfigureAwait(false);
+        var block = await blockTask.ConfigureAwait(false);
         var isLive = live != null && live.Id == conversation.Id;
+        var hasAttended = block?.HasAttended ?? false;
         // The rest stay conditional: asking them when there is no live session would add dependencies
         // that recompute this card for sessions it doesn't show
-        var isJoined = isLive
-            && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
         var isVoiceOnly = isLive
             && !await LiveSessionUI.IsTranscriptionOn(chatId, cancellationToken).ConfigureAwait(false);
-        var participantsText = isLive
-            ? await ConversationParticipantsFormatter
-                .GetText(Authors, L, Hub.Session, chatId, conversation.AuthorIds, cancellationToken)
-                .ConfigureAwait(false)
-            : "";
-        var hasFoldedEntries = isLive && !isVoiceOnly
-            && rawLive is { SessionStartedAt: not null }
-            && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
         var isExpanded = Message.IsExpanded;
         var tailPreview = isLive && !isVoiceOnly && !isExpanded
-            ? await GetTailPreview(chatId, rawLive?.EffectiveVisibleStartLid ?? 0, cancellationToken)
+            ? await GetTailPreview(chatId, conversation.Id.StartEntryLid, cancellationToken)
                 .ConfigureAwait(false)
             : null;
-        var hasSummary = !translated.Title.Text.IsNullOrEmpty();
         // Expanded is the auto-swallow mode - rows that scrolled above the viewport fold behind the card,
         // and "show more" is the way back to them. Collapsed is the card alone, previewing the latest
         // spoken rows (exactly what a viewer who never joined sees), with nothing to reveal.
         var swallowedCount = 0;
-        var revealBatch = 0;
-        if (isLive && !isVoiceOnly && isExpanded) {
+        if (isLive && !isVoiceOnly && isExpanded)
             swallowedCount = await LiveBlockUI.GetSwallowedCount(chatId, cancellationToken).ConfigureAwait(false);
-            if (swallowedCount > 0)
-                revealBatch = Math.Min(LiveFoldMath.RevealBatchSize, swallowedCount);
-        }
         var isAnyoneTalking = isLive
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new ConversationLiveState(
-            translated, isLive, isJoined, isVoiceOnly, participantsText, hasFoldedEntries,
-            tailPreview, hasSummary, swallowedCount, revealBatch, isAnyoneTalking,
-            blockState.Overlay != null);
+            translated, isLive, isVoiceOnly, tailPreview, swallowedCount, isAnyoneTalking,
+            hasAttended);
     }
 
     private async Task<IReadOnlyList<PreviewEntry>> GetTailPreview(

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderState.cs
@@ -3,9 +3,8 @@ namespace ActualChat.UI.Blazor.App.Components;
 public sealed record LiveConversationHeaderState(
     string Title,
     string ParticipantsText,
-    bool HasFoldedEntries,
     bool IsJoined = false,
-    bool HasOverlay = false,
+    bool HasAttended = false,
     bool IsDissolving = false,
     bool CanExpand = false,
     bool IsAnyoneTalking = false);

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/Items/Conversation/LiveConversationHeaderView.razor
@@ -15,7 +15,7 @@
         cls += " quiet";
     // The tint says "you were here", so it can't be keyed on the Join button: that button comes back
     // when you leave, and leaving must not repaint the block as one you never attended.
-    if (!s.IsJoined && !s.HasOverlay) {
+    if (!s.IsJoined && !s.HasAttended) {
         cls += " unjoined";
         childNames += " unjoined-live-block";
     }
@@ -55,7 +55,7 @@
             t => new ComputedState<LiveConversationHeaderState>.Options() {
                 // IsJoined defaults true in the placeholder so the clickable Join button doesn't flash
                 // before the first ComputeState resolves the real join state.
-                InitialValue = new LiveConversationHeaderState(conversation.Title, "", false, true),
+                InitialValue = new LiveConversationHeaderState(conversation.Title, "", true),
                 Category = GetStateCategory(t),
             });
     }
@@ -67,14 +67,12 @@
 
         var translatedTask = ConversationUI.GetTranslatedConversation(conversation, cancellationToken);
         var liveTask = LiveSessionUI.GetConversation(chatId, cancellationToken);
-        var rawLiveTask = LiveSessionUI.GetState(chatId, cancellationToken);
-        var blockStateTask = LiveBlockUI.GetBlockState(chatId, cancellationToken);
+        var blockTask = LiveBlockUI.GetBlock(chatId, cancellationToken);
         var translated = await translatedTask.ConfigureAwait(false);
         var live = await liveTask.ConfigureAwait(false);
-        var rawLive = await rawLiveTask.ConfigureAwait(false);
-        var blockState = await blockStateTask.ConfigureAwait(false);
+        var block = await blockTask.ConfigureAwait(false);
         var isLive = live != null && live.Id == conversation.Id;
-        var isDissolving = blockState.Overlay?.IsDissolving ?? false;
+        var isDissolving = block is ClosedLiveBlock { IsDissolving: true };
         // The rest stay conditional: asking them when there is no live session would add dependencies
         // that recompute this header for sessions it doesn't show
         var isJoined = isLive
@@ -86,15 +84,12 @@
                 .GetText(Authors, L, Hub.Session, chatId, conversation.AuthorIds, cancellationToken)
                 .ConfigureAwait(false)
             : "";
-        var hasFoldedEntries = isLive && !isVoiceOnly
-            && rawLive is { SessionStartedAt: not null }
-            && blockState.FoldBoundaryLid > rawLive.EffectiveVisibleStartLid;
-        var canExpand = isLive && !isVoiceOnly && rawLive is { SessionStartedAt: not null };
+        var canExpand = isLive && !isVoiceOnly && block is not ClosedLiveBlock;
         var isAnyoneTalking = isLive
             && await LiveStreamUI.IsAnyoneStreamingAudio(chatId, cancellationToken).ConfigureAwait(false);
         return new LiveConversationHeaderState(
-            translated.Title.Text, participantsText, hasFoldedEntries, isJoined,
-            blockState.Overlay != null, isDissolving, canExpand,
+            translated.Title.Text, participantsText, isJoined,
+            block?.HasAttended ?? false, isDissolving, canExpand,
             isAnyoneTalking);
     }
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatBlock.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatBlock.cs
@@ -3,12 +3,8 @@ namespace ActualChat.UI.Blazor.App.Services;
 public sealed record ChatBlock(
     Conversation Conversation,
     Range<long> EntryLidRange,
-    bool IsExpanded,
-    bool IsLive)
+    Moment? CollapsedAt)
 {
     public ConversationId Id => Conversation.Id;
-    // Compatibility defaults only: collapse actions do not record a cutoff yet.
-    public Moment CollapsedAt { get; init; } = IsLive
-        ? Conversation.StartsAt
-        : Conversation.EndsAt == Moment.MaxValue ? Moment.MaxValue : Conversation.EndsAt + TimeSpan.FromTicks(1);
+    public bool IsExpanded => CollapsedAt == null;
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Blocks.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Blocks.cs
@@ -76,7 +76,7 @@ public partial class ChatUI
             if (!byId.TryGetValue(id, out var conversation))
                 continue;
 
-            blocks.Add(new(conversation, range, view.ExpandedConversations.Contains(id), false));
+            blocks.Add(new(conversation, range, GetCollapsedAt(conversation)));
         }
 
         var blockConversation = view.MaterializedBlockId is { } materializedId
@@ -85,8 +85,7 @@ public partial class ChatUI
         if (view.LiveBlockConversationId is { } renderId && blockConversation != null && !liveBlockRange.IsEmpty) {
             if (blockConversation.Id != renderId)
                 blockConversation = blockConversation with { Id = renderId };
-            blocks.Add(new(blockConversation, liveBlockRange,
-                view.ExpandedConversations.Contains(renderId), view.MaterializedBlockId == null));
+            blocks.Add(new(blockConversation, liveBlockRange, GetCollapsedAt(blockConversation)));
         }
 
         var byStart = blocks.ToDictionary(b => b.EntryLidRange.Start);
@@ -101,6 +100,18 @@ public partial class ChatUI
                 Conversation = byStart[r.Start].Conversation with { EndEntryLid = r.End - 1 },
             })
             .ToList();
+
+        Moment? GetCollapsedAt(Conversation conversation) {
+            // Compatibility cutoffs only: collapse actions do not record their actual time yet.
+            if (view.ExpandedConversations.Contains(conversation.Id))
+                return null;
+            if (conversation.Id == view.LiveBlockConversationId && view.MaterializedBlockId == null)
+                return conversation.StartsAt;
+
+            return conversation.EndsAt == Moment.MaxValue
+                ? Moment.MaxValue
+                : conversation.EndsAt + TimeSpan.FromTicks(1);
+        }
     }
 
     // Private methods

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Query.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Query.cs
@@ -33,7 +33,8 @@ public partial class ChatUI
             .EnsureMonotonic();
         var collapsedBlocks = blocks.Where(b => !b.IsExpanded).ToList();
         // Coverage includes the whole live block; only its governed fold may exclude entry tiles.
-        var excludedRanges = blocks.Where(b => !b.IsExpanded || (b.Id == liveBlockId && b.IsLive))
+        var excludedRanges = blocks.Where(b => !b.IsExpanded
+                || (b.Id == liveBlockId && conversationView.MaterializedBlockId == null))
             .Select(b => b.Id == liveBlockId ? liveBlockFoldRange.IntersectWith(b.EntryLidRange) : b.EntryLidRange)
             .Where(r => !r.IsEmpty)
             .ToList();

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -181,12 +181,11 @@ public partial class ChatUI
         // Everything GetChatItemsInternal issues before its first await, in the same order
         var chatTask = Chats.Get(Session, chatId, cancellationToken);
         var liveConversationTask = Hub.LiveSessionUI.GetConversation(chatId, cancellationToken);
-        var rawLiveTask = Hub.LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken);
-        var blockStateTask = Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken);
+        var liveBlockTask = Hub.LiveBlockUI.GetBlock(chatId, cancellationToken);
         var chatLidRangeTask = Chats.GetIdRange(Session, chatId, cancellationToken);
         var readPositionTask = ChatPositions.GetOwn(Session, chatId, ChatPositionKind.Read, cancellationToken);
         var pending = new List<Task> {
-            chatTask, liveConversationTask, rawLiveTask, blockStateTask, chatLidRangeTask, readPositionTask,
+            chatTask, liveConversationTask, liveBlockTask, chatLidRangeTask, readPositionTask,
         };
         try {
             // The anchor is read from the cached ChatInfo rather than awaited, because on a cold chat
@@ -303,7 +302,8 @@ public partial class ChatUI
         bool isPrefetch,
         CancellationToken cancellationToken)
     {
-        // DebugLog?.LogDebug("GetTiles: {ChatId} {IdRange} {ShownReadyEntryLid}", chatId, dataQuery, shownReadyEntryLid);
+        // DebugLog?.LogDebug("GetTiles: {ChatId} {IdRange} {ShownReadyEntryLid}",
+        //     chatId, dataQuery, shownReadyEntryLid);
         // NOTE: Changing what this requests? Review Prefetch - it warms these same calls in advance, and only
         // helps while its arguments still match the ones below.
         var startedAt = CpuTimestamp.Now;
@@ -319,8 +319,7 @@ public partial class ChatUI
         // per rebuild - a full second on a 200ms+ link, which is invisible on Blazor Server.
         var chatTask = Chats.Get(Session, chatId, cancellationToken);
         var liveConversationTask = Hub.LiveSessionUI.GetConversation(chatId, cancellationToken);
-        var rawLiveTask = Hub.LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken);
-        var blockStateTask = Hub.LiveBlockUI.GetBlockState(chatId, cancellationToken);
+        var liveBlockTask = Hub.LiveBlockUI.GetBlock(chatId, cancellationToken);
         var cidTiles = GetCidTiles(dataQuery.ExistingLidRange);
         var chatRangeTilesTask = cidTiles
             .Select(cidTile
@@ -355,7 +354,7 @@ public partial class ChatUI
         if (chat == null) {
             // Everything above is already in flight, so bailing out here would leave those tasks unobserved.
             _ = Task.WhenAll(
-                    liveConversationTask, rawLiveTask, blockStateTask,
+                    liveConversationTask, liveBlockTask,
                     chatRangeTilesTask, conversationTilesTask, chatLidRangeTask)
                 .SilentAwait(false);
             return ChatItems.Empty;
@@ -371,38 +370,11 @@ public partial class ChatUI
         var amInLiveConversation = liveConversation != null
             && await Hub.LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
         var amInLiveAt = CpuTimestamp.Now;
-        var rawLive = await Hub.LiveSessionUI
-            .UseSnapshotOrLastKnown(chatId, rawLiveTask)
-            .ConfigureAwait(false);
-        var snapshotAt = CpuTimestamp.Now;
-        var blockState = await blockStateTask.ConfigureAwait(false);
-        var overlay = blockState.Overlay;
-
-        // The governed boundary replaces the raw fold end: it tracks the viewer's viewport top,
-        // monotonically, so un-summarised rows above the viewport fold too (LiveBlockUI owns this).
-        // No EndEntryLid cap here - FoldBoundaryLid is itself the monotonic max of real visible
-        // message lids, so it never exceeds the loaded entries. RevealedBoundaryLid pins the
-        // *effective* boundary below the monotonic one once the reader asks for more (§7), so
-        // revealed rows stay visible even as the governor keeps advancing.
-        var effectiveFoldBoundaryLid = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
-        var liveFoldRange = rawLive is { IsLatched: true }
-            && effectiveFoldBoundaryLid > rawLive.VisibleStartLid
-                ? new Range<long>(rawLive.VisibleStartLid, effectiveFoldBoundaryLid)
-                : default;
-
-        ConversationId? liveBlockId;
-        Range<long> liveBlockFoldRange;
-        ConversationId? materializedBlockId = null;
-        if (overlay != null) {
-            liveBlockId = overlay.RenderId;
-            liveBlockFoldRange = overlay.FoldRange;
-            materializedBlockId = overlay.MaterializedId;
-        }
-        else {
-            // The live block uses the same shell joined or not; only the tint + header affordance differ.
-            liveBlockId = liveConversation?.Id;
-            liveBlockFoldRange = liveFoldRange;
-        }
+        var liveBlock = await liveBlockTask.ConfigureAwait(false);
+        var closedBlock = liveBlock as ClosedLiveBlock;
+        var liveBlockId = liveBlock?.ConversationId;
+        var liveBlockFoldRange = liveBlock?.FoldRange ?? default;
+        var materializedBlockId = closedBlock?.MaterializedId;
 
         // A non-joined viewer sees the block's summary card only — never its live entries. The card
         // collapses [V, foldEnd) and this range hides everything from there on, so the two together
@@ -412,8 +384,8 @@ public partial class ChatUI
         // EndEntryLid would leak the entries in [foldEnd, EndEntryLid+1). Pre-first-summary the fold
         // range is empty, so hide from V onward. Hiding the wider range is harmless - a non-joined
         // viewer has no visible live entries to keep.
-        var hiddenLiveTailRange = overlay != null
-            ? overlay.HiddenTailRange
+        var hiddenLiveTailRange = closedBlock != null
+            ? closedBlock.HiddenTailRange
             : liveConversation is { } liveConv && !amInLiveConversation
                 ? new Range<long>(
                     liveBlockFoldRange.IsEmpty
@@ -435,11 +407,11 @@ public partial class ChatUI
         var chatRangeTiles = lastKnownRangeTiles
             ?? (await chatRangeTilesTask.ConfigureAwait(false))
                 .OrderBy(m => m.LidRange.Start)
-                .ThenByDescending(m => m.LidRange.Size()) // ChatRangeTile can be overlapping, so we need to keep the largest
+                .ThenByDescending(m => m.LidRange.Size()) // Overlapping ChatRangeTiles keep the largest.
                 .EnsureMonotonic(Comparer<ChatRangeTile>.Create((a, b) => a.LidRange.Start.CompareTo(b.LidRange.Start)))
                 .ToList();
 
-        var dissolvingConversation = overlay?.DissolvingConversation;
+        var dissolvingConversation = closedBlock?.DissolvingConversation;
         var showConversations = (chat.IsSummarized ?? false)
             || liveConversation != null || dissolvingConversation != null;
 
@@ -642,7 +614,7 @@ public partial class ChatUI
         var blockRange = liveBlockId is { } coverageId
             ? new Range<long>(coverageId.StartEntryLid,
                 Math.Max(coverageId.StartEntryLid + 1,
-                    Math.Min(overlay?.BlockEndLid ?? chatLidRange.End, chatLidRange.End)))
+                    Math.Min(closedBlock?.EndLid ?? chatLidRange.End, chatLidRange.End)))
             : default;
         var knownConversations = conversationTiles.SelectMany(t => t)
             .DistinctBy(c => c.Id).ToDictionary(c => c.Id);
@@ -932,16 +904,14 @@ public partial class ChatUI
             var chatMs = (long)(chatAt - startedAt).TotalMilliseconds;
             var conversationMs = (long)(conversationAt - chatAt).TotalMilliseconds;
             var amInLiveMs = (long)(amInLiveAt - conversationAt).TotalMilliseconds;
-            var snapshotMs = (long)(snapshotAt - amInLiveAt).TotalMilliseconds;
-            var blockStateMs = (long)(liveAt - snapshotAt).TotalMilliseconds;
+            var blockMs = (long)(liveAt - amInLiveAt).TotalMilliseconds;
             if (!wasBackgrounded) {
                 RecordPhase(totalMs, "total");
                 RecordPhase(liveMs, "live");
                 RecordPhase(chatMs, "live.chat");
                 RecordPhase(conversationMs, "live.conversation");
                 RecordPhase(amInLiveMs, "live.am-in-live");
-                RecordPhase(snapshotMs, "live.snapshot");
-                RecordPhase(blockStateMs, "live.block-state");
+                RecordPhase(blockMs, "live.block");
                 RecordPhase(metaMs, "meta");
                 RecordPhase(loadMs, "load");
                 RecordPhase(buildMs, "build");
@@ -950,15 +920,15 @@ public partial class ChatUI
             // there, and Sentry drops Activity tags (it stores no AC.* span attribute at all).
             ChatSwitchTracer.Mark("ChatUI.GetChatItems: phases",
                 $"total={totalMs} (live={liveMs} [chat={chatMs} conv={conversationMs} amInLive={amInLiveMs} "
-                + $"snapshot={snapshotMs} blockState={blockStateMs}], meta={metaMs}, load={loadMs}, build={buildMs})");
+                + $"block={blockMs}], meta={metaMs}, load={loadMs}, build={buildMs})");
             if (totalMs > SlowBuildMs && !wasBackgrounded)
                 Log.LogWarning(
                     "GetChatItems: {ChatId} took {TotalMs}ms (live {LiveMs} = chat {ChatMs} "
-                    + "+ conversation {ConversationMs} + amInLive {AmInLiveMs} + snapshot {SnapshotMs} "
-                    + "+ blockState {BlockStateMs}, meta {MetaMs}, load {LoadMs}, build {BuildMs}) "
+                    + "+ conversation {ConversationMs} + amInLive {AmInLiveMs} "
+                    + "+ block {BlockMs}, meta {MetaMs}, load {LoadMs}, build {BuildMs}) "
                     + "for {DataQuery}",
                     chatId, totalMs, liveMs, chatMs, conversationMs, amInLiveMs,
-                    snapshotMs, blockStateMs, metaMs, loadMs, buildMs, dataQuery.Format());
+                    blockMs, metaMs, loadMs, buildMs, dataQuery.Format());
             else
                 DebugLog?.LogDebug(
                     "GetChatItems: {ChatId} took {TotalMs}ms "
@@ -971,13 +941,12 @@ public partial class ChatUI
         if (expandedConversations.Count == 0 && liveBlockId == null)
             return new ChatItems(groupedItems, hasMoreBefore, hasMoreAfter, lastKnownRangeTiles != null);
 
-        var liveBlock = blocks.FirstOrDefault(b => b.Id == liveBlockId);
+        var projectedLiveBlock = blocks.FirstOrDefault(b => b.Id == liveBlockId);
         // Fetch coverage stays finite; active grouping also owns optimistic sends and the long.MaxValue placeholder.
-        // Frozen and materialized blocks must not absorb entries from after their boundary.
-        var liveBlockRange = liveBlock is { IsLive: true }
-            && (overlay == null || overlay is { MaterializedId: null, BlockEndLid: long.MaxValue })
-            ? new Range<long>(liveBlock.EntryLidRange.Start, long.MaxValue)
-            : liveBlock?.EntryLidRange ?? default;
+        // Closed blocks must not absorb entries from after their boundary.
+        var liveBlockRange = liveBlock is OpenLiveBlock && projectedLiveBlock != null
+            ? new Range<long>(projectedLiveBlock.EntryLidRange.Start, long.MaxValue)
+            : projectedLiveBlock?.EntryLidRange ?? default;
         // Expanded is not the only form that renders rows: a closed block that kept its card hides
         // nothing, and those rows belong inside the block rather than loose under its footer. Only a
         // live block that is both collapsed and hiding absorbs nothing.
@@ -988,7 +957,7 @@ public partial class ChatUI
         return new ChatItems(groupedTiles, hasMoreBefore, hasMoreAfter, lastKnownRangeTiles != null);
     }
 
-    // NOTE: Please don't add excessive computed dependencies without real reason - it might rerender whole chat view content
+    // Extra computed dependencies here can rerender the whole chat view.
     [ComputeMethod(MinCacheDuration = 30, InvalidationDelay = 0.1)]
     protected virtual async Task<VirtualListTile<ChatMessage>> GetTile(
         ChatId chatId,
@@ -1009,9 +978,9 @@ public partial class ChatUI
             liveBlockId, liveFoldRange, materializedBlockId) = conversationView;
 
         var chatSendingMessages = chatSendingMessagesWrapper.Value;
+        // Include the preceding item to render the block start correctly, then discard it.
         var requestedIdRange = prevMessage == null
-            ? lidRange.MoveStart(-EntryIdTiles
-                .TileSize) // to request previous item of requested range to properly render block star - we will drop it off
+            ? lidRange.MoveStart(-EntryIdTiles.TileSize)
             : lidRange;
         var idRangesToSkip = Array.Empty<Range<long>>();
         var conversations = Array.Empty<Conversation>();
@@ -1089,10 +1058,12 @@ public partial class ChatUI
                 .Select(e => e.ClientId)
                 .ToHashSet();
             chatSendingMessages.ProcessLoadedEntriesRange(rangeEnd.Value, loadedClientIds);
-            var newMessages = await chatSendingMessages.GetNewMessages(currentAuthorId!, rangeEnd.Value).ConfigureAwait(false);
+            var newMessages = await chatSendingMessages.GetNewMessages(currentAuthorId!, rangeEnd.Value)
+                .ConfigureAwait(false);
             entries.AddRange(newMessages);
 
-            var audioRecordingEntry = await GetAudioRecordingEntry(chatId, currentAuthorId!, cancellationToken).ConfigureAwait(false);
+            var audioRecordingEntry = await GetAudioRecordingEntry(chatId, currentAuthorId!, cancellationToken)
+                .ConfigureAwait(false);
             if (audioRecordingEntry is not null) {
                 // Hide "Transcribing..." when a real transcription entry already exists
                 // (i.e., the last entry from this author is streaming content).
@@ -1484,7 +1455,7 @@ public partial class ChatUI
 
         // Index of each conversation's last item. A Conversation-less item before it is an interruption
         // *inside* that conversation, not its end - which is the one question the lid ranges below can't
-        // answer reliably: a frozen BlockEndLid, or an entry not yet part of the conversation, falls
+        // answer reliably: a closed block's captured end, or an entry not yet part of the conversation, falls
         // outside them, ends the block, and lets the items after it open a second one.
         var lastIndexById = new Dictionary<ConversationId, int>();
         for (var i = 0; i < messages.Count; i++)
@@ -1496,8 +1467,7 @@ public partial class ChatUI
             var conversation = itemConversations[i];
             var isLiveBlock = liveBlockId != null && blockConversation?.Id == liveBlockId;
             // A Conversation-less item is held by its lid alone, so the live block's range must cover the
-            // conversation as well: the frozen BlockEndLid stops at the summary that was live when the
-            // viewer left, and a later summary stretches the conversation past it.
+            // conversation as well: a later summary can extend past the closed block's captured end.
             var blockRange = blockConversation == null
                 ? default
                 : isLiveBlock
@@ -1515,7 +1485,7 @@ public partial class ChatUI
                     : takesEntries
                         && (i < lastIndexById.GetValueOrDefault(blockConversation.Id, -1)
                             // Range.Contains excludes End, so a still-live [V, ∞) range needs the open-ended
-                            // form - a closed block carries a real BlockEndLid and uses Contains as usual.
+                            // form - a closed block carries a finite end and uses Contains as usual.
                             // Keeps the frozen tail past the conversation's last item inside the block.
                             || (blockRange.End == long.MaxValue
                                 ? item.Id >= blockRange.Start
@@ -1637,7 +1607,8 @@ public partial class ChatUI
                     .Collect(ApiConstants.Concurrency.High, cancellationToken)
                 : Task.CompletedTask;
             var prefetchChatInfoTask = PrefetchChatInfo(chatId, cancellationToken);
-            await Task.WhenAll(prefetchEntriesTask, prefetchConversationsTask, prefetchChatInfoTask).ConfigureAwait(false);
+            await Task.WhenAll(prefetchEntriesTask, prefetchConversationsTask, prefetchChatInfoTask)
+                .ConfigureAwait(false);
             return await prefetchEntriesTask.ConfigureAwait(false);
         }, cancellationToken);
 

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -493,13 +493,11 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
 
     public void ToggleExpandConversation(ConversationId conversationId)
     {
-        // A closed live-block overlay intercepts its own toggle: collapsing it is "dismiss the
-        // frozen view", not an expansion override on the overlay's render id.
-        if (Hub.LiveBlockUI.TryCollapseOverlay(conversationId))
+        // Dismissing a closed block switches back to its persisted conversation's expansion state.
+        if (Hub.LiveBlockUI.TryDismissClosedBlock(conversationId))
             return;
 
-        // ResetReveal takes LiveBlockUI's lock, so it stays outside this one - a ChatUI -> LiveBlockUI
-        // lock edge would invert the one TryCollapseOverlay acquires in the other direction.
+        // ResetReveal also updates live-block state; do it outside this lock.
         lock (Lock) {
             var isAutoExpanded = SuppressAutoExpansion(conversationId);
             var overrides = _conversationExpansionOverrides.Value;
@@ -635,7 +633,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     internal bool SuppressAutoExpansion(ConversationId conversationId)
     {
         // Returns whether an auto-expansion was dropped - for the toggle, that removal IS the collapse.
-        // Called on its own for ids whose IsExpandedByDefault isn't knowable: a frozen block's render id
+        // Called on its own for ids whose IsExpandedByDefault isn't knowable: a closed block's render id
         // has no conversation behind it once materialized, so normalizing its override would expand it.
         lock (Lock) {
             _suppressedAutoExpansions[conversationId] = default;
@@ -660,7 +658,7 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
     {
         // A conversation that appeared (or grew) over rows the user has actually seen this visit must
         // not swallow them in place; it auto-expands until the user leaves the chat. Live/materialized
-        // block ids are excluded - the live overlay machinery owns their expansion. An id carrying a
+        // block ids are excluded - the live block lifecycle owns their expansion. An id carrying a
         // manual override is excluded too: suppression dies with the visit but the override doesn't,
         // so without this an earlier visit's deliberate collapse would be undone by later range growth.
         var result = new List<ConversationId>();

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlock.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlock.cs
@@ -1,0 +1,33 @@
+namespace ActualChat.UI.Blazor.App.Services;
+
+/// <summary>
+/// A viewer's live block, including its effective fold after revealing older messages.
+/// Open/closed describe the session lifecycle, independently of expansion.
+/// </summary>
+public abstract record LiveBlock(
+    ConversationId ConversationId,
+    bool HasAttended,
+    long FoldEndLid)
+{
+    public Range<long> FoldRange => FoldEndLid > ConversationId.StartEntryLid
+        ? new(ConversationId.StartEntryLid, FoldEndLid)
+        : default;
+}
+
+public sealed record OpenLiveBlock(
+    ConversationId ConversationId,
+    bool HasAttended,
+    long FoldEndLid)
+    : LiveBlock(ConversationId, HasAttended, FoldEndLid);
+
+public sealed record ClosedLiveBlock(
+    ConversationId ConversationId,
+    long FoldEndLid,
+    long EndLid,
+    ConversationId? MaterializedId,
+    Conversation? DissolvingConversation = null)
+    : LiveBlock(ConversationId, true, FoldEndLid)
+{
+    public bool IsDissolving => MaterializedId == null;
+    public Range<long> HiddenTailRange => IsDissolving ? new(EndLid, long.MaxValue) : default;
+}

--- a/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveBlockUI.cs
@@ -1,45 +1,11 @@
-﻿using ActualChat.Live;
+using ActualChat.Live;
 using ActualLab.Interception;
 
 namespace ActualChat.UI.Blazor.App.Services;
 
 /// <summary>
-/// Frozen render state for a live block once the viewer stops watching it live: which entries stay
-/// folded behind the card, which tail stays hidden, and (once closed) which persisted conversation
-/// replaces the live render id.
-/// </summary>
-public sealed record LiveBlockOverlay(
-    ConversationId RenderId,
-    long CardLid,
-    Range<long> FoldRange,
-    Range<long> HiddenTailRange,
-    long BlockEndLid,
-    ConversationId? MaterializedId,
-    bool IsExpandedByDefault,
-    bool IsDissolving = false)
-{
-    public Conversation? DissolvingConversation { get; init; }
-}
-
-/// <summary>
-/// The live block's fold state. <see cref="FoldBoundaryLid"/> is the governed fold end, already
-/// bounded by the viewport top and by both floors when it was advanced - see
-/// <see cref="LiveFoldMath.Advance"/> - so consumers use it as-is.
-/// </summary>
-public sealed record LiveBlockState(
-    long FoldBoundaryLid,
-    LiveBlockOverlay? Overlay,
-    bool WasAttending = false,
-    bool IsDissolving = false,
-    long RevealedBoundaryLid = long.MaxValue)
-{
-    public static readonly LiveBlockState None = new(0, null);
-}
-
-/// <summary>
 /// Governs how far a live block's fold boundary is allowed to advance (monotonic viewport-top
-/// tracking via <see cref="LiveFoldMath"/>), and freezes/materializes the block's render once the
-/// viewer leaves or the session closes, so a watched viewport never mutates under the reader.
+/// tracking via <see cref="LiveFoldMath"/>), and retains attended blocks after session closure.
 /// </summary>
 public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeService, INotifyInitialized
 {
@@ -56,25 +22,42 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         => this.Start();
 
     [ComputeMethod]
-    public virtual async Task<LiveBlockState> GetBlockState(ChatId chatId, CancellationToken cancellationToken = default)
+    public virtual async Task<LiveBlock?> GetBlock(ChatId chatId, CancellationToken cancellationToken = default)
     {
-        // The freeze overlay is derived here, reactively, from "am I still attending this block" -
-        // never latched by the async governor a beat later. That's what keeps a hang-up (or close)
-        // from ever flashing a collapsed frame: the moment AmIInLiveConversation flips, this recomputes
-        // and the overlay is already present. The governor only advances the fold boundary and keeps
-        // the frozen template fresh; it no longer owns whether the overlay exists.
+        // Derive lifecycle changes directly from their sources: waiting for the governor can flash
+        // a collapsed frame between leaving/closing and its next iteration.
         var chatState = await GetOrCreateChatState(chatId, cancellationToken).ConfigureAwait(false);
-        var baseState = await chatState.State.Use(cancellationToken).ConfigureAwait(false);
-        var snapshotTask = LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken);
-        var raw = await LiveSessionUI.UseSnapshotOrLastKnown(chatId, snapshotTask).ConfigureAwait(false);
-        var amInLive = raw != null
+        _ = await chatState.FoldEndLid.Use(cancellationToken).ConfigureAwait(false);
+        var blockStateTask = LiveSessionUI.GetBlockState(chatId, cancellationToken);
+        var raw = await LiveSessionUI.UseBlockStateOrLastKnown(chatId, blockStateTask).ConfigureAwait(false);
+        // The projections consolidate independently; the conversation can arrive before the block state.
+        var conversationTask = raw is { IsLatched: true }
+            ? null
+            : LiveSessionUI.GetConversation(chatId, cancellationToken);
+        var conversation = conversationTask == null
+            ? null
+            : await LiveSessionUI.UseConversationOrLastKnown(chatId, conversationTask).ConfigureAwait(false);
+        var amInLive = (raw != null || conversation != null)
             && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
+        bool mustLatchAttendance;
+        lock (Lock)
+            mustLatchAttendance = amInLive && raw is { IsLatched: true } && !chatState.WasAttending;
+        var template = mustLatchAttendance
+            ? await BuildTemplate(chatId, raw!, cancellationToken).ConfigureAwait(false)
+            : null;
         lock (Lock) {
-            var effectiveBoundaryLid = Math.Min(baseState.FoldBoundaryLid, chatState.RevealedBoundaryLid);
-            return baseState with {
-                Overlay = DeriveOverlay(chatState, effectiveBoundaryLid, raw, amInLive),
-                RevealedBoundaryLid = chatState.RevealedBoundaryLid,
-            };
+            // This compute deliberately latches attendance and its descriptor idempotently, so a join
+            // followed by an immediate leave/close cannot outrun the governor.
+            if (template != null && !chatState.WasAttending) {
+                chatState.Template = template;
+                chatState.WasAttending = true;
+            }
+            var block = DeriveBlock(chatId, chatState, raw);
+            if (block != null || conversation == null)
+                return block;
+
+            return new OpenLiveBlock(conversation.Id, chatState.WasAttending || amInLive,
+                Math.Min(chatState.FoldEndLid.Value, chatState.RevealedBoundaryLid));
         }
     }
 
@@ -83,20 +66,15 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
     {
         // Cached (this is a [ComputeMethod]) but counts real messages via a full read of the swallowed
         // range on each recompute - never approximate with a lid span, since lids have gaps.
-        var blockState = await GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
-        var raw = await LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken).ConfigureAwait(false);
-        if (raw is not { IsLatched: true })
-            return 0;
-        var v = raw.VisibleStartLid;
-        var effectiveBoundary = Math.Min(blockState.FoldBoundaryLid, blockState.RevealedBoundaryLid);
-        if (effectiveBoundary <= v)
+        var block = await GetBlock(chatId, cancellationToken).ConfigureAwait(false);
+        if (block is not OpenLiveBlock || block.FoldRange.IsEmpty)
             return 0;
 
         // Bounded to the fold itself: read from the chat end, this would re-walk the whole live tail and
         // depend on every tile of it, for every participant, on every new entry.
         var count = 0;
         var reader = Chats.NewEntryReader(Session, chatId);
-        var foldRange = new Range<long>(v, effectiveBoundary);
+        var foldRange = block.FoldRange;
         await foreach (var entry in reader.ReadReverse(foldRange, cancellationToken).ConfigureAwait(false))
             if (!entry.IsSystemEntry)
                 count++;
@@ -111,8 +89,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             if (!_chatStates.TryGetValue(chatId, out var s) || s.Template is not { } t)
                 return;
             chatState = s;
-            v = t.V;
-            effectiveBoundary = Math.Min(chatState.State.Value.FoldBoundaryLid, chatState.RevealedBoundaryLid);
+            v = t.ConversationId.StartEntryLid;
+            effectiveBoundary = Math.Min(chatState.FoldEndLid.Value, chatState.RevealedBoundaryLid);
         }
         if (effectiveBoundary <= v)
             return;
@@ -139,7 +117,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             chatState.RevealScrolledInto = false;
         }
         using (Invalidation.Begin())
-            _ = GetBlockState(chatId, default);
+            _ = GetBlock(chatId, default);
     }
 
     public void ResetReveal(ChatId chatId)
@@ -151,64 +129,53 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             chatState.RevealScrolledInto = false;
         }
         using (Invalidation.Begin())
-            _ = GetBlockState(chatId, default);
+            _ = GetBlock(chatId, default);
     }
 
-    public bool TryCollapseOverlay(ConversationId conversationId)
+    public bool TryDismissClosedBlock(ConversationId conversationId)
     {
+        LiveBlockTemplate? dismissed = null;
         lock (Lock) {
             foreach (var chatState in _chatStates.Values) {
-                // WasAttending gates the intercept to a still-visible overlay: once dismissed, later
+                // WasAttending gates the intercept to a still-visible block: once dismissed, later
                 // toggles on the materialized conversation must reach the ordinary expand/collapse path.
                 if (!chatState.IsClosed || !chatState.WasAttending || chatState.Template is not { HadSummary: true } t)
                     continue;
-                if (t.LiveRenderId != conversationId && t.MaterializedId != conversationId)
+                if (t.ConversationId != conversationId && t.MaterializedId != conversationId)
                     continue;
 
                 chatState.WasAttending = false;
-                chatState.State.Value = chatState.State.Value with { WasAttending = false };
-                if (t.LiveRenderId != t.MaterializedId)
-                    Hub.ChatUI.SuppressAutoExpansion(t.LiveRenderId);
-                Hub.ChatUI.EnsureConversationCollapsed(t.MaterializedId, t.IsExpandedByDefault);
-                return true;
+                dismissed = t;
+                break;
             }
         }
-        return false;
+        if (dismissed == null)
+            return false;
+
+        using (Invalidation.Begin())
+            _ = GetBlock(conversationId.ChatId, default);
+        if (dismissed.ConversationId != dismissed.MaterializedId)
+            Hub.ChatUI.SuppressAutoExpansion(dismissed.ConversationId);
+        Hub.ChatUI.EnsureConversationCollapsed(dismissed.MaterializedId, dismissed.IsExpandedByDefault);
+        return true;
     }
 
-    private static LiveBlockOverlay? DeriveOverlay(
-        ChatFoldState chatState, long foldBoundaryLid, LiveBlockSnapshot? raw, bool amInLive)
+    private static LiveBlock? DeriveBlock(ChatId chatId, ChatFoldState chatState, LiveBlockState? raw)
     {
+        var foldEndLid = Math.Min(chatState.FoldEndLid.Value, chatState.RevealedBoundaryLid);
+        if (raw != null)
+            return raw.IsLatched
+                ? new OpenLiveBlock(ConversationId.New(chatId, raw.VisibleStartLid), chatState.WasAttending, foldEndLid)
+                : null;
         if (!chatState.WasAttending || chatState.Template is not { } t)
             return null;
 
-        if (raw == null)
-            // Close: freeze the block under its live-era render id and hand over to the materialized
-            // conversation. Tier-1 (never summarized) has no card - it dissolves immediately here (no
-            // wait on the governor, or the block would be gone before the animation starts), then the
-            // governor flips DissolveDone once the window passes and it drops to plain messages.
-            return t.HadSummary
-                ? new LiveBlockOverlay(t.LiveRenderId, t.V, FoldRangeOf(t.V, foldBoundaryLid),
-                    default, t.BlockEndLid, t.MaterializedId, t.IsExpandedByDefault)
-                : chatState.DissolveDone
-                    ? null
-                    : new LiveBlockOverlay(t.LiveRenderId, t.V, FoldRangeOf(t.V, foldBoundaryLid),
-                        new Range<long>(t.TailStart, long.MaxValue), t.TailStart, null, false, IsDissolving: true) {
-                        DissolvingConversation = t.DissolvingConversation,
-                    };
-
-        if (!amInLive)
-            // Leave, session still live: the block goes on exactly as it was - same fold, same
-            // expansion, no boundary at the moment of leaving - so the only thing that marks the
-            // viewer as having been there is the overlay itself, which the tint reads.
-            return new LiveBlockOverlay(t.LiveRenderId, t.V, FoldRangeOf(t.V, foldBoundaryLid),
-                default, long.MaxValue, null, false);
-
-        return null; // still joined and live
+        return t.HadSummary
+            ? new ClosedLiveBlock(t.ConversationId, foldEndLid, t.SummaryEndLid, t.MaterializedId)
+            : chatState.DissolveDone
+                ? null
+                : new ClosedLiveBlock(t.ConversationId, foldEndLid, t.ChatEndLid, null, t.DissolvingConversation);
     }
-
-    private static Range<long> FoldRangeOf(long v, long boundaryLid)
-        => boundaryLid > v ? new Range<long>(v, boundaryLid) : default;
 
     // Protected/internal methods
 
@@ -222,7 +189,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         if (chatId is null)
             return GovernorInputs.None;
 
-        var raw = await LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken).ConfigureAwait(false);
+        var raw = await LiveSessionUI.GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
         var visibility = await Hub.ChatUI.ItemVisibility.Use(cancellationToken).ConfigureAwait(false);
         var isJoined = raw != null
             && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
@@ -287,18 +254,16 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         // attending latch is seeded here too - whichever caller creates the state first (this read
         // path or the governor loop) must agree on it, or a join immediately followed by a leave (no
         // governor iteration lands in between) would never mark the viewer as having attended.
-        LiveBlockSnapshot? raw;
+        LiveBlockState? raw;
         bool isJoined;
-        FrozenTemplate? template = null;
+        LiveBlockTemplate? template = null;
         var floorLid = long.MaxValue;
         using (Computed.BeginIsolation()) {
-            raw = await LiveSessionUI.GetBlockSnapshot(chatId, cancellationToken).ConfigureAwait(false);
+            raw = await LiveSessionUI.GetBlockState(chatId, cancellationToken).ConfigureAwait(false);
             isJoined = raw != null
                 && await LiveSessionUI.AmIInLiveConversation(chatId, cancellationToken).ConfigureAwait(false);
-            // Seed the template alongside the attending latch: a join immediately followed by a leave
-            // (before the governor's first iteration) must still freeze, so WasAttending never outruns
-            // the template GetBlockState needs to derive the overlay. Built for a viewer who never joined
-            // too - RevealMore reads V from it, and their expanded block folds like anyone's.
+            // Attendance must retain its descriptor even before the governor runs. Other viewers
+            // need the template too: RevealMore uses its start when walking back through entries.
             if (raw is { IsLatched: true })
                 template = await BuildTemplate(chatId, raw, cancellationToken).ConfigureAwait(false);
             // The seed is the one fold end no advance produced, so the floors have to bound it here
@@ -313,9 +278,9 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 return existing;
 
             var chatState = new ChatFoldState {
-                State = StateFactory.NewMutable(
-                    new LiveBlockState(foldEndLid, null, isJoined),
-                    StateCategories.Get(GetType(), nameof(GetBlockState), "[*]")),
+                FoldEndLid = StateFactory.NewMutable(
+                    foldEndLid,
+                    StateCategories.Get(GetType(), nameof(GetBlock), "[*]")),
                 WasAttending = isJoined,
                 Template = template,
             };
@@ -324,7 +289,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         }
     }
 
-    private async Task<FrozenTemplate> BuildTemplate(ChatId chatId, LiveBlockSnapshot raw, CancellationToken cancellationToken)
+    private async Task<LiveBlockTemplate> BuildTemplate(
+        ChatId chatId,
+        LiveBlockState raw,
+        CancellationToken cancellationToken)
     {
         Range<long> chatIdRange;
         Conversation? conversation;
@@ -339,11 +307,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         // A close may reach the conversation read before its snapshot; keep the descriptor already shown.
         if (conversation == null && !raw.HasSummary)
             lock (Lock)
-                if (_chatStates.TryGetValue(chatId, out var state) && state.Template?.LiveRenderId == renderId)
+                if (_chatStates.TryGetValue(chatId, out var state) && state.Template?.ConversationId == renderId)
                     conversation = state.Template.DissolvingConversation;
 
-        return new FrozenTemplate(
-            v,
+        return new LiveBlockTemplate(
             chatIdRange.End,
             raw.EndEntryLid + 1,
             renderId,
@@ -355,7 +322,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 : null);
     }
 
-    private static long GetRawFoldEndLid(LiveBlockSnapshot? raw)
+    private static long GetRawFoldEndLid(LiveBlockState? raw)
         => raw is { IsLatched: true, HasSummary: true }
             && raw.EndEntryLid >= raw.VisibleStartLid
             ? raw.EndEntryLid + 1
@@ -402,24 +369,19 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         var (_, raw, visibility, isJoined, isBlockExpanded, rawStreamingFloorLid, tailFloorLid) = inputs;
         var chatState = await GetOrCreateChatState(chatId, cancellationToken).ConfigureAwait(false);
 
-        // While the session is live, keep a frozen template ready - the exact descriptor GetBlockState
-        // needs to freeze the block the instant it closes, and the V that RevealMore walks back from.
-        // Leaving doesn't stop the refresh: the block goes on exactly as it was, so the descriptor has
-        // to go on tracking it, and only the close (raw == null) freezes what it holds.
+        // Keep tracking the descriptor after leaving; only session closure stops the refresh.
         var template = raw is { IsLatched: true }
             ? await BuildTemplate(chatId, raw, cancellationToken).ConfigureAwait(false)
             : null;
         var streamingFloorLid = StreamingFloorOf(raw, rawStreamingFloorLid);
 
-        var clearedReveal = false;
+        bool mustInvalidate;
         Moment? wakeAt = null;
         lock (Lock) {
-            // A session everyone has left and then restarted is a new conversation as far as the viewer
-            // is concerned: they watched the block go quiet. Left latched, the template they froze on
-            // leaving keeps its unbounded hidden tail, and every entry the restart produces falls inside
-            // it - so the block sits there frozen while people talk into it. IsClosing going false again
-            // after it was true is that restart; the identity of the session cannot say so, because
-            // resuming keeps the one it was closing.
+            var oldBlock = DeriveBlock(chatId, chatState, raw);
+            var foldEndLid = chatState.FoldEndLid.Value;
+            // Resuming keeps the session identity, so detect the restart from IsClosing and discard
+            // the previous attendance/fold state before it hides messages from the new call.
             if (raw is { IsClosing: true })
                 chatState.WasQuiet = true;
             else if (raw != null && chatState.WasQuiet) {
@@ -435,7 +397,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 chatState.StaleVisibility = null;
                 // The fold boundary only ever advances, so the one the last session left behind would
                 // fold the restart's first entries into the card the moment they arrive.
-                chatState.State.Value = LiveBlockState.None;
+                foldEndLid = 0;
             }
 
             chatState.WasAttending |= isJoined;
@@ -446,13 +408,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
             else if (raw != null)
                 chatState.IsClosed = false;
 
-            var state = chatState.State.Value with { WasAttending = chatState.WasAttending };
-
-            // A tier-1 (never-summarized) close leaves no card behind. DeriveOverlay dissolves the
-            // block immediately (synchronously) so the animation actually starts; the governor only
-            // arms the window and flips DissolveDone once it passes, dropping the block to plain
-            // messages. The state's IsDissolving mirror is just the signal that re-invalidates
-            // GetBlockState when the window ends.
+            // DeriveBlock exposes dissolve immediately; the governor owns its expiry.
             var isTierOneClose = raw == null && chatState.WasAttending
                 && chatState.Template is { HadSummary: false };
             if (isTierOneClose) {
@@ -465,7 +421,6 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 if (!chatState.DissolveDone)
                     wakeAt = chatState.DissolveEndsAt;
             }
-            state = state with { IsDissolving = isTierOneClose && !chatState.DissolveDone };
 
             if (raw is { IsLatched: true }) {
                 var v = raw.VisibleStartLid;
@@ -485,8 +440,8 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                 var minVisibleLid = isVisibilityUsable
                     ? visibility.VisibleMessageLids.Where(lid => lid >= v).DefaultIfEmpty(0).Min()
                     : 0;
-                var oldBoundary = state.FoldBoundaryLid;
-                var boundaryLid = LiveFoldMath.Advance(
+                var oldBoundary = foldEndLid;
+                foldEndLid = LiveFoldMath.Advance(
                     oldBoundary, minVisibleLid, streamingFloorLid, tailFloorLid);
                 // A reveal is a temporary peek. Latch that the reader scrolled up into the revealed region
                 // (above the governed boundary); once they scroll back down so every revealed row is above
@@ -500,18 +455,19 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
                     else if (chatState.RevealScrolledInto && minVisibleLid >= oldBoundary) {
                         chatState.RevealedBoundaryLid = long.MaxValue;
                         chatState.RevealScrolledInto = false;
-                        clearedReveal = true;
                     }
                 }
-                state = new LiveBlockState(boundaryLid, null, chatState.WasAttending);
             }
 
-            if (!Equals(chatState.State.Value, state))
-                chatState.State.Value = state;
+            // Publish the fold last, so its notification sees all private changes. Unchanged folds
+            // need explicit invalidation for reveal or lifecycle changes.
+            mustInvalidate = foldEndLid == chatState.FoldEndLid.Value
+                && !Equals(oldBlock, DeriveBlock(chatId, chatState, raw));
+            chatState.FoldEndLid.Value = foldEndLid;
         }
-        if (clearedReveal)
+        if (mustInvalidate)
             using (Invalidation.Begin())
-                _ = GetBlockState(chatId, default);
+                _ = GetBlock(chatId, default);
         return wakeAt;
     }
 
@@ -528,10 +484,10 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
         using (Invalidation.Begin())
             foreach (var chatId in removed)
-                _ = GetBlockState(chatId, default);
+                _ = GetBlock(chatId, default);
     }
 
-    private async Task<long> GetFloorLid(ChatId chatId, LiveBlockSnapshot raw, CancellationToken cancellationToken)
+    private async Task<long> GetFloorLid(ChatId chatId, LiveBlockState raw, CancellationToken cancellationToken)
     {
         var ownAuthor = await Authors.GetOwn(Session, chatId, cancellationToken).ConfigureAwait(false);
         var streamingTail = await Hub.ChatUI
@@ -542,7 +498,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
         return Math.Min(StreamingFloorOf(raw, streamingTail.FloorLid), tailFloorLid);
     }
 
-    private static long StreamingFloorOf(LiveBlockSnapshot? raw, long rawStreamingFloorLid)
+    private static long StreamingFloorOf(LiveBlockState? raw, long rawStreamingFloorLid)
         // A transcript that started before the block latched isn't the block's to hold open.
         => raw is { IsLatched: true } && rawStreamingFloorLid >= raw.VisibleStartLid
             ? rawStreamingFloorLid
@@ -552,24 +508,23 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
     private sealed class ChatFoldState
     {
-        public MutableState<LiveBlockState> State = null!;
+        public MutableState<long> FoldEndLid = null!;
         public bool WasAttending;
         public bool IsClosed;
         public bool WasQuiet;
         public Moment DissolveEndsAt;
         public bool DissolveDone;
-        public FrozenTemplate? Template;
+        public LiveBlockTemplate? Template;
         public long RevealedBoundaryLid = long.MaxValue;
         public bool RevealScrolledInto;
         public bool WasBlockExpanded;
         public ChatViewItemVisibility? StaleVisibility;
     }
 
-    private sealed record FrozenTemplate(
-        long V,
-        long TailStart,
-        long BlockEndLid,
-        ConversationId LiveRenderId,
+    private sealed record LiveBlockTemplate(
+        long ChatEndLid,
+        long SummaryEndLid,
+        ConversationId ConversationId,
         ConversationId MaterializedId,
         bool IsExpandedByDefault,
         bool HadSummary,
@@ -577,7 +532,7 @@ public class LiveBlockUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), IComputeSe
 
     protected sealed record GovernorInputs(
         ChatId? ChatId,
-        LiveBlockSnapshot? Raw,
+        LiveBlockState? Raw,
         ChatViewItemVisibility Visibility,
         bool IsJoined,
         bool IsBlockExpanded,

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -27,7 +27,7 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
 
     private readonly ConcurrentDictionary<ChatId, CancellationTokenSource> _callWatches = new();
     private readonly ConcurrentDictionary<ChatId, Conversation?> _lastConversations = new();
-    private readonly ConcurrentDictionary<ChatId, LiveBlockSnapshot?> _lastBlockSnapshots = new();
+    private readonly ConcurrentDictionary<ChatId, LiveBlockState?> _lastBlockStates = new();
     private readonly Lock _ringbackLock = new();
     private object? _ringbackOwner;
 
@@ -51,14 +51,14 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     }
 
     [ComputeMethod(ConsolidationDelay = 0)]
-    public virtual async Task<LiveBlockSnapshot?> GetBlockSnapshot(ChatId chatId, CancellationToken cancellationToken)
+    public virtual async Task<LiveBlockState?> GetBlockState(ChatId chatId, CancellationToken cancellationToken)
     {
         // Consolidated at the SOURCE deliberately: everything downstream of AmIInLiveConversation has to
         // stay immediately reactive, so the churn has to be absorbed here rather than on their outputs.
         var state = await LiveSessions.GetState(Session, chatId, cancellationToken).ConfigureAwait(false);
-        return _lastBlockSnapshots[chatId] = state is null
+        return _lastBlockStates[chatId] = state is null
             ? null
-            : new LiveBlockSnapshot(
+            : new LiveBlockState(
                 state.SessionStartedAt is not null,
                 state.EffectiveVisibleStartLid,
                 state.ContextStartLid,
@@ -71,8 +71,8 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     public Task<Conversation?> UseConversationOrLastKnown(ChatId chatId, Task<Conversation?> conversationTask)
         => UseOrLastKnown(_lastConversations, chatId, conversationTask);
 
-    public Task<LiveBlockSnapshot?> UseSnapshotOrLastKnown(ChatId chatId, Task<LiveBlockSnapshot?> snapshotTask)
-        => UseOrLastKnown(_lastBlockSnapshots, chatId, snapshotTask);
+    public Task<LiveBlockState?> UseBlockStateOrLastKnown(ChatId chatId, Task<LiveBlockState?> blockStateTask)
+        => UseOrLastKnown(_lastBlockStates, chatId, blockStateTask);
 
     [ComputeMethod]
     public virtual Task<LiveSessionState?> GetState(ChatId chatId, CancellationToken cancellationToken)
@@ -262,8 +262,8 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
     // Protected/internal methods
 
     // It's internal to be accessible from tests
-    internal LiveBlockSnapshot? GetLastKnownBlockSnapshot(ChatId chatId)
-        => _lastBlockSnapshots.GetValueOrDefault(chatId);
+    internal LiveBlockState? GetLastKnownBlockState(ChatId chatId)
+        => _lastBlockStates.GetValueOrDefault(chatId);
 
     [ComputeMethod]
     protected virtual async Task<ChatId?> GetMutedRecordingChat(CancellationToken cancellationToken)
@@ -449,7 +449,7 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
 /// <see cref="LiveSessionState"/> - participants, rules, ring state, activity - can churn without
 /// invalidating them.
 /// </summary>
-public sealed record LiveBlockSnapshot(
+public sealed record LiveBlockState(
     bool IsLatched,
     long VisibleStartLid,
     long ContextStartLid,

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveBlockProjectionDelayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveBlockProjectionDelayTest.cs
@@ -1,0 +1,116 @@
+using ActualChat.Hashing;
+using ActualChat.Live;
+using ActualChat.Streaming;
+using ActualChat.Testing.Host;
+using ActualChat.UI.Blazor.App.Components;
+using ActualChat.UI.Blazor.App.Services;
+using Bunit;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
+
+public sealed class LiveBlockProjectionDelayTest(ITestOutputHelper @out)
+    : AppHostTestBase("live-block-projection-delay", @out)
+{
+    [Fact]
+    public async Task ConversationShouldKeepLivePresentationBeforeBlockStateArrives()
+    {
+        // arrange
+        await using var appHost = await NewAppHost(o => o with {
+            ConfigureServices = (_, services) =>
+                services.AddFusion().AddService<LiveSessionUI, DelayedLiveSessionUI>(ServiceLifetime.Scoped),
+        });
+        await using var tester = appHost.NewBlazorTester(Out);
+        await tester.SignInAsUniqueBob().WaitAsync(TimeSpan.FromSeconds(5));
+        var (chat, _) = await tester.CreateAndGetChat(true, "pending-live-block-state-test")
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await ComputedTest.When(async ct => {
+            var range = await tester.Chats.GetIdRange(tester.Session, chat.Id, ct);
+            range.Start.Should().BePositive();
+        }, TimeSpan.FromSeconds(10));
+        var author = (await tester.GetOwnAuthor(chat.Id)).Require();
+        var liveBackend = appHost.Services.GetRequiredService<ILiveSessionsBackend>();
+        await liveBackend.OnStreamRegistered(chat.Id, author.Id, null, true, true, CancellationToken.None);
+        await liveBackend.OnStreamRegistered(chat.Id, AuthorId.New(chat.Id, 777_080),
+            null, true, true, CancellationToken.None);
+        var entry = await tester.CreateTextEntry(chat.Id, "live tail");
+        await liveBackend.UpdateSummary(chat.Id, new LiveSessionSummary {
+            Title = "Recap", Description = "d", Summary = "s", EndEntryLid = entry.LocalId, MessageCount = 1,
+        }, CancellationToken.None);
+        var liveSessionUI = (DelayedLiveSessionUI)tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+        var liveBlockUI = tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        Conversation live = null!;
+        await ComputedTest.When(async ct => {
+            live = (await liveSessionUI.GetConversation(chat.Id, ct)).Require();
+        }, TimeSpan.FromSeconds(5));
+        var chatAudioUI = tester.ScopedAppServices.GetRequiredService<ChatAudioUI>();
+        var chatUI = tester.ScopedAppServices.GetRequiredService<ChatUI>();
+        await chatAudioUI.SetListeningState(chat.Id, true);
+        using (Invalidation.Begin())
+            _ = chatAudioUI.GetState(chat.Id);
+        chatUI.SelectChatOnNavigation(chat.Id);
+        var idRange = await tester.Chats.GetIdRange(tester.Session, chat.Id, CancellationToken.None);
+        var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
+        var sendingMessages = tester.ScopedAppServices.GetRequiredService<SendingMessages>();
+        var pending = sendingMessages.GetSendingMessages(chat.Id).ChatSendingMessages;
+        pending.AddSendingMessage(new SendingMessage(
+            Guid.NewGuid().ToString(), "", chat.Id, null, tester.AppServices.Clocks().SystemClock.Now,
+            "pending tail", HashString.None, null, () => { }));
+
+        await ComputedTest.When(async ct => {
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeTrue();
+
+            // act
+            var liveBlock = await liveBlockUI.GetBlock(chat.Id, ct);
+            var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
+
+            // assert
+            liveBlock.Should().BeOfType<OpenLiveBlock>()
+                .Which.Should().Be(new OpenLiveBlock(live.Id, true, 0));
+            var block = items.Items.OfType<ExpandedConversationMessage>().Should().ContainSingle().Subject;
+            block.Items.OfType<LiveConversationHeader>().Should().ContainSingle();
+            block.Items.SelectMany(i => i.GetLeafMessages()).OfType<ChatEntryMessage>()
+                .Should().Contain(m => m.Id == idRange.End && m.Entry.SendingTag != null);
+            block.Items[^1].Should().BeOfType<LiveConversationFooter>();
+        }, TimeSpan.FromSeconds(5));
+        tester.Renderer.SetRendererInfo(new RendererInfo("Server", true));
+        var chatContext = new ChatContext(tester.ScopedAppServices.GetRequiredService<AppUIHub>(), chat);
+        var card = tester.Render<ConversationMessageView>(p => p
+            .Add(x => x.Message, new ConversationMessage(live))
+            .Add(x => x.ChatContext, chatContext));
+        card.WaitForAssertion(() => card.FindAll(".conversation-message.live.joined").Should().ContainSingle());
+        var header = tester.Render<LiveConversationHeaderView>(p => p
+            .Add(x => x.Header, new LiveConversationHeader(live))
+            .Add(x => x.ChatContext, chatContext));
+        header.WaitForAssertion(() => header.FindAll(".c-lc-expand").Should().ContainSingle());
+
+        // act
+        liveSessionUI.IsBlockStateDelayed.Value = false;
+        await ComputedTest.When(async ct => {
+            (await liveSessionUI.GetBlockState(chat.Id, ct)).Should().NotBeNull();
+            (await liveBlockUI.GetBlock(chat.Id, ct)).Should().BeOfType<OpenLiveBlock>()
+                .Which.HasAttended.Should().BeTrue();
+        }, TimeSpan.FromSeconds(5));
+        await chatAudioUI.SetListeningState(chat.Id, false);
+        using (Invalidation.Begin())
+            _ = chatAudioUI.GetState(chat.Id);
+
+        // assert
+        await ComputedTest.When(async ct => {
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            (await liveBlockUI.GetBlock(chat.Id, ct)).Should().BeOfType<OpenLiveBlock>()
+                .Which.HasAttended.Should().BeTrue();
+        }, TimeSpan.FromSeconds(5));
+        card.WaitForAssertion(() => card.FindAll(".conversation-message.live.joined").Should().ContainSingle());
+    }
+
+    public class DelayedLiveSessionUI(AppUIHub hub) : LiveSessionUI(hub)
+    {
+        public MutableState<bool> IsBlockStateDelayed { get; } = hub.StateFactory.NewMutable(true);
+
+        public override async Task<LiveBlockState?> GetBlockState(ChatId chatId, CancellationToken cancellationToken)
+            => await IsBlockStateDelayed.Use(cancellationToken)
+                ? null
+                : await base.GetBlockState(chatId, cancellationToken);
+    }
+}

--- a/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/LiveConversationDisplayTest.cs
@@ -5,6 +5,7 @@ using ActualChat.Streaming;
 using ActualChat.Testing.Host;
 using ActualChat.UI.Blazor.App.Components;
 using ActualChat.UI.Blazor.App.Services;
+using ActualLab.Fusion.Blazor;
 using Bunit;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -49,10 +50,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             await chatAudioUI.SetListeningState(chat.Id, false);
             InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
             await ComputedTest.When(async ct => {
-                var overlay = (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay;
-                overlay.Should().NotBeNull();
-                overlay!.MaterializedId.Should().BeNull();
-                overlay.BlockEndLid.Should().Be(long.MaxValue);
+                var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+                (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+                var block = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+                block.Should().BeOfType<OpenLiveBlock>();
+                block.HasAttended.Should().BeTrue();
             }, TimeSpan.FromSeconds(10));
         }
 
@@ -78,10 +80,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             await ComputedTest.When(async ct => {
                 var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
                 if (mustLeave) {
-                    var overlay = (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay;
-                    overlay.Should().NotBeNull();
-                    overlay!.MaterializedId.Should().BeNull();
-                    overlay.BlockEndLid.Should().Be(long.MaxValue);
+                    var openBlock = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+                    openBlock.Should().BeOfType<OpenLiveBlock>();
+                    openBlock.HasAttended.Should().BeTrue();
                 }
 
                 var block = items.Items.OfType<ExpandedConversationMessage>()
@@ -266,11 +267,12 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // act
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        var blockState = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
+        var blockState = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
 
         // assert
-        blockState.FoldBoundaryLid.Should().Be(v + 3);
-        blockState.Overlay.Should().BeNull();
+        blockState.FoldEndLid.Should().Be(v + 3);
+        blockState.Should().BeOfType<OpenLiveBlock>();
+        blockState.HasAttended.Should().BeFalse();
     }
 
     [Fact]
@@ -317,11 +319,14 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await chatAudioUI.SetListeningState(chat.Id, false);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
 
-        // assert - wait for the governor to actually latch the leave overlay, not just for a render
+        // assert - wait for attendance to be retained after leaving, not just for a render
         // that still coincidentally looks unchanged before the leave propagates
         await ComputedTest.When(async ct => {
-            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
-            blockState.Overlay.Should().NotBeNull();
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var blockState = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            blockState.Should().BeOfType<OpenLiveBlock>();
+            blockState.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
         await ComputedTest.When(async ct => {
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
@@ -469,11 +474,14 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await chatAudioUI.SetListeningState(chat.Id, false);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
-        // Wait for the governor to actually latch the leave overlay - a render that still
+        // Wait for attendance to be retained after leaving - a render that still
         // coincidentally looks unchanged before the leave propagates would snapshot too early.
         await ComputedTest.When(async ct => {
-            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
-            blockState.Overlay.Should().NotBeNull();
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var blockState = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            blockState.Should().BeOfType<OpenLiveBlock>();
+            blockState.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
         List<long> frozenLeafLids = null!;
         await ComputedTest.When(async ct => {
@@ -657,8 +665,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     [Fact]
     public async Task ToggleAfterCloseCollapsesBlock()
     {
-        // Once closed, the reader can still manually collapse the frozen block - it just dismisses
-        // the overlay rather than acting as an ordinary expand/collapse toggle.
+        // Dismissing a retained closed block must also collapse its materialized conversation.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -702,11 +709,16 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             var block = items.Items.OfType<ExpandedConversationMessage>().Single();
             blockConversationId = block.Conversation!.Id;
         }, TimeSpan.FromSeconds(15));
+        var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
+        var closedBlock = await Computed.Capture(() => liveBlockUI.GetBlock(chat.Id, CancellationToken.None));
+        closedBlock.Value.Should().BeOfType<ClosedLiveBlock>();
 
         // act
         chatUI.ToggleExpandConversation(blockConversationId);
 
         // assert
+        closedBlock.IsConsistent().Should().BeFalse("dismissal changes the block even when its fold does not move");
+        (await liveBlockUI.GetBlock(chat.Id)).Should().BeNull();
         await ComputedTest.When(async ct => {
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
             items.Items.OfType<ExpandedConversationMessage>().Should().BeEmpty();
@@ -715,9 +727,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task ToggleAfterOverlayDismissExpandsBlockAgain()
+    public async Task ToggleAfterClosedBlockDismissExpandsBlockAgain()
     {
-        // The first toggle on a closed block dismisses the frozen overlay; every toggle after that
+        // The first toggle dismisses the retained closed block; every toggle after that
         // must act as an ordinary expand/collapse - a dead expand button here is a regression.
 
         // arrange
@@ -763,7 +775,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             blockConversationId = block.Conversation!.Id;
         }, TimeSpan.FromSeconds(15));
 
-        // act - first toggle dismisses the overlay and collapses the materialized block
+        // act - dismiss the retained block and collapse its materialized conversation
         chatUI.ToggleExpandConversation(blockConversationId);
         ConversationId materializedId = null!;
         await ComputedTest.When(async ct => {
@@ -868,12 +880,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task LeaveFreezesReactivelyWithoutWaitingForGovernor()
+    public async Task LeaveInvalidatesBlockWithoutWaitingForGovernor()
     {
-        // Determinism: the freeze must be a reactive function of "am I still attending this block",
-        // not an async governor write that lands a beat later - otherwise a hang-up can flash a
-        // collapsed frame before the overlay latches. Prove GetBlockState goes stale from the leave
-        // signal alone, before the governor has had a turn to write anything.
+        // Leaving must invalidate GetBlock directly, without relying on a later governor write.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -901,15 +910,16 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await chatAudioUI.SetListeningState(chat.Id, true);
         chatUI.SelectChatOnNavigation(chat.Id);
-        // Let the governor latch the joined state and the attending latch first.
+        // Establish attendance before leaving.
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.Overlay.Should().BeNull();
-            s.WasAttending.Should().BeTrue();
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.Should().BeOfType<OpenLiveBlock>();
+            s.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
 
-        var computed = await Computed.Capture(() => liveBlockUI.GetBlockState(chat.Id, CancellationToken.None));
-        computed.Value.Overlay.Should().BeNull();
+        var computed = await Computed.Capture(() => liveBlockUI.GetBlock(chat.Id, CancellationToken.None));
+        computed.Value.Should().BeOfType<OpenLiveBlock>();
+        computed.Value!.HasAttended.Should().BeTrue();
 
         // act - hang up, then invalidate the leave signal source synchronously. The governor loop
         // reacts to the same invalidation, but only asynchronously; we do NOT yield to it before the
@@ -918,18 +928,19 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         using (Invalidation.Begin())
             _ = chatAudioUI.GetState(chat.Id);
 
-        // assert - GetBlockState is already stale purely from the leave signal (it depends on it
-        // reactively). Checked synchronously: the governor cannot have run yet. This is the actual
-        // determinism guarantee - the freeze reacts to leaving directly, not via the governor's write.
+        // Assert immediately, without another await that would let the governor catch up.
         computed.IsConsistent().Should().BeFalse(
-            "the freeze must react to leaving directly, not wait for the governor's async write");
+            "the block must react to leaving directly, not wait for the governor's async write");
 
-        // and the recomputed state carries the freeze overlay (re-invalidate each poll to defeat the
+        // The recomputed open block retains attendance (re-invalidate each poll to defeat the
         // non-reactive ChatAudioUI.GetState lag - see InvalidateAmIInLiveConversation).
         await ComputedTest.When(async ct => {
             InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.Overlay.Should().NotBeNull();
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.Should().BeOfType<OpenLiveBlock>();
+            s.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
     }
 
@@ -1315,8 +1326,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         chatUI.SelectChatOnNavigation(chat.Id);
         // Let the governor latch WasAttending + the template (HadSummary == false).
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.WasAttending.Should().BeTrue();
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.Should().BeOfType<OpenLiveBlock>();
+            s.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
 
         await AwaitJoinedBlockExpansion(chatUI, chat.Id, live!.ToConversation());
@@ -1331,7 +1343,14 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             .Add(x => x.Header, beforeBlock.Items.OfType<LiveConversationHeader>().Single())
             .Add(x => x.ChatContext, new ChatContext(
                 Tester.ScopedAppServices.GetRequiredService<AppUIHub>(), chat)));
-        header.WaitForAssertion(() => header.Find(".c-lc-name").TextContent.Should().NotBeNullOrEmpty());
+        var headerState = ((IStatefulComponent<LiveConversationHeaderState>)header.Instance).State;
+        header.WaitForAssertion(() => {
+            // The initial placeholder is not the participant title this test must preserve on close.
+            headerState.IsInitial(out var state).Should().BeFalse();
+            var title = state.Title.NullIfEmpty() ?? state.ParticipantsText;
+            title.Should().NotBeNullOrEmpty();
+            header.Find(".c-lc-name").TextContent.Should().Be(title);
+        });
         var beforeTitle = header.Find(".c-lc-name").TextContent;
 
         // act - tier-1 close (never summarized)
@@ -1341,11 +1360,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // assert - the block is held, dissolving, rather than dropping to null immediately
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.Overlay.Should().NotBeNull("a tier-1 close dissolves the block before removing it");
-            s.Overlay!.IsDissolving.Should().BeTrue();
-            s.Overlay.MaterializedId.Should().BeNull();
-            s.Overlay.BlockEndLid.Should().BeLessThan(long.MaxValue);
+            var block = (await liveBlockUI.GetBlock(chat.Id, ct)) as ClosedLiveBlock;
+            block.Should().NotBeNull("a tier-1 close dissolves the block before removing it");
+            block!.IsDissolving.Should().BeTrue();
+            block.MaterializedId.Should().BeNull();
+            block.EndLid.Should().BeLessThan(long.MaxValue);
             (await liveSessionUI.GetConversation(chat.Id, ct)).Should().BeNull();
         }, TimeSpan.FromSeconds(3));
         if (mustSkipTile)
@@ -1357,17 +1376,17 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var expectedLids = LeafEntryLids(before).Append(afterClose.LocalId).ToList();
         for (var sample = 0; sample < 10; sample++) {
             await Task.Delay(TimeSpan.FromMilliseconds(50));
-            var overlay = (await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None)).Overlay;
-            overlay.Should().NotBeNull();
-            overlay!.IsDissolving.Should().BeTrue();
-            overlay.MaterializedId.Should().BeNull();
-            overlay.BlockEndLid.Should().BeLessThan(long.MaxValue);
+            var closedBlock = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)) as ClosedLiveBlock;
+            closedBlock.Should().NotBeNull();
+            closedBlock!.IsDissolving.Should().BeTrue();
+            closedBlock.MaterializedId.Should().BeNull();
+            closedBlock.EndLid.Should().BeLessThan(long.MaxValue);
             var items = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None)
                 .WaitAsync(TimeSpan.FromSeconds(5));
             LeafEntryLids(items).Should().Equal(expectedLids);
             var block = items.Items.OfType<ExpandedConversationMessage>()
                 .Should().ContainSingle(
-                    $"sample {sample}, overlay {overlay}: the header must remain to dissolve: " + Dump(items))
+                    $"sample {sample}, block {closedBlock}: the header must remain to dissolve: " + Dump(items))
                 .Subject;
             ((IVirtualListItem)block).RenderKey.Should().Be(((IVirtualListItem)beforeBlock).RenderKey);
             block.Items.OfType<LiveConversationHeader>().Should().ContainSingle();
@@ -1380,7 +1399,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             });
         }
         await ComputedTest.When(async ct => {
-            (await liveBlockUI.GetBlockState(chat.Id, ct)).Overlay.Should().BeNull();
+            (await liveBlockUI.GetBlock(chat.Id, ct)).Should().BeNull();
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct).WaitAsync(TimeSpan.FromSeconds(5));
             items.Items.OfType<ExpandedConversationMessage>().Should().BeEmpty();
             LeafEntryLids(items).Should().Equal(expectedLids);
@@ -1613,8 +1632,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // top, so un-summarised rows above it are swallowed too
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await ComputedTest.When(async ct => {
-            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
-            blockState.FoldBoundaryLid.Should().BeGreaterThanOrEqualTo(viewportTop,
+            var blockState = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            blockState.FoldEndLid.Should().BeGreaterThanOrEqualTo(viewportTop,
                 "the boundary tracks the viewport top, folding un-summarised rows above it");
         }, TimeSpan.FromSeconds(15));
 
@@ -1731,8 +1750,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await ComputedTest.When(async ct => {
             var streamingTail = await chatUI.GetStreamingTail(chat.Id, author.Id, ct);
             streamingTail.FloorLid.Should().Be(streamingLid);
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().BeLessThanOrEqualTo(streamingLid,
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeLessThanOrEqualTo(streamingLid,
                 "a still-transcribing entry must stay outside the fold");
         }, TimeSpan.FromSeconds(15));
 
@@ -1745,8 +1764,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await ComputedTest.When(async ct => {
             var streamingTail = await chatUI.GetStreamingTail(chat.Id, author.Id, ct);
             streamingTail.FloorLid.Should().Be(long.MaxValue);
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().BeGreaterThan(streamingLid,
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeGreaterThan(streamingLid,
                 "closing the transcript releases the fold");
         }, TimeSpan.FromSeconds(15));
     }
@@ -1799,8 +1818,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var idRange = await Tester.Chats.GetIdRange(Tester.Session, chat.Id, CancellationToken.None);
         SetViewportTop(idRange.End - 1);
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().Be(streamingLid, "the streaming entry is what stops the fold");
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().Be(streamingLid, "the streaming entry is what stops the fold");
         }, TimeSpan.FromSeconds(15));
 
         // act - the reader scrolls back up onto the streaming entry, and that render is the baseline
@@ -1808,8 +1827,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var query = new ChatDataQuery(idRange, -chatUI.HalfLoadLimit, chatUI.HalfLoadLimit);
         List<long> beforeLeaveLids = null!;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().Be(streamingLid, "the streaming entry still stops the fold");
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().Be(streamingLid, "the streaming entry still stops the fold");
             beforeLeaveLids = LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, ct));
         }, TimeSpan.FromSeconds(15));
 
@@ -1817,8 +1836,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await chatAudioUI.SetListeningState(chat.Id, false);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.Overlay.Should().NotBeNull("the overlay is what marks this viewer as having been there");
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.Should().BeOfType<OpenLiveBlock>();
+            s.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
 
         // assert - leaving is only "stop listening": same fold, same rows
@@ -1835,8 +1857,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         // assert - the lapse may only let the fold reach the viewport top, which is the streaming row
         // itself, so nothing the reader had is swallowed
         await Task.Delay(500);
-        var afterLapse = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
-        afterLapse.FoldBoundaryLid.Should().BeLessThanOrEqualTo(streamingLid,
+        var afterLapse = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
+        afterLapse.FoldEndLid.Should().BeLessThanOrEqualTo(streamingLid,
             "a lapsing floor must not push the fold past the reader's viewport top");
         LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None))
             .Should().Equal(beforeLeaveLids, "closing the transcript must not re-fold the block");
@@ -1882,9 +1904,9 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         long foldedBoundary = 0;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
-            foldedBoundary = s.FoldBoundaryLid;
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeGreaterThan(v + 5);
+            foldedBoundary = s.FoldEndLid;
         }, TimeSpan.FromSeconds(15));
 
         // act - reveal one batch
@@ -1892,22 +1914,22 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // assert - the effective fold boundary retreats below where the governor had it
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            Math.Min(s.FoldBoundaryLid, s.RevealedBoundaryLid).Should().BeLessThan(foldedBoundary,
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeLessThan(foldedBoundary,
                 "revealing a batch retreats the effective fold boundary");
         }, TimeSpan.FromSeconds(10));
 
         // assert - it survives a further governor advance (viewport unchanged, so nothing pushes it back up)
         await Task.Delay(500);
-        var afterReveal = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
-        Math.Min(afterReveal.FoldBoundaryLid, afterReveal.RevealedBoundaryLid).Should().BeLessThan(foldedBoundary,
+        var afterReveal = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
+        afterReveal.FoldEndLid.Should().BeLessThan(foldedBoundary,
             "the revealed boundary persists across governor re-evaluation");
 
         // act - reset clears the reveal
         liveBlockUI.ResetReveal(chat.Id);
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.RevealedBoundaryLid.Should().Be(long.MaxValue, "reset clears the reveal");
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeGreaterThanOrEqualTo(foldedBoundary, "reset restores the governed fold");
         }, TimeSpan.FromSeconds(10));
     }
 
@@ -1954,42 +1976,40 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         SetViewportTop(tailTop);
         long boundary = 0;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
-            boundary = s.FoldBoundaryLid;
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeGreaterThan(v + 5);
+            boundary = s.FoldEndLid;
         }, TimeSpan.FromSeconds(15));
 
         // reveal a batch
         await liveBlockUI.RevealMore(chat.Id);
         long revealed = 0;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.RevealedBoundaryLid.Should().BeLessThan(boundary, "reveal retreats below the boundary");
-            revealed = s.RevealedBoundaryLid;
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeLessThan(boundary, "reveal retreats below the boundary");
+            revealed = s.FoldEndLid;
         }, TimeSpan.FromSeconds(10));
 
         // scroll UP into the revealed region: the reveal must persist (only the latch flips here)
         SetViewportTop(revealed);
         await Task.Delay(500);
-        var whileReading = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
-        whileReading.RevealedBoundaryLid.Should().Be(revealed,
+        var whileReading = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
+        whileReading.FoldEndLid.Should().Be(revealed,
             "the reveal persists while the reader is inside the revealed region");
 
-        // scroll back DOWN to the live tail: every revealed row is now above the viewport -> re-swallow
-        SetViewportTop(tailTop);
+        // Reset the reveal without advancing the governed fold, which cannot notify consumers itself.
+        SetViewportTop(boundary);
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.RevealedBoundaryLid.Should().Be(long.MaxValue,
-                "returning to the live tail re-swallows the revealed batch");
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().Be(boundary,
+                "returning to the governed boundary re-swallows the revealed batch without moving the fold");
         }, TimeSpan.FromSeconds(10));
     }
 
     [Fact]
-    public async Task RevealMoreSurvivesLeaveFreeze()
+    public async Task RevealMoreSurvivesLeaving()
     {
-        // §7 cross-task fix: a revealed batch must survive the freeze on leave/close - DeriveOverlay
-        // must use the reveal-aware effective boundary, not the raw monotonic FoldBoundaryLid, or
-        // leaving re-folds the rows the reader just revealed (a content shrink right under them).
+        // Leaving must not fold away the rows the reader just revealed.
 
         // arrange
         await Tester.SignInAsUniqueBob();
@@ -2005,7 +2025,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             Title = "Recap", Description = "d", Summary = "s", EndEntryLid = v, MessageCount = 1,
         }, CancellationToken.None);
         // Enough that one reveal batch leaves rows still folded: revealing the whole backlog would
-        // collapse FoldRange to the empty range, and the freeze would have nothing to preserve.
+        // empty FoldRange, leaving no folded boundary to compare after leaving.
         for (var i = 0; i < 40; i++)
             await Tester.CreateTextEntry(chat.Id, $"m-{i}");
 
@@ -2027,31 +2047,33 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         long foldedBoundary = 0;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.FoldBoundaryLid.Should().BeGreaterThan(v + 5);
-            foldedBoundary = s.FoldBoundaryLid;
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.FoldEndLid.Should().BeGreaterThan(v + 5);
+            foldedBoundary = s.FoldEndLid;
         }, TimeSpan.FromSeconds(15));
 
         // act - reveal one batch, retreating the effective boundary below the raw governed one
         await liveBlockUI.RevealMore(chat.Id);
         long revealedEffectiveBoundary = 0;
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            revealedEffectiveBoundary = Math.Min(s.FoldBoundaryLid, s.RevealedBoundaryLid);
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            revealedEffectiveBoundary = s.FoldEndLid;
             revealedEffectiveBoundary.Should().BeLessThan(foldedBoundary);
         }, TimeSpan.FromSeconds(10));
 
-        // act - leave: hang up, which freezes the block via the overlay
+        // act - leave while the session continues
         await chatAudioUI.SetListeningState(chat.Id, false);
         InvalidateAmIInLiveConversation(chatAudioUI, chat.Id);
 
-        // assert - the frozen overlay's FoldRange must end at the reveal-aware effective boundary,
-        // not the full monotonic FoldBoundaryLid the governor had reached before the reveal
+        // assert - leaving preserves the effective boundary established by the reveal
         await ComputedTest.When(async ct => {
-            var s = await liveBlockUI.GetBlockState(chat.Id, ct);
-            s.Overlay.Should().NotBeNull();
-            s.Overlay!.FoldRange.End.Should().Be(revealedEffectiveBoundary,
-                "the freeze must preserve what the reader had revealed, not re-fold it back under them");
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var s = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            s.Should().BeOfType<OpenLiveBlock>();
+            s.HasAttended.Should().BeTrue();
+            s.FoldRange.End.Should().Be(revealedEffectiveBoundary,
+                "leaving must preserve what the reader had revealed, not re-fold it back under them");
         }, TimeSpan.FromSeconds(10));
     }
 
@@ -2130,7 +2152,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
     }
 
     [Fact]
-    public async Task ShouldRememberTheLastKnownBlockSnapshot()
+    public async Task ShouldRememberTheLastKnownBlockState()
     {
         // The stand-in a non-waiting caller falls back to: if it stays empty, the live block would
         // collapse to "no session" on every rebuild that outruns the remote read.
@@ -2146,12 +2168,12 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
 
         // act
-        var snapshot = await liveSessionUI.GetBlockSnapshot(chat.Id, CancellationToken.None);
+        var snapshot = await liveSessionUI.GetBlockState(chat.Id, CancellationToken.None);
 
         // assert
         snapshot.Should().NotBeNull();
         snapshot!.IsLatched.Should().BeTrue("two registered streams latch the session");
-        liveSessionUI.GetLastKnownBlockSnapshot(chat.Id)
+        liveSessionUI.GetLastKnownBlockState(chat.Id)
             .Should().Be(snapshot, "the computed read must leave a stand-in behind");
     }
 
@@ -2201,18 +2223,26 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await liveBackend.SetParticipation(chat.Id, author.Id, ParticipationKind.Record, false, CancellationToken.None);
         var liveBlockUI = Tester.ScopedAppServices.GetRequiredService<LiveBlockUI>();
         await ComputedTest.When(async ct => {
-            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
-            blockState.Overlay.Should().NotBeNull();
+            var liveSessionUI = Tester.ScopedAppServices.GetRequiredService<LiveSessionUI>();
+            (await liveSessionUI.AmIInLiveConversation(chat.Id, ct)).Should().BeFalse();
+            var blockState = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            blockState.HasAttended.Should().BeTrue();
         }, TimeSpan.FromSeconds(10));
-        var afterStop = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
+        var afterStop = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
         var stateAfterStop = await liveBackend.GetState(chat.Id, CancellationToken.None);
-        Out.WriteLine($"after stop: overlay={Describe(afterStop)}");
-        Out.WriteLine($"after stop: session={(stateAfterStop == null ? "<null>" : $"v={stateAfterStop.EffectiveVisibleStartLid}, isClosing={stateAfterStop.IsClosing}, authors={stateAfterStop.AuthorIds.Count}, end={stateAfterStop.EndEntryLid}")}");
+        Out.WriteLine($"after stop: block={Describe(afterStop)}");
+        Out.WriteLine(stateAfterStop == null
+            ? "after stop: session=<null>"
+            : $"after stop: session=v={stateAfterStop.EffectiveVisibleStartLid}, isClosing={stateAfterStop.IsClosing}, "
+                + $"authors={stateAfterStop.AuthorIds.Count}, end={stateAfterStop.EndEntryLid}");
 
         // act - one of them starts talking again, and says something
         await liveBackend.OnStreamRegistered(chat.Id, peerId, null, true, true, CancellationToken.None);
         var restarted = await liveBackend.GetState(chat.Id, CancellationToken.None);
-        Out.WriteLine($"after restart: session={(restarted == null ? "<null>" : $"v={restarted.EffectiveVisibleStartLid}, isClosing={restarted.IsClosing}, authors={restarted.AuthorIds.Count}, end={restarted.EndEntryLid}")}");
+        Out.WriteLine(restarted == null
+            ? "after restart: session=<null>"
+            : $"after restart: session=v={restarted.EffectiveVisibleStartLid}, isClosing={restarted.IsClosing}, "
+                + $"authors={restarted.AuthorIds.Count}, end={restarted.EndEntryLid}");
         var spoken = new List<ChatEntry>();
         for (var i = 0; i < 3; i++)
             spoken.Add(await CreateSpokenEntry(chat.Id, $"second-{i}"));
@@ -2221,14 +2251,11 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             typed.Add(await Tester.CreateTextEntry(chat.Id, $"typed after restart {i}"));
         await Task.Delay(2000);
 
-        // assert - the block must not still be frozen against the session that ended. A viewer who is
-        // not attending never sees a live block's entries, by design; what they do see is the card's
-        // tail preview, and ConversationMessageView gates that on there being no overlay. Left frozen,
-        // the card shows nothing of what is being said, and its hidden tail runs to long.MaxValue - so
-        // the restart's transcript only surfaces once the conversation ends and materializes.
-        var afterRestart = await liveBlockUI.GetBlockState(chat.Id, CancellationToken.None);
-        Out.WriteLine($"after restart: overlay={Describe(afterRestart)}");
-        afterRestart.Overlay.Should().BeNull();
+        // A viewer who left the old call must see the new call's collapsed card and typed messages.
+        var afterRestart = (await liveBlockUI.GetBlock(chat.Id, CancellationToken.None)).Require();
+        Out.WriteLine($"after restart: block={Describe(afterRestart)}");
+        afterRestart.Should().BeOfType<OpenLiveBlock>();
+        afterRestart.HasAttended.Should().BeFalse();
         var finalItems = await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None);
         var finalLids = LeafEntryLids(finalItems);
         Out.WriteLine($"spoken lids: {string.Join(", ", spoken.Select(e => e.Id.LocalId))}");
@@ -2512,15 +2539,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             EntryIds = [entryId],
         });
 
-    private static string Describe(LiveBlockState? state)
-    {
-        var overlay = state?.Overlay;
-        return overlay == null
-            ? "<null>"
-            : $"renderId={overlay.RenderId}, cardLid={overlay.CardLid}, hiddenTail={overlay.HiddenTailRange}, "
-                + $"foldRange={overlay.FoldRange}, blockEnd={overlay.BlockEndLid}, "
-                + $"materialized={overlay.MaterializedId}, wasAttending={state!.WasAttending}";
-    }
+    private static string Describe(LiveBlock? block) => block?.ToString() ?? "<null>";
 
     [Fact]
     public async Task ExpandedBlockAutoSwallowsAndCollapseIsTheCardOnly()
@@ -2586,8 +2605,8 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         var folded = spoken.Where(l => l < viewportTop).ToList();
         var tail = spoken.Where(l => l >= viewportTop).ToList();
         await ComputedTest.When(async ct => {
-            var blockState = await liveBlockUI.GetBlockState(chat.Id, ct);
-            blockState.FoldBoundaryLid.Should().Be(viewportTop, "the fold tracks the viewport top");
+            var blockState = (await liveBlockUI.GetBlock(chat.Id, ct)).Require();
+            blockState.FoldEndLid.Should().Be(viewportTop, "the fold tracks the viewport top");
             var items = await chatUI.GetChatItems(chat.Id, query, 0, ct);
             var lids = LeafEntryLids(items);
             lids.Should().NotContain(folded, "the expanded block swallows what scrolled above the viewport");
@@ -2626,7 +2645,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
 
         // assert - the card stands in for the rows, so what shows below it says nothing about what the
         // reader scrolled past: the fold holds where the collapse found it
-        (await liveBlockUI.GetBlockState(chat.Id)).FoldBoundaryLid.Should().Be(viewportTop,
+        (await liveBlockUI.GetBlock(chat.Id)).Require().FoldEndLid.Should().Be(viewportTop,
             "a collapsed block must not feed its viewport to the fold");
 
         // act - un-collapse
@@ -2650,7 +2669,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
             lids.Should().Contain(folded, "a reveal must actually show the rows it walked back");
             lids.Should().Contain(tail);
         }, TimeSpan.FromSeconds(15));
-        var revealedBoundaryLid = (await liveBlockUI.GetBlockState(chat.Id)).RevealedBoundaryLid;
+        var revealedBoundaryLid = (await liveBlockUI.GetBlock(chat.Id)).Require().FoldEndLid;
 
         // act - pinned to the live tail: the revealed rows are on screen for a moment, then the stream
         // pushes them above the viewport
@@ -2664,7 +2683,7 @@ public sealed class LiveConversationDisplayTest(ChatAppHostFixture fixture, ITes
         await Task.Delay(700);
 
         // assert - the stream moving is not the reader returning to the tail, so the reveal holds
-        (await liveBlockUI.GetBlockState(chat.Id)).RevealedBoundaryLid.Should().Be(revealedBoundaryLid,
+        (await liveBlockUI.GetBlock(chat.Id)).Require().FoldEndLid.Should().Be(revealedBoundaryLid,
             "a reveal made at the pinned tail must not be re-swallowed by the next messages");
         LeafEntryLids(await chatUI.GetChatItems(chat.Id, query, 0, CancellationToken.None))
             .Should().Contain(folded, "the revealed rows stay revealed while the reader is pinned");

--- a/tests/Chat.UI.Blazor.UnitTests/ChatBlockProjectionTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatBlockProjectionTest.cs
@@ -6,12 +6,14 @@ public sealed class ChatBlockProjectionTest
 {
     private static readonly ChatId TestChatId = ChatId.Parse("the-actual-one");
 
-    [Fact]
-    public void CompletedBlockShouldUseMetadataCoverageAndCollapseAfterItsMessages()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompletedBlockShouldUseMetadataCoverageAndCollapseAfterItsMessages(bool isExpanded)
     {
         // arrange
         var conversation = NewConversation(100, 119);
-        var expanded = ImmutableHashSet.Create(conversation.Id);
+        var expanded = isExpanded ? ImmutableHashSet.Create(conversation.Id) : ImmutableHashSet<ConversationId>.Empty;
         var view = NewView() with { ExpandedConversations = expanded };
 
         // act
@@ -20,9 +22,11 @@ public sealed class ChatBlockProjectionTest
         // assert
         var block = blocks.Should().ContainSingle().Subject;
         block.EntryLidRange.Should().Be(new Range<long>(100, 200));
-        block.IsExpanded.Should().BeTrue();
-        block.IsLive.Should().BeFalse();
-        block.CollapsedAt.Should().BeGreaterThan(conversation.EndsAt);
+        block.IsExpanded.Should().Be(isExpanded);
+        if (isExpanded)
+            block.CollapsedAt.Should().BeNull();
+        else
+            block.CollapsedAt.Should().Be(conversation.EndsAt + TimeSpan.FromTicks(1));
     }
 
     [Fact]
@@ -43,9 +47,8 @@ public sealed class ChatBlockProjectionTest
         blocks.Select(b => b.Id).Should().Equal(preceding.Id, overlapping.Id, live.Id);
         blocks[1].EntryLidRange.Should().Be(new Range<long>(90, 100));
         blocks[2].EntryLidRange.Should().Be(new Range<long>(100, 250));
-        blocks[2].IsLive.Should().BeTrue();
         blocks[2].IsExpanded.Should().BeFalse();
-        blocks[2].CollapsedAt.Should().BeLessThanOrEqualTo(live.StartsAt);
+        blocks[2].CollapsedAt.Should().Be(live.StartsAt);
         var meta = new ChatRangeTile(new(0, 1280), [new(50, 250)],
             [preceding.EntryLidRange, overlapping.EntryLidRange, live.EntryLidRange], 0, null, null);
         ChatUI.TryGetIdTilesToLoad(view, blocks,
@@ -53,8 +56,10 @@ public sealed class ChatBlockProjectionTest
         tiles.Should().Contain(new Range<long>(100, 105));
     }
 
-    [Fact]
-    public void MaterializedBlockShouldKeepItsRenderIdentityAndExpansion()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MaterializedBlockShouldKeepItsRenderIdentityAndExpansion(bool isExpanded)
     {
         // arrange
         var materialized = NewConversation(90, 249);
@@ -62,7 +67,9 @@ public sealed class ChatBlockProjectionTest
         var view = NewView() with {
             LiveBlockConversationId = renderId,
             MaterializedBlockId = materialized.Id,
-            ExpandedConversations = ImmutableHashSet.Create(renderId),
+            ExpandedConversations = isExpanded
+                ? ImmutableHashSet.Create(renderId)
+                : ImmutableHashSet<ConversationId>.Empty,
         };
 
         // act
@@ -72,10 +79,61 @@ public sealed class ChatBlockProjectionTest
         // assert
         var block = blocks.Should().ContainSingle().Subject;
         block.Id.Should().Be(renderId);
-        block.IsLive.Should().BeFalse();
-        block.IsExpanded.Should().BeTrue();
-        block.CollapsedAt.Should().BeGreaterThan(materialized.EndsAt);
+        block.IsExpanded.Should().Be(isExpanded);
+        if (isExpanded)
+            block.CollapsedAt.Should().BeNull();
+        else
+            block.CollapsedAt.Should().Be(materialized.EndsAt + TimeSpan.FromTicks(1));
         block.EntryLidRange.Should().Be(new Range<long>(100, 250));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DissolvingBlockShouldKeepItsEarlyCollapseCutoff(bool isExpanded)
+    {
+        // arrange
+        var conversation = NewConversation(100, 149);
+        var view = NewView() with {
+            LiveBlockConversationId = conversation.Id,
+            DissolvingConversation = conversation,
+            ExpandedConversations = isExpanded
+                ? ImmutableHashSet.Create(conversation.Id)
+                : ImmutableHashSet<ConversationId>.Empty,
+        };
+
+        // act
+        var blocks = ChatUI.BuildChatBlocks(TestChatId, [], [], view, null, new(100, 150));
+
+        // assert
+        var block = blocks.Should().ContainSingle().Subject;
+        block.Id.Should().Be(conversation.Id);
+        block.IsExpanded.Should().Be(isExpanded);
+        if (isExpanded)
+            block.CollapsedAt.Should().BeNull();
+        else
+            block.CollapsedAt.Should().Be(conversation.StartsAt);
+        block.EntryLidRange.Should().Be(new Range<long>(100, 150));
+    }
+
+    [Fact]
+    public void ExpandedLiveBlockShouldHaveNoCollapseCutoff()
+    {
+        // arrange
+        var live = NewConversation(100, 149);
+        var view = NewView() with {
+            LiveBlockConversationId = live.Id,
+            ExpandedConversations = ImmutableHashSet.Create(live.Id),
+        };
+
+        // act
+        var blocks = ChatUI.BuildChatBlocks(TestChatId, [], [], view, live, new(100, 200));
+
+        // assert
+        var block = blocks.Should().ContainSingle().Subject;
+        block.IsExpanded.Should().BeTrue();
+        block.CollapsedAt.Should().BeNull();
+        block.EntryLidRange.Should().Be(new Range<long>(100, 200));
     }
 
     [Fact]

--- a/tests/Chat.UI.Blazor.UnitTests/ChatBlockQueryTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ChatBlockQueryTest.cs
@@ -222,7 +222,6 @@ public sealed class ChatBlockQueryTest
         => ranges.Select(r => {
             var id = ConversationId.New(TestChatId, r.Start);
             return new ChatBlock(new(id) { EndEntryLid = r.End - 1 }, r,
-                view.ExpandedConversations.Contains(id),
-                id == view.LiveBlockConversationId && view.MaterializedBlockId == null);
+                view.ExpandedConversations.Contains(id) ? null : Moment.EpochStart);
         }).ToArray();
 }


### PR DESCRIPTION
## Summary

Live block rendering mixed session state, fold bookkeeping, and a nullable overlay whose absence could
mean either an active joined block or no retained block. Model that lifecycle explicitly with
`OpenLiveBlock` and `ClosedLiveBlock`, while preserving rendering, reveal behavior, and the 300 ms dissolve.

## Changes

- Rename the session projection to `LiveBlockState` and expose the viewer-specific model through
  `LiveBlockUI.GetBlock`. Keep effective folds public and governor/reveal bookkeeping private.
- Remove unused and redundant overlay/view properties. Derive fold, summary, reveal-count, and dissolve
  values; retain the dissolve conversation descriptor and distinguish captured chat and summary ends.
- Remove `ChatBlock.IsLive` and its stored expansion flag. A nullable `CollapsedAt` encodes expansion
  (`null` means expanded), with compatibility cutoff dates for collapsed blocks.
- Invalidate private lifecycle changes explicitly, including dismissal without fold movement. Latch
  attendance together with its descriptor so an immediate leave can retain the block.
  Publish governor fold changes once after all private updates; unchanged-fold reveal/lifecycle changes
  use explicit invalidation, avoiding duplicate notifications on fold advances.
- Preserve finite entry fetching and open-ended optimistic grouping after leaving a running session.
  `GetBlock` also handles a conversation projection arriving before block state, preserving the live shell,
  effective fold, tint, and expand control without consumers reconstructing the block.
- Update the lifecycle documentation and regression tests. No backend contract or conversation-write changes.

## Testing

- 52 lifecycle/cache/projection integration cases and 41 block/query/grouping unit cases passed.
- Nullable-cutoff tests cover expanded/collapsed completed, materialized, open, and dissolving blocks.
  The reveal regression verifies re-swallowing without advancing the governed fold.
- The staged-projection test delays the session source while exercising the real block service. It failed
  with a null block before centralizing the fallback and passed afterward; it also verifies pending-message
  grouping, bUnit card/header rendering, projection recovery, and attendance after leaving.
- Direct UI build passed. Server-loop frontend/.NET build and health probes passed before the final
  invalidation/cutoff cleanup; restarting the shared server for that cleanup was blocked by automatic
  approval review. Browser and shared-server verification of the final cleanup remains unperformed.
- Independent code review findings addressed. Existing build warnings remain.
- Browser, Safari, microphone, and device verification was not performed for this refactor.