### PR TITLE
fix(ptt): release a client's participations when its RPC peer stays disconnected

### DIFF
--- a/src/dotnet/Streaming.Service/Module/StreamingServiceModule.cs
+++ b/src/dotnet/Streaming.Service/Module/StreamingServiceModule.cs
@@ -27,6 +27,7 @@ public sealed class StreamingServiceModule(IServiceProvider moduleServices)
         rpcHost.AddBackend<ILiveSessionsBackend, LiveSessionsBackend>();
         rpcHost.AddBackend<IChatTypingActivitiesBackend, ChatTypingActivitiesBackend>();
         services.AddSingleton<LiveStreamAccess>();
+        services.AddSingleton<PeerParticipations>();
         services.AddSingleton<RemoteVideoStreamCache>();
         services.AddSingleton<RemoteAudioStreamCache>();
         services.TryAddSingleton<AudioSettings>(); // AudioSettings are not configured now

--- a/src/dotnet/Streaming.Service/Module/StreamingSettings.cs
+++ b/src/dotnet/Streaming.Service/Module/StreamingSettings.cs
@@ -6,4 +6,7 @@ public class StreamingSettings
     // is enough. Configurable so tests, whose clips run a few seconds, can opt out of it.
     public int MinRetranscriptionWords { get; set; } = Constants.Transcription.MinRetranscriptionWords;
     public TimeSpan MinRetranscriptionDuration { get; set; } = Constants.Transcription.MinRetranscriptionDuration;
+    // How long a peer may stay disconnected before the participations it claimed are released:
+    // long enough for a reconnecting blip, short next to the 90s participant staleness.
+    public TimeSpan ParticipationDisconnectGrace { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/src/dotnet/Streaming.Service/Services/LiveSessions.cs
+++ b/src/dotnet/Streaming.Service/Services/LiveSessions.cs
@@ -1,5 +1,6 @@
 using ActualChat.Audio;
 using ActualChat.Live;
+using ActualLab.Rpc.Infrastructure;
 
 namespace ActualChat.Streaming.Services;
 
@@ -20,6 +21,7 @@ public class LiveSessions(IServiceProvider services) : ILiveSessions
     private ILiveAudioBackend LiveAudioBackend => field ??= Services.GetRequiredService<ILiveAudioBackend>();
     private ILiveVideoBackend LiveVideoBackend => field ??= Services.GetRequiredService<ILiveVideoBackend>();
     private ILiveSessionsBackend Backend => field ??= Services.GetRequiredService<ILiveSessionsBackend>();
+    private PeerParticipations PeerParticipations => field ??= Services.GetRequiredService<PeerParticipations>();
     private IAudioStreamingBackend AudioStreamingBackend
         => field ??= Services.GetRequiredService<IAudioStreamingBackend>();
 
@@ -124,6 +126,8 @@ public class LiveSessions(IServiceProvider services) : ILiveSessions
 
         var authorId = chat.Rules.Author!.Id;
         await Backend.SetParticipation(chatId, authorId, kind, isActive, cancellationToken).ConfigureAwait(false);
+        if (RpcInboundContext.Current?.Peer is { } peer)
+            PeerParticipations.Set(peer, chatId, authorId, kind, isActive);
     }
 
     public async Task SetRules(Session session, ChatId chatId, SessionRules rules, CancellationToken cancellationToken)

--- a/src/dotnet/Streaming.Service/Services/LiveSessions.cs
+++ b/src/dotnet/Streaming.Service/Services/LiveSessions.cs
@@ -125,9 +125,9 @@ public class LiveSessions(IServiceProvider services) : ILiveSessions
             return;
 
         var authorId = chat.Rules.Author!.Id;
-        await Backend.SetParticipation(chatId, authorId, kind, isActive, cancellationToken).ConfigureAwait(false);
-        if (RpcInboundContext.Current?.Peer is { } peer)
-            PeerParticipations.Set(peer, chatId, authorId, kind, isActive);
+        var peer = RpcInboundContext.Current?.Peer;
+        await PeerParticipations.SetParticipation(peer, chatId, authorId, kind, isActive, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task SetRules(Session session, ChatId chatId, SessionRules rules, CancellationToken cancellationToken)

--- a/src/dotnet/Streaming.Service/Services/PeerParticipations.cs
+++ b/src/dotnet/Streaming.Service/Services/PeerParticipations.cs
@@ -1,7 +1,7 @@
 using ActualChat.Live;
 using ActualChat.Streaming.Module;
+using ActualLab.Locking;
 using ActualLab.Rpc;
-using ActualLab.Rpc.Infrastructure;
 
 namespace ActualChat.Streaming.Services;
 
@@ -12,13 +12,20 @@ namespace ActualChat.Streaming.Services;
 /// </summary>
 public sealed class PeerParticipations(IServiceProvider services)
 {
+    private static readonly RetryDelaySeq ReleaseRetryDelays = RetryDelaySeq.Exp(0.5, 4);
+    private const int MaxReleaseAttemptCount = 3;
+
     private sealed class Entry
     {
         public readonly Dictionary<ChatId, (AuthorId AuthorId, ParticipationKind Kind)> Items = new();
+        public bool IsWatched;
         public bool IsReleased;
     }
 
     private readonly ConcurrentDictionary<RpcPeer, Entry> _entries = new();
+    // Serializes a peer's claim + write against the release of the same author's
+    // participation, so a release can never overwrite a claim that raced past it.
+    private readonly AsyncLockSet<(ChatId ChatId, AuthorId AuthorId)> _keyLocks = new(LockReentryMode.CheckedFail);
 
     private IServiceProvider Services { get; } = services;
     private StreamingSettings Settings => field ??= Services.GetRequiredService<StreamingSettings>();
@@ -26,28 +33,57 @@ public sealed class PeerParticipations(IServiceProvider services)
     private MomentClockSet Clocks => field ??= Services.Clocks();
     private ILogger Log => field ??= Services.LogFor(GetType());
 
-    public void Set(RpcPeer peer, ChatId chatId, AuthorId authorId, ParticipationKind kind, bool isActive)
+    public async Task SetParticipation(
+        RpcPeer? peer,
+        ChatId chatId,
+        AuthorId authorId,
+        ParticipationKind kind,
+        bool isActive,
+        CancellationToken cancellationToken)
+    {
+        if (peer is null) {
+            await Backend.SetParticipation(chatId, authorId, kind, isActive, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var _ = await _keyLocks.Lock((chatId, authorId), cancellationToken).ConfigureAwait(false);
+        Claim(peer, chatId, authorId, kind, isActive);
+        await Backend.SetParticipation(chatId, authorId, kind, isActive, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Private methods
+
+    private void Claim(RpcPeer peer, ChatId chatId, AuthorId authorId, ParticipationKind kind, bool isActive)
     {
         while (true) {
             var entry = _entries.GetOrAdd(peer, static _ => new Entry());
-            var isNew = false;
+            var mustWatch = false;
             lock (entry) {
                 if (entry.IsReleased)
                     continue; // Released between GetOrAdd and the lock; the next GetOrAdd starts a fresh entry
 
-                isNew = entry.Items.Count == 0;
+                if (!entry.IsWatched)
+                    entry.IsWatched = mustWatch = true;
                 if (isActive)
                     entry.Items[chatId] = (authorId, kind);
                 else
                     entry.Items.Remove(chatId);
             }
-            if (isNew && isActive)
+            if (mustWatch)
                 _ = Watch(peer, entry);
             return;
         }
     }
 
-    // Private methods
+    private bool IsClaimed(ChatId chatId, AuthorId authorId)
+    {
+        foreach (var entry in _entries.Values)
+            lock (entry) {
+                if (!entry.IsReleased && entry.Items.TryGetValue(chatId, out var item) && item.AuthorId == authorId)
+                    return true;
+            }
+        return false;
+    }
 
     private async Task Watch(RpcPeer peer, Entry entry)
     {
@@ -78,13 +114,29 @@ public sealed class PeerParticipations(IServiceProvider services)
             return;
 
         Log.LogInformation("Peer {Peer} is gone, releasing {Count} participation(s)", peer.Ref, items.Length);
-        foreach (var (chatId, (authorId, kind)) in items)
+        foreach (var (chatId, (authorId, kind)) in items) {
+            using var _ = await _keyLocks.Lock((chatId, authorId), CancellationToken.None).ConfigureAwait(false);
+            if (IsClaimed(chatId, authorId))
+                continue; // Another device of the same account (or this peer, reconnected) still holds it
+
+            await ReleaseOne(peer, chatId, authorId, kind).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReleaseOne(RpcPeer peer, ChatId chatId, AuthorId authorId, ParticipationKind kind)
+    {
+        for (var attempt = 1;; attempt++)
             try {
                 await Backend.SetParticipation(chatId, authorId, kind, false, CancellationToken.None).ConfigureAwait(false);
+                return;
             }
             catch (Exception e) {
-                Log.LogWarning(e, "Peer {Peer}: failed to release {Kind} participation of {AuthorId} in {ChatId}",
-                    peer.Ref, kind, authorId, chatId);
+                if (attempt >= MaxReleaseAttemptCount) {
+                    Log.LogWarning(e, "Peer {Peer}: failed to release {Kind} participation of {AuthorId} in {ChatId}",
+                        peer.Ref, kind, authorId, chatId);
+                    return;
+                }
+                await Clocks.CpuClock.Delay(ReleaseRetryDelays[attempt], CancellationToken.None).ConfigureAwait(false);
             }
     }
 }

--- a/src/dotnet/Streaming.Service/Services/PeerParticipations.cs
+++ b/src/dotnet/Streaming.Service/Services/PeerParticipations.cs
@@ -1,0 +1,90 @@
+using ActualChat.Live;
+using ActualChat.Streaming.Module;
+using ActualLab.Rpc;
+using ActualLab.Rpc.Infrastructure;
+
+namespace ActualChat.Streaming.Services;
+
+/// <summary>
+/// Releases the participations a client claimed over RPC once its peer stays disconnected
+/// past <see cref="StreamingSettings.ParticipationDisconnectGrace"/>: a killed app sends no
+/// leave, and its 90s staleness window would keep suppressing PTT wakes for that author.
+/// </summary>
+public sealed class PeerParticipations(IServiceProvider services)
+{
+    private sealed class Entry
+    {
+        public readonly Dictionary<ChatId, (AuthorId AuthorId, ParticipationKind Kind)> Items = new();
+        public bool IsReleased;
+    }
+
+    private readonly ConcurrentDictionary<RpcPeer, Entry> _entries = new();
+
+    private IServiceProvider Services { get; } = services;
+    private StreamingSettings Settings => field ??= Services.GetRequiredService<StreamingSettings>();
+    private ILiveSessionsBackend Backend => field ??= Services.GetRequiredService<ILiveSessionsBackend>();
+    private MomentClockSet Clocks => field ??= Services.Clocks();
+    private ILogger Log => field ??= Services.LogFor(GetType());
+
+    public void Set(RpcPeer peer, ChatId chatId, AuthorId authorId, ParticipationKind kind, bool isActive)
+    {
+        while (true) {
+            var entry = _entries.GetOrAdd(peer, static _ => new Entry());
+            var isNew = false;
+            lock (entry) {
+                if (entry.IsReleased)
+                    continue; // Released between GetOrAdd and the lock; the next GetOrAdd starts a fresh entry
+
+                isNew = entry.Items.Count == 0;
+                if (isActive)
+                    entry.Items[chatId] = (authorId, kind);
+                else
+                    entry.Items.Remove(chatId);
+            }
+            if (isNew && isActive)
+                _ = Watch(peer, entry);
+            return;
+        }
+    }
+
+    // Private methods
+
+    private async Task Watch(RpcPeer peer, Entry entry)
+    {
+        try {
+            while (true) {
+                await peer.ConnectionState.When(x => !x.IsConnected()).ConfigureAwait(false);
+                await Clocks.CpuClock.Delay(Settings.ParticipationDisconnectGrace).ConfigureAwait(false);
+                if (!peer.ConnectionState.Value.IsConnected())
+                    break;
+            }
+        }
+        catch (Exception e) {
+            Log.LogWarning(e, "Peer {Peer}: connection watch failed, releasing its participations", peer.Ref);
+        }
+        await Release(peer, entry).ConfigureAwait(false);
+    }
+
+    private async Task Release(RpcPeer peer, Entry entry)
+    {
+        KeyValuePair<ChatId, (AuthorId AuthorId, ParticipationKind Kind)>[] items;
+        lock (entry) {
+            entry.IsReleased = true;
+            items = entry.Items.ToArray();
+            entry.Items.Clear();
+        }
+        _entries.TryRemove(new KeyValuePair<RpcPeer, Entry>(peer, entry));
+        if (items.Length == 0)
+            return;
+
+        Log.LogInformation("Peer {Peer} is gone, releasing {Count} participation(s)", peer.Ref, items.Length);
+        foreach (var (chatId, (authorId, kind)) in items)
+            try {
+                await Backend.SetParticipation(chatId, authorId, kind, false, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception e) {
+                Log.LogWarning(e, "Peer {Peer}: failed to release {Kind} participation of {AuthorId} in {ChatId}",
+                    peer.Ref, kind, authorId, chatId);
+            }
+    }
+}

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -196,19 +196,23 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
         var lastHeartbeatAt = Clocks.CpuClock.Now;
         var isConnected = Hub.ConnectivityUI.IsConnected;
         var wasConnected = isConnected.Value;
+        var isResendPending = false;
         try {
             while (!cancellationToken.IsCancellationRequested) {
                 // A reconnect re-sends everything: the server drops a peer's participations
                 // once it stays disconnected past its grace, and the next heartbeat is up to 45s away.
-                var isReconnected = isConnected.Value && !wasConnected;
+                // The resend stays pending until a pass actually sends, so an errored computed doesn't eat it.
+                isResendPending |= isConnected.Value && !wasConnected;
                 wasConnected = isConnected.Value;
                 // ValueOrDefault is null only when the computed errored; skipping the pass keeps
                 // the reported participations until a recompute succeeds, where .Value would throw.
                 if (cParticipations.ValueOrDefault is { } next) {
                     var now = Clocks.CpuClock.Now;
-                    var isHeartbeat = isReconnected || now - lastHeartbeatAt >= HeartbeatInterval;
-                    if (isHeartbeat)
+                    var isHeartbeat = isResendPending || now - lastHeartbeatAt >= HeartbeatInterval;
+                    if (isHeartbeat) {
                         lastHeartbeatAt = now;
+                        isResendPending = false;
+                    }
 
                     foreach (var chatId in current.Keys.Except(next.Keys).ToList()) {
                         await SetParticipation(chatId, current[chatId], false, cancellationToken).ConfigureAwait(false);

--- a/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/LiveSessionUI.cs
@@ -194,13 +194,19 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
             .ConfigureAwait(false);
         var current = new Dictionary<ChatId, ParticipationKind>();
         var lastHeartbeatAt = Clocks.CpuClock.Now;
+        var isConnected = Hub.ConnectivityUI.IsConnected;
+        var wasConnected = isConnected.Value;
         try {
             while (!cancellationToken.IsCancellationRequested) {
+                // A reconnect re-sends everything: the server drops a peer's participations
+                // once it stays disconnected past its grace, and the next heartbeat is up to 45s away.
+                var isReconnected = isConnected.Value && !wasConnected;
+                wasConnected = isConnected.Value;
                 // ValueOrDefault is null only when the computed errored; skipping the pass keeps
                 // the reported participations until a recompute succeeds, where .Value would throw.
                 if (cParticipations.ValueOrDefault is { } next) {
                     var now = Clocks.CpuClock.Now;
-                    var isHeartbeat = now - lastHeartbeatAt >= HeartbeatInterval;
+                    var isHeartbeat = isReconnected || now - lastHeartbeatAt >= HeartbeatInterval;
                     if (isHeartbeat)
                         lastHeartbeatAt = now;
 
@@ -218,7 +224,8 @@ public class LiveSessionUI(AppUIHub hub) : UIWorkerBase<AppUIHub>(hub), ICompute
                 using var cts = cancellationToken.CreateLinkedTokenSource();
                 var whenInvalidated = cParticipations.WhenInvalidated(cts.Token);
                 var whenHeartbeat = Clocks.CpuClock.Delay(HeartbeatInterval, cts.Token);
-                await Task.WhenAny(whenInvalidated, whenHeartbeat).ConfigureAwait(false);
+                var whenConnectivityChanged = isConnected.Computed.WhenInvalidated(cts.Token);
+                await Task.WhenAny(whenInvalidated, whenHeartbeat, whenConnectivityChanged).ConfigureAwait(false);
                 cts.CancelAndDisposeSilently();
                 cParticipations = await cParticipations.Update(cancellationToken).ConfigureAwait(false);
             }

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -135,6 +135,47 @@ public sealed class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITes
     }
 
     [Fact]
+    public async Task ParticipationShouldSurviveWhileAnotherPeerOfTheSameAccountHoldsIt()
+    {
+        // arrange - two devices of one account, both listening
+        await using var host = await NewAppHost("live-peer-twin", o => o with {
+            ConfigureHost = (_, cfg) =>
+                cfg.AddInMemory<StreamingSettings>((x => x.ParticipationDisconnectGrace, "00:00:01")),
+        });
+        var phone = host.NewWebClientTester(Out,
+            services => services.AddSingleton(Mock.Of<IJSRuntime>(MockBehavior.Strict)));
+        var account = await phone.SignInAsUniqueBob();
+        var (chatId, _) = await phone.CreateChat(true);
+        var author = await phone.AppServices.GetRequiredService<IAuthors>().GetOwn(phone.Session, chatId, default);
+        var laptop = host.NewWebClientTester(Out,
+            services => services.AddSingleton(Mock.Of<IJSRuntime>(MockBehavior.Strict)));
+        await laptop.SignIn(account);
+        var backend = host.Services.GetRequiredService<ILiveSessionsBackend>();
+        await phone.ClientServices.GetRequiredService<ILiveSessions>()
+            .SetParticipation(phone.Session, chatId, ParticipationKind.AudioListen, true, default);
+        await laptop.ClientServices.GetRequiredService<ILiveSessions>()
+            .SetParticipation(laptop.Session, chatId, ParticipationKind.AudioListen, true, default);
+        await ComputedTest.When(async ct =>
+            (await backend.ListParticipants(chatId, ct)).Contains(author!.Id).Should().BeTrue());
+
+        // act - the phone vanishes, the laptop keeps listening
+        await phone.DisposeAsync();
+
+        // assert - well past the grace, the author is still present
+        await Task.Delay(TimeSpan.FromSeconds(4));
+        (await backend.ListParticipants(chatId, default)).Contains(author!.Id).Should().BeTrue(
+            "the laptop still holds this author's participation");
+
+        // act - the laptop vanishes too
+        await laptop.DisposeAsync();
+
+        // assert
+        await ComputedTest.When(async ct =>
+            (await backend.ListParticipants(chatId, ct)).Contains(author!.Id).Should().BeFalse(),
+            TimeSpan.FromSeconds(20));
+    }
+
+    [Fact]
     public async Task ExplicitLeaveShouldCloseImmediately()
     {
         // arrange

--- a/tests/Chat.IntegrationTests/LiveSessionsTest.cs
+++ b/tests/Chat.IntegrationTests/LiveSessionsTest.cs
@@ -1,6 +1,8 @@
 using ActualChat.Live;
 using ActualChat.Streaming;
+using ActualChat.Streaming.Module;
 using ActualChat.Testing.Host;
+using Microsoft.JSInterop;
 
 namespace ActualChat.Chat.IntegrationTests;
 
@@ -96,6 +98,40 @@ public sealed class LiveSessionsTest(ChatCollection.AppHostFixture fixture, ITes
         // assert — they are back
         await ComputedTest.When(async ct =>
             (await backend.ListParticipants(chatId, ct)).Contains(authorId).Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task ParticipationShouldBeReleasedWhenThePeerDisconnects()
+    {
+        // arrange - a real RPC client, so the server has a peer to watch
+        await using var host = await NewAppHost("live-peer-gone", o => o with {
+            ConfigureHost = (_, cfg) =>
+                cfg.AddInMemory<StreamingSettings>((x => x.ParticipationDisconnectGrace, "00:00:01")),
+        });
+        var tester = host.NewWebClientTester(Out,
+            services => services.AddSingleton(Mock.Of<IJSRuntime>(MockBehavior.Strict)));
+        await tester.SignInAsUniqueBob();
+        var session = tester.Session;
+        var (chatId, _) = await tester.CreateChat(true);
+        var author = await tester.AppServices.GetRequiredService<IAuthors>().GetOwn(session, chatId, default);
+        var backend = host.Services.GetRequiredService<ILiveSessionsBackend>();
+        var liveSessions = tester.ClientServices.GetRequiredService<ILiveSessions>();
+
+        // act - the client claims a listening participation over RPC
+        await liveSessions.SetParticipation(session, chatId, ParticipationKind.AudioListen, true, default);
+
+        // assert
+        await ComputedTest.When(async ct =>
+            (await backend.ListParticipants(chatId, ct)).Contains(author!.Id).Should().BeTrue());
+
+        // act - the client vanishes without a leave (a killed app sends none)
+        await tester.DisposeAsync();
+
+        // assert - released after the disconnect grace, not after the 90s staleness
+        await ComputedTest.When(async ct =>
+            (await backend.ListParticipants(chatId, ct)).Contains(author!.Id).Should().BeFalse(
+                "a gone peer must not keep its author present, or its PTT wakes stay suppressed"),
+            TimeSpan.FromSeconds(20));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

A swiped-away iOS app sends no leave for its live-session participations. The server treats a participation as present until it is 90 s stale, and `SendPttWake` skips authors who are present, so for up to 90 s after a force-quit every PTT utterance for that phone was silently dropped. The client heartbeat runs every 45 s and the WebSocket dies at once, so the server already knows the client is gone long before staleness expires.

## Fix

- New `PeerParticipations` (Streaming.Service) remembers which RPC peer claimed each participation. It watches the peer's `ConnectionState`; once the peer stays disconnected past `StreamingSettings.ParticipationDisconnectGrace` (10 s), it releases all of that peer's participations through `ILiveSessionsBackend.SetParticipation(..., false)`. A reconnect inside the grace is a no-op.
- `LiveSessions.SetParticipation` records the calling peer via `RpcInboundContext.Current`. In-process callers (Blazor Server scopes) have no peer and are untouched.
- Client: `LiveSessionUI.RunParticipationSync` re-sends its participations as soon as `ConnectivityUI.IsConnected` flips back to true, so a blip longer than the grace heals immediately instead of at the next 45 s heartbeat.

Invariants for reviewers: the watcher is keyed on connection state, not peer lifetime, because server peers are only stopped after the 3–15 min shutdown timeout; the Terminal state also counts as disconnected. One watcher per peer. The backend keeps one participation per (chat, author), so a release skips keys another live peer still claims (a second device, or the same peer reconnected). Claim+write and release are serialized per (chat, author) with an `AsyncLockSet`, so a release can never overwrite a claim that raced past it. A failed release retries 3 times.

## Testing

- New `LiveSessionsTest.ParticipationShouldBeReleasedWhenThePeerDisconnects`: a real RPC client claims a listen participation, is disposed without a leave, and the author is gone within 20 s (staleness alone would need 90 s).
- New `ParticipationShouldSurviveWhileAnotherPeerOfTheSameAccountHoldsIt`: two RPC clients of one account, the first is dropped, the author stays present past the grace; both dropped, the author is gone.
- `Chat.IntegrationTests` LiveSessionsTest: 50 green. `Notifications.IntegrationTests` PttPushTest: 18 green.
- Not verified on a device yet: the actual swipe-away wake on the iPhone after a dev deploy is still owed.

Part of #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1AyMsJVLUbYW3hcZrFY52
