### PR TITLE
fix(chat): slow chat opens after navigating into a conversation, and MAUI <Virtualize> spacer errors

### DIFF
--- a/src/dotnet/App.Maui/App.Maui.csproj
+++ b/src/dotnet/App.Maui/App.Maui.csproj
@@ -163,6 +163,8 @@
     <PackageReference Include="libphonenumber-csharp" />
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+    <!-- WebView.Maui rc.1 pulls Components.WebView preview.7: its blazor.webview.js breaks rc.1 <Virtualize> -->
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView" />
     <!-- This seems weird, but w/o this line MSBuild concludes the version is 1.0.0! -->
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="Plugin.Maui.Audio" />

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.Tiles.cs
@@ -565,11 +565,14 @@ public partial class ChatUI
                 // diff is a one-shot signal: an update lost here leaves an expanded conversation blank
                 lock (Lock) {
                     var lastExpansions = GetLastExpansions(chatId);
-                    changedIds = overrides.SymmetricExcept(lastExpansions.Overrides)
-                        .Union(autoExpanded.SymmetricExcept(lastExpansions.AutoExpanded))
-                        .OrderBy(c => c.StartEntryLid)
-                        .ToList();
-                    _lastExpansions[chatId] = new ExpansionSnapshot(overrides, autoExpanded);
+                    // Every chat switch wipes the auto set, so an earlier visit's snapshot would report that wipe
+                    // as a collapse and widen the window on return - for rows ExpandToCollapsedBlocks loads anyway.
+                    var lastAutoExpanded = lastExpansions.AutoExpansionEpoch == autoExpansionEpoch
+                        ? lastExpansions.AutoExpanded
+                        : ImmutableHashSet<ConversationId>.Empty;
+                    changedIds = GetChangedExpansions(
+                        chatId, overrides, autoExpanded, lastExpansions.Overrides, lastAutoExpanded);
+                    _lastExpansions[chatId] = new ExpansionSnapshot(overrides, autoExpanded, autoExpansionEpoch);
                 }
                 if (changedIds.FirstOrDefault() is { } toggledId)
                     // Extend the data query to cover the toggled conversation's entries. It must extend,
@@ -1840,10 +1843,12 @@ public partial class ChatUI
 
     private sealed record ExpansionSnapshot(
         IImmutableSet<ConversationId> Overrides,
-        IImmutableSet<ConversationId> AutoExpanded)
+        IImmutableSet<ConversationId> AutoExpanded,
+        int AutoExpansionEpoch)
     {
         public static readonly ExpansionSnapshot None = new(
             ImmutableHashSet<ConversationId>.Empty,
-            ImmutableHashSet<ConversationId>.Empty);
+            ImmutableHashSet<ConversationId>.Empty,
+            -1);
     }
 }

--- a/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
+++ b/src/dotnet/UI.Blazor.App/Services/ChatUI.cs
@@ -681,6 +681,20 @@ public partial class ChatUI : UIWorkerBase<AppUIHub>, IComputeService, INotifyIn
         return result;
     }
 
+    internal static List<ConversationId> GetChangedExpansions(
+        ChatId chatId,
+        IImmutableSet<ConversationId> overrides,
+        IImmutableSet<ConversationId> autoExpanded,
+        IImmutableSet<ConversationId> lastOverrides,
+        IImmutableSet<ConversationId> lastAutoExpanded)
+        // Both sets span every chat, while the snapshots are per chat: a change made in another chat must not
+        // count here, or that conversation's lid widens this chat's load window by thousands of entries.
+        => overrides.SymmetricExcept(lastOverrides)
+            .Union(autoExpanded.SymmetricExcept(lastAutoExpanded))
+            .Where(c => c.ChatId == chatId)
+            .OrderBy(c => c.StartEntryLid)
+            .ToList();
+
     // Private methods
 
     private async Task<ChatViewItemVisibility> ComputeItemVisibility(CancellationToken cancellationToken)

--- a/tests/Chat.UI.Blazor.UnitTests/ExpansionChangeTest.cs
+++ b/tests/Chat.UI.Blazor.UnitTests/ExpansionChangeTest.cs
@@ -1,0 +1,74 @@
+using ActualChat.UI.Blazor.App.Services;
+
+namespace ActualChat.Chat.UI.Blazor.UnitTests;
+
+public class ExpansionChangeTest
+{
+    private static readonly ChatId ChatA = ChatId.Parse("aaaaaaaaaaaaaaaaaaaa");
+    private static readonly ChatId ChatB = ChatId.Parse("bbbbbbbbbbbbbbbbbbbb");
+    private static readonly IImmutableSet<ConversationId> Empty = ImmutableHashSet<ConversationId>.Empty;
+
+    [Fact]
+    public void ShouldIgnoreConversationsOfOtherChats()
+    {
+        // arrange: another chat's navigation flipped an override for a conversation at a lower lid
+        var overrides = ImmutableHashSet.Create(ConversationId.New(ChatB, 3175), ConversationId.New(ChatA, 9000));
+        var autoExpanded = ImmutableHashSet.Create(ConversationId.New(ChatB, 100));
+
+        // act
+        var result = ChatUI.GetChangedExpansions(ChatA, overrides, autoExpanded, Empty, Empty);
+
+        // assert
+        result.Should().Equal(
+            [ConversationId.New(ChatA, 9000)],
+            because: "a foreign conversation's lid must never widen this chat's load window");
+    }
+
+    [Fact]
+    public void ShouldBeEmptyWhenOnlyOtherChatsChanged()
+    {
+        // arrange
+        var lastOverrides = ImmutableHashSet.Create(ConversationId.New(ChatA, 500));
+        var overrides = lastOverrides.Add(ConversationId.New(ChatB, 3175));
+
+        // act
+        var result = ChatUI.GetChangedExpansions(ChatA, overrides, Empty, lastOverrides, Empty);
+
+        // assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldReportAdditionsAndRemovalsInBothSetsOrderedByLid()
+    {
+        // arrange
+        var lastOverrides = ImmutableHashSet.Create(ConversationId.New(ChatA, 300));
+        var autoExpanded = ImmutableHashSet.Create(ConversationId.New(ChatA, 200));
+        var lastAutoExpanded = ImmutableHashSet.Create(ConversationId.New(ChatA, 400));
+        var overrides = ImmutableHashSet.Create(ConversationId.New(ChatA, 100));
+
+        // act
+        var result = ChatUI.GetChangedExpansions(ChatA, overrides, autoExpanded, lastOverrides, lastAutoExpanded);
+
+        // assert
+        result.Should().Equal(
+            ConversationId.New(ChatA, 100),
+            ConversationId.New(ChatA, 200),
+            ConversationId.New(ChatA, 300),
+            ConversationId.New(ChatA, 400));
+    }
+
+    [Fact]
+    public void ShouldBeEmptyWhenNothingChanged()
+    {
+        // arrange
+        var overrides = ImmutableHashSet.Create(ConversationId.New(ChatA, 100), ConversationId.New(ChatB, 50));
+        var autoExpanded = ImmutableHashSet.Create(ConversationId.New(ChatA, 200));
+
+        // act
+        var result = ChatUI.GetChangedExpansions(ChatA, overrides, autoExpanded, overrides, autoExpanded);
+
+        // assert
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Two bugs found on the prod Windows app (v2.20.109). Both are also on dev.

**Chats take seconds to show after a navigation into a conversation.** After a build whose expanded conversations
changed, `ChatUI.GetChatItemsInternal` widens the data query's `ExistingLidRange` down to the tile of the lowest changed
conversation. It detects "changed" by diffing `_conversationExpansionOverrides` and `_autoExpandedConversations` against
a snapshot. Those two sets are service-wide and hold conversation ids of every chat, but since f6590eda9d the snapshot is
kept per chat, and nothing checked the conversation's `ChatId`. So once any chat flips an override (opening a chat at an
entry inside a collapsed conversation does it via the navigation branch), the first build of every other chat reports
that foreign id as a change and widens to its lid. On prod, after opening a chat at entry 3213, the next three chats all
loaded from lid 3175: 945, 3915 and 4310 items, 5-9 s each before the chat rendered.

The same diff had a second source of phantom changes: `ClearAutoExpansionState` empties the auto-expanded set on every
chat switch, while the returned-to chat's snapshot still holds the previous visit's auto set, so the first build on
return read the wipe as a collapse and widened to that conversation.

**`<Virtualize>` spacer callbacks throw in the MAUI apps.** `Microsoft.AspNetCore.Components.WebView.Maui`
11.0.0-rc.1.26451.6 depends on `Components.WebView` 11.0.0-preview.7 for every TFM, and `App.Maui` had no direct
reference, so the apps shipped preview.7's `blazor.webview.js` next to rc.1 `Components.Web`. That script calls
`OnSpacerBeforeVisible`/`OnSpacerAfterVisible` with 3 arguments; rc.1 `Virtualize` expects 4, so every call failed with
`ArgumentException ... expects '4' parameters, but received '3'` (the right panel's `AuthorList`).

## Fix

- `ChatUI.GetChangedExpansions` (internal static, next to `GetNewAutoExpansions`) computes the diff and keeps only the
  built chat's ids, ordered by `StartEntryLid`. The filter applies to the whole union, so a foreign lower lid can't
  shadow a real change in this chat either.
- `ExpansionSnapshot` records the auto-expansion epoch the build captured; a snapshot from an earlier visit contributes
  no auto-expanded ids (`None` uses epoch -1). Overrides are not visit-scoped and are still diffed as before. Skipping
  the widening on return is safe: `TryGetIdTilesToLoad` -> `ExpandToCollapsedBlocks` already extends every build's
  load range over intersecting collapsed conversations.
- `App.Maui.csproj` references `Microsoft.AspNetCore.Components.WebView` directly, so it resolves to
  `$(AspNetCoreVersion)` (11.0.0-rc.1.26425.128). Keep it until a WebView.Maui release depends on a matching version.

## Testing

- Unit: new `ExpansionChangeTest` (foreign-chat ids ignored, additions and removals in both sets, ordering, no change);
  `Chat.UI.Blazor.UnitTests` 903/903 pass.
- Server-loop, Server render mode: expanded conversation `T7bfyw5vri:12`, then opened `the-actual-one` via the chat list.
  Before: `GetChatItems ... for {"start":10,"end":5390}`, 460 items. After: `{"start":5385,"end":5390}`, 35 items. The
  toggled chat itself still widens to cover its conversation.
- Windows Debug app (unpackaged): output ships `Components.WebView` 11.0.0-rc.1.26425.128 and its `blazor.webview.js`
  passes 4 arguments; the author list was opened and scrolled against dev.voxt.ai with no `OnSpacer` errors in the app
  log (the build before the fix logged 10), and no `MissingMethodException`/`TypeLoadException`.
- Not verified: the return-to-chat epoch path at runtime (needs an auto-expansion; covered by reasoning only); Android,
  iOS and Mac builds with the new package reference; WASM render mode.
- release/v2.20 has both bugs; cherry-picking is not done yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8BsMRLfE5u1G5rTssnDy5
