### PR TITLE
feat(auth): static email sign-in codes for NPC accounts on dev

### DIFF
--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -65,6 +65,19 @@ For automated testing and AI agent authentication, special test accounts are ava
 
 Phone authentication supports predefined TOTP codes configured via `UsersSettings.PredefinedTotps`. These are typically set via environment variables for specific test phone numbers.
 
+### Email Auth NPC Accounts
+
+`UsersSettings.PredefinedEmailTotps` maps a lowercase prefix to a static code for every
+`<prefix>+<suffix>@actual.chat` address, e.g. `UsersSettings__PredefinedEmailTotps__npc=123123`
+makes `npc+promo@actual.chat` sign in with `123123` and no email sent. Set it only in the deployment
+environment, never in `appsettings*.json` — the repository is public.
+
+**Restrictions:**
+- Honored on `dev.voxt.ai` and local dev domains only; never on production, unlike `PredefinedTotps`.
+- The `<prefix>@actual.chat` mailbox itself isn't matched, and an empty suffix isn't either.
+- All suffixes of a prefix share one code-validation rate-limit budget.
+- Such accounts are never admins, even though `actual.chat` is the team email domain.
+
 ### Programmatic Test Sign-In
 
 For integration tests, use the `TestAuthExt` helper methods:

--- a/src/dotnet/Users.Service/AccountsBackend.cs
+++ b/src/dotnet/Users.Service/AccountsBackend.cs
@@ -4,6 +4,7 @@ using ActualChat.Db;
 using ActualChat.Flows;
 using ActualChat.Security;
 using ActualChat.Users.Db;
+using ActualChat.Users.Email;
 using ActualChat.Users.Flows;
 using ActualChat.Users.Module;
 using ActualLab.Fusion.EntityFramework;
@@ -495,12 +496,16 @@ public class AccountsBackend(IServiceProvider services) : DbServiceBase<UsersDbC
     // Protected/internal methods
 
     internal bool IsAdmin(AccountFull account)
-        => IsAdmin(account, HostInfo.BaseUrlKind == BaseUrlKind.Local, UsersSettings.PredefinedTotps);
+        => IsAdmin(account,
+            HostInfo.BaseUrlKind == BaseUrlKind.Local,
+            UsersSettings.PredefinedTotps,
+            UsersSettings.PredefinedEmailTotps);
 
     internal static bool IsAdmin(
         AccountFull account,
         bool areTestAgentsAdmins,
-        IReadOnlyDictionary<string, int> predefinedTotps)
+        IReadOnlyDictionary<string, int> predefinedTotps,
+        IReadOnlyDictionary<string, int> predefinedEmailTotps)
     {
         // TODO(AY): Remove the check relying on test/internal auth providers in the production code
         if (account.Identities.HasInternalIdentity() && account.Id == Constants.User.Admin.UserId)
@@ -513,6 +518,13 @@ public class AccountsBackend(IServiceProvider services) : DbServiceBase<UsersDbC
         }
 
         var emails = account.Identities.GetEmails();
+        // Emails with a predefined TOTP sign in with a shared code, so they're never admins either,
+        // even though they're on the team email domain
+        foreach (var email in emails) {
+            if (EmailAuth.GetPredefinedTotpPrefix(predefinedEmailTotps, email) is not null)
+                return false;
+        }
+
         foreach (var email in emails) {
             if (email.IsNullOrEmpty() || !MailAddress.TryCreate(email, out var emailAddress))
                 continue;

--- a/src/dotnet/Users.Service/Email/EmailAuth.cs
+++ b/src/dotnet/Users.Service/Email/EmailAuth.cs
@@ -76,6 +76,8 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
 
         if (Constants.Auth.TestAgent.IsTestAgentEmail(email) && IsTestAgentEmailTotpHost(HostInfo))
             return NextSendAt();
+        if (GetPredefinedTotpPrefix(email) is not null)
+            return NextSendAt();
 
         await CaptchaProofs
             .Require(session, command.CaptchaToken, command.CaptchaAction, purpose, cancellationToken)
@@ -133,7 +135,9 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
         var session = command.Session;
         var email = command.Email;
         var totp = command.Totp;
-        if (!await ValidateCode(session, email.Value, totp, TotpPurpose.SignInEmail, cancellationToken).ConfigureAwait(false))
+        var isValid = await ValidateCode(session, email.Value, totp, TotpPurpose.SignInEmail, cancellationToken)
+            .ConfigureAwait(false);
+        if (!isValid)
             return false;
 
         var identities = new ApiMap<UserIdentity, string>().WithEmailIdentity(email, out var emailIdentity);
@@ -153,7 +157,9 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
         var session = command.Session;
         var email = command.Email;
         var totp = command.Token;
-        if (!await ValidateCode(session, email.Value, totp, TotpPurpose.VerifyEmail, cancellationToken).ConfigureAwait(false))
+        var isValid = await ValidateCode(session, email.Value, totp, TotpPurpose.VerifyEmail, cancellationToken)
+            .ConfigureAwait(false);
+        if (!isValid)
             return false;
 
         var account = await Accounts.GetOwn(session, cancellationToken).ConfigureAwait(false);
@@ -185,6 +191,25 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
             || Constants.Hosts.IsLocalDev(baseUri.Host);
     }
 
+    internal static bool IsPredefinedTotpHost(HostInfo hostInfo)
+        => hostInfo.IsTested || hostInfo.BaseUrlKind is BaseUrlKind.Development or BaseUrlKind.Local;
+
+    internal static string? GetPredefinedTotpPrefix(IReadOnlyDictionary<string, int> predefinedTotps, string email)
+    {
+        // The <prefix>@actual.chat mailbox itself isn't matched: only <prefix>+<suffix>@actual.chat is
+        var emailSuffix = Constants.Team.EmailSuffix;
+        if (predefinedTotps.Count == 0 || !email.EndsWith(emailSuffix, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var localPart = email[..^emailSuffix.Length];
+        var plusIndex = localPart.IndexOf('+');
+        if (plusIndex <= 0 || plusIndex == localPart.Length - 1)
+            return null;
+
+        var prefix = localPart[..plusIndex].ToLower();
+        return predefinedTotps.ContainsKey(prefix) ? prefix : null;
+    }
+
     // Private methods
 
     private async Task<bool> ValidateCode(
@@ -194,10 +219,15 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
         TotpPurpose purpose,
         CancellationToken cancellationToken)
     {
+        var predefinedTotpPrefix = GetPredefinedTotpPrefix(email);
+        // All suffixes of a predefined prefix share one budget, otherwise each new suffix would reset it
+        var target = predefinedTotpPrefix is null
+            ? email
+            : $"{predefinedTotpPrefix}+*{Constants.Team.EmailSuffix}";
         var method = $"{nameof(EmailAuth)}.{purpose}";
         var identities = new RateLimitIdentity[2];
         var identityCount = 0;
-        identities[identityCount++] = new RateLimitIdentity(RateLimitIdentityKind.Target, $"{purpose}:{email}");
+        identities[identityCount++] = new RateLimitIdentity(RateLimitIdentityKind.Target, $"{purpose}:{target}");
         if (RateLimitIdentity.ForIP(RpcInboundContext.Current.GetRemoteIPAddress()) is { } ipIdentity)
             identities[identityCount++] = ipIdentity;
         await RateLimitPolicy
@@ -208,9 +238,16 @@ public class EmailAuth(IServiceProvider services) : DbServiceBase<UsersDbContext
             && Constants.Auth.TestAgent.IsTestAgentEmail(email)
             && IsTestAgentEmailTotpHost(HostInfo))
             return true;
+        if (predefinedTotpPrefix is not null)
+            return totp == UsersSettings.PredefinedEmailTotps[predefinedTotpPrefix];
 
         return await TotpCodes.Validate(purpose, email, session, totp, cancellationToken).ConfigureAwait(false);
     }
+
+    private string? GetPredefinedTotpPrefix(string email)
+        => IsPredefinedTotpHost(HostInfo)
+            ? GetPredefinedTotpPrefix(UsersSettings.PredefinedEmailTotps, email)
+            : null;
 
     private async Task<bool> IsThrottled(Session session, string email, CancellationToken cancellationToken)
     {

--- a/src/dotnet/Users.Service/Module/UsersSettings.cs
+++ b/src/dotnet/Users.Service/Module/UsersSettings.cs
@@ -32,6 +32,9 @@ public sealed class UsersSettings
     public string BlockedPhonePrefixes { get; set; } = "";
     public string SkipTelegramPhonePrefixes { get; set; } = "";
     public IReadOnlyDictionary<string, int> PredefinedTotps { get; set; } = ImmutableDictionary<string, int>.Empty;
+    // Keys are the lowercase <prefix> of <prefix>+<suffix>@actual.chat.
+    // Unlike PredefinedTotps, these are never honored on production.
+    public IReadOnlyDictionary<string, int> PredefinedEmailTotps { get; set; } = ImmutableDictionary<string, int>.Empty;
     public AppUpdateSettings AppUpdates { get; set; } = new();
     // A kill switch: MauiAuthController.Start assumes every browser component the app can reach
     // reports Sec-Fetch-Site: none. Turn this off if some platform turns out not to.

--- a/tests/Users.IntegrationTests/PredefinedEmailTotpTest.cs
+++ b/tests/Users.IntegrationTests/PredefinedEmailTotpTest.cs
@@ -1,0 +1,112 @@
+using ActualChat.Testing.Host;
+using ActualChat.Users.Email;
+using ActualChat.Users.Module;
+
+namespace ActualChat.Users.IntegrationTests;
+
+[Collection(nameof(UserCollection))]
+public class PredefinedEmailTotpTest(AppHostFixture fixture, ITestOutputHelper @out)
+    : SharedAppHostTestBase<AppHostFixture>(fixture, @out)
+{
+    private const int PredefinedTotp = 123123;
+    private UsersSettings Settings => AppHost.Services.GetRequiredService<UsersSettings>();
+
+    [Fact]
+    public async Task PredefinedCodeShouldSignInWithoutASentCode()
+    {
+        // arrange
+        var email = ActualChat.Email.Parse($"npc+{Ulid.NewUlid().ToString().ToLower()}@actual.chat");
+        var settings = Settings;
+        var oldPredefinedEmailTotps = settings.PredefinedEmailTotps;
+        settings.PredefinedEmailTotps = new Dictionary<string, int> { { "npc", PredefinedTotp } };
+        var tester = AppHost.NewWebClientTester(Out);
+        await using var _ = tester.ConfigureAwait(false);
+        var session = tester.Session;
+
+        // act
+        bool isWrongAccepted;
+        bool isPredefinedAccepted;
+        AccountFull account;
+        try {
+            await tester.Commander.Call(new EmailAuth_SendTotp { Session = session, Email = email });
+            isWrongAccepted = await tester.Commander
+                .Call(new EmailAuth_ValidateTotp { Session = session, Email = email, Totp = 222222 });
+            isPredefinedAccepted = await tester.Commander
+                .Call(new EmailAuth_ValidateTotp { Session = session, Email = email, Totp = PredefinedTotp });
+            await AppHost.ConfirmPendingRegistration(session);
+            account = await tester.Accounts.GetOwn(session, default);
+        }
+        finally {
+            settings.PredefinedEmailTotps = oldPredefinedEmailTotps;
+        }
+
+        // assert
+        isWrongAccepted.Should().BeFalse();
+        isPredefinedAccepted.Should().BeTrue();
+        account.Email.Should().Be(email.Value);
+        account.IsAdmin.Should().BeFalse("a predefined code is shared, even though the email is a team one");
+    }
+
+    [Theory]
+    [InlineData("npc+promo@actual.chat", "npc")]
+    [InlineData("NPC+Promo@Actual.Chat", "npc")]
+    [InlineData("npc+a+b@actual.chat", "npc")]
+    [InlineData("npc@actual.chat", null)]
+    [InlineData("npc+@actual.chat", null)]
+    [InlineData("+promo@actual.chat", null)]
+    [InlineData("npcx+promo@actual.chat", null)]
+    [InlineData("xnpc+promo@actual.chat", null)]
+    [InlineData("npc+promo@gmail.com", null)]
+    [InlineData("npc+promo@notactual.chat", null)]
+    [InlineData("npc+promo@sub.actual.chat", null)]
+    public void PrefixShouldMatchOnlySuffixedTeamEmails(string email, string? expectedPrefix)
+    {
+        // arrange
+        var predefinedEmailTotps = new Dictionary<string, int> { { "npc", PredefinedTotp } };
+
+        // act
+        var prefix = EmailAuth.GetPredefinedTotpPrefix(predefinedEmailTotps, email);
+
+        // assert
+        prefix.Should().Be(expectedPrefix);
+    }
+
+    [Theory]
+    [InlineData("https://voxt.ai", false)]
+    [InlineData("https://preview.example.com", false)]
+    [InlineData("https://dev.voxt.ai", true)]
+    [InlineData("https://local.voxt.ai", true)]
+    [InlineData("https://wt1.local.voxt.ai", true)]
+    public void PredefinedCodeShouldNeverWorkOnProduction(string baseUrl, bool expectedIsAllowed)
+    {
+        // arrange
+        var hostInfo = new HostInfo {
+            BaseUrl = baseUrl,
+            IsTested = false,
+        };
+
+        // act
+        var isAllowed = EmailAuth.IsPredefinedTotpHost(hostInfo);
+
+        // assert
+        isAllowed.Should().Be(expectedIsAllowed);
+    }
+
+    [Fact]
+    public void PredefinedEmailShouldNeverBeAdmin()
+    {
+        // arrange
+        var email = ActualChat.Email.Parse("npc+promo@actual.chat");
+        var account = new AccountFull("").WithEmailIdentity(email);
+        var predefinedTotps = ImmutableDictionary<string, int>.Empty;
+        var predefinedEmailTotps = new Dictionary<string, int> { { "npc", PredefinedTotp } };
+
+        // act
+        var isAdmin = AccountsBackend.IsAdmin(account, true, predefinedTotps, predefinedEmailTotps);
+        var isAdminWithoutSetting = AccountsBackend.IsAdmin(account, true, predefinedTotps, predefinedTotps);
+
+        // assert
+        isAdmin.Should().BeFalse();
+        isAdminWithoutSetting.Should().BeTrue("without the setting it's a regular team email");
+    }
+}

--- a/tests/Users.IntegrationTests/TestAgentSignInTest.cs
+++ b/tests/Users.IntegrationTests/TestAgentSignInTest.cs
@@ -37,8 +37,8 @@ public class TestAgentSignInTest(AppHostFixture fixture, ITestOutputHelper @out)
         var predefinedTotps = ImmutableDictionary<string, int>.Empty;
 
         // act
-        var isAdminOnLocal = AccountsBackend.IsAdmin(account, true, predefinedTotps);
-        var isAdminElsewhere = AccountsBackend.IsAdmin(account, false, predefinedTotps);
+        var isAdminOnLocal = AccountsBackend.IsAdmin(account, true, predefinedTotps, predefinedTotps);
+        var isAdminElsewhere = AccountsBackend.IsAdmin(account, false, predefinedTotps, predefinedTotps);
 
         // assert
         isAdminOnLocal.Should().BeTrue();


### PR DESCRIPTION
UsersSettings.PredefinedEmailTotps maps a lowercase prefix to a static code for <prefix>+<suffix>@actual.chat, e.g. UsersSettings__PredefinedEmailTotps__npc. No email is sent for such addresses, and the code is accepted for both sign-in and email verification.

- Honored on dev, local and test hosts only - never on production, unlike the phone PredefinedTotps.
- All suffixes of a prefix share one validation rate-limit budget.
- Such accounts are never admins, even though actual.chat is the team domain.

Refs #4479


Claude-Session: https://claude.ai/code/session_01MWddiXQTGqmxeUKM9dRB69