### PR TITLE
fix(pooling): stop SharedResourcePool.Rent from retrying a failed factory forever

### DIFF
--- a/src/dotnet/Core/Pooling/SharedResourcePool.Lease.cs
+++ b/src/dotnet/Core/Pooling/SharedResourcePool.Lease.cs
@@ -134,11 +134,15 @@ public partial class SharedResourcePool<TKey, TResource>
                 throw;
             }
             catch (Exception e) {
+                // Rent must not retry: a factory that keeps failing would make it loop forever.
+                // So the failure goes to the caller, and the lease leaves the pool as on cancellation.
                 Pool.Log.LogError(e, nameof(Pool.ResourceFactory) + " failed");
                 lock (_lock) {
                     _renterCount = 0;
-                    return _endRentTask ??= EndRent();
+                    _endRentTask = Task.CompletedTask;
                 }
+                Pool._leases.TryRemove(Key, this);
+                throw;
             }
         }
 

--- a/src/dotnet/Core/Pooling/SharedResourcePool.cs
+++ b/src/dotnet/Core/Pooling/SharedResourcePool.cs
@@ -3,34 +3,41 @@ namespace ActualChat.Pooling;
 /// <summary>
 /// A pool of shared resources keyed by an identifier, with reference counting.
 /// </summary>
-public partial class SharedResourcePool<TKey, TResource>(
-    Func<TKey, CancellationToken, Task<TResource>> resourceFactory,
-    Func<TKey, TResource, ValueTask>? resourceDisposer = null) : IAsyncDisposable
+public partial class SharedResourcePool<TKey, TResource> : IAsyncDisposable
     where TKey : notnull
     where TResource : class
 {
     private readonly ConcurrentDictionary<TKey, Lease> _leases = new ();
     private readonly CancellationTokenSource _disposeTokenSource = new();
     private volatile int _isDisposed;
-    private ILogger? _log;
 
-    private Func<TKey, CancellationToken, Task<TResource>> ResourceFactory { get; } = resourceFactory;
-    private Func<TKey, TResource, ValueTask> ResourceDisposer { get; } = resourceDisposer ?? DefaultResourceDisposer;
+    private Func<TKey, CancellationToken, Task<TResource>> ResourceFactory { get; }
+    private Func<TKey, TResource, ValueTask> ResourceDisposer { get; }
 
     public TimeSpan ResourceDisposeDelay { get; init; } = TimeSpan.FromSeconds(10);
-    public CancellationToken DisposeToken => _disposeTokenSource.Token;
+    // Cached: Token of a disposed CTS throws, and DisposeToken is read after DisposeAsync too
+    public CancellationToken DisposeToken { get; }
     public bool IsDisposed => _isDisposed != 0;
 
     public ILogger Log {
-        get => _log ??= StaticLog.For(GetType());
-        init => _log = value;
+        get => field ??= StaticLog.For(GetType());
+        init;
+    }
+
+    public SharedResourcePool(
+        Func<TKey, CancellationToken, Task<TResource>> resourceFactory,
+        Func<TKey, TResource, ValueTask>? resourceDisposer = null)
+    {
+        ResourceFactory = resourceFactory;
+        ResourceDisposer = resourceDisposer ?? DefaultResourceDisposer;
+        DisposeToken = _disposeTokenSource.Token;
     }
 
     public async ValueTask<Lease> Rent(TKey key, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(IsDisposed, this);
-
         while (true) {
+            // Checked on every iteration: a Rent waiting for an ending lease can outlive the pool
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             var lease = _leases.GetOrAdd(key, static (key1, self) => new Lease(self, key1), this);
             lease.Initialize(cancellationToken);
             var endRentTask = await lease.BeginRent(cancellationToken).ConfigureAwait(false);

--- a/tests/Core.UnitTests/SharedResourcePoolTest.cs
+++ b/tests/Core.UnitTests/SharedResourcePoolTest.cs
@@ -1,5 +1,6 @@
 using ActualChat.Pooling;
 using ActualLab.Time.Testing;
+using Xunit.Sdk;
 
 namespace ActualChat.Core.UnitTests;
 
@@ -280,6 +281,121 @@ public class SharedResourcePoolTest(ITestOutputHelper @out) : TestBase(@out)
         await rent.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    [Theory(Timeout = TestTimeoutMs)]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ObjectDisposedException))]
+    public async Task RentShouldPropagateFactoryFailure(Type errorType)
+    {
+        // arrange
+        var error = (Exception)Activator.CreateInstance(errorType, "Factory failed")!;
+        var factoryCallCount = 0;
+        var pool = new SharedResourcePool<int, Resource>(
+            (_, _) => Interlocked.Increment(ref factoryCallCount) == 1
+                ? Task.FromException<Resource>(error)
+                : Task.FromResult(new Resource())) {
+            ResourceDisposeDelay = TimeSpan.Zero,
+        };
+
+        // act
+        var rent = () => pool.Rent(10).AsTask().WaitAsync(WaitTimeout);
+
+        // assert
+        (await rent.Should().ThrowAsync<Exception>()).Which.Should().BeSameAs(error);
+        factoryCallCount.Should().Be(1, "a failed factory must not be retried behind the caller's back");
+        using var lease = await pool.Rent(10);
+        factoryCallCount.Should().Be(2, "the lease with a failed factory must not stay in the pool");
+    }
+
+    [Fact(Timeout = TestTimeoutMs)]
+    public async Task RentShouldCreateResourceOnlyAfterPreviousOneIsDisposed()
+    {
+        // arrange
+        var disposerStarted = TaskCompletionSourceExt.New();
+        var disposerGate = TaskCompletionSourceExt.New();
+        var disposeCount = 0;
+        var factoryCallCount = 0;
+        var pool = new SharedResourcePool<int, Resource>(
+            (_, _) => {
+                Interlocked.Increment(ref factoryCallCount);
+                return Task.FromResult(new Resource());
+            },
+            async (_, resource) => {
+                if (Interlocked.Increment(ref disposeCount) == 1) {
+                    disposerStarted.TrySetResult();
+                    await disposerGate.Task.ConfigureAwait(false);
+                }
+                resource.Dispose();
+            }) {
+            ResourceDisposeDelay = TimeSpan.Zero,
+        };
+        var oldLease = await pool.Rent(10);
+        var oldResource = oldLease.Resource;
+        oldLease.Dispose();
+        await disposerStarted.Task.WaitAsync(WaitTimeout);
+
+        // act
+        var rentTask = pool.Rent(10).AsTask();
+        await Task.Delay(100);
+        var factoryCallCountBeforeDisposal = factoryCallCount;
+        disposerGate.TrySetResult();
+        using var lease = await rentTask.WaitAsync(WaitTimeout);
+
+        // assert
+        factoryCallCountBeforeDisposal.Should().Be(1, "the old resource was still being disposed");
+        factoryCallCount.Should().Be(2);
+        oldResource.WhenDisposed.IsCompleted.Should().BeTrue();
+        lease.Resource.Should().NotBeSameAs(oldResource);
+    }
+
+    [Fact(Timeout = TestTimeoutMs)]
+    public async Task RentShouldThrowWhenPoolIsDisposed()
+    {
+        // arrange
+        var pool = new SharedResourcePool<int, Resource>(ResourceFactory);
+        await pool.DisposeAsync();
+
+        // act
+        var rent = () => pool.Rent(10).AsTask();
+
+        // assert
+        await rent.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact(Timeout = TestTimeoutMs)]
+    public async Task RentShouldThrowWhenPoolIsDisposedWhileItWaits()
+    {
+        // arrange
+        var disposerStarted = TaskCompletionSourceExt.New();
+        var disposerGate = TaskCompletionSourceExt.New();
+        var disposeCount = 0;
+        var pool = new SharedResourcePool<int, Resource>(
+            ResourceFactory,
+            async (_, resource) => {
+                if (Interlocked.Increment(ref disposeCount) == 1) {
+                    disposerStarted.TrySetResult();
+                    await disposerGate.Task.ConfigureAwait(false);
+                }
+                resource.Dispose();
+            }) {
+            ResourceDisposeDelay = TimeSpan.Zero,
+            Log = new RetryLoopGuardLogger(),
+        };
+        var lease = await pool.Rent(10);
+        lease.Dispose();
+        await disposerStarted.Task.WaitAsync(WaitTimeout);
+        var rentTask = pool.Rent(10).AsTask();
+        rentTask.IsCompleted.Should().BeFalse("the rent must wait for the lease that is being ended");
+
+        // act
+        var disposeTask = pool.DisposeAsync().AsTask();
+        disposerGate.TrySetResult();
+        await disposeTask.WaitAsync(WaitTimeout);
+
+        // assert
+        var rent = () => rentTask.WaitAsync(WaitTimeout);
+        await rent.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
     // Private methods
 
     private Task<Resource> ResourceFactory(int _, CancellationToken cancellationToken)
@@ -294,5 +410,30 @@ public class SharedResourcePoolTest(ITestOutputHelper @out) : TestBase(@out)
 
         public void Dispose()
             => _whenDisposed.TrySetResult();
+    }
+
+    // A retry loop never yields, so no timeout can stop it - failing the logging call turns it into a test failure
+    private sealed class RetryLoopGuardLogger : ILogger
+    {
+        private const int MaxErrorCount = 100;
+        private int _errorCount;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel)
+            => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Error && Interlocked.Increment(ref _errorCount) > MaxErrorCount)
+                throw new XunitException($"Rent kept retrying: over {MaxErrorCount} errors were logged");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`SharedResourcePool.Rent` could loop forever. When the resource factory failed, `Lease.BeginRent` logged the error,
started `EndRent()` and returned its task - the same answer it gives for "this lease is being ended, wait and take a
fresh one". `Rent` then created a new lease and called the factory again, with no delay and no limit. Every await in
an iteration got an already-completed task, so the loop never yielded, and `WaitAsync(ct)` on a completed task
ignores the token, so cancellation did not stop it either.

Since `804fb4cbdd` this happened on every pool disposal that raced with a `Rent`: `DisposeAsync` ended with
`_disposeTokenSource.Dispose()`, `InvokeFactory` reads `Pool.DisposeToken`, and `IsDisposed` was checked only
before the loop. Seen on Android prod 2.19.6 after sign-out → sign-in: sign-out recreates the WebView, the old
scope's `ChatUI._readPositionStates` gets disposed while a `Rent` is in flight, and one thread spins until the
process dies - ~1 core for the loop plus ~1.5 cores in Crashlytics, ~90k logcat lines/min
([ACTUAL-CHAT-UI-11AQ](https://actual-chat.sentry.io/issues/ACTUAL-CHAT-UI-11AQ); the same loop with
`ObjectDisposedException: IServiceProvider` is
[ACTUAL-CHAT-UI-ZYM](https://actual-chat.sentry.io/issues/ACTUAL-CHAT-UI-ZYM), 11 users since June).

The retry wasn't a deliberate policy: `ab5f7f8816` (2022) added it to get failed leases out of the pool - before
that a failed factory poisoned its key - by reusing the ending-lease path, which retries by construction. None of
the current factories fails in a way a retry could fix.

## Fix

- A failed factory ends the rent: the lease leaves the pool, as on cancellation, and the error goes to the caller.
  The next `Rent` for the key calls the factory again, so the key isn't poisoned. `ResourceFactory failed` is still
  logged.
- `Rent` checks `IsDisposed` on every iteration, not only before the loop.
- `DisposeToken` is cached at construction (the class moves from a primary constructor to a regular one for that),
  so it stays readable after `DisposeAsync` disposes the CTS.

Kept as is: a new resource for a key is created only after the previous one is disposed (#4477 looks into whether
that ordering is needed). A full rewrite without the retry loop is parked on `refactor/sharedresourcepool-no-loop`.

## Testing

- New in `SharedResourcePoolTest`:
  - `RentShouldPropagateFactoryFailure` (`InvalidOperationException`, `ObjectDisposedException`) - fails before the fix;
  - `RentShouldThrowWhenPoolIsDisposedWhileItWaits` - the device scenario; fails before the fix via a logger that
    turns the endless loop into a test failure instead of a hang;
  - `RentShouldCreateResourceOnlyAfterPreviousOneIsDisposed`, `RentShouldThrowWhenPoolIsDisposed` - guard existing
    behavior.
- `SharedResourcePoolTest`: 13/13, class run 10 times in a row. `Core.UnitTests`: 749 passed, 3 skipped.
- `UI.Blazor.App` and `Kubernetes` build.
- Not verified on a device: the fix hasn't been run on Android, and the black screen after the second sign-in is
  not explained yet - whether this loop causes it is still open.

Closes #4468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZ1tqsyV4kcLQfk51xLNC2
