### PR TITLE
fix(mentions): don't crash on a mention of yourself in a chat you haven't joined

### DIFF
--- a/src/dotnet/UI.Blazor.App/Services/AuthorUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/AuthorUI.cs
@@ -16,7 +16,7 @@ public class AuthorUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub)
     public virtual async Task<string> GetUserName(ChatId chatId, UserId userId, CancellationToken cancellationToken)
     {
         // The name you see for this user: their avatar name in this chat if they're a member of it,
-        // otherwise your rename of them. Both already account for a rename; "" means neither applies.
+        // otherwise your rename of them, or your own avatar name if it's you. "" means none applies.
         if (userId.IsGuestOrNull())
             return "";
 
@@ -27,6 +27,8 @@ public class AuthorUI(AppUIHub hub) : UIServiceBase<AppUIHub>(hub)
         var ownAccount = await Accounts.GetOwn(Session, cancellationToken).ConfigureAwait(false);
         if (ownAccount.IsGuestOrNull())
             return "";
+        if (ownAccount.Id == userId)
+            return ownAccount.Avatar.Name;
 
         var contactId = ContactId.NewUser(ownAccount.Id, userId);
         var contact = await Contacts.Get(Session, contactId, cancellationToken).ConfigureAwait(false);

--- a/tests/Chat.UI.Blazor.IntegrationTests/AuthorUITest.cs
+++ b/tests/Chat.UI.Blazor.IntegrationTests/AuthorUITest.cs
@@ -1,0 +1,35 @@
+using ActualChat.Testing.Host;
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.IntegrationTests;
+
+[Collection(nameof(ChatUICollection))]
+public class AuthorUITest(ChatAppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<ChatAppHostFixture>(fixture, @out)
+{
+    private BlazorTester Tester => field ??= AppHost.NewBlazorTester(Out);
+
+    protected override async Task DisposeAsync()
+    {
+        await Tester.DisposeSilentlyAsync();
+        await base.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetUserNameShouldReturnOwnAvatarNameInChatYouAreNotMemberOf()
+    {
+        // arrange
+        await Tester.SignInAsUniqueBob();
+        var (chat, _) = await Tester.CreateAndGetChat(true, "author-ui-own-name-test");
+        await Tester.SignInAsNew("Alice");
+        var alice = await Tester.Accounts.GetOwn(Tester.Session, CancellationToken.None);
+        alice.Avatar.Name.Should().NotBeEmpty();
+        var authorUI = Tester.ScopedAppServices.GetRequiredService<AuthorUI>();
+
+        // act
+        var name = await authorUI.GetUserName(chat.Id, alice.Id, CancellationToken.None);
+
+        // assert
+        name.Should().Be(alice.Avatar.Name, "there is no rename of yourself, and your avatar name is what others see");
+    }
+}


### PR DESCRIPTION
## Summary

Opening a chat you aren't a member of, whose history contains a user mention of **you**, blanked the
central and right panels a moment after the chat opened.

`UserMentionView` asks `AuthorUI.GetUserName(chatId, userId)` for the name to show. When the mentioned
user isn't a member of the chat, that falls back to your rename of them and builds
`ContactId.NewUser(ownAccount.Id, userId)`. With `userId` being you, both ids are equal, `PeerChatId.New`
throws `ArgumentOutOfRangeException: Both user IDs are the same`, and the exception escapes the badge's
`BuildRenderTree` into `ErrorBarrier PageWithHeaderAndFooter-Body` - which has `MustHidePanels`.

Other members never hit it: for them the two ids differ. Regressed in 8e83d3cb43.

## Fix

`GetUserName` returns your own avatar name when the user is you, before the contact lookup. There is no
rename of yourself, and the avatar name is both what others see and what `BackendChatMentionResolver`
writes into the mention on save - so the badge matches everyone else's, just without the staleness of
the copy stored in the message.

The member path (author found in the chat) is unchanged and still runs first.

## Testing

- New `AuthorUITest.GetUserNameShouldReturnOwnAvatarNameInChatYouAreNotMemberOf`: failed with
  `Both user IDs are the same` before the fix, passes after.
- `AuthorUITest`, `UserMentionStrikeTest`, `ChatMentionSearchTest`: 6/6 green.
- Not verified in a browser.

Closes #4469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRA14fpjaaJbkZoeM2SNs
