### PR TITLE
feat(win): paint the title bar in the theme's colors

### DIFF
--- a/.claude/style-bypasses.md
+++ b/.claude/style-bypasses.md
@@ -244,6 +244,13 @@ edited. The reason can be as short as whose decision it was.
   for legacy KVAS reads, and MemoryPack's generator rejects a partially annotated
   object outright (MEMPACK025), so a new member cannot opt out of `MemoryPackOrder`
 
+## src/dotnet/App.Maui/MauiThemeHandler.cs
+
+- L95 `protected virtual void ApplyStatusBar(ThemeColors colors, Theme? theme)`
+  — blank line between two multi-line methods — same "0 blank lines inside types" read
+  as "strip every blank line between members" as the `AudioRecorder.cs` entry; every
+  other method pair in this file is separated the same way. NEEDS ALEX'S CALL
+
 ## src/dotnet/UI.Blazor.App/Components/Share/ShareQrModal.razor
 
 - L48-49 `new (ShowTabId, L.ShareQr_TabShow),`

--- a/src/dotnet/App.Maui/MauiThemeHandler.cs
+++ b/src/dotnet/App.Maui/MauiThemeHandler.cs
@@ -12,6 +12,8 @@ public class MauiThemeHandler
     public static readonly MauiThemeHandler Instance =
 #if ANDROID
         new AndroidThemeHandler();
+#elif WINDOWS
+        new WindowsThemeHandler();
 #else
         new();
 #endif
@@ -23,14 +25,9 @@ public class MauiThemeHandler
 
     protected ILogger Log => _log ??= StaticLog.Factory.CreateLogger(GetType());
 
-    public string TopBarColor {
-        get {
-            // --background-01 (see getColors in theme.ts), restored from preferences in the ctor,
-            // so it's known before the web app loads.
-            var items = _colors.Split(';');
-            return items[0].Trim();
-        }
-    }
+    public ThemeColors CurrentColors
+        // Restored from preferences in the ctor, so they're known before the web app loads
+        => ThemeColors.Parse(_colors);
 
     protected MauiThemeHandler()
     {
@@ -73,15 +70,7 @@ public class MauiThemeHandler
                 return;
 
             try {
-                var items = colors.Split(";");
-                var topBarColor = colors;
-                var bottomBarColor = colors;
-                if (items.Length >= 2) {
-                    topBarColor = items[0].Trim();
-                    bottomBarColor = items[1].Trim();
-                }
-
-                if (Apply(topBarColor, bottomBarColor, theme))
+                if (Apply(ThemeColors.Parse(colors), theme))
                     _appliedColors = colors;
             }
             catch (Exception e) {
@@ -90,7 +79,7 @@ public class MauiThemeHandler
         });
     }
 
-    protected virtual bool Apply(string topBarColor, string bottomBarColor, Theme? theme)
+    protected virtual bool Apply(ThemeColors colors, Theme? theme)
     {
  #pragma warning disable CA1826
         var mainPage = App.Current.Windows.FirstOrDefault()?.Page;
@@ -98,6 +87,13 @@ public class MauiThemeHandler
         if (mainPage == null)
             return false;
 
+        ApplyStatusBar(colors, theme);
+        mainPage.BackgroundColor = Color.FromArgb(colors.BottomBar);
+        return true;
+    }
+
+    protected virtual void ApplyStatusBar(ThemeColors colors, Theme? theme)
+    {
         var style = theme switch {
             Theme.Light => StatusBarStyle.DarkContent,
             Theme.Ash => StatusBarStyle.DarkContent,
@@ -109,12 +105,27 @@ public class MauiThemeHandler
         if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Q)
             StatusBar.SetColor(Colors.Transparent);
         else
-            StatusBar.SetColor(Color.FromArgb(topBarColor));
+            StatusBar.SetColor(Color.FromArgb(colors.TopBar));
 #else
         StatusBar.SetColor(Colors.Transparent);
 #endif
         StatusBar.SetStyle(style);
-        mainPage.BackgroundColor = Color.FromArgb(bottomBarColor);
-        return true;
+    }
+
+    // Nested types
+
+    public sealed record ThemeColors(string TopBar, string BottomBar, string Navbar, string Text)
+    {
+        public static ThemeColors Parse(string colors)
+        {
+            // The order is set by getColors in theme.ts. Colors stored by an older version stop after
+            // BottomBar, and a single color used to stand for both bars.
+            var items = colors.Split(';');
+            var topBar = items[0].Trim();
+            return new ThemeColors(topBar, GetItem(1, topBar), GetItem(2, topBar), GetItem(3, ""));
+
+            string GetItem(int index, string defaultValue)
+                => index < items.Length ? items[index].Trim() : defaultValue;
+        }
     }
 }

--- a/src/dotnet/App.Maui/Platforms/Android/AndroidThemeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Android/AndroidThemeHandler.cs
@@ -10,13 +10,13 @@ public class AndroidThemeHandler : MauiThemeHandler
     [UnconditionalSuppressMessage("Trimming",
         "CA1422: Call site is reachable on Android >= v.X, obsolete on >= v.Y",
         Justification = "Fine for Window.SetNavigationBarColor")]
-    protected override bool Apply(string topBarColor, string bottomBarColor, Theme? theme)
+    protected override bool Apply(ThemeColors colors, Theme? theme)
     {
         // Call base for status bar handling via CommunityToolkit and background color
-        if (!base.Apply(topBarColor, bottomBarColor, theme))
+        if (!base.Apply(colors, theme))
             return false;
 
-        SetBarsAppearance(topBarColor, bottomBarColor);
+        SetBarsAppearance(colors.TopBar, colors.BottomBar);
         return true;
     }
 

--- a/src/dotnet/App.Maui/Platforms/Windows/App.xaml
+++ b/src/dotnet/App.Maui/Platforms/Windows/App.xaml
@@ -4,5 +4,41 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:ActualChat.App.Maui.WinUI">
-
+    <maui:MauiWinUIApplication.Resources>
+        <!-- MAUI picks MauiAppTitleBarTemplate over its default title strip (WindowRootViewStyle.xaml in
+             dotnet/maui), which is transparent and dims the title in an inactive window. This one is a single
+             color: WindowConfigurator.UpdateTitleBar sets both brushes to the theme's navbar and text colors. -->
+        <SolidColorBrush x:Key="VoxtTitleBarBackgroundBrush" Color="#28282E"/>
+        <SolidColorBrush x:Key="VoxtTitleBarForegroundBrush" Color="#F5F5FC"/>
+        <DataTemplate x:Key="MauiAppTitleBarTemplate">
+            <Grid Background="{StaticResource VoxtTitleBarBackgroundBrush}">
+                <Grid Margin="{Binding WindowTitleMargin}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Image
+                        x:Name="AppFontIcon"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Source="Square44x44Logo.png"
+                        Visibility="{Binding WindowTitleIconVisibility}"
+                        Width="16"
+                        Height="16"
+                        Margin="8,0,0,0"/>
+                    <TextBlock
+                        x:Name="AppTitle"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Margin="16,0,0,0"
+                        MinWidth="48"
+                        Text="{Binding WindowTitle}"
+                        Foreground="{StaticResource VoxtTitleBarForegroundBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="NoWrap"/>
+                </Grid>
+            </Grid>
+        </DataTemplate>
+    </maui:MauiWinUIApplication.Resources>
 </maui:MauiWinUIApplication>

--- a/src/dotnet/App.Maui/Platforms/Windows/WindowConfigurator.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/WindowConfigurator.cs
@@ -1,15 +1,26 @@
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Windowing;
 using WinRT.Interop;
+using Color = Microsoft.Maui.Graphics.Color;
+using SolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 using Window = Microsoft.UI.Xaml.Window;
+using XamlApplication = Microsoft.UI.Xaml.Application;
 
 namespace ActualChat.App.Maui;
 
+/// <summary>
+/// Desktop window policy of the Windows app: the close button minimizes while
+/// <see cref="App.MustMinimizeOnQuit"/> holds, and the title bar takes the theme's navbar and text colors.
+/// </summary>
 internal static partial class WindowConfigurator
 {
+    private static AppWindow? _appWindow;
+
     public static void Configure(Window window)
     {
         ConfigureMinimization(window);
         ConfigureStartupSize(window);
+        ConfigureTitleBar(window);
         WindowsSplashScreen.Attach(window);
     }
 
@@ -26,6 +37,34 @@ internal static partial class WindowConfigurator
         }
     }
 
+    public static void UpdateTitleBar(string backgroundColor, string textColor)
+    {
+        if (backgroundColor.IsNullOrEmpty() || textColor.IsNullOrEmpty())
+            return;
+
+        var background = Color.FromArgb(backgroundColor);
+        var text = Color.FromArgb(textColor);
+        // The title strip is MauiAppTitleBarTemplate from App.xaml, painted with these brushes
+        SetBrushColor("VoxtTitleBarBackgroundBrush", background);
+        SetBrushColor("VoxtTitleBarForegroundBrush", text);
+        if (_appWindow is not { } appWindow)
+            return;
+
+        // The caption buttons keep MAUI's transparent backgrounds over the strip and the same colors in an
+        // inactive window. The title bar takes transparency only for those plain backgrounds, so the hover
+        // and pressed shades are blended against the strip color.
+        var foreground = text.ToWindowsColor();
+        var titleBar = appWindow.TitleBar;
+        titleBar.ButtonForegroundColor = foreground;
+        titleBar.ButtonInactiveForegroundColor = foreground;
+        titleBar.ButtonHoverForegroundColor = foreground;
+        titleBar.ButtonPressedForegroundColor = foreground;
+        titleBar.ButtonHoverBackgroundColor = Blend(background, text, 0.1f).ToWindowsColor();
+        titleBar.ButtonPressedBackgroundColor = Blend(background, text, 0.2f).ToWindowsColor();
+    }
+
+    // Private methods
+
     private static void ConfigureMinimization(Window window)
     {
         WinUI.App.AppInstanceActivated += arguments => {
@@ -36,8 +75,8 @@ internal static partial class WindowConfigurator
                 }
 
                 try {
-                    if (window.GetAppWindow() is { Presenter: Microsoft.UI.Windowing.OverlappedPresenter presenter }
-                        && presenter.State == Microsoft.UI.Windowing.OverlappedPresenterState.Minimized)
+                    if (window.GetAppWindow() is { Presenter: OverlappedPresenter presenter }
+                        && presenter.State == OverlappedPresenterState.Minimized)
                         presenter.Restore();
                 }
                 catch {
@@ -61,7 +100,7 @@ internal static partial class WindowConfigurator
 
                 // Presenter may not be OverlappedPresenter — e.g. CompactOverlay /
                 // FullScreen. Use pattern-match to avoid InvalidCastException FCE.
-                if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter) {
+                if (appWindow.Presenter is OverlappedPresenter presenter) {
                     presenter.Minimize();
                     e.Cancel = true;
                 }
@@ -76,7 +115,7 @@ internal static partial class WindowConfigurator
     {
         try {
             var appWindow = window.GetAppWindow()!;
-            if (appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            if (appWindow.Presenter is OverlappedPresenter presenter)
                 presenter.Maximize();
         }
         catch {
@@ -84,6 +123,33 @@ internal static partial class WindowConfigurator
             window.Activate();
         }
     }
+
+    private static void ConfigureTitleBar(Window window)
+    {
+        try {
+            if (AppWindowTitleBar.IsCustomizationSupported())
+                _appWindow = window.GetAppWindow();
+        }
+        catch {
+            // In unpackaged/AOT mode, GetAppWindow may fail
+        }
+        // The web app reports its theme only once it's loaded, so the window starts with the stored one
+        var colors = MauiThemeHandler.Instance.CurrentColors;
+        UpdateTitleBar(colors.Navbar, colors.Text);
+    }
+
+    private static void SetBrushColor(string resourceKey, Color color)
+    {
+        if (XamlApplication.Current.Resources.TryGetValue(resourceKey, out var resource)
+            && resource is SolidColorBrush brush)
+            brush.Color = color.ToWindowsColor();
+    }
+
+    private static Color Blend(Color background, Color foreground, float amount)
+        => new(
+            background.Red + (foreground.Red - background.Red) * amount,
+            background.Green + (foreground.Green - background.Green) * amount,
+            background.Blue + (foreground.Blue - background.Blue) * amount);
 
     [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/dotnet/App.Maui/Platforms/Windows/WindowsSplashScreen.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/WindowsSplashScreen.cs
@@ -173,7 +173,7 @@ public static class WindowsSplashScreen
         // The theme background, so the splash, the WebView and the app all show the same color and the
         // transition is invisible. There's no stored theme on a first run - fall back to the dark theme's
         // --background-01 rather than the splash color, which blinks against every theme.
-        var color = MauiThemeHandler.Instance.TopBarColor;
+        var color = MauiThemeHandler.Instance.CurrentColors.TopBar;
         return color.IsNullOrEmpty() ? DefaultBackgroundColor : Color.FromArgb(color);
     }
 

--- a/src/dotnet/App.Maui/Platforms/Windows/WindowsThemeHandler.cs
+++ b/src/dotnet/App.Maui/Platforms/Windows/WindowsThemeHandler.cs
@@ -1,0 +1,20 @@
+using ActualChat.UI;
+
+namespace ActualChat.App.Maui;
+
+public sealed class WindowsThemeHandler : MauiThemeHandler
+{
+    protected override bool Apply(ThemeColors colors, Theme? theme)
+    {
+        if (!base.Apply(colors, theme))
+            return false;
+
+        WindowConfigurator.UpdateTitleBar(colors.Navbar, colors.Text);
+        return true;
+    }
+
+    // WinUI has no status bar: the toolkit's StatusBar throws NotSupportedException there,
+    // which used to abort the whole Apply
+    protected override void ApplyStatusBar(ThemeColors colors, Theme? theme)
+    { }
+}

--- a/src/nodejs/src/theme.ts
+++ b/src/nodejs/src/theme.ts
@@ -94,10 +94,12 @@ function getColors(): string {
     if (!storage)
         return '';
 
+    // MauiThemeHandler.ThemeColors reads these by position, and the native apps store the string, so a
+    // new color goes last
     const style = getComputedStyle(document.body);
-    const headerColor = style.getPropertyValue('--background-01');
-    const postPanelColor = style.getPropertyValue('--post-panel');
-    return normalizeColor(headerColor) + ';' + normalizeColor(postPanelColor);
+    return ['--background-01', '--post-panel', '--background-04', '--text-01']
+        .map(name => normalizeColor(style.getPropertyValue(name)))
+        .join(';');
 }
 
 function normalizeColor(hexColor: string): string {


### PR DESCRIPTION
## Summary

The Windows app's title bar is a black strip that ignores the app theme. MAUI extends the window content into the title bar area and draws its own title strip there. That strip is transparent (over the window backdrop), and its title dims in an inactive window. Windows draws the caption buttons in its default colors, and those change with the window's active state too.

## Fix

The title bar stays where it is, but it's painted in one color: the theme's navbar background with the app's text color, the same whether the window is active or not.

- **Title strip:** MAUI picks a `MauiAppTitleBarTemplate` resource over its default strip (`DefaultOrUserDataTemplateSelector` in `WindowRootViewStyle.xaml`). `Platforms/Windows/App.xaml` defines one: MAUI's own layout (icon, title, `WindowTitleMargin`), on a background brush, with a fixed foreground brush instead of MAUI's active/inactive `WindowTitleForeground`. Its root is a `Grid`, not a `Border`, so MAUI's "accent color on title bars" handling (`ApplyTitlebarColorPrevalence`) leaves it alone. The background spans the full width, so it also shows through the caption buttons' transparent backgrounds.
- **Colors:** `WindowConfigurator.UpdateTitleBar` recolors the two brushes. It also sets the caption buttons' foregrounds, active and inactive, to the text color. Hover and pressed backgrounds are blended against the strip color, because the title bar supports transparency only for the plain button backgrounds. It runs from the new `WindowsThemeHandler` on every theme apply, and once at window creation with the stored colors, so the bar is right before the web app loads.
- **Theme colors:** `getColors` in `theme.ts` now also sends `--background-04` (navbar) and `--text-01`, appended so older stored strings still parse. `MauiThemeHandler` parses the string once into `ThemeColors`; `CurrentColors` replaces `TopBarColor` (used by the splash screen). The Android override is updated to the new `Apply` signature.

- **Theme changes now reach native code on Windows.** `MauiThemeHandler.Apply` called the toolkit's `StatusBar.SetColor`, which throws `NotSupportedException` on WinUI. Every Windows apply therefore stopped there with an "ApplyColors failed" warning, before the page background or the title bar was updated. The status bar part is now the virtual `ApplyStatusBar`, which `WindowsThemeHandler` makes a no-op.

An earlier revision extended the page under the title bar instead; that was dropped in favor of the always-visible bar.

Related: #4461 handles the macOS app's titlebar (not merged); this PR doesn't touch those files.

## Testing

- `b app build windows` (Debug): 0 errors, no new warnings.
- `npm run build:Verify`: green.
- Unpackaged Debug app: see the latest comment for what was checked on a real window.
- Android compiles unverified locally (the signature change in `AndroidThemeHandler` is mechanical); CI builds it.

Closes #4485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqRR6J1UvkBxP2vZoCGL3X
