### PR TITLE
fix(ui): generated avatars stuck on the skeleton after a move mid-raster

### DIFF
--- a/docs/api-index-ts.md
+++ b/docs/api-index-ts.md
@@ -287,6 +287,7 @@ See also: [C# Full API Index](api-index-full.md), [Condensed API Index](api-inde
 - `LogLevel` (enum) - Log severity level.
 - `Log` (class) - Logging system instance.
 - `LogLevelController` (class) - Control log levels at runtime.
+- `escapeHtml` (function) - Escape &, <, >, " for HTML/SVG markup.
 
 
 ## Worklets (`src/nodejs/src/worklets`)

--- a/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/code-block-markup-view.ts
+++ b/src/dotnet/UI.Blazor.App/Components/MarkupParts/CodeBlockMarkupView/code-block-markup-view.ts
@@ -27,6 +27,7 @@ import markdown from 'highlight.js/lib/languages/markdown';
 import diff from 'highlight.js/lib/languages/diff';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 import { getLogs } from 'logging';
+import { escapeHtml } from 'strings';
 import { Theme, ThemeInfo } from 'theme';
 
 const { errorLog } = getLogs('CodeBlockMarkupView');
@@ -79,14 +80,6 @@ function looksLikeTable(code: string): boolean {
         return false;
     const pipeLines = lines.filter(l => l.trimStart().startsWith('|'));
     return pipeLines.length >= lines.length / 2;
-}
-
-function escapeHtml(text: string): string {
-    return text
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
 }
 
 function highlightTableCells(code: string): string {

--- a/src/dotnet/UI.Blazor/Components/Avatar/generated-avatar.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Avatar/generated-avatar.lit.ts
@@ -23,6 +23,10 @@ export abstract class GeneratedAvatar extends LitElement {
         // Observe the sized parent (.c-content); the host itself may be inline.
         this.resizeObserver.observe(this.parentElement ?? this);
         GeneratedAvatar.scheduleMeasure(this);
+        // A move (e.g. a keyed Blazor reorder) drops the SvgCache listener in disconnectedCallback, and
+        // re-measuring to the same bucket doesn't re-render, so an avatar mid-raster would stay a skeleton.
+        if (this.hasUpdated)
+            this.requestUpdate();
     }
 
     disconnectedCallback() {

--- a/src/dotnet/UI.Blazor/Components/Avatar/marble-avatar.lit.ts
+++ b/src/dotnet/UI.Blazor/Components/Avatar/marble-avatar.lit.ts
@@ -1,4 +1,5 @@
 import { customElement, property } from 'lit/decorators.js';
+import { escapeHtml } from 'strings';
 
 import { getRandomColor, getUnit, hashCode } from './avatar-utils';
 import { GeneratedAvatar } from './generated-avatar.lit';
@@ -37,7 +38,8 @@ export class MarbleAvatar extends GeneratedAvatar {
             ? ''
             : `<feGaussianBlur stdDeviation='7' result='effect1_foregroundBlur' />`;
 
-        const displayTitle = !title ? '' : title[0].toUpperCase();
+        // The title lands in SVG markup, where a bare '&' or '<' makes the image fail to load.
+        const displayTitle = !title ? '' : escapeHtml(title[0].toUpperCase());
 
         return `<svg viewBox='0 0 ${SIZE} ${SIZE}' fill='none' xmlns='http://www.w3.org/2000/svg' width='${SIZE}' height='${SIZE}'>` +
             `<mask id='m' maskUnits='userSpaceOnUse' x='0' y='0' width='${SIZE}' height='${SIZE}'>` +

--- a/src/dotnet/UI.Blazor/Components/Avatar/svg-cache.ts
+++ b/src/dotnet/UI.Blazor/Components/Avatar/svg-cache.ts
@@ -1,3 +1,7 @@
+import { getLogs } from 'logging';
+
+const { warnLog } = getLogs('SvgCache');
+
 type CacheListener = (url: string) => void;
 
 const BITMAP_THRESHOLD = 144;
@@ -12,7 +16,8 @@ export class SvgCache {
     }
 
     static add(cacheKey: string, svgString: string, pixelSize: number): void {
-        if (this.cache.has(cacheKey) || this.pending.has(cacheKey)) return;
+        if (this.cache.has(cacheKey) || this.pending.has(cacheKey))
+            return;
 
         const promise =
             pixelSize <= BITMAP_THRESHOLD
@@ -20,15 +25,22 @@ export class SvgCache {
                 : SvgCache.renderToSvgBlob(svgString);
 
         this.pending.set(cacheKey, promise);
-        void promise.then(url => {
-            this.cache.set(cacheKey, url);
-            this.pending.delete(cacheKey);
-            SvgCache.notifyListeners(cacheKey, url);
-        });
+        void promise.then(
+            url => {
+                this.cache.set(cacheKey, url);
+                this.pending.delete(cacheKey);
+                SvgCache.notifyListeners(cacheKey, url);
+            },
+            (error: unknown) => {
+                // Otherwise the key stays pending forever, and every later add() for it is a no-op.
+                this.pending.delete(cacheKey);
+                warnLog?.log(`add: failed to rasterize '${cacheKey}'`, error);
+            });
     }
 
     static clear(): void {
-        for (const url of this.cache.values()) URL.revokeObjectURL(url);
+        for (const url of this.cache.values())
+            URL.revokeObjectURL(url);
         this.cache.clear();
         this.pending.clear();
         this.listeners.clear();
@@ -43,7 +55,8 @@ export class SvgCache {
         set.add(listener);
         return () => {
             set.delete(listener);
-            if (set.size === 0) this.listeners.delete(cacheKey);
+            if (set.size === 0)
+                this.listeners.delete(cacheKey);
         };
     }
 
@@ -51,10 +64,12 @@ export class SvgCache {
 
     private static notifyListeners(cacheKey: string, url: string): void {
         const set = this.listeners.get(cacheKey);
-        if (!set) return;
+        if (!set)
+            return;
 
         this.listeners.delete(cacheKey);
-        for (const listener of set) listener(url);
+        for (const listener of set)
+            listener(url);
     }
 
     private static renderToSvgBlob(svgString: string): Promise<string> {
@@ -75,8 +90,10 @@ export class SvgCache {
                 const ctx = canvas.getContext('2d')!;
                 ctx.drawImage(img, 0, 0, pixelSize, pixelSize);
                 canvas.toBlob(pngBlob => {
-                    if (pngBlob) resolve(URL.createObjectURL(pngBlob));
-                    else reject(new Error('canvas.toBlob failed'));
+                    if (pngBlob)
+                        resolve(URL.createObjectURL(pngBlob));
+                    else
+                        reject(new Error('canvas.toBlob failed'));
                 }, 'image/png');
             };
             img.onerror = () => {

--- a/src/nodejs/src/logging.ts
+++ b/src/nodejs/src/logging.ts
@@ -67,6 +67,7 @@ export type LogScope =
     | 'ScreenSize'
     | 'ServiceWorker'
     | 'SessionTokens'
+    | 'SvgCache'
     | 'TimerQueue'
     | 'UndoStack'
     | 'Versioning'
@@ -186,6 +187,7 @@ const defaults: Record<LogScope, LogLevel> = {
     ScreenSize: LogLevel.Warn,
     ServiceWorker: LogLevel.Warn,
     SessionTokens: LogLevel.Warn,
+    SvgCache: LogLevel.Warn,
     TimerQueue: LogLevel.Warn,
     UndoStack: LogLevel.Warn,
     Versioning: LogLevel.Warn,

--- a/src/nodejs/src/strings.ts
+++ b/src/nodejs/src/strings.ts
@@ -1,0 +1,7 @@
+export function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
## Summary

Generated marble/beam avatars could stay on their round skeleton until a reload. The Bugs chat report showed several places in the navbar rail drawn as empty squares with a dark circle inside, which "sometimes" recovered after a refresh.

The mechanism is in `GeneratedAvatar`:
1. The avatar measures, sets `pixelSize`, and `render()` subscribes to `SvgCache` while the bitmap rasterizes asynchronously (image load + `canvas.toBlob`).
2. If Blazor moves the element before the raster completes, `disconnectedCallback` drops that subscription. A keyed reorder of `NavbarPlaceButtons` after the place order changes is one such move.
3. `connectedCallback` re-measures to the same power-of-two bucket. No state changes, so Lit never re-renders and nothing re-subscribes. The raster lands with no listener, and the element stays a skeleton for the session.

This isn't a recent regression: the unsubscribe-on-disconnect plus no-op re-measure predates the batched measurement (f405962df3). Which event reorders the rail at startup on the desktop app is not proven. The synced place order arriving after the first render is the plausible one. The fix doesn't depend on the trigger.

Two smaller defects on the same path:
- `SvgCache.add` never cleared `pending` when a raster rejected, so that key stayed a skeleton everywhere for the session.
- The marble's title letter went into the SVG unescaped, so a title starting with `&` or `<` produced an image that never loaded.

## Fix

- `generated-avatar.lit.ts`: on reconnect, if the element has rendered before, `requestUpdate()`. `render()` then re-reads the cache or re-subscribes (`SvgCache.add` is a no-op while the key is pending). An avatar that isn't moved renders exactly as before; a moved one costs one extra Lit render.
- `svg-cache.ts`: the rejection handler clears `pending` and logs a `SvgCache` warning, so a later render can retry. The file's one-line `if (…) return;` guards were reformatted per the style guide.
- `marble-avatar.lit.ts`: the title letter goes through `escapeHtml`. That function moved verbatim from `code-block-markup-view.ts` into a shared `src/nodejs/src/strings.ts`, which both now import, and it is listed in `docs/api-index-ts.md`.

## Testing

Local server (server render mode), Chrome:
- **Real navbar repro, before the fix.** `toBlob` was delayed 6 s, and a keyed Blazor reorder of the rail (via `OnOrderChanged`) ran while the rasters were pending. Both place avatars were still skeletons 19 s later: no listener, no `cachedUrl`, no rejection. A bare `requestUpdate()` repaired them.
- **Same repro, after the fix.** For each moved avatar: disconnect → connect → render (re-subscribed) → image once the raster landed. Unmoved avatars elsewhere on the page had no extra renders (3 per instance, 0 disconnects).
- **Synthetic checks.** `&` / `<` titles rasterize. A forced `toBlob` failure logs the warning, and a second avatar with the same key then renders. Detach/reattach mid-raster renders.
- `tsc --noEmit` + bundle build (server-loop rebundle) and `eslint` on the changed files pass.

Not verified: WASM / the MAUI desktop app. The WASM tab wedged during testing, so the startup reorder there wasn't observed. One thing seen while testing: after a rebundle, a normal reload (even with cache disabled and the service worker unregistered) kept running the old immutable `/dist/bundle.<hash>.js`. That caching is unrelated to this bug, and it's worth not confusing it with the "WebView doesn't cache images" theory from the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkXkjXqdQGG32ZNK5K1RqS
