### PR TITLE
fix(threads): notifications, Threads-tab unread badge, mention picker and back button

### DIFF
--- a/src/dotnet/Chat.Service/ChatThreads.cs
+++ b/src/dotnet/Chat.Service/ChatThreads.cs
@@ -193,6 +193,12 @@ public class ChatThreads(IServiceProvider services) : IChatThreads
                     IsPublic = false,
                 });
                 threadChat = await Commander.Call(new ChatsBackend_Change(threadChatId, null, chatChange, OwnerId:ownerId), cancellationToken).ConfigureAwait(false);
+                // Only followers get a thread's notifications. The start entry's author follows via
+                // ContactsBackend.OnChatEntryChangedEvent, but that's who wrote it, not who started the thread.
+                var starterContactId = ContactId.NewAny(ownerId, threadChatId);
+                var followCommand = new ContactsBackend_ChangeThreadContact(
+                    starterContactId, null, Change.Create(new ThreadContact(starterContactId)));
+                await Commander.Call(followCommand, cancellationToken).ConfigureAwait(false);
             }
             var chatId = threadChat.Id;
 

--- a/src/dotnet/Contacts.Service/ContactsBackend.cs
+++ b/src/dotnet/Contacts.Service/ContactsBackend.cs
@@ -22,7 +22,6 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
     private IAuthorsBackend AuthorsBackend => field ??= Services.GetRequiredService<IAuthorsBackend>();
     private IChatsBackend ChatsBackend => field ??= Services.GetRequiredService<IChatsBackend>();
     private IExternalContactsBackend ExternalContactsBackend => field ??= Services.GetRequiredService<IExternalContactsBackend>();
-    private IRolesBackend RolesBackend => field ??= Services.GetRequiredService<IRolesBackend>();
     private IDbEntityResolver<string, DbContact> DbContactResolver => field ??= Services.GetRequiredService<IDbEntityResolver<string, DbContact>>();
     private IMeshLocks GreetLocks => field ??= Services.MeshLocks().WithKeyPrefix(nameof(GreetLocks));
     public RedisDb<ContactsDbContext> RedisDb => field ??= Services.GetRequiredService<RedisDb<ContactsDbContext>>();
@@ -848,32 +847,11 @@ public class ContactsBackend(IServiceProvider services) : DbServiceBase<Contacts
             return; // It just spawns other commands, so nothing to do here
 
         var (chat, oldChat, changeKind) = eventCommand;
-        if (chat.Id.IsThread(out var threadChatId)) {
-            if (changeKind is ChangeKind.Remove) {
-                // TODO: implement remove thread contacts
-                // var command = new ContactsBackend_RemoveChatContacts(chat.Id);
-                // await Commander.Call(command, true, cancellationToken).ConfigureAwait(false);
-            }
-            else if (changeKind is ChangeKind.Create) {
-                // Create a thread contact for the thread starter.
-                var ownerRole = await RolesBackend
-                    .GetSystem(chat.Id, SystemRole.Owner, cancellationToken)
-                    .Require()
-                    .ConfigureAwait(false);
-
-                var authorIds = await RolesBackend.ListAuthorIds(chat.Id, ownerRole.Id, cancellationToken).ConfigureAwait(false);
-                foreach (var authorId in authorIds) {
-                    var author = await AuthorsBackend
-                        .Get(authorId.ChatId, authorId, RequestedAuthorKind.Full, cancellationToken)
-                        .ConfigureAwait(false);
-                    if (author is null)
-                        continue;
-
-                    await EnsureThreadContactExits(author.UserId, threadChatId, cancellationToken).ConfigureAwait(false);
-                }
-            }
+        // Thread contacts are created elsewhere: the starter's by ChatThreads.OnStart (threads have no
+        // roles to find an owner in), everyone else's when they post or get mentioned.
+        // TODO: remove thread contacts when a thread is removed
+        if (chat.Id.IsThread())
             return;
-        }
 
         if (changeKind == ChangeKind.Remove) {
             var command = new ContactsBackend_RemoveChatContacts(chat.Id);

--- a/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
+++ b/src/dotnet/Localization/Resources/LocalizedStringsLocalizerExt.cs
@@ -329,6 +329,10 @@ public static class LocalizedStringsLocalizerExt
 
         public string ThreadMenu_GoToThread => l["ThreadMenu_GoToThread"].Value;
         public string ThreadMenu_CopyThread => l["ThreadMenu_CopyThread"].Value;
+        public string ThreadMenu_Mute => l["ThreadMenu_Mute"].Value;
+        public string ThreadMenu_Unmute => l["ThreadMenu_Unmute"].Value;
+        public string ThreadMenu_GoToStartMessage => l["ThreadMenu_GoToStartMessage"].Value;
+        public string ThreadMenu_CopyThreadLink => l["ThreadMenu_CopyThreadLink"].Value;
 
         public string LocationMessage_Live => l["LocationMessage_Live"].Value;
         public string LocationMessage_Static => l["LocationMessage_Static"].Value;

--- a/src/dotnet/Localization/Resources/Strings.bg.json
+++ b/src/dotnet/Localization/Resources/Strings.bg.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Към нишката",
   "ThreadMenu_CopyThread": "Копирайте нишката",
+  "ThreadMenu_Mute": "Заглуши",
+  "ThreadMenu_Unmute": "Премахни заглушаването",
+  "ThreadMenu_GoToStartMessage": "Към началното съобщение",
+  "ThreadMenu_CopyThreadLink": "Копирайте линка към нишката",
 
   "LocationMessage_Live": "Местоположение на живо",
   "LocationMessage_Static": "Местоположение",

--- a/src/dotnet/Localization/Resources/Strings.bs.json
+++ b/src/dotnet/Localization/Resources/Strings.bs.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Idite na nit",
   "ThreadMenu_CopyThread": "Kopirajte nit",
+  "ThreadMenu_Mute": "Utišaj",
+  "ThreadMenu_Unmute": "Ukini utišavanje",
+  "ThreadMenu_GoToStartMessage": "Idite na početnu poruku",
+  "ThreadMenu_CopyThreadLink": "Kopirajte link niti",
 
   "LocationMessage_Live": "Lokacija uživo",
   "LocationMessage_Static": "Lokacija",

--- a/src/dotnet/Localization/Resources/Strings.cnr.json
+++ b/src/dotnet/Localization/Resources/Strings.cnr.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Idite na nit",
   "ThreadMenu_CopyThread": "Kopirajte nit",
+  "ThreadMenu_Mute": "Utišaj",
+  "ThreadMenu_Unmute": "Ukini utišavanje",
+  "ThreadMenu_GoToStartMessage": "Idite na početnu poruku",
+  "ThreadMenu_CopyThreadLink": "Kopirajte link niti",
 
   "LocationMessage_Live": "Lokacija uživo",
   "LocationMessage_Static": "Lokacija",

--- a/src/dotnet/Localization/Resources/Strings.cs.json
+++ b/src/dotnet/Localization/Resources/Strings.cs.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Přejít na vlákno",
   "ThreadMenu_CopyThread": "Kopírovat vlákno",
+  "ThreadMenu_Mute": "Ztlumit",
+  "ThreadMenu_Unmute": "Zrušit ztlumení",
+  "ThreadMenu_GoToStartMessage": "Přejít na úvodní zprávu",
+  "ThreadMenu_CopyThreadLink": "Kopírovat odkaz na vlákno",
 
   "LocationMessage_Live": "Poloha živě",
   "LocationMessage_Static": "Poloha",

--- a/src/dotnet/Localization/Resources/Strings.de.json
+++ b/src/dotnet/Localization/Resources/Strings.de.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Zum Thread",
   "ThreadMenu_CopyThread": "Thread kopieren",
+  "ThreadMenu_Mute": "Stummschalten",
+  "ThreadMenu_Unmute": "Stummschaltung aufheben",
+  "ThreadMenu_GoToStartMessage": "Zur Startnachricht springen",
+  "ThreadMenu_CopyThreadLink": "Thread-Link kopieren",
 
   "LocationMessage_Live": "Live-Standort",
   "LocationMessage_Static": "Standort",

--- a/src/dotnet/Localization/Resources/Strings.en.json
+++ b/src/dotnet/Localization/Resources/Strings.en.json
@@ -386,9 +386,13 @@
   "ConversationMenu_CopySummary": "Copy summary",
   "ConversationMenu_CopySummaryLink": "Copy summary link",
 
-  // The context menu of a thread card in the transcript.
+  // The context menu of a thread: its card in the transcript and its row in a thread list.
   "ThreadMenu_GoToThread": "Go to thread",
   "ThreadMenu_CopyThread": "Copy thread",
+  "ThreadMenu_Mute": "Mute",
+  "ThreadMenu_Unmute": "Unmute",
+  "ThreadMenu_GoToStartMessage": "Go to start message",
+  "ThreadMenu_CopyThreadLink": "Copy thread link",
 
   // A location posted into a chat. LocationMessage_Place is the plain geographic word for a pin
   // on a map - NOT the product term Place, which docs/i18n.md rules on separately.

--- a/src/dotnet/Localization/Resources/Strings.es.json
+++ b/src/dotnet/Localization/Resources/Strings.es.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Ir al hilo",
   "ThreadMenu_CopyThread": "Copiar hilo",
+  "ThreadMenu_Mute": "Silenciar",
+  "ThreadMenu_Unmute": "Reactivar",
+  "ThreadMenu_GoToStartMessage": "Ir al mensaje inicial",
+  "ThreadMenu_CopyThreadLink": "Copiar enlace al hilo",
 
   "LocationMessage_Live": "Ubicación en tiempo real",
   "LocationMessage_Static": "Ubicación",

--- a/src/dotnet/Localization/Resources/Strings.fr.json
+++ b/src/dotnet/Localization/Resources/Strings.fr.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Aller au fil",
   "ThreadMenu_CopyThread": "Copier le fil",
+  "ThreadMenu_Mute": "Mettre en sourdine",
+  "ThreadMenu_Unmute": "Réactiver",
+  "ThreadMenu_GoToStartMessage": "Aller au message initial",
+  "ThreadMenu_CopyThreadLink": "Copier le lien du fil",
 
   "LocationMessage_Live": "Position en direct",
   "LocationMessage_Static": "Position",

--- a/src/dotnet/Localization/Resources/Strings.hi.json
+++ b/src/dotnet/Localization/Resources/Strings.hi.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "थ्रेड पर जाएँ",
   "ThreadMenu_CopyThread": "थ्रेड कॉपी करें",
+  "ThreadMenu_Mute": "म्यूट करें",
+  "ThreadMenu_Unmute": "अनम्यूट करें",
+  "ThreadMenu_GoToStartMessage": "शुरुआती संदेश पर जाएँ",
+  "ThreadMenu_CopyThreadLink": "थ्रेड का लिंक कॉपी करें",
 
   "LocationMessage_Live": "लाइव लोकेशन",
   "LocationMessage_Static": "लोकेशन",

--- a/src/dotnet/Localization/Resources/Strings.hr.json
+++ b/src/dotnet/Localization/Resources/Strings.hr.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Idite na nit",
   "ThreadMenu_CopyThread": "Kopirajte nit",
+  "ThreadMenu_Mute": "Utišaj",
+  "ThreadMenu_Unmute": "Ukini utišavanje",
+  "ThreadMenu_GoToStartMessage": "Idite na početnu poruku",
+  "ThreadMenu_CopyThreadLink": "Kopirajte link niti",
 
   "LocationMessage_Live": "Lokacija uživo",
   "LocationMessage_Static": "Lokacija",

--- a/src/dotnet/Localization/Resources/Strings.id.json
+++ b/src/dotnet/Localization/Resources/Strings.id.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Buka utas",
   "ThreadMenu_CopyThread": "Salin utas",
+  "ThreadMenu_Mute": "Bisukan",
+  "ThreadMenu_Unmute": "Bunyikan",
+  "ThreadMenu_GoToStartMessage": "Buka pesan awal",
+  "ThreadMenu_CopyThreadLink": "Salin tautan utas",
 
   "LocationMessage_Live": "Lokasi langsung",
   "LocationMessage_Static": "Lokasi",

--- a/src/dotnet/Localization/Resources/Strings.it.json
+++ b/src/dotnet/Localization/Resources/Strings.it.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Vai al thread",
   "ThreadMenu_CopyThread": "Copia il thread",
+  "ThreadMenu_Mute": "Silenzia",
+  "ThreadMenu_Unmute": "Riattiva",
+  "ThreadMenu_GoToStartMessage": "Vai al messaggio iniziale",
+  "ThreadMenu_CopyThreadLink": "Copia il link al thread",
 
   "LocationMessage_Live": "Posizione in tempo reale",
   "LocationMessage_Static": "Posizione",

--- a/src/dotnet/Localization/Resources/Strings.ja.json
+++ b/src/dotnet/Localization/Resources/Strings.ja.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "スレッドへ移動",
   "ThreadMenu_CopyThread": "スレッドをコピー",
+  "ThreadMenu_Mute": "ミュート",
+  "ThreadMenu_Unmute": "ミュート解除",
+  "ThreadMenu_GoToStartMessage": "最初のメッセージに移動",
+  "ThreadMenu_CopyThreadLink": "スレッドのリンクをコピー",
 
   "LocationMessage_Live": "リアルタイムの位置情報",
   "LocationMessage_Static": "位置情報",

--- a/src/dotnet/Localization/Resources/Strings.ko.json
+++ b/src/dotnet/Localization/Resources/Strings.ko.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "스레드로 이동",
   "ThreadMenu_CopyThread": "스레드 복사",
+  "ThreadMenu_Mute": "음소거",
+  "ThreadMenu_Unmute": "음소거 해제",
+  "ThreadMenu_GoToStartMessage": "시작 메시지로 이동",
+  "ThreadMenu_CopyThreadLink": "스레드 링크 복사",
 
   "LocationMessage_Live": "실시간 위치",
   "LocationMessage_Static": "위치",

--- a/src/dotnet/Localization/Resources/Strings.max.json
+++ b/src/dotnet/Localization/Resources/Strings.max.json
@@ -386,9 +386,13 @@
   "ConversationMenu_CopySummary": "Zusammenfassung kopieren",
   "ConversationMenu_CopySummaryLink": "Копіювати посилання на стислий виклад",
 
-  // The context menu of a thread card in the transcript.
+  // The context menu of a thread: its card in the transcript and its row in a thread list.
   "ThreadMenu_GoToThread": "Перейти до треду",
   "ThreadMenu_CopyThread": "Копирайте нишката",
+  "ThreadMenu_Mute": "Отключить уведомления",
+  "ThreadMenu_Unmute": "Stummschaltung aufheben",
+  "ThreadMenu_GoToStartMessage": "Перейти до вихідного повідомлення",
+  "ThreadMenu_CopyThreadLink": "Копирайте линка към нишката",
 
   // A location posted into a chat. LocationMessage_Place is the plain geographic word for a pin
   // on a map - NOT the product term Place, which docs/i18n.md rules on separately.

--- a/src/dotnet/Localization/Resources/Strings.pl.json
+++ b/src/dotnet/Localization/Resources/Strings.pl.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Przejdź do wątku",
   "ThreadMenu_CopyThread": "Kopiuj wątek",
+  "ThreadMenu_Mute": "Wycisz",
+  "ThreadMenu_Unmute": "Wyłącz wyciszenie",
+  "ThreadMenu_GoToStartMessage": "Przejdź do wiadomości początkowej",
+  "ThreadMenu_CopyThreadLink": "Kopiuj link do wątku",
 
   "LocationMessage_Live": "Lokalizacja na żywo",
   "LocationMessage_Static": "Lokalizacja",

--- a/src/dotnet/Localization/Resources/Strings.pt.json
+++ b/src/dotnet/Localization/Resources/Strings.pt.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Ir para o tópico",
   "ThreadMenu_CopyThread": "Copiar tópico",
+  "ThreadMenu_Mute": "Silenciar",
+  "ThreadMenu_Unmute": "Reativar",
+  "ThreadMenu_GoToStartMessage": "Ir para a mensagem inicial",
+  "ThreadMenu_CopyThreadLink": "Copiar link do tópico",
 
   "LocationMessage_Live": "Localização em tempo real",
   "LocationMessage_Static": "Localização",

--- a/src/dotnet/Localization/Resources/Strings.ru.json
+++ b/src/dotnet/Localization/Resources/Strings.ru.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Перейти к треду",
   "ThreadMenu_CopyThread": "Копировать тред",
+  "ThreadMenu_Mute": "Отключить уведомления",
+  "ThreadMenu_Unmute": "Включить уведомления",
+  "ThreadMenu_GoToStartMessage": "Перейти к исходному сообщению",
+  "ThreadMenu_CopyThreadLink": "Копировать ссылку на тред",
 
   "LocationMessage_Live": "Трансляция геопозиции",
   "LocationMessage_Static": "Геопозиция",

--- a/src/dotnet/Localization/Resources/Strings.sr.json
+++ b/src/dotnet/Localization/Resources/Strings.sr.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Идите на нит",
   "ThreadMenu_CopyThread": "Копирајте нит",
+  "ThreadMenu_Mute": "Утишај",
+  "ThreadMenu_Unmute": "Укини утишавање",
+  "ThreadMenu_GoToStartMessage": "Идите на почетну поруку",
+  "ThreadMenu_CopyThreadLink": "Копирајте линк нити",
 
   "LocationMessage_Live": "Локација уживо",
   "LocationMessage_Static": "Локација",

--- a/src/dotnet/Localization/Resources/Strings.tr.json
+++ b/src/dotnet/Localization/Resources/Strings.tr.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Konuya gidin",
   "ThreadMenu_CopyThread": "Konuyu kopyalayın",
+  "ThreadMenu_Mute": "Sessize al",
+  "ThreadMenu_Unmute": "Sessizden çıkar",
+  "ThreadMenu_GoToStartMessage": "Başlangıç mesajına gidin",
+  "ThreadMenu_CopyThreadLink": "Konu bağlantısını kopyalayın",
 
   "LocationMessage_Live": "Canlı konum",
   "LocationMessage_Static": "Konum",

--- a/src/dotnet/Localization/Resources/Strings.uk.json
+++ b/src/dotnet/Localization/Resources/Strings.uk.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Перейти до треду",
   "ThreadMenu_CopyThread": "Копіювати тред",
+  "ThreadMenu_Mute": "Вимкнути сповіщення",
+  "ThreadMenu_Unmute": "Увімкнути сповіщення",
+  "ThreadMenu_GoToStartMessage": "Перейти до вихідного повідомлення",
+  "ThreadMenu_CopyThreadLink": "Копіювати посилання на тред",
 
   "LocationMessage_Live": "Трансляція геопозиції",
   "LocationMessage_Static": "Геопозиція",

--- a/src/dotnet/Localization/Resources/Strings.vi.json
+++ b/src/dotnet/Localization/Resources/Strings.vi.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "Đến chủ đề",
   "ThreadMenu_CopyThread": "Sao chép chủ đề",
+  "ThreadMenu_Mute": "Tắt tiếng",
+  "ThreadMenu_Unmute": "Bật tiếng",
+  "ThreadMenu_GoToStartMessage": "Đến tin nhắn gốc",
+  "ThreadMenu_CopyThreadLink": "Sao chép liên kết chủ đề",
 
   "LocationMessage_Live": "Vị trí trực tiếp",
   "LocationMessage_Static": "Vị trí",

--- a/src/dotnet/Localization/Resources/Strings.zh.json
+++ b/src/dotnet/Localization/Resources/Strings.zh.json
@@ -308,6 +308,10 @@
 
   "ThreadMenu_GoToThread": "前往话题",
   "ThreadMenu_CopyThread": "复制话题",
+  "ThreadMenu_Mute": "静音",
+  "ThreadMenu_Unmute": "取消静音",
+  "ThreadMenu_GoToStartMessage": "跳转到起始消息",
+  "ThreadMenu_CopyThreadLink": "复制话题链接",
 
   "LocationMessage_Live": "实时位置",
   "LocationMessage_Static": "位置",

--- a/src/dotnet/Notifications.Service/NotificationsBackend.cs
+++ b/src/dotnet/Notifications.Service/NotificationsBackend.cs
@@ -864,11 +864,26 @@ public class NotificationsBackend(IServiceProvider services)
         // The mode != Muted superset; ImportantOnly users must survive until the split below.
         var userIds = await ListSubscribedUserIds(chatId, NotificationImportance.Important, cancellationToken)
             .ConfigureAwait(false);
+        var mentionedUserIds = await GetMentionedUserIds(chatId, mentionIds, cancellationToken).ConfigureAwait(false);
+        var mentionableUserIds = userIds;
+        if (mentionedUserIds.Count > 0 && chatId.IsThread(out var threadChatId)) {
+            // A thread notifies only its followers, but a mention must reach whoever it names: being mentioned
+            // is what makes them follow, and that follow is created by another event chain racing this one.
+            var parentUserIds = await ListSubscribedUserIds(
+                threadChatId.ParentChatId, NotificationImportance.Important, cancellationToken)
+                .ConfigureAwait(false);
+            mentionableUserIds = await FilterByNotificationMode(
+                parentUserIds.Where(mentionedUserIds.Contains).ToList(),
+                chatId, NotificationImportance.Important, cancellationToken)
+                .ConfigureAwait(false);
+        }
         // Don't interrupt users who are actively in this chat's live call — they're present.
         if (live is { SessionStartedAt: not null }) {
             var active = await GetActiveParticipantUserIds(chatId, cancellationToken).ConfigureAwait(false);
-            if (active.Count != 0)
+            if (active.Count != 0) {
                 userIds = userIds.Where(x => !active.Contains(x)).ToList();
+                mentionableUserIds = mentionableUserIds.Where(x => !active.Contains(x)).ToList();
+            }
         }
 
         // The voice context the beep policy groups by. A latched session's own utterances never
@@ -882,8 +897,7 @@ public class NotificationsBackend(IServiceProvider services)
         // ImportantOnly, individually per entry); everyone else gets the plain coalescing Message
         // notification (Default mode only). Mentions are per-entry, so they alert once on their
         // own and never need the voice grouping.
-        var mentionedUserIds = await GetMentionedUserIds(chatId, mentionIds, cancellationToken).ConfigureAwait(false);
-        var mentioned = userIds.Where(mentionedUserIds.Contains).ToList();
+        var mentioned = mentionableUserIds.Where(mentionedUserIds.Contains).ToList();
         if (mentioned.Count > 0)
             await EnqueueMessageRelatedNotifications(
                 chatId, entryId, author, content, NotificationKind.Mention,
@@ -907,20 +921,23 @@ public class NotificationsBackend(IServiceProvider services)
     {
         var userIds = new HashSet<UserId>();
         var mentionedAuthorIds = new List<AuthorId>();
+        // A thread has no authors of its own - its author ids share local ids with its outermost parent's,
+        // and mentions made in a thread may carry either form
+        var authorChatId = chatId.GetThreadOutermostParentOrSelf();
         foreach (var mention in mentionIds)
             switch (mention.Target) {
             case UserId userId:
                 userIds.Add(userId);
                 break;
-            case AuthorId authorId:
-                mentionedAuthorIds.Add(authorId);
+            case AuthorId authorId when authorId.ChatId.GetThreadOutermostParentOrSelf() == authorChatId:
+                mentionedAuthorIds.Add(AuthorId.New(authorChatId, authorId.LocalId));
                 break;
             }
         if (mentionedAuthorIds.Count == 0)
             return userIds;
 
         var mentionedUserIds = await AuthorsBackend
-            .ListUserIds(chatId, mentionedAuthorIds, RequestedAuthorKind.Full, cancellationToken)
+            .ListUserIds(authorChatId, mentionedAuthorIds, RequestedAuthorKind.Full, cancellationToken)
             .ConfigureAwait(false);
         userIds.AddRange(mentionedUserIds);
         return userIds;

--- a/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatHeader.razor
@@ -108,17 +108,9 @@
 
     private async Task OnOpenLeftPanelClick() {
         if (Chat is not null && Chat.Id.IsThread(out var threadChatId)) {
-            var parentChatId = threadChatId.ParentChatId;
-            var parentChatLink = Links.Chat(parentChatId);
-            if (History.TryGetStepBackUrl(out var backUrl)) {
-                var threadChatLink = Links.Chat(Chat.Id);
-                if (backUrl.StartsWith(parentChatLink) && !backUrl.StartsWith(threadChatLink)) {
-                    if (await History.TryStepBack())
-                        return;
-                }
-            }
-
-            await History.NavigateTo(parentChatLink, true);
+            // Not a step back: that restores the parent's old scroll position instead of the thread start
+            var threadStartLink = Links.Chat(threadChatId.ParentChatId, threadChatId.ThreadId);
+            await History.NavigateTo(threadStartLink, true);
             return;
         }
 

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListNavbarWidget.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ChatListNavbarWidget.razor
@@ -13,6 +13,8 @@
                                    <ChatListTabUnreadCount
                                        PlaceChatListSettings="@_placeChatListSettings"
                                        ChatListFilter="@filter"/>
+                               } else if (id == ThreadsTabId) {
+                                   <ThreadListTabUnreadCount PlaceId="@PlaceId"/>
                                }
                            </text>,
         };

--- a/src/dotnet/UI.Blazor.App/Components/ChatList/ThreadListTabUnreadCount.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatList/ThreadListTabUnreadCount.razor
@@ -1,0 +1,65 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits ComputedRenderStateComponent<AppUIHub, ThreadListTabUnreadCount.Model>
+@{
+    var m = State.Value;
+    if (m.Count <= 0)
+        return;
+    var notificationMode = m.IsMuted ? ChatNotificationMode.Muted : ChatNotificationMode.Default;
+}
+
+<div class="c-badge" data-child="badge">
+    <UnreadCount Value="@m.Count" NotificationMode="@notificationMode" Click="OnUnreadBadgeClick"/>
+</div>
+
+@code {
+    private ChatUI ChatUI => Hub.ChatUI;
+    private ChatListUI ChatListUI => Hub.ChatListUI;
+
+    [Parameter, EditorRequired] public PlaceId? PlaceId { get; set; }
+
+    protected override ComputedState<Model>.Options GetStateOptions()
+        => ComputedStateComponent.GetStateOptions(GetType(),
+            static t => new ComputedState<Model>.Options() {
+                InitialValue = new(),
+                UpdateDelayer = FixedDelayer.Get(0.1),
+                Category = GetStateCategory(t),
+            });
+
+    protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
+        var placeId = PlaceId;
+        // Done w/ preps for .ConfigureAwait(false)
+
+        var count = await ChatListUI.GetUnreadThreadCount(placeId, false, cancellationToken)
+            .ConfigureAwait(false);
+        if (count <= 0)
+            return new(count);
+
+        var unmutedCount = await ChatListUI.GetUnreadThreadCount(placeId, true, cancellationToken)
+            .ConfigureAwait(false);
+        return new(count, unmutedCount <= 0);
+    }
+
+    private async Task OnUnreadBadgeClick() {
+        var placeId = PlaceId;
+        var threads = await ChatListUI.ListThreads(placeId);
+        if (placeId != PlaceId)
+            return;
+
+        // The selected thread is excluded for the same reason ChatListTabUnreadCount excludes the selected chat
+        var selectedChatId = ChatUI.SelectedChatId.Value;
+        var firstUnreadThread = threads.FirstOrDefault(c => c.UnmutedUnreadCount > 0 && c.Id != selectedChatId)
+            ?? threads.FirstOrDefault(c => c.UnreadCount > 0 && c.Id != selectedChatId);
+        if (firstUnreadThread == null)
+            return;
+
+        _ = History.NavigateTo(Links.Chat(firstUnreadThread.Id));
+    }
+
+    protected override void OnInitialized()
+        // Same as ChatListTabUnreadCount: it renders nothing but the model
+        => StateEqualityComparer = EqualityComparer<Model>.Default;
+
+    // Nested types
+
+    public sealed record Model(Trimmed<int> Count = default, bool IsMuted = false);
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadListMenu.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadListMenu.razor
@@ -1,0 +1,72 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits ComputedMenuBase<AppUIHub, ThreadListMenu.Model>
+@{
+    var m = State.Value;
+    if (m == Model.None)
+        return;
+
+    var threadChatId = m.ThreadChatId;
+}
+
+<ThreadMenuFollow ThreadChatId="@threadChatId" IsFollowing="@m.IsFollowing"/>
+<ThreadMenuMute ThreadChatId="@threadChatId" NotificationMode="@m.NotificationMode"/>
+<MenuEntry
+    Icon="icon-message-ellipse"
+    Text="@L.ThreadMenu_GoToStartMessage"
+    Click="@OnGoToStartMessage">
+</MenuEntry>
+<ThreadMenuCopyLink ThreadChatId="@threadChatId"/>
+<ThreadMenuCopyThread ThreadChatId="@threadChatId" Title="@m.Title"/>
+
+@code {
+    private ThreadChatId _threadChatId = null!;
+
+    private IChats Chats => Hub.Chats;
+    private IChatThreads ChatThreads => Hub.ChatThreads;
+
+    protected override void OnParametersSet() {
+        if (Arguments is not [var sThreadChatId])
+            throw new ArgumentOutOfRangeException(nameof(Arguments));
+
+        _threadChatId = ThreadChatId.Parse(sThreadChatId);
+    }
+
+    protected override ComputedState<Model>.Options GetStateOptions()
+        => ComputedStateComponent.GetStateOptions(GetType(),
+            static t => new ComputedState<Model>.Options() {
+                InitialValue = Model.None,
+                Category = GetStateCategory(t),
+            });
+
+    protected override async Task<Model> ComputeState(CancellationToken cancellationToken) {
+        var threadChatId = _threadChatId;
+        var chat = await Chats.Get(Session, threadChatId, cancellationToken).ConfigureAwait(false);
+        if (chat == null)
+            return Model.None;
+
+        var isFollowing = await ChatThreads.GetThreadFollowStatus(Session, threadChatId, cancellationToken)
+            .ConfigureAwait(false);
+        var settings = await UserSettingsUI.ChatUserSettings(threadChatId).Get(cancellationToken)
+            .ConfigureAwait(false);
+        return new() {
+            ThreadChatId = threadChatId,
+            Title = chat.Title,
+            IsFollowing = isFollowing,
+            NotificationMode = settings.NotificationMode,
+        };
+    }
+
+    private Task OnGoToStartMessage()
+        => NavigateTo(Links.Chat(_threadChatId.ParentChatId, _threadChatId.ThreadId));
+
+    // Nested types
+
+    public sealed record Model {
+        public static readonly Model None = new();
+
+        public ThreadChatId ThreadChatId { get; init; } = null!;
+        public string Title { get; init; } = "";
+        public bool IsFollowing { get; init; }
+        public ChatNotificationMode NotificationMode { get; init; }
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenu.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenu.razor
@@ -1,5 +1,4 @@
 @namespace ActualChat.UI.Blazor.App.Components
-@using StringBuilderExt = ActualLab.Text.StringBuilderExt
 @inherits ComputedMenuBase<AppUIHub, ThreadMenu.Model>
 @{
     var m = State.Value;
@@ -7,6 +6,7 @@
         return;
 
     var entry = m.Entry;
+    var threadChatId = m.ThreadChatId;
     var messageLink = Links.Chat(entry.Id).ToAbsolute(UrlMapper);
     var canCopyMessageLink = !entry.IsSystemEntry;
 }
@@ -17,6 +17,8 @@
         Text="@L.ThreadMenu_GoToThread"
         Click="@(OnGoToTheThread)">
     </MenuEntry>
+    <ThreadMenuFollow ThreadChatId="@threadChatId" IsFollowing="@m.IsFollowing"/>
+    <ThreadMenuMute ThreadChatId="@threadChatId" NotificationMode="@m.NotificationMode"/>
     @if (canCopyMessageLink) {
         <CopyTrigger Tooltip="" CopyText="@messageLink" Class="ac-menu-item !p-0">
             <MenuEntry
@@ -25,11 +27,8 @@
             </MenuEntry>
         </CopyTrigger>
     }
-    <MenuEntry
-        Icon="icon-copy"
-        Text="@L.ThreadMenu_CopyThread"
-        Click="@OnCopyToClipboardRequested">
-    </MenuEntry>
+    <ThreadMenuCopyLink ThreadChatId="@threadChatId"/>
+    <ThreadMenuCopyThread ThreadChatId="@threadChatId" Title="@(_title ?? m.Chat.Title)"/>
     @if (m.EnableIncompleteUI) {
         <MenuEntry
             Icon="icon-reply-2"
@@ -63,8 +62,8 @@
     private string? _title;
 
     private IChats Chats => Hub.Chats;
+    private IChatThreads ChatThreads => Hub.ChatThreads;
     private ChatUI ChatUI => Hub.ChatUI;
-    private ClipboardUI ClipboardUI => Hub.ClipboardUI;
 
     protected override void OnParametersSet() {
         if (Arguments is not [var sEntryId, var sChatId, var title ])
@@ -97,10 +96,17 @@
         if (chat == null)
             return Model.None;
 
+        var isFollowing = await ChatThreads.GetThreadFollowStatus(Session, threadChatId, cancellationToken)
+            .ConfigureAwait(false);
+        var settings = await UserSettingsUI.ChatUserSettings(threadChatId).Get(cancellationToken)
+            .ConfigureAwait(false);
         var enableIncompleteUI = await Features.IsIncompleteUIEnabled(cancellationToken).ConfigureAwait(false);
         return new() {
             Entry = entry,
             Chat = chat,
+            ThreadChatId = threadChatId,
+            IsFollowing = isFollowing,
+            NotificationMode = settings.NotificationMode,
             EnableIncompleteUI = enableIncompleteUI,
         };
     }
@@ -109,19 +115,6 @@
         await WhenClosed;
         var m = State.Value;
         _ = History.NavigateTo(Links.Chat(m.Chat.Id));
-    }
-
-    private async Task OnCopyToClipboardRequested() {
-        var text = GetText();
-        await ClipboardUI.WriteText(text).ConfigureAwait(false);
-    }
-
-    private string GetText() {
-        var m = State.Value;
-        return L.Share_ThreadText_Format(
-            _title ?? m.Chat.Title,
-            CoreConstants.AppName,
-            UrlMapper.ToAbsolute(Links.Chat(m.Chat.Id)));
     }
 
     private void Reply() {}
@@ -139,6 +132,9 @@
 
         public ChatEntry Entry { get; init; } = null!;
         public Chat Chat { get; init; } = null!;
+        public ThreadChatId ThreadChatId { get; init; } = null!;
+        public bool IsFollowing { get; init; }
+        public ChatNotificationMode NotificationMode { get; init; }
         public bool EnableIncompleteUI { get; init; }
     }
 }

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuCopyLink.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuCopyLink.razor
@@ -1,0 +1,16 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits FusionComponentBase<AppUIHub>
+@{
+    var threadLink = Links.Chat(ThreadChatId).ToAbsolute(UrlMapper);
+}
+
+<CopyTrigger Tooltip="" CopyText="@threadLink" Class="ac-menu-item !p-0">
+    <MenuEntry
+        Icon="icon-link-2"
+        Text="@L.ThreadMenu_CopyThreadLink">
+    </MenuEntry>
+</CopyTrigger>
+
+@code {
+    [Parameter, EditorRequired] public ThreadChatId ThreadChatId { get; set; } = null!;
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuCopyThread.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuCopyThread.razor
@@ -1,0 +1,23 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits FusionComponentBase<AppUIHub>
+
+<MenuEntry
+    Icon="icon-copy"
+    Text="@L.ThreadMenu_CopyThread"
+    Click="@OnClick">
+</MenuEntry>
+
+@code {
+    private ClipboardUI ClipboardUI => Hub.ClipboardUI;
+
+    [Parameter, EditorRequired] public ThreadChatId ThreadChatId { get; set; } = null!;
+    [Parameter, EditorRequired] public string Title { get; set; } = "";
+
+    private async Task OnClick() {
+        var text = L.Share_ThreadText_Format(
+            Title,
+            CoreConstants.AppName,
+            UrlMapper.ToAbsolute(Links.Chat(ThreadChatId)));
+        await ClipboardUI.WriteText(text).ConfigureAwait(false);
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuFollow.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuFollow.razor
@@ -1,0 +1,18 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits FusionComponentBase<AppUIHub>
+
+<MenuEntry
+    Icon="@(IsFollowing ? "icon-eye-off" : "icon-eye")"
+    Text="@(IsFollowing ? L.ChatHeader_UnfollowThread : L.ChatHeader_FollowThread)"
+    Click="@OnClick">
+</MenuEntry>
+
+@code {
+    [Parameter, EditorRequired] public ThreadChatId ThreadChatId { get; set; } = null!;
+    [Parameter, EditorRequired] public bool IsFollowing { get; set; }
+    private async Task OnClick()
+        => await UICommander.Call(new ChatThreads_ToggleThreadFollowStatus {
+            Session = Session,
+            ThreadChatId = ThreadChatId,
+        }).ConfigureAwait(false);
+}

--- a/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuMute.razor
+++ b/src/dotnet/UI.Blazor.App/Components/ChatView/ThreadMenu/ThreadMenuMute.razor
@@ -1,0 +1,27 @@
+@namespace ActualChat.UI.Blazor.App.Components
+@inherits FusionComponentBase<AppUIHub>
+@{
+    var isMuted = NotificationMode == ChatNotificationMode.Muted;
+}
+
+<MenuEntry
+    Icon="@(isMuted ? "icon-bell" : "icon-bell-off")"
+    Text="@(isMuted ? L.ThreadMenu_Unmute : L.ThreadMenu_Mute)"
+    Click="@OnClick">
+</MenuEntry>
+
+@code {
+    [Parameter, EditorRequired] public ThreadChatId ThreadChatId { get; set; } = null!;
+    [Parameter, EditorRequired] public ChatNotificationMode NotificationMode { get; set; }
+
+    private Task OnClick() {
+        // Two-state, like a peer chat's bell: ImportantOnly counts as not muted
+        var threadChatId = ThreadChatId;
+        var mode = NotificationMode == ChatNotificationMode.Muted
+            ? ChatNotificationMode.Default
+            : ChatNotificationMode.Muted;
+        return UICommander.RunLocal(ct
+            => UserSettingsUI.ChatUserSettings(threadChatId)
+                .Update(x => x with { NotificationMode = mode }, ct));
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
+++ b/src/dotnet/UI.Blazor.App/Components/RightPanel/ThreadListItem.razor
@@ -9,6 +9,8 @@
 
 @* data-prefetch tracks OnItemClicked's target - Chat.Id, not the model's chat *@
 <div class="thread-list-item" role="option" tabindex="0" @onclick="OnItemClicked"
+     data-menu="@(MenuRef.New<ThreadListMenu>(Chat.Id.Value).ToString())"
+     data-menu-placement="@(FloatingPosition.BottomStart.ToPositionString())"
      data-prefetch="@(PrefetchRef.New<ChatPrefetcher>(Chat.Id.Value).ToString())">
     <div class="c-description">
         <div class="c-top">

--- a/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatListUI.cs
@@ -29,6 +29,7 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     private IContacts Contacts => Hub.Contacts;
     private IAuthors Authors => Hub.Authors;
     private IPlaces Places => Hub.Places;
+    private IChatThreads ChatThreads => Hub.ChatThreads;
     private ActiveChatsUI ActiveChatsUI => Hub.ActiveChatsUI;
     private ChatUI ChatUI => Hub.ChatUI;
     private SearchUI SearchUI => Hub.SearchUI;
@@ -135,6 +136,29 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
     {
         var chatById = await ListUnordered(placeId, filter, cancellationToken).ConfigureAwait(false);
         return await ComputeGatedUnreadChatCount(chatById, true, cancellationToken).ConfigureAwait(false);
+    }
+
+    [ComputeMethod]
+    public virtual async Task<IReadOnlyList<ChatInfo>> ListThreads(
+        PlaceId? placeId, CancellationToken cancellationToken = default)
+    {
+        var threadIds = await ChatThreads.ListIdsForPlace(Session, placeId, cancellationToken).ConfigureAwait(false);
+        var threads = (await threadIds
+            .Select(id => ChatUI.Get(id, cancellationToken))
+            .CollectResults(ApiConstants.Concurrency.High, cancellationToken)
+            .ConfigureAwait(false)
+            ).Select(x => x.ValueOrDefault)
+            .SkipNullItems();
+        return threads.ToList();
+    }
+
+    [ComputeMethod(InvalidationDelay = 0.6)]
+    public virtual async Task<Trimmed<int>> GetUnreadThreadCount(
+        PlaceId? placeId, bool mustBeUnmuted, CancellationToken cancellationToken = default)
+    {
+        var threads = await ListThreads(placeId, cancellationToken).ConfigureAwait(false);
+        var threadById = threads.ToDictionary(x => x.Id);
+        return await ComputeGatedUnreadChatCount(threadById, mustBeUnmuted, cancellationToken).ConfigureAwait(false);
     }
 
     [ComputeMethod]
@@ -515,12 +539,13 @@ public partial class ChatListUI : UIWorkerBase<AppUIHub>, IComputeService, INoti
         // Only the selected chat's badge can be gated off (IsReadingTail short-circuits on
         // IsSelected), so fold the raw per-chat counts and override that single chat - a
         // per-chat GetUnreadState fan-out would re-register O(N) dependencies per recompute.
+        // In a thread list that chat is the selected thread itself rather than its parent.
         var selectedChatId = await ChatUI.SelectedChatId.Use(cancellationToken).ConfigureAwait(false);
         var gatedChatId = selectedChatId?.GetThreadOutermostParentOrSelf() ?? default;
         var count = 0;
         foreach (var (chatId, chatInfo) in chatById) {
             bool hasUnread;
-            if (chatId == gatedChatId) {
+            if (chatId == gatedChatId || chatId == selectedChatId) {
                 var unreadState = await ChatUI.GetUnreadState(chatId, cancellationToken).ConfigureAwait(false);
                 hasUnread = mustBeUnmuted ? unreadState.HasUnmutedUnread : unreadState.Count > 0;
             }

--- a/src/dotnet/UI.Blazor.App/Services/LocalSearchUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LocalSearchUI.cs
@@ -36,6 +36,8 @@ public class LocalSearchUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         int limit,
         CancellationToken cancellationToken)
     {
+        // A thread has no members of its own - its authors are the parent chat's
+        chatId = chatId?.GetThreadOutermostParentOrSelf();
         // The empty-query views are served from the precomputed per-category top lists.
         if (query.IsNullOrEmpty()) {
             FoundMention[]? mentions = null;
@@ -381,7 +383,7 @@ public class LocalSearchUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
             if (ChatUI.SelectedChatId.Value != chatId)
                 continue;
 
-            await ListDefaultMentions(chatId, cancellationToken).ConfigureAwait(false);
+            await ListDefaultMentions(chatId.GetThreadOutermostParentOrSelf(), cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/tests/Chat.IntegrationTests/ChatThreadOperationsTest.cs
+++ b/tests/Chat.IntegrationTests/ChatThreadOperationsTest.cs
@@ -62,6 +62,42 @@ public class ChatThreadOperationsTest(ChatCollection.AppHostFixture fixture, ITe
     }
 
     [Fact]
+    public async Task StarterShouldFollowThreadStartedOnAnotherUsersMessage()
+    {
+        // arrange
+        var appHost = AppHost;
+        await using var bobTester = appHost.NewBlazorTester(Out);
+        await bobTester.SignInAsUniqueBob();
+        await using var aliceTester = appHost.NewBlazorTester(Out);
+        await aliceTester.SignInAsUniqueAlice();
+        CancellationToken cancellationToken = default;
+
+        var (parentChatId, inviteId) = await bobTester.CreateChat(false);
+        await aliceTester.JoinChat(parentChatId, inviteId);
+        var aliceEntries = await InsertEntries(
+            aliceTester.Commander, aliceTester.Session, parentChatId, ["Start a thread here"], cancellationToken);
+
+        // act
+        var bobChats = bobTester.AppServices.GetRequiredService<IChats>();
+        var threadChat = await CreateThreadChat(
+            bobTester.Commander, bobChats, bobTester.Session, parentChatId, "Thread#1",
+            [aliceEntries[0].Id], cancellationToken);
+
+        // assert
+        var threadChatId = (ThreadChatId)threadChat.Id;
+        var bobChatThreads = bobTester.AppServices.GetRequiredService<IChatThreads>();
+        var aliceChatThreads = aliceTester.AppServices.GetRequiredService<IChatThreads>();
+        await TestExt.When(async () => {
+            var isBobFollowing = await bobChatThreads
+                .GetThreadFollowStatus(bobTester.Session, threadChatId, cancellationToken);
+            isBobFollowing.Should().BeTrue("the starter follows a thread even when its start message isn't theirs");
+            var isAliceFollowing = await aliceChatThreads
+                .GetThreadFollowStatus(aliceTester.Session, threadChatId, cancellationToken);
+            isAliceFollowing.Should().BeTrue("the start message's author follows the thread");
+        }, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
     public async Task CreateChildThread()
     {
         var appHost = AppHost;


### PR DESCRIPTION
## Summary

These are the four thread bugs from the Bugs chat. The "live calls in threads are hard to find" report is the first one.

1. **No notifications on new thread content.** Only a thread's followers are notified, and the person who started a thread never became one. Since 01fa11a297 threads have no roles. `ContactsBackend.OnChatChangedEvent` still did `RolesBackend.GetSystem(thread, Owner).Require()`, which threw `'Role' is not found` on every thread creation, with several NATS redeliveries each time. The starter's follow was never created. Only the start message's author followed, plus whoever later posted. On top of that, a first @mention of a parent-chat member who didn't follow the thread was dropped. The follow a mention creates comes from a separate event chain, so the notification fan-out still saw a non-follower.
2. **No unread counter on the Threads tab.** The tab was added without a filter, and the badge only rendered for filters. Those counts come from the contact list, which never includes threads.
3. **The mention picker in a thread showed everyone as "not in this chat".** Threads have no authors of their own and no `SeeMembers`, so the member list was empty.
4. **The back button in the thread header** stepped back in history, restoring the parent's old scroll position, or opened the parent at its end.

## Fix

One commit per bug:
- **Notifications.** `ChatThreads.OnStart` creates the starter's thread contact itself, and the dead `ContactsBackend` branch is removed. In `SendChatMessageNotification`, thread mention recipients come from the parent chat's subscribers, filtered to the mentioned users before any per-user mode lookup, so the cost is per mention rather than per member. Plain messages stay followers-only. Author mentions in a thread resolve against its outermost parent, which is what the thread's author ids mirror.
- **Threads tab badge.** `ChatListUI.GetUnreadThreadCount` counts the place's followed threads with the same gated fold the other tabs use. That gate now also covers the selected thread; for plain chats nothing changes. `ThreadListTabUnreadCount` shows the count; clicking it opens the first unread thread.
- **Mention picker.** `LocalSearchUI` resolves a thread to its outermost parent before building candidates, so threads also share the parent's cached lists.
- **Back button.** It always opens `Links.Chat(parent, threadStartLid)`, which scrolls to and highlights the start message.

- **Thread context menus** (follow-up request):
  - **Thread rows** in the left Threads tab and in a chat's Threads panel get a context menu. It has Follow/Unfollow, Mute/Unmute, Go to start message, Copy thread link and Copy thread.
  - **The thread card** in the transcript gains Follow/Unfollow, Mute/Unmute and Copy thread link.
  - **Shared code.** The entries are shared components in `ChatView/ThreadMenu/`.
  - **Mute** is two-state on the thread's own notification settings, the same setting the server's thread notification filter reads.
  - **Localization.** New `ThreadMenu_*` keys are in every catalog; the derived catalogs were regenerated.

Not changed: a call started in a thread still rings only its followers. With the starter now following, participants do get rung. Ringing every parent-chat member would be a product decision, not part of this fix.

## Testing

- New integration test `ChatThreadOperationsTest.StarterShouldFollowThreadStartedOnAnotherUsersMessage`. The whole `ChatThreadOperationsTest` class passes (8/8).
- Live, on a local server with two test users plus a third who was never online:
  - **Before the fix (reproduced).** Starting a thread on another user's message logged the failed `ChatChangedEvent` and left the starter without a follow. The starter then got nothing when the other user posted in the thread.
  - **After the fix: follows and notifications.**
    - The starter follows the new thread, and no queued events failed.
    - Followers get notified of new messages, including the starter.
    - An @mention of a parent member who didn't follow the thread produced a `MentionNotification` for them and made them a follower.
  - **After the fix: UI.**
    - The picker in a thread lists parent members without the "not in this chat" suffix; non-member contacts keep it.
    - The Threads tab shows "1" when a followed thread has unread messages. Clicking it opens that thread, and the badge clears.
    - The back button lands on `?n=<start lid>`, with the start message in view.

Not verified:
- Author-id mentions of anonymous authors in threads at runtime; only user mentions were exercised.
- The highlight animation itself.
- WASM / MAUI; everything ran in server render mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkXkjXqdQGG32ZNK5K1RqS
