### PR TITLE
fix(ios-ptt): route framework-activated playback to the speaker

### DIFF
--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -122,9 +122,8 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
     {
         using var cts = cancellationToken.LinkWith(StopToken);
         using var _1 = await _lock.Lock(cts.Token).ConfigureAwait(false);
-        if (_activeScopes.IsEmpty)
-            return;
-
+        // No scope check: a PTT playback's engine starts before its listening scope arrives, and
+        // the route is the session category's business, not the scopes'.
         await AudioSession.ApplyOutputRoute(_activeScopes.GetMode()).ConfigureAwait(false);
     }
 
@@ -249,6 +248,10 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
         var isActivated = await AudioSession.RequestPttActivation().ConfigureAwait(false);
         Log.LogInformation("SetMode: {Mode} - the PTT framework {Result} the session",
             mode, isActivated ? "activated" : "didn't activate");
+        // The pending path returned before the route was applied, and the framework's session
+        // starts on the receiver.
+        if (isActivated)
+            await AudioSession.ApplyOutputRoute(mode).ConfigureAwait(false);
         return setup with { IsActivated = isActivated, IsPttActivationPending = false };
     }
 

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -318,8 +318,10 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         var isConfigured = AudioSessionOwnership.MayConfigure(owner, mode);
         if (isConfigured)
             ConfigureUnsafe(session, mode);
-        if (!AudioSessionOwnership.MayActivate(owner))
+        if (!AudioSessionOwnership.MayActivate(owner)) {
+            ApplyOutputRouteUnsafe(mode);
             return new AudioSessionSetup(isConfigured, false);
+        }
 
         if (!session.SetActive(true, out var error)) {
             if (TryRequestPttActivation(error, mode))
@@ -349,13 +351,11 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         var owner = Owner;
         if (!AudioSessionOwnership.MayActivate(owner)) {
             var isConfigured = AudioSessionOwnership.MayConfigure(owner, minMode);
-            if (isConfigured) {
-                // The framework's session is already active, and SetCategory on an active session
-                // is what lets an in-app recording get PlayAndRecord during a live wake playback.
+            // The framework's session is already active, and SetCategory on an active session
+            // is what lets an in-app recording get PlayAndRecord during a live wake playback.
+            if (isConfigured)
                 ConfigureUnsafe(session, minMode);
-                ApplyOutputRouteUnsafe(minMode);
-            }
-
+            ApplyOutputRouteUnsafe(minMode);
             return new AudioSessionSetup(isConfigured, false);
         }
 
@@ -415,14 +415,14 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
 
     private void ApplyOutputRouteUnsafe(AudioFocusMode mode, bool mustDropOverride = false)
     {
-        if (!AudioSessionOwnership.MayConfigure(Owner, mode))
-            return;
         // PlayAndRecord is the only category with a route to pick: Playback and Ambient always
-        // reach the speaker, and an override on either is rejected. See ConfigureUnsafe.
-        if (mode is not AudioFocusMode.Recording)
+        // reach the speaker, and an override on either is rejected. The category decides, not
+        // the mode or the owner: a session the PTT framework activated is PlayAndRecord whatever
+        // the app plays on it, and it lands on the receiver until the app overrides the port.
+        var session = AVAudioSession.SharedInstance();
+        if (session.Category != AVAudioSession.CategoryPlayAndRecord)
             return;
 
-        var session = AVAudioSession.SharedInstance();
         // CurrentRoute reports the speaker while our own override holds it there, which hides a
         // device that just arrived and would outrank it - the override has to go before the read.
         if (mustDropOverride)


### PR DESCRIPTION
## Summary

Incoming PTT audio on iOS came out of the receiver, and so did plain in-app listening after any PTT activity. Since #4429 every PTT activation prepares the session as `PlayAndRecord` + `VoiceChat` (required for the framework to activate it in the background). iOS's default output for that category is the receiver, like a phone call. The app forces the speaker with a port override, but `ApplyOutputRouteUnsafe` only did so for `Recording` mode and only where the app "may configure" the session, which is never true under a PTT owner, so a framework-activated playback session, and any listening started while the session was still `PlayAndRecord`, kept the receiver. Before #4429 that session was `Playback`, which always reaches the speaker.

## Fix

- The speaker override keys off the session's actual category alone: `PlayAndRecord` gets it whatever mode the app plays in and whoever owns the session; `Playback` and `Ambient` are untouched. External devices (headset, Bluetooth, CarPlay) still win, unchanged.
- It is applied on every path a PTT-owned session takes: the withheld `Reconfigure`/`Reactivate` branches, a pending framework activation once it arrives (`WaitForPttActivation`), and `EnsureOutputRoute` even before a listening scope exists, since the playback engine starts ahead of its scope. A mid-playback category change (a push arriving during foreground listening) goes through the existing route-change handler, which now applies it too.

Invariant for reviewers: the port override is the app's to make under any owner; only the category and mode are the framework's while it owns the session.

## Testing

- `net11.0-ios` compiles (0 errors; the Mac worktree pinned to the installed preview.7 SDK since dev now pins rc.1).
- Not device-verified: needs the next dev TestFlight build. Expected: incoming PTT audio and in-app listening both on the speaker, and `ApplyOutputRoute: mode=Listening … -> Speaker` in the breadcrumbs.

Part of #4414 (tracking issue, intentionally not closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCSrk8fMcsfM5AyU8aFSqF
