### PR TITLE
fix(anonymous-chat): disable anonymous chat UI everywhere via constant flag

### DIFF
--- a/src/dotnet/UI.Blazor/Services/Features/Features_EnableAnonymousChat.cs
+++ b/src/dotnet/UI.Blazor/Services/Features/Features_EnableAnonymousChat.cs
@@ -1,14 +1,10 @@
-
 namespace ActualChat.UI.Blazor.Services;
 
 // ReSharper disable once InconsistentNaming
 public sealed class Features_EnableAnonymousChat : FeatureDef<bool>, IClientFeatureDef
 {
-    public static bool IsEnabled { get; } = !(OSInfo.IsIOS || OSInfo.IsMacOS || OSInfo.IsAndroid || OSInfo.IsWindows);
+    public static bool IsEnabled => false;
 
     public override Task<bool> Compute(IServiceProvider services, CancellationToken cancellationToken)
-    {
-        var hostInfo = services.HostInfo();
-        return Task.FromResult(!hostInfo.AppKind.IsMaui());
-    }
+        => Task.FromResult(false);
 }


### PR DESCRIPTION


Anonymous chat was gated per-platform (enabled on web, off on all MAUI native apps). The web UI was still incomplete, so switch the feature flag to a constant false to hide every anonymous-chat entry point (author card block/toggle/button, chat menu item, allow-anonymous toggles, join-anonymously) across all platforms. Feature code is left intact for a future re-enable.