### PR TITLE
fix(translation): send reasoning_effort only to models that accept it

### DIFF
--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -350,6 +350,7 @@ Resolving *which* language a given user reads is `UserLocalizers`
 - `IEmbeddingsCalculator` — text embeddings
 - `IEntryGroupExtractor`, `EntryGroupBuilder` — group entries for ML
 - `RateLimitedChatCompletionService` — rate-limited LLM calls
+- `OpenAIModels` — per-model OpenAI request capabilities (lowest `reasoning_effort` a model accepts)
 - `OpenAITranscriber` — OpenAI-based ASR
 - `TokenEstimator` — token-count estimator
 

--- a/src/dotnet/Chat.ML/ChatCompletionService/OpenAIModels.cs
+++ b/src/dotnet/Chat.ML/ChatCompletionService/OpenAIModels.cs
@@ -1,0 +1,23 @@
+using OpenAI.Chat;
+
+namespace ActualChat.Chat.ML;
+
+#pragma warning disable OPENAI001 // TODO: remove once ChatReasoningEffortLevel is no longer [Experimental]
+public static class OpenAIModels
+{
+    public static ChatReasoningEffortLevel? GetLowestReasoningEffort(string? modelId)
+    {
+        // Each reasoning family has its own floor: "none" came with gpt-5.1, gpt-5 stops at "minimal",
+        // o-series at "low". Chat variants and older models answer HTTP 400 to any value, so null omits it.
+        if (modelId.IsNullOrEmpty() || modelId.Contains("-chat"))
+            return null;
+        if (modelId.StartsWith("gpt-5."))
+            return ChatReasoningEffortLevel.None;
+        if (modelId == "gpt-5" || modelId.StartsWith("gpt-5-"))
+            return ChatReasoningEffortLevel.Minimal;
+        if (modelId is ['o', >= '0' and <= '9', ..])
+            return ChatReasoningEffortLevel.Low;
+
+        return null;
+    }
+}

--- a/src/dotnet/Chat.ML/ConversationSummarizer.cs
+++ b/src/dotnet/Chat.ML/ConversationSummarizer.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Services;
 using HttpOperationException = Microsoft.SemanticKernel.HttpOperationException;
 
 namespace ActualChat.Chat.ML;
@@ -64,7 +65,7 @@ public class ConversationSummarizer(ConversationSummarizer.Options settings, ISe
         var language = await GetMostCommonLanguage(chatId, chatEntries, cancellationToken).ConfigureAwait(false);
         var discussion = await ChatDialogFormatter.EntriesToText(chatEntries, _chatDialogFormatterOptions).ConfigureAwait(false);
         var authorMap = await BuildAuthorMap(authorIds).ConfigureAwait(false);
-        var executionSettings = CreateExecutionSettings();
+        var executionSettings = CreateExecutionSettings(Completion.GetModelId());
         var chatHistory = await BuildRequest(language, authorMap, discussion, cancellationToken).ConfigureAwait(false);
         string? result;
         try {
@@ -258,11 +259,9 @@ public class ConversationSummarizer(ConversationSummarizer.Options settings, ISe
         return true;
     }
 
-    private static PromptExecutionSettings CreateExecutionSettings()
+    private static PromptExecutionSettings CreateExecutionSettings(string? modelId)
         => new OpenAIPromptExecutionSettings {
-#pragma warning disable OPENAI001 // TODO: remove once ChatReasoningEffortLevel is no longer [Experimental]
-            ReasoningEffort = OpenAI.Chat.ChatReasoningEffortLevel.None,
-#pragma warning restore OPENAI001
+            ReasoningEffort = OpenAIModels.GetLowestReasoningEffort(modelId),
             ResponseFormat = ChatResponseFormat.ForJsonSchema(
                 JsonDocument.Parse(
                     """

--- a/src/dotnet/Chat.Service/Translation/LanguageDetector.cs
+++ b/src/dotnet/Chat.Service/Translation/LanguageDetector.cs
@@ -1,9 +1,11 @@
+using ActualChat.Chat.ML;
 using ActualChat.Chat.Module;
 using ActualChat.Module;
 using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Services;
 
 namespace ActualChat.Chat;
 
@@ -38,9 +40,7 @@ public class LanguageDetector(IServiceProvider services)
 
         var executionSettings = new OpenAIPromptExecutionSettings {
             Temperature = 0,
-#pragma warning disable OPENAI001 // TODO: remove once ChatReasoningEffortLevel is no longer [Experimental]
-            ReasoningEffort = OpenAI.Chat.ChatReasoningEffortLevel.None,
-#pragma warning restore OPENAI001
+            ReasoningEffort = OpenAIModels.GetLowestReasoningEffort(Completion.GetModelId()),
             ChatSystemPrompt = Prompt.Trim(),
             ResponseFormat =  ChatResponseFormat.ForJsonSchema(
                 JsonDocument.Parse(

--- a/src/dotnet/Chat.Service/Translation/Translator.cs
+++ b/src/dotnet/Chat.Service/Translation/Translator.cs
@@ -10,6 +10,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Google;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Services;
 
 namespace ActualChat.Chat;
 
@@ -161,9 +162,7 @@ public class Translator(IServiceProvider services, [ServiceKey] string serviceKe
                 Temperature = 0.1,
                 MaxTokens = maxTokens,
                 TopP = 0.1,
-#pragma warning disable OPENAI001 // TODO: remove once ChatReasoningEffortLevel is no longer [Experimental]
-                ReasoningEffort = OpenAI.Chat.ChatReasoningEffortLevel.None,
-#pragma warning restore OPENAI001
+                ReasoningEffort = OpenAIModels.GetLowestReasoningEffort(Completion.GetModelId()),
                 ResponseFormat = "text",
             };
 

--- a/tests/Chat.UnitTests/OpenAIModelsTest.cs
+++ b/tests/Chat.UnitTests/OpenAIModelsTest.cs
@@ -1,0 +1,31 @@
+using ActualChat.Chat.ML;
+
+namespace ActualChat.Chat.UnitTests;
+
+public class OpenAIModelsTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    [Theory]
+    [InlineData("gpt-5.6-terra", "none")]
+    [InlineData("gpt-5.6-luna", "none")]
+    [InlineData("gpt-5.1", "none")]
+    [InlineData("gpt-5", "minimal")]
+    [InlineData("gpt-5-mini", "minimal")]
+    [InlineData("o4-mini", "low")]
+    [InlineData("o3", "low")]
+    [InlineData("gpt-4.1", null)]
+    [InlineData("gpt-4.1-nano", null)]
+    [InlineData("gpt-4o", null)]
+    [InlineData("gpt-5-chat-latest", null)]
+    [InlineData("gpt-5.1-chat-latest", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void LowestReasoningEffortShouldBeOneTheModelAccepts(string? modelId, string? expectedWireValue)
+    {
+        // act
+        var wireValue = OpenAIModels.GetLowestReasoningEffort(modelId)?.ToString();
+
+        // assert
+        wireValue.Should().Be(expectedWireValue,
+            "OpenAI answers HTTP 400 to a reasoning_effort the model doesn't support, and gpt-4.x accepts no value");
+    }
+}

--- a/tests/Chat.UnitTests/RateLimitedChatCompletionServiceTest.cs
+++ b/tests/Chat.UnitTests/RateLimitedChatCompletionServiceTest.cs
@@ -1,0 +1,23 @@
+using ActualChat.Chat.ML;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Services;
+
+namespace ActualChat.Chat.UnitTests;
+
+public class RateLimitedChatCompletionServiceTest(ITestOutputHelper @out) : TestBase(@out)
+{
+    [Fact]
+    public void ModelIdShouldComeFromWrappedService()
+    {
+        // arrange
+        var wrapped = new OpenAIChatCompletionService("gpt-4.1", "sk-test");
+        var service = new RateLimitedChatCompletionService(wrapped, null!, "rate_limit:test");
+
+        // act
+        var modelId = service.GetModelId();
+
+        // assert
+        modelId.Should().Be("gpt-4.1",
+            "the OpenAI call sites pick reasoning_effort by the model id they read through this wrapper");
+    }
+}


### PR DESCRIPTION
## Summary

69cb4bdb97 (v2.20) switched the default OpenAI models to gpt-5.6 and made every OpenAI call — translation,
language detection, summarization — send `reasoning_effort: none`. Prod's flux config still pinned `gpt-4.1` /
`gpt-4.1-nano` for translation, and non-reasoning models reject the parameter outright
(`HTTP 400 Unrecognized request argument supplied: reasoning_effort`), so every translation on prod failed from
the v2.20 rollout until the pins were dropped from flux-team-core `prod`.

The value is model-specific as well: `none` exists only from gpt-5.1 on, gpt-5 stops at `minimal`, and o-series
models at `low`. Pinning `o4-mini` (the previous `ChatSettings.OpenAIModel` default) would fail the same way.

## Fix

- `OpenAIModels.GetLowestReasoningEffort(modelId)` in `Chat.ML` maps a model id to the lowest effort it accepts:
  gpt-5.1+ → `none`, gpt-5 → `minimal`, o-series → `low`; anything else (gpt-4.x, gpt-4o, `*-chat` variants,
  unknown ids) → null, which leaves the parameter out of the request.
- `Translator`, `LanguageDetector` and `ConversationSummarizer` pass the model id of the completion service they
  call (`Completion.GetModelId()`; `RateLimitedChatCompletionService` forwards `Attributes` to the wrapped
  service), so the value follows config overrides.
- With the current gpt-5.6 defaults the request is unchanged (`none`).

Keep the call sites reading the model id from the service rather than from settings: a settings lookup would
miss the fallback to `ChatSettings.OpenAIModel` in `ChatServiceModule.AddKeyedOpenAI`.

## Testing

- `OpenAIModelsTest` (14 literal cases): failed against the previous always-`none` behaviour, passes now.
- `RateLimitedChatCompletionServiceTest`: the model id is readable through the rate-limit wrapper.
- Both unit tests pass on this branch.
- `TranslatorTest.ShouldTranslateWithoutContext` against real OpenAI: 5/5 pass with
  `ChatSettings__Translation__OpenAIModel=gpt-4.1`. A control run with a nonexistent model failed with
  `model_not_found`, confirming the override reached the test host.
- Not run: the full test suite; language detection and summarization against a live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VAxFWpii6bbgsFJa17ds1
