### PR TITLE
fix(chat): contain transcript errors to the message list

### DIFF
--- a/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/chat-view.css
@@ -3,6 +3,11 @@
 .chat-view-swap {
     @apply w-full h-full min-h-0;
 }
+/* The ChatView barrier in ChatPage: a swap layer is a plain block, so the barrier's own flex centering
+   has nothing to fill without an explicit height */
+.chat-view-swap > .c-layer > .error-barrier {
+    @apply h-full;
+}
 
 .message-wrapper {
     @apply relative;

--- a/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
+++ b/src/dotnet/UI.Blazor.App/Pages/ChatPage.razor
@@ -77,9 +77,13 @@
             <chat-view-skeleton count="15" class="chat-view-skeleton-list no-scrollbar"/>
             <ContentSwapDisplay/>
         } else if (chatContext is not null) {
-            <CascadingValue Value="@chatContext">
-                <ChatView @key="@chatKey"/>
-            </CascadingValue>
+            @* Keeps a failing transcript item from taking down the page along with the header, footer and
+               right panel it renders into layout slots *@
+            <ErrorBarrier Name="ChatView" Kind="@ErrorBarrierKind.Full" MustHidePanels="@true">
+                <CascadingValue Value="@chatContext">
+                    <ChatView @key="@chatKey"/>
+                </CascadingValue>
+            </ErrorBarrier>
         } else if (m is { CanSendJoinPlaceRequest: true, EnableIncompleteUI: true }) {
             <InaccessiblePlace ShowSignIn="@account.IsGuestOrNull()"/>
             <ContentSwapDisplay/>


### PR DESCRIPTION
## Summary

One message that failed to render took down the whole chat page. In #4471 that was a single broken mention
badge. The nearest barrier was `PageWithHeaderAndFooter-Body`, which wraps `ChatPage` itself. `ChatPage` puts
the header, the footer (editor or "Join this chat") and the right panel into layout slots, so when that barrier
replaced `ChatPage` with its error view, they all went with it and only the left panel stayed on screen.

## Fix

- `ChatPage` wraps `ChatView` in `<ErrorBarrier Name="ChatView" Kind="Full" MustHidePanels="true">`. A failing
  transcript item now replaces only the message list. `ChatPage` itself keeps rendering, so its slot contents
  stay. There is one barrier per chat page instead of one per entry, so there's no per-entry cost.
- `chat-view.css`: the `ContentSwap` layer around it is a plain block, so the barrier's flex centering had no
  height to fill and the error view stuck to the top of the list. It now gets `h-full` and sits in the middle.
- `ContentSwap` needed nothing extra: its 0.333 s display backstop brings in the error view, and switching to
  another chat recovers the list (`ErrorBarrier` resets on navigation).

The outer `PageWithHeaderAndFooter-Body` barrier stays as the backstop for a failure in `ChatPage` itself.

## Testing

- Manual, WASM, local server, with #4474 and the pre-#4471 `AuthorUI` applied temporarily (neither is in this
  branch). I followed a link to a public chat I hadn't joined that had 4 mentions of me. The chat header, banner,
  footer ("Join this chat") and open right panel stayed; the error view took the list area, vertically centered,
  and counted down to auto-reload. Switching to another chat brought the list back.
- Without #4474, the same 4-mention case leaves this barrier blank as well, since it's the same Blazor race.
  The two PRs are independent, but the full result needs both.
- Not run: unit tests (markup and CSS only; the server and web builds pass), Server render mode and MAUI by hand.

Closes #4476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183qFh4rgmCmRa3G5NLQLrb
