### PR TITLE
fix(ui): keep ErrorBarrier's error view when several children fail at once

### DIFF
--- a/src/dotnet/UI.Blazor/Components/ErrorBarrier/ErrorBarrier.razor
+++ b/src/dotnet/UI.Blazor/Components/ErrorBarrier/ErrorBarrier.razor
@@ -2,7 +2,7 @@
 @namespace ActualChat.UI.Blazor.Components
 @implements IDisposable
 
-<ErrorBoundary @ref="_errorBoundary">
+<ErrorBarrierBoundary @ref="_errorBoundary" Activated="OnActivated">
     <ChildContent>
         @{
             _childContentRenderedAt = CpuNow;
@@ -10,26 +10,18 @@
         @ChildContent
     </ChildContent>
     <ErrorContent>
-        @{
-            var now = CpuNow;
-            if (now - _childContentRenderedAt < SameFailurePeriod)
-                _errorCount++;
-            else
-                _errorCount = 1;
-            Log.LogError(context, "ErrorBarrier {Name} activated, error count = {ErrorCount}", Name, _errorCount);
-        }
         <ErrorBarrierError
             Barrier="@this"
             Kind="@Kind"
             ErrorCount="@_errorCount"
             MustAutoReload="@MustAutoReload"/>
     </ErrorContent>
-</ErrorBoundary>
+</ErrorBarrierBoundary>
 
 @code {
     private static readonly TimeSpan SameFailurePeriod = TimeSpan.FromSeconds(3);
 
-    private ErrorBoundary? _errorBoundary;
+    private ErrorBarrierBoundary? _errorBoundary;
     private Moment _childContentRenderedAt;
     private int _errorCount;
     private bool _arePanelsHidden;
@@ -70,5 +62,14 @@
 
         _arePanelsHidden = true;
         PanelsUI.HidePanels();
+    }
+
+    // Private methods
+
+    private void OnActivated(Exception error) {
+        _errorCount = CpuNow - _childContentRenderedAt < SameFailurePeriod
+            ? _errorCount + 1
+            : 1;
+        Log.LogError(error, "ErrorBarrier {Name} activated, error count = {ErrorCount}", Name, _errorCount);
     }
 }

--- a/src/dotnet/UI.Blazor/Components/ErrorBarrier/ErrorBarrierBoundary.cs
+++ b/src/dotnet/UI.Blazor/Components/ErrorBarrier/ErrorBarrierBoundary.cs
@@ -1,0 +1,27 @@
+namespace ActualChat.UI.Blazor.Components;
+
+/// <summary>
+/// An <see cref="ErrorBoundary"/> that keeps its error content when several children fail in one render:
+/// the renderer queues an empty render of the boundary per error, while the boundary's own re-render is
+/// deduplicated, so without a follow-up render the later empty renders would leave it blank.
+/// </summary>
+public sealed class ErrorBarrierBoundary : ErrorBoundary
+{
+    private bool _isRerenderScheduled;
+    [Parameter] public Action<Exception>? Activated { get; set; }
+
+    protected override async Task OnErrorAsync(Exception exception)
+    {
+        // Called before CurrentException is set, so it's null only for the first error since Recover
+        if (CurrentException is null)
+            Activated?.Invoke(exception);
+        await base.OnErrorAsync(exception).ConfigureAwait(true);
+        if (_isRerenderScheduled)
+            return;
+
+        _isRerenderScheduled = true;
+        await Task.Yield(); // Lets the current render batch, with all its queued empty renders, finish
+        _isRerenderScheduled = false;
+        this.NotifyStateHasChanged();
+    }
+}

--- a/tests/Chat.UI.Blazor.UnitTests/ErrorBarrierBoundaryTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ErrorBarrierBoundaryTest.cs
@@ -1,0 +1,71 @@
+using Bunit;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class ErrorBarrierBoundaryTest
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    public void ErrorContentShouldSurviveSeveralErrorsInOneRender(int failingChildCount)
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        var activations = new List<Exception>();
+
+        // act
+        var cut = context.Render<ErrorBarrierBoundary>(p => p
+            .Add(x => x.Activated, activations.Add)
+            .Add(x => x.ChildContent, b => AddFailingChildren(b, failingChildCount))
+            .Add(x => x.ErrorContent, _ => b => b.AddContent(0, "failed")));
+
+        // assert
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("failed",
+            "the renderer's empty render queued for each later error must not wipe the error content"));
+        activations.Select(e => e.Message).Should().Equal(["child 1"],
+            "errors arriving while the boundary is already failed are the same activation");
+    }
+
+    [Fact]
+    public void RecoveredBoundaryShouldReportTheNextErrorAsNewActivation()
+    {
+        // arrange
+        using var context = TestBunitContext.New();
+        var activations = new List<Exception>();
+        var cut = context.Render<ErrorBarrierBoundary>(p => p
+            .Add(x => x.Activated, activations.Add)
+            .Add(x => x.ChildContent, b => AddFailingChildren(b, 2))
+            .Add(x => x.ErrorContent, _ => b => b.AddContent(0, "failed")));
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("failed"));
+
+        // act
+        cut.InvokeAsync(cut.Instance.Recover);
+
+        // assert
+        cut.WaitForAssertion(() => activations.Should().HaveCount(2));
+        cut.WaitForAssertion(() => cut.Markup.Should().Be("failed"));
+    }
+
+    // Private methods
+
+    private static void AddFailingChildren(RenderTreeBuilder builder, int count)
+    {
+        for (var i = 1; i <= count; i++) {
+            builder.OpenComponent<FailingChild>(0);
+            builder.AddComponentParameter(1, nameof(FailingChild.Index), i);
+            builder.SetKey(i);
+            builder.CloseComponent();
+        }
+    }
+
+    // Nested types
+
+    private sealed class FailingChild : ComponentBase
+    {
+        [Parameter] public int Index { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+            => throw new InvalidOperationException($"child {Index}");
+    }
+}


### PR DESCRIPTION
## Summary

When more than one component under the same `ErrorBarrier` failed in one render pass, the barrier ended up
blank: no "Aw, Snap!", no Reload button, no auto-reload, until you navigated away.

Blazor's `Renderer.HandleExceptionViaErrorBoundary` queues an empty render of the boundary for **every**
error, so failed children can't keep running. `ErrorBoundaryBase.HandleException` then asks for its own
re-render via `StateHasChanged`, which is deduplicated while a render is already queued. With N errors in one
batch the queue ends as `[empty, error content, empty, …]`, and the trailing empty renders remove
`ErrorBarrierError` together with the `UITimer` that drives the silent retries and the reload countdown.

That's what the #4471 client log shows: `activated, error count = 2`, four `ErrorBoundary` errors within 5 ms,
then nothing. The chat had several mentions of the user, so the second retry hit several failing badges at
once. Since `ChatPage` renders the header, footer and right panel into layout slots, they vanish with the
body, and only the left panel was left on screen.

## Fix

- `ErrorBarrierBoundary` (an `ErrorBoundary` subclass) schedules one more re-render after the current batch
  (`Task.Yield`, then `NotifyStateHasChanged`), so the error content is what the boundary shows last. There is
  at most one per burst of errors.
- It reports each activation once, through `Activated`: `CurrentException` is still null when `OnErrorAsync`
  runs for the first error after `Recover`. `ErrorBarrier` now counts failures and logs "activated" there
  instead of inside its `ErrorContent` fragment. Counting there bumped the count on every re-render of the
  error content, and the extra render would have doubled it.

Nothing else changes: the first 3 quick failures still reload silently, and the error view with the backoff
countdown appears from the 4th.

## Testing

- New `ErrorBarrierBoundaryTest` (bUnit): 1 and 4 children failing in one render; activation after
  `Recover`. The 4-children case and the recovery case fail on a plain `ErrorBoundary` and pass with the fix.
  `Chat.UI.Blazor.UnitTests`: 899/899 green.
- Manual, WASM, local server with the pre-#4471 `AuthorUI` put back temporarily: navigate by link to a public
  chat you haven't joined that has 4 mentions of you. Before the fix the body went blank after the first
  activation and stayed blank. After the fix there are 3 silent reloads, then "Aw, Snap!" with "Reload in 5s"
  at about 3.2 s, an auto-reload, then a 7 s countdown. The log counts 1..5, one per activation.
- Not run: Server render mode and MAUI by hand. `BlazorUIAotSource.g.cs` is not regenerated; that's left to
  the next `chore(aot)` pass.

Closes #4473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183qFh4rgmCmRa3G5NLQLrb
