### PR TITLE
fix(settings): open Settings on the requested tab, not the first one

### DIFF
--- a/src/dotnet/UI.Blazor/Components/SettingsPanel/SettingsPanel.razor
+++ b/src/dotnet/UI.Blazor/Components/SettingsPanel/SettingsPanel.razor
@@ -127,10 +127,14 @@
         var selectable = tabs.Where(x => x.Content != null).ToList();
         if (selectable.Count == 0)
             return null;
-        if (selectedTabId is null || lastTabs.All(x => x.Id != selectedTabId))
+        if (selectedTabId is null)
             return selectable[0].Id;
+        // Checked before the lastTabs lookup: on the first pass lastTabs is empty,
+        // and DefaultTabId must survive it.
         if (selectable.Any(x => x.Id == selectedTabId))
             return selectedTabId;
+        if (lastTabs.All(x => x.Id != selectedTabId))
+            return selectable[0].Id;
 
         // The selected tab is gone: take the nearest survivor after it in the order it had,
         // and fall back to the last tab if everything after it went away too.

--- a/tests/ts/e2e/language-setup-opens-transcription-settings.test.ts
+++ b/tests/ts/e2e/language-setup-opens-transcription-settings.test.ts
@@ -1,0 +1,116 @@
+/**
+ * E2E test: the "(setup)" links in the voice-settings and translation-language modals open
+ * Settings on the Voice & Transcription tab, not on the first tab (#4486).
+ *
+ * Run:
+ *   npx vitest run tests/ts/e2e/language-setup-opens-transcription-settings.test.ts --config vitest.config.e2e.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Locator, Page } from 'playwright';
+import {
+    BASE_URL, connectBrowser, ensureSignedIn, screenshot, skipOnboarding,
+    waitForChatReady, waitForEditor, type BrowserConnection,
+} from './helpers';
+
+const shot = (name: string) => screenshot('e2e', `4486-language-setup-${name}`);
+
+const CHAT_URL = `${BASE_URL}/chat/the-actual-one`;
+const TRANSCRIPTION_TAB = 'transcription';
+
+describe('language "(setup)" link opens the Voice & Transcription settings tab', () => {
+    let conn: BrowserConnection;
+    let page: Page;
+    let mustHideTranslationSubHeader = false;
+
+    beforeAll(async () => {
+        conn = await connectBrowser();
+        page = await conn.context.newPage();
+        await ensureSignedIn(page);
+    }, 120_000);
+
+    afterAll(async () => {
+        if (mustHideTranslationSubHeader) {
+            await openChat(page);
+            await page.locator('.chat-header-control-panel .translation-btn').first().click({ force: true })
+                .catch(() => { /* ignore */ });
+        }
+        await page.close().catch(() => { /* ignore */ });
+        if (conn.ownsBrowser) {
+            await conn.context.close();
+            await conn.browser.close();
+        }
+    }, 60_000);
+
+    it('from the transcription language modal', async () => {
+        await openChat(page);
+
+        // The language options button: a round button on a wide screen, a text button on a narrow one.
+        await page.locator('.transcription-options-btn, .volume-settings-btn').first().click({ force: true });
+        const modal = page.locator('.transcription-options-modal').first();
+        await modal.waitFor({ state: 'visible', timeout: 10_000 });
+        await page.screenshot({ path: shot('voice-modal') });
+
+        // "(setup)" shows with 2+ languages; with one, the hint's "Settings" link opens the same tab.
+        await modal.locator('.language-btn-group .c-edit, .language-btn-group .c-settings-hint .link')
+            .first().click({ force: true });
+
+        await expectTranscriptionTabSelected(page, 'voice-settings');
+        await closeSettings(page);
+    }, 60_000);
+
+    it('from the translation language modal', async () => {
+        await openChat(page);
+
+        const subHeader = page.locator('.translation-sub-header').first();
+        if (!await subHeader.isVisible().catch(() => false)) {
+            await page.locator('.chat-header-control-panel .translation-btn').first().click({ force: true });
+            mustHideTranslationSubHeader = true;
+        }
+        await subHeader.waitFor({ state: 'visible', timeout: 10_000 });
+        await subHeader.locator('.c-language').first().click({ force: true });
+
+        const modal = page.locator('.translation-language-modal').first();
+        await modal.waitFor({ state: 'visible', timeout: 10_000 });
+        await page.screenshot({ path: shot('translation-modal') });
+        await modal.locator('.language-btn-group .c-edit').first().click({ force: true });
+
+        await expectTranscriptionTabSelected(page, 'translation-settings');
+        await closeSettings(page);
+    }, 60_000);
+});
+
+async function openChat(page: Page) {
+    await page.goto(CHAT_URL, { waitUntil: 'domcontentloaded' });
+    await waitForChatReady(page);
+    await skipOnboarding(page);
+    await waitForEditor(page);
+}
+
+async function expectTranscriptionTabSelected(page: Page, shotName: string) {
+    const settings = page.locator('.settings-modal').first();
+    await settings.waitFor({ state: 'visible', timeout: 15_000 });
+    const selectedTab = settings.locator('.c-tab-item.on button[data-tab-id]').first();
+    await selectedTab.waitFor({ state: 'visible', timeout: 10_000 });
+    // The wrong tab renders its content right away; give the selection a beat to settle
+    // so the assertion catches a late fallback to the first tab too.
+    await page.waitForTimeout(1_000);
+    await page.screenshot({ path: shot(shotName) });
+
+    expect(await selectedTab.getAttribute('data-tab-id')).toBe(TRANSCRIPTION_TAB);
+    expect((await tabContentHeaderOf(settings).innerText()).trim()).toBe(await tabTitleOf(selectedTab));
+}
+
+function tabContentHeaderOf(settings: Locator): Locator {
+    return settings.locator('.settings-tab .settings-tab-header .c-title').first();
+}
+
+async function tabTitleOf(tab: Locator): Promise<string> {
+    return (await tab.locator('.settings-tab-item > span').first().innerText()).trim();
+}
+
+async function closeSettings(page: Page) {
+    const settings = page.locator('.settings-modal').first();
+    await page.keyboard.press('Escape');
+    await settings.waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => { /* ignore */ });
+}


### PR DESCRIPTION
## Summary

Every link that opens Settings on a specific tab landed on **Your Account** instead: the "(setup)" links in the voice-settings and translation-language modals, and the Log Viewer's "Application" link.

`SettingsPanel.ResolveSelectedTabId` checked "was the selected tab in the previous tab list" before "does it exist now". On the first `OnParametersSet` the previous list is the empty seed, so the seeded `DefaultTabId` never matched and the first selectable tab won. Introduced when the ContentSwap change inlined this logic (feaadfc1f8).

## Fix

The existence check now runs before the previous-list check, so a default tab that is present is kept.

Invariant for reviewers: after the first pass, `SelectedTabId` always holds an id from the previous list (it comes from a click on an existing tab, the keep branch, the nearest-survivor branch, or the last-tab fallback). So the reorder only changes the outcome on the seeded first pass; the ContentSwap "nearest survivor" handover for a tab that disappears is untouched.

## Testing

- New e2e test `tests/ts/e2e/language-setup-opens-transcription-settings.test.ts` opens Settings from both modals and asserts the Voice & Transcription tab is selected. Fails on `dev` (receives `account`), passes with the fix.
- Existing `log-viewer` and `ui-language-picker` e2e tests rerun green (tab clicks and tab-list changes).
- eslint and tsc clean on the test file. No .NET unit tests cover `SettingsPanel`; none were run.

Closes #4486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
