### PR TITLE
fix(ios-ptt): stop the port-override route-change loop, ask the framework on a refused category

### DIFF
--- a/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AppleAudioFocusUI.cs
@@ -354,6 +354,11 @@ public sealed class AppleAudioFocusUI : AudioFocusUI
 
     private async Task HandleRouteChange(AVAudioSessionRouteChangeReason reason)
     {
+        // Our own port override is a route change too; re-applying on it clears and restates the
+        // override, which raises the next one - a loop of route flaps under a starting engine.
+        if (reason is AVAudioSessionRouteChangeReason.Override)
+            return;
+
         bool shouldRecover;
         using (await _lock.Lock(StopToken).ConfigureAwait(false)) {
             if (_activeScopes.IsEmpty)

--- a/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
+++ b/src/dotnet/App.Maui/MaciOS/Audio/AudioSession.cs
@@ -316,8 +316,8 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         var session = AVAudioSession.SharedInstance();
         var owner = Owner;
         var isConfigured = AudioSessionOwnership.MayConfigure(owner, mode);
-        if (isConfigured)
-            ConfigureUnsafe(session, mode);
+        if (isConfigured && !TryConfigureUnsafe(session, mode))
+            return new AudioSessionSetup(false, false, true);
         if (!AudioSessionOwnership.MayActivate(owner)) {
             ApplyOutputRouteUnsafe(mode);
             return new AudioSessionSetup(isConfigured, false);
@@ -353,8 +353,8 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
             var isConfigured = AudioSessionOwnership.MayConfigure(owner, minMode);
             // The framework's session is already active, and SetCategory on an active session
             // is what lets an in-app recording get PlayAndRecord during a live wake playback.
-            if (isConfigured)
-                ConfigureUnsafe(session, minMode);
+            if (isConfigured && !TryConfigureUnsafe(session, minMode))
+                return new AudioSessionSetup(false, false, true);
             ApplyOutputRouteUnsafe(minMode);
             return new AudioSessionSetup(isConfigured, false);
         }
@@ -363,7 +363,8 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
             ? AVAudioSessionSetActiveOptions.NotifyOthersOnDeactivation
             : 0;
         session.SetActive(false, deactivateOptions).Assert("Failed to deactivate session");
-        ConfigureUnsafe(session, minMode);
+        if (!TryConfigureUnsafe(session, minMode))
+            return new AudioSessionSetup(false, false, true);
         if (!session.SetActive(true, out var error)) {
             if (TryRequestPttActivation(error, minMode))
                 return new AudioSessionSetup(true, false, true);
@@ -372,6 +373,21 @@ public sealed class AudioSession(AppUIHub hub) : IAsyncDisposable
         }
         ApplyOutputRouteUnsafe(minMode);
         return new AudioSessionSetup(true, true);
+    }
+
+    private bool TryConfigureUnsafe(AVAudioSession session, AudioFocusMode mode)
+    {
+        // SetCategory is refused on the same terms as SetActive - a PTT-joined app in the
+        // background just after the framework let its session go - and the answer is the same:
+        // ask the framework, which configures on the way in.
+        try {
+            ConfigureUnsafe(session, mode);
+            return true;
+        }
+        catch (Exception e) when (e.InnerException is NSErrorException { Error: { } nsError }
+            && TryRequestPttActivation(nsError, mode)) {
+            return false;
+        }
     }
 
     private bool TryRequestPttActivation(NSError error, AudioFocusMode mode)


### PR DESCRIPTION
## Summary

Two iOS PTT audio-session problems found in the 2.20.104 device trail:

1. Every `OverrideOutputAudioPort(Speaker)` raises a route change, and the route-change handler re-applied the override on it, so each engine start produced a clear/restate flap (five in 0.7 s in the trail), now on listening as well as recording.
2. A PTT-joined app in the background, right after the framework released its session, is refused `SetCategory` on the same terms as `SetActive` (`'!int'`). That threw out of the focus acquisition instead of asking the framework for an activation.

## Fix

- `AppleAudioFocusUI.HandleRouteChange` ignores our own `Override` reason; all other route-change reasons still re-apply the route.
- `AudioSession.TryConfigureUnsafe` wraps `ConfigureUnsafe`; a refused category is turned into a pending PTT activation (`TryRequestPttActivation`) and `ReactivateUnsafe`/`ReconfigureUnsafe` report it as a pending setup instead of failing, the same path `SetActive` refusals already take.

Invariant: only the `Override` reason is skipped. Device/category changes must keep re-applying the speaker route.

## Testing

- iOS build compiles on `mba`.
- Not device-verified yet: the earpiece symptom on 2.20.104 is still being captured at the system-route level; this branch removes the flap that the trail shows but is not proven to be the earpiece cause.

Part of #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1AyMsJVLUbYW3hcZrFY52
